### PR TITLE
Set up CI with SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,10 @@ name: CI
 on:
   pull_request:
     branches: [dev]
-  push:
-    branches: [dev]
+  # Manual trigger as an escape hatch (e.g. to refresh the SonarCloud
+  # baseline on `dev` after a merge). Plain pushes to `dev` do NOT run CI
+  # by design — quality gates run pre-merge, on the PR.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,116 @@
+# Continuous integration for the Flutter/Dart port.
+#
+# Scope: ONLY the new Dart packages under `packages/`. The legacy WPF/C#
+# code under `legacy-wpf/` is reference material and is explicitly excluded
+# from analysis (see sonar-project.properties).
+#
+# ----------------------------------------------------------------------------
+# Operator setup (one-time, after this workflow lands):
+#   1. Create a SonarCloud (aka SonarQube Cloud) project for
+#      github.com/yvanvds/AccountManager. Use the default project key
+#      `yvanvds_AccountManager` and organization `yvanvds`. Adjust
+#      sonar-project.properties if SonarCloud assigns different values.
+#   2. Generate a SonarCloud token and add it as a repository secret named
+#      `SONAR_TOKEN`.
+#   3. Add a repository variable `SONARCLOUD_ENABLED=true` to turn on the
+#      SonarCloud job. Until this is set, the sonar job is skipped and the
+#      workflow still passes — so this file can land before the operator
+#      finishes the SonarCloud setup.
+# ----------------------------------------------------------------------------
+#
+# Until issue #19 (account_core) lands a root `pubspec.yaml`, the Dart steps
+# are no-ops and the workflow reports green based on the workspace-detection
+# notice alone. That is intentional: we want CI scaffolding committed early.
+
+name: CI
+
+on:
+  pull_request:
+    branches: [dev]
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dart:
+    name: Dart analyze + test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # SonarCloud needs full history for blame-based new-code detection.
+          fetch-depth: 0
+
+      - name: Detect Dart workspace
+        id: workspace
+        run: |
+          if [ -f pubspec.yaml ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=No Dart workspace yet::Skipping Dart steps. CI will become meaningful once issue #19 (account_core) lands a root pubspec.yaml."
+          fi
+
+      - name: Set up Dart
+        if: steps.workspace.outputs.exists == 'true'
+        uses: dart-lang/setup-dart@v1
+
+      - name: dart pub get
+        if: steps.workspace.outputs.exists == 'true'
+        run: dart pub get
+
+      - name: dart analyze
+        if: steps.workspace.outputs.exists == 'true'
+        run: dart analyze --fatal-infos --fatal-warnings
+
+      - name: dart test (with coverage)
+        if: steps.workspace.outputs.exists == 'true'
+        run: |
+          dart test --coverage=coverage
+          dart pub global activate coverage
+          dart pub global run coverage:format_coverage \
+            --lcov \
+            --in=coverage \
+            --out=coverage/lcov.info \
+            --report-on=packages \
+            --packages=.dart_tool/package_config.json
+
+      - name: Upload coverage artifact
+        if: steps.workspace.outputs.exists == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+          if-no-files-found: warn
+          retention-days: 7
+
+  sonar:
+    name: SonarQube Cloud scan
+    needs: dart
+    runs-on: ubuntu-latest
+    # Skipped until the operator sets repo variable SONARCLOUD_ENABLED=true.
+    # See the header comment for setup steps.
+    if: ${{ vars.SONARCLOUD_ENABLED == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage
+        # Coverage may not exist yet (no Dart workspace).
+        continue-on-error: true
+
+      - name: SonarQube Cloud scan
+        uses: SonarSource/sonarqube-scan-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Arcadia Account Manager
+
+[![CI](https://github.com/yvanvds/AccountManager/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/yvanvds/AccountManager/actions/workflows/ci.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=yvanvds_AccountManager&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=yvanvds_AccountManager)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=yvanvds_AccountManager&metric=coverage)](https://sonarcloud.io/summary/new_code?id=yvanvds_AccountManager)
+
+Synchronises user accounts and class groups between WISA, Smartschool, and Azure AD / Office 365 for a Belgian secondary-school group.
+
+This repository is in transition from a WPF / .NET Framework 4.8 desktop application to a **Flutter / Dart** application.
+
+- **Project goal, layout, port order:** [CLAUDE.md](CLAUDE.md)
+- **Architectural reference:** [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md)
+- **Spec for the port:** [docs/domain-model.md](docs/domain-model.md)
+- **Legacy WPF code (read-only reference):** [legacy-wpf/](legacy-wpf/)
+
+The SonarCloud badges above will activate once the operator finishes the SonarCloud project setup — see [.github/workflows/ci.yml](.github/workflows/ci.yml) for the steps.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,49 @@
+# SonarQube Cloud configuration for the Arcadia Account Manager Flutter/Dart port.
+#
+# IMPORTANT: This config covers ONLY the new Dart packages under `packages/`.
+# The legacy C#/WPF code under `legacy-wpf/` is reference material and is
+# explicitly excluded from analysis — see sonar.exclusions below.
+#
+# If SonarCloud assigned a different project key / organization when you
+# imported this repo, change projectKey / organization here.
+
+sonar.projectKey=yvanvds_AccountManager
+sonar.organization=yvanvds
+sonar.projectName=Arcadia Account Manager
+sonar.projectDescription=Flutter/Dart port of the WPF Arcadia Account Manager. Syncs accounts and groups across WISA, Smartschool, and Azure AD.
+
+# Encoding
+sonar.sourceEncoding=UTF-8
+
+# Inclusion: scan only Dart files. Defensive — `legacy-wpf/` is explicitly
+# excluded below as well.
+sonar.inclusions=**/*.dart
+
+# Sources live under packages/* once issue #19 (account_core) has landed.
+# Until then there are no Dart files to scan and SonarCloud will report
+# 0 lines, which is fine.
+sonar.sources=packages
+
+# Test files
+sonar.tests=packages
+sonar.test.inclusions=**/test/**/*.dart
+
+# Exclusions. The legacy-wpf entry is the load-bearing one — this repository
+# carries both the legacy C# code and the new Dart port side by side; we only
+# analyse the Dart port.
+sonar.exclusions=\
+  legacy-wpf/**,\
+  .vs/**,\
+  **/.dart_tool/**,\
+  **/build/**,\
+  **/coverage/**,\
+  **/*.g.dart,\
+  **/*.freezed.dart,\
+  **/*.mocks.dart,\
+  docs/**
+
+# Coverage report (produced by the CI workflow).
+sonar.coverage.reportPaths=coverage/lcov.info
+
+# Branch / PR analysis is auto-detected by the SonarSource action; no extra
+# config needed here.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -31,6 +31,13 @@ sonar.test.inclusions=**/test/**/*.dart
 # Exclusions. The legacy-wpf entry is the load-bearing one — this repository
 # carries both the legacy C# code and the new Dart port side by side; we only
 # analyse the Dart port.
+#
+# Sonar distinguishes three exclusion lists; all three need the legacy entry
+# so a future config change that widens sonar.sources/sonar.tests cannot
+# drag the C# code back into the Dart-port quality metrics:
+#   - sonar.exclusions          → main (non-test) source files
+#   - sonar.test.exclusions     → test source files
+#   - sonar.coverage.exclusions → coverage % calculation
 sonar.exclusions=\
   legacy-wpf/**,\
   .vs/**,\
@@ -41,6 +48,19 @@ sonar.exclusions=\
   **/*.freezed.dart,\
   **/*.mocks.dart,\
   docs/**
+
+sonar.test.exclusions=\
+  legacy-wpf/**,\
+  .vs/**,\
+  **/.dart_tool/**,\
+  **/build/**,\
+  **/coverage/**
+
+sonar.coverage.exclusions=\
+  legacy-wpf/**,\
+  **/*.g.dart,\
+  **/*.freezed.dart,\
+  **/*.mocks.dart
 
 # Coverage report (produced by the CI workflow).
 sonar.coverage.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` — runs `dart analyze` + `dart test --coverage` on PRs targeting `dev`. Dart steps gate on the presence of a root `pubspec.yaml`, so the workflow no-ops cleanly until issue #19 (account_core) lands the workspace.
- Add an opt-in SonarQube Cloud scan job (gated on repo variable `SONARCLOUD_ENABLED=true`) so this scaffolding can land before the operator finishes the SonarCloud project setup. Required operator steps are documented in the workflow's header comment.
- Add `sonar-project.properties` with `legacy-wpf/**` excluded from **all three** Sonar exclusion lists (`sonar.exclusions`, `sonar.test.exclusions`, `sonar.coverage.exclusions`) — the legacy C# code never contributes to Dart-port quality metrics, even under future config drift. `sonar.inclusions=**/*.dart` is belt-and-suspenders on top.
- Add `README.md` with CI / SonarCloud quality-gate / coverage badges. Badges go green once the operator completes the SonarCloud setup.
- Workflow triggers on **PR only** (plus `workflow_dispatch` as a manual escape hatch). No CI runs on plain pushes to `dev` — quality gates run pre-merge, on the PR.

## Test plan

- [ ] Open this PR and confirm the `Dart analyze + test` job runs and reports green via the "No Dart workspace yet" notice.
- [ ] Confirm the `SonarQube Cloud scan` job is **skipped** (the `SONARCLOUD_ENABLED` repo variable hasn't been set yet).
- [ ] After this lands, follow the operator steps in [`.github/workflows/ci.yml`](https://github.com/yvanvds/AccountManager/blob/issue-23-set-up-ci-with-sonarcloud/.github/workflows/ci.yml) to create the SonarCloud project, add the `SONAR_TOKEN` secret, and set `SONARCLOUD_ENABLED=true`. Trigger the workflow via the Actions tab (`workflow_dispatch`) to verify the Sonar scan completes and the SonarCloud badges in the README turn green.
- [ ] On a future PR following #19, confirm the workflow actually exercises `dart analyze` and `dart test --coverage` against the new `account_core` package.

## Notes for the reviewer

- Acceptance criterion in the issue mentioned "runs on PRs and pushes to `dev`"; this PR narrows that to PR-only by user request. See commit `cf3b0f9`.
- `legacy-wpf/` exclusion is enforced four ways: `sonar.inclusions=**/*.dart`, `sonar.sources=packages`, `sonar.tests=packages`, and explicit `legacy-wpf/**` entries in all three exclusion lists. See commit `24a08a1` for the rationale.

Closes #23