### PR TITLE
Live WISA integration: capture script, opt-in test, CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,13 @@ jobs:
 
       - name: dart test (with coverage)
         if: steps.workspace.outputs.exists == 'true'
+        # Dart workspaces don't auto-discover tests from the root; pass
+        # each workspace package's test/ directory explicitly. Update
+        # this list whenever a new package is added to pubspec.yaml.
         run: |
-          dart test --coverage=coverage
+          dart test --coverage=coverage \
+            packages/account_core/test \
+            packages/wisa_api/test
           dart pub global activate coverage
           dart pub global run coverage:format_coverage \
             --lcov \

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -44,9 +44,12 @@ jobs:
         run: dart analyze --fatal-infos --fatal-warnings
 
       - name: dart test
+        # Dart workspaces don't auto-discover tests from the root; pass
+        # each workspace package's test/ directory explicitly. Update
+        # this list whenever a new package is added to pubspec.yaml.
         # No WISA_USERNAME in this job — the integration test self-skips,
         # see test/integration/wisa_live_test.dart.
-        run: dart test
+        run: dart test packages/account_core/test packages/wisa_api/test
 
   live-test:
     name: WISA live integration

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,80 @@
+# Dart CI for the wisa_api package (and any future workspace package).
+#
+# Two jobs:
+#   - test       : offline `dart analyze` + `dart test`. Always runs.
+#   - live-test  : opt-in WISA integration test (`test/integration/`).
+#                  Gated to this repository so fork PRs cannot trigger
+#                  secret access — fork pull_request runs do not expose
+#                  secrets anyway, the gate is belt-and-suspenders.
+#
+# Operator setup for live-test (one-time):
+#   Add the following six repository secrets:
+#     WISA_SERVER, WISA_PORT, WISA_DATABASE,
+#     WISA_USERNAME, WISA_PASSWORD, WISA_SCHOOL_ID
+#   See packages/wisa_api/README.md and .wisa.env.example for the names.
+#
+# Overlap note: an older workflow (`ci.yml`) also runs `dart analyze` +
+# `dart test` on pull_request, plus coverage / SonarCloud. The two
+# workflows are kept side-by-side for now; consolidation is a follow-up.
+
+name: Dart
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Analyze + test (offline)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: dart pub get
+        run: dart pub get
+
+      - name: dart analyze
+        run: dart analyze --fatal-infos --fatal-warnings
+
+      - name: dart test
+        # No WISA_USERNAME in this job — the integration test self-skips,
+        # see test/integration/wisa_live_test.dart.
+        run: dart test
+
+  live-test:
+    name: WISA live integration
+    needs: test
+    runs-on: ubuntu-latest
+    # Only run on the canonical repo. Fork PRs do not get secrets even
+    # without this gate, but skipping the job outright keeps the build
+    # matrix tidy.
+    if: github.repository == 'yvanvds/AccountManager'
+    env:
+      WISA_SERVER: ${{ secrets.WISA_SERVER }}
+      WISA_PORT: ${{ secrets.WISA_PORT }}
+      WISA_DATABASE: ${{ secrets.WISA_DATABASE }}
+      WISA_USERNAME: ${{ secrets.WISA_USERNAME }}
+      WISA_PASSWORD: ${{ secrets.WISA_PASSWORD }}
+      WISA_SCHOOL_ID: ${{ secrets.WISA_SCHOOL_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: dart pub get
+        run: dart pub get
+
+      - name: Run live integration test
+        # If WISA_USERNAME is unset (secrets not configured yet) the test
+        # self-skips and this still passes — by design, so the workflow
+        # can land before secrets are provisioned.
+        run: dart test packages/wisa_api/test/integration/

--- a/.gitignore
+++ b/.gitignore
@@ -282,3 +282,10 @@ packages/*/pubspec.lock
 # redaction script. Contains real PII (names, national IDs, addresses);
 # never commit raw. See packages/wisa_api/tool/redact_fixtures.dart.
 artifacts/
+
+# Raw SOAP + CSV dumps from packages/wisa_api/tool/capture_responses.dart.
+# Local-only diagnostic output; contains real PII straight from WISA.
+packages/wisa_api/captures/
+
+# Populated .wisa.env (real credentials). Only .wisa.env.example is committed.
+.wisa.env

--- a/.wisa.env.example
+++ b/.wisa.env.example
@@ -1,0 +1,22 @@
+# Live WISA credentials for the capture script and integration test.
+#
+# Copy this file to `.wisa.env` (gitignored) and fill in the real values,
+# then source it before running:
+#
+#     # PowerShell
+#     Get-Content .wisa.env | ForEach-Object {
+#       if ($_ -match '^([^#=]+)=(.*)$') { Set-Item "env:$($matches[1])" $matches[2] }
+#     }
+#
+#     # bash
+#     set -a; source .wisa.env; set +a
+#
+# Never commit a populated copy. Real values stay local; CI reads them
+# from `secrets.WISA_*` (see .github/workflows/dart.yml).
+
+WISA_SERVER=
+WISA_PORT=
+WISA_DATABASE=
+WISA_USERNAME=
+WISA_PASSWORD=
+WISA_SCHOOL_ID=

--- a/packages/wisa_api/README.md
+++ b/packages/wisa_api/README.md
@@ -33,3 +33,52 @@ small SOAP envelope builder.
 
 Spec: [`docs/domain-model.md`](../../docs/domain-model.md) §3.3, §3.4,
 §3.11. Legacy reference: [`legacy-wpf/AccountApi/Wisa/`](../../legacy-wpf/AccountApi/Wisa/).
+
+## Live WISA access (capture script + integration test)
+
+Two things in this package talk to a real WISA host: the manual capture
+script in [`tool/capture_responses.dart`](tool/capture_responses.dart) and
+the opt-in integration test at
+[`test/integration/wisa_live_test.dart`](test/integration/wisa_live_test.dart).
+Both read the same six environment variables:
+
+| Variable         | Purpose                                  |
+| ---------------- | ---------------------------------------- |
+| `WISA_SERVER`    | Hostname of the WISA SOAP server         |
+| `WISA_PORT`      | TCP port (integer)                       |
+| `WISA_DATABASE`  | WISA database name                       |
+| `WISA_USERNAME`  | API user                                 |
+| `WISA_PASSWORD`  | API password                             |
+| `WISA_SCHOOL_ID` | Integer ID of the school to capture/test |
+
+Copy [`.wisa.env.example`](../../.wisa.env.example) at the repo root to
+`.wisa.env` (gitignored) and fill in the real values. `.wisa.env` itself
+is never committed.
+
+When `WISA_USERNAME` is empty the integration test self-skips, so
+`dart test` stays offline by default.
+
+### CI
+
+CI reads these as repository secrets in
+[`.github/workflows/dart.yml`](../../.github/workflows/dart.yml):
+
+- `test` job — offline `dart analyze` + `dart test`, always runs.
+- `live-test` job — runs the integration test using `secrets.WISA_*`.
+  Gated to this repository so fork PRs cannot trigger secret access.
+
+Add the secrets at **Settings → Secrets and variables → Actions**, using
+the same six names listed above.
+
+### Capture script
+
+Run from anywhere inside the repo, after exporting the env vars:
+
+```sh
+dart run packages/wisa_api/tool/capture_responses.dart
+```
+
+The script dumps raw SOAP XML + decoded CSV under
+`packages/wisa_api/captures/<timestamp>/` (gitignored, local-only) and
+prints an issue-#29 verdict for the `SyncKlas` response — i.e. whether
+WISA quotes class-group descriptions that contain literal commas.

--- a/packages/wisa_api/lib/src/config/live_config.dart
+++ b/packages/wisa_api/lib/src/config/live_config.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'package:account_core/account_core.dart' as core;
+
+import '../connector.dart';
+
+/// Six-variable configuration for talking to a live WISA host.
+///
+/// Used by both the capture script (`tool/capture_responses.dart`) and
+/// the opt-in integration test (`test/integration/wisa_live_test.dart`).
+/// Offline unit tests never read this; they pass credentials in directly.
+///
+/// See `.wisa.env.example` at the repository root for the variable names.
+class WisaLiveConfig {
+  final String server;
+  final int port;
+  final String database;
+  final String username;
+  final String password;
+  final int schoolId;
+
+  const WisaLiveConfig({
+    required this.server,
+    required this.port,
+    required this.database,
+    required this.username,
+    required this.password,
+    required this.schoolId,
+  });
+
+  /// Names of the six environment variables, in canonical order.
+  static const List<String> envVarNames = [
+    'WISA_SERVER',
+    'WISA_PORT',
+    'WISA_DATABASE',
+    'WISA_USERNAME',
+    'WISA_PASSWORD',
+    'WISA_SCHOOL_ID',
+  ];
+
+  /// Reads config from environment variables (defaulting to
+  /// `Platform.environment`). Returns `null` when `WISA_USERNAME` is
+  /// empty or missing — the integration test uses this as its skip
+  /// signal, so `dart test` stays offline by default.
+  ///
+  /// Throws [ArgumentError] when `WISA_USERNAME` is set but one of the
+  /// other five variables is missing/empty or a numeric variable cannot
+  /// be parsed.
+  static WisaLiveConfig? fromEnvironment([Map<String, String>? env]) {
+    final source = env ?? Platform.environment;
+    final username = (source['WISA_USERNAME'] ?? '').trim();
+    if (username.isEmpty) return null;
+
+    final missing = <String>[
+      for (final name in const [
+        'WISA_SERVER',
+        'WISA_PORT',
+        'WISA_DATABASE',
+        'WISA_PASSWORD',
+        'WISA_SCHOOL_ID',
+      ])
+        if ((source[name] ?? '').trim().isEmpty) name,
+    ];
+    if (missing.isNotEmpty) {
+      throw ArgumentError(
+        'WISA_USERNAME is set but the following env vars are missing or '
+        'empty: ${missing.join(', ')}',
+      );
+    }
+
+    final portRaw = source['WISA_PORT']!.trim();
+    final port = int.tryParse(portRaw);
+    if (port == null) {
+      throw ArgumentError('WISA_PORT is not an integer: "$portRaw"');
+    }
+    final schoolIdRaw = source['WISA_SCHOOL_ID']!.trim();
+    final schoolId = int.tryParse(schoolIdRaw);
+    if (schoolId == null) {
+      throw ArgumentError(
+        'WISA_SCHOOL_ID is not an integer: "$schoolIdRaw"',
+      );
+    }
+
+    return WisaLiveConfig(
+      server: source['WISA_SERVER']!.trim(),
+      port: port,
+      database: source['WISA_DATABASE']!.trim(),
+      username: username,
+      password: source['WISA_PASSWORD']!.trim(),
+      schoolId: schoolId,
+    );
+  }
+
+  /// Builds a connector from this config. The connector uses the default
+  /// HTTP transport unless [log] is provided to capture diagnostics.
+  WisaConnector connector({core.ILog? log}) => WisaConnector.fromParts(
+        server: server,
+        port: port,
+        database: database,
+        username: username,
+        password: password,
+        log: log,
+      );
+}

--- a/packages/wisa_api/lib/src/soap/soap_envelope.dart
+++ b/packages/wisa_api/lib/src/soap/soap_envelope.dart
@@ -160,7 +160,11 @@ String decodeGetCsvDataResponse(String responseXml) {
   if (results.isEmpty) {
     throw WisaSoapResponseException('No <Result> element in response');
   }
-  final encoded = results.first.innerText.trim();
+  // WISA emits the base64 payload wrapped across lines (~76-char chunks
+  // separated by CRLF). Dart's `base64.decode` is strict and rejects any
+  // inline whitespace, unlike .NET's `Convert.FromBase64String`, which
+  // is why the legacy app never hit this. Strip all whitespace first.
+  final encoded = results.first.innerText.replaceAll(RegExp(r'\s+'), '');
   if (encoded.isEmpty) return '';
   try {
     final bytes = base64.decode(encoded);

--- a/packages/wisa_api/lib/src/soap/soap_transport.dart
+++ b/packages/wisa_api/lib/src/soap/soap_transport.dart
@@ -14,12 +14,33 @@ abstract interface class WisaSoapTransport {
 }
 
 /// Thrown when the HTTP transport receives a non-2xx response.
+///
+/// Some WISA error responses echo back the original request envelope,
+/// which contains the password in plaintext. [toString] redacts those
+/// credential fields so the exception is safe to log.
 class WisaSoapHttpException implements Exception {
   final int statusCode;
   final String body;
   WisaSoapHttpException(this.statusCode, this.body);
   @override
-  String toString() => 'WisaSoapHttpException($statusCode): $body';
+  String toString() =>
+      'WisaSoapHttpException($statusCode): ${redactCredentials(body)}';
+}
+
+/// Replaces the contents of `<Username>…</Username>` and
+/// `<Password>…</Password>` elements with `[REDACTED]`. Used by
+/// transport exceptions and by the capture script. Conservative — runs
+/// on plain strings, never throws.
+String redactCredentials(String input) {
+  return input
+      .replaceAllMapped(
+        RegExp(r'(<Username[^>]*>).*?(</Username>)', dotAll: true),
+        (m) => '${m.group(1)}[REDACTED]${m.group(2)}',
+      )
+      .replaceAllMapped(
+        RegExp(r'(<Password[^>]*>).*?(</Password>)', dotAll: true),
+        (m) => '${m.group(1)}[REDACTED]${m.group(2)}',
+      );
 }
 
 /// Default transport backed by `package:http`. Sends a SOAP 1.1 POST with

--- a/packages/wisa_api/lib/wisa_api.dart
+++ b/packages/wisa_api/lib/wisa_api.dart
@@ -9,6 +9,7 @@
 /// (read-only): `legacy-wpf/AccountApi/Wisa/`.
 library;
 
+export 'src/config/live_config.dart' show WisaLiveConfig;
 export 'src/connector.dart' show WisaConnector, WisaQuery;
 export 'src/csv/csv_parser.dart' show CsvHeaderMismatch, CsvRowParseException;
 export 'src/models/wisa_class_group.dart';
@@ -19,6 +20,13 @@ export 'src/rules/import_rules.dart';
 export 'src/snapshot.dart';
 export 'src/soap/credentials.dart';
 export 'src/soap/soap_envelope.dart'
-    show WisaSoapFault, WisaSoapResponseException;
+    show
+        WisaSoapFault,
+        WisaSoapResponseException,
+        decodeGetCsvDataResponse;
 export 'src/soap/soap_transport.dart'
-    show HttpWisaSoapTransport, WisaSoapHttpException, WisaSoapTransport;
+    show
+        HttpWisaSoapTransport,
+        WisaSoapHttpException,
+        WisaSoapTransport,
+        redactCredentials;

--- a/packages/wisa_api/test/integration/wisa_live_test.dart
+++ b/packages/wisa_api/test/integration/wisa_live_test.dart
@@ -1,0 +1,121 @@
+/// Opt-in integration test: drives the connector against a real WISA
+/// host. Skipped when `WISA_USERNAME` is empty so `dart test` stays
+/// offline by default.
+///
+/// Asserts only structural invariants — connection, presence of the
+/// configured school, non-empty sync — and logs counts/booleans only.
+/// Never logs row contents, never echoes the request envelope.
+///
+/// CI runs this in the `live-test` job of `.github/workflows/dart.yml`.
+library;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+void main() {
+  final config = WisaLiveConfig.fromEnvironment();
+  final skipReason = config == null
+      ? 'WISA_USERNAME not set; skipping live integration tests.'
+      : null;
+
+  group('wisa_api live integration', skip: skipReason, () {
+    late WisaConnector connector;
+
+    setUpAll(() {
+      // config is non-null here because the group is unskipped.
+      connector = config!.connector();
+    });
+
+    test('testConnection succeeds', () async {
+      bool ok;
+      try {
+        ok = await connector.testConnection();
+      } on Exception catch (e) {
+        // Defensive: redact before rethrowing so the test report cannot
+        // echo a request envelope with credentials.
+        throw Exception(
+          'testConnection threw: ${redactCredentials(e.toString())}',
+        );
+      }
+      expect(ok, isTrue, reason: 'WISA testConnection returned false');
+    });
+
+    test('loadSchools returns the configured school', () async {
+      List<WisaSchool> schools;
+      try {
+        schools = await connector.loadSchools();
+      } on Exception catch (e) {
+        throw Exception(
+          'loadSchools threw: ${redactCredentials(e.toString())}',
+        );
+      }
+      expect(
+        schools,
+        isNotEmpty,
+        reason: 'loadSchools returned no schools at all',
+      );
+      final ids = schools.map((s) => s.id).toSet();
+      expect(
+        ids,
+        contains(config!.schoolId),
+        reason:
+            'WISA_SCHOOL_ID=${config.schoolId} not present in schools '
+            '(${schools.length} returned)',
+      );
+    });
+
+    test('sync of the configured school is non-empty', () async {
+      List<WisaSchool> schools;
+      try {
+        schools = await connector.loadSchools();
+      } on Exception catch (e) {
+        throw Exception(
+          'loadSchools threw: ${redactCredentials(e.toString())}',
+        );
+      }
+      final target = schools.where((s) => s.id == config!.schoolId).toList();
+      expect(
+        target,
+        isNotEmpty,
+        reason: 'WISA_SCHOOL_ID not in schools list',
+      );
+
+      WisaSnapshot snapshot;
+      try {
+        snapshot = await connector.sync(
+          schools: target,
+          workDate: DateTime.now(),
+        );
+      } on Exception catch (e) {
+        throw Exception(
+          'sync threw: ${redactCredentials(e.toString())}',
+        );
+      }
+
+      // Counts only — never the rows themselves.
+      stdout.writeln(
+        '  students=${snapshot.students.length} '
+        'staff=${snapshot.staff.length} '
+        'classGroups=${snapshot.classGroups.length}',
+      );
+
+      expect(
+        snapshot.students,
+        isNotEmpty,
+        reason: 'sync returned zero students',
+      );
+      expect(
+        snapshot.staff,
+        isNotEmpty,
+        reason: 'sync returned zero staff',
+      );
+      expect(
+        snapshot.classGroups,
+        isNotEmpty,
+        reason: 'sync returned zero class groups',
+      );
+    });
+  });
+}

--- a/packages/wisa_api/test/soap/soap_envelope_test.dart
+++ b/packages/wisa_api/test/soap/soap_envelope_test.dart
@@ -91,6 +91,25 @@ void main() {
       expect(decodeGetCsvDataResponse(makeResponse('')), '');
     });
 
+    test('tolerates whitespace inside the base64 payload', () {
+      // WISA wraps the base64 across ~76-char lines separated by CRLF.
+      // Dart's base64.decode is strict; the decoder must strip whitespace.
+      const csv = 'ID,NAME\n1,Alpha\n2,Beta\n';
+      final encoded = base64.encode(utf8.encode(csv));
+      final wrapped =
+          '${encoded.substring(0, 8)}\r\n${encoded.substring(8, 16)}\n  '
+          '${encoded.substring(16)}';
+      final xml = '''<?xml version="1.0" encoding="utf-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body>
+    <NS1:GetCSVDataResponse xmlns:NS1="urn:WisaAPIService-WisaAPIService">
+      <Result xsi:type="xsd:base64Binary" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">$wrapped</Result>
+    </NS1:GetCSVDataResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>''';
+      expect(decodeGetCsvDataResponse(xml), csv);
+    });
+
     test('throws WisaSoapResponseException when Result is missing', () {
       const xml = '''<?xml version="1.0"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">

--- a/packages/wisa_api/test/soap/soap_transport_test.dart
+++ b/packages/wisa_api/test/soap/soap_transport_test.dart
@@ -51,5 +51,37 @@ void main() {
       );
       transport.close();
     });
+
+    test('WisaSoapHttpException.toString redacts echoed credentials',
+        () async {
+      const echoed =
+          '<Envelope><Username>alice</Username><Password>hunter2</Password></Envelope>';
+      final ex = WisaSoapHttpException(500, echoed);
+      final s = ex.toString();
+      expect(s, isNot(contains('hunter2')));
+      expect(s, isNot(contains('alice')));
+      expect(s, contains('[REDACTED]'));
+    });
+  });
+
+  group('redactCredentials', () {
+    test('replaces Username and Password element contents', () {
+      const input =
+          '<x><Username>u</Username><Password>p</Password></x>';
+      expect(
+        redactCredentials(input),
+        '<x><Username>[REDACTED]</Username><Password>[REDACTED]</Password></x>',
+      );
+    });
+
+    test('handles attributes on the element tag', () {
+      const input = '<Password xsi:type="xsd:string">secret</Password>';
+      expect(redactCredentials(input), contains('[REDACTED]'));
+      expect(redactCredentials(input), isNot(contains('secret')));
+    });
+
+    test('is a no-op when neither element is present', () {
+      expect(redactCredentials('<x>plain</x>'), '<x>plain</x>');
+    });
   });
 }

--- a/packages/wisa_api/tool/capture_responses.dart
+++ b/packages/wisa_api/tool/capture_responses.dart
@@ -1,0 +1,233 @@
+/// Manual capture script: hits a real WISA host and dumps raw SOAP
+/// responses + decoded CSV under `packages/wisa_api/captures/`
+/// (gitignored, local-only).
+///
+/// Run from anywhere inside the repo:
+///
+///     dart run packages/wisa_api/tool/capture_responses.dart
+///
+/// Requires the six `WISA_*` env vars (see `.wisa.env.example` at the
+/// repo root). Output captures one file per SOAP call:
+///
+///     captures/<timestamp>/<query>.xml   — raw SOAP response
+///     captures/<timestamp>/<query>.csv   — decoded CSV payload
+///
+/// Always-on issue #29 diagnostic: after `SyncKlas` is captured the
+/// script reports whether any class group description appears to contain
+/// a literal comma (i.e. WISA is *not* quoting the field) and whether
+/// every row has the same field count as the header. One real capture
+/// is enough to decide between the three avenues listed in issue #29.
+library;
+
+import 'dart:io';
+
+import 'package:account_core/account_core.dart' as core;
+import 'package:wisa_api/wisa_api.dart';
+
+Future<int> main(List<String> args) async {
+  final config = WisaLiveConfig.fromEnvironment();
+  if (config == null) {
+    stderr.writeln(
+      'WISA_USERNAME is not set. Source .wisa.env first '
+      '(see .wisa.env.example).',
+    );
+    return 2;
+  }
+
+  final repoRoot = _findRepoRoot();
+  final stamp = DateTime.now()
+      .toIso8601String()
+      .replaceAll(':', '-')
+      .split('.')
+      .first;
+  final outDir = Directory(
+    '${repoRoot.path}/packages/wisa_api/captures/$stamp',
+  )..createSync(recursive: true);
+  stdout.writeln('Writing captures to ${outDir.path}');
+
+  final recorder = _RecordingTransport(HttpWisaSoapTransport());
+  final logger = _StdoutLog();
+  final connector = WisaConnector.fromParts(
+    server: config.server,
+    port: config.port,
+    database: config.database,
+    username: config.username,
+    password: config.password,
+    transport: recorder,
+    log: logger,
+  );
+
+  try {
+    stdout.writeln('\n=== testConnection ===');
+    final ok = await connector.testConnection();
+    stdout.writeln('  result: $ok');
+
+    stdout.writeln('\n=== loadSchools ===');
+    final schools = await connector.loadSchools();
+    stdout.writeln('  schools loaded: ${schools.length}');
+    final target = schools.where((s) => s.id == config.schoolId).toList();
+    if (target.isEmpty) {
+      stderr.writeln(
+        '  no school with ID ${config.schoolId} in the response; '
+        'sync will be skipped.',
+      );
+    } else {
+      stdout.writeln('  syncing school ${target.first.id} '
+          '("${target.first.name}")');
+      stdout.writeln('\n=== sync ===');
+      final snapshot = await connector.sync(
+        schools: target,
+        workDate: DateTime.now(),
+      );
+      stdout.writeln(
+        '  students=${snapshot.students.length} '
+        'staff=${snapshot.staff.length} '
+        'classGroups=${snapshot.classGroups.length}',
+      );
+    }
+  } on Exception catch (e) {
+    stderr.writeln('Capture failed: ${redactCredentials(e.toString())}');
+    return 1;
+  } finally {
+    recorder.dump(outDir);
+  }
+
+  _runIssue29Diagnostic(outDir);
+  stdout.writeln('\nDone. Captures: ${outDir.path}');
+  return 0;
+}
+
+/// Walks the records the [_RecordingTransport] gathered and prints the
+/// issue-29 verdict for the `SyncKlas` capture.
+void _runIssue29Diagnostic(Directory outDir) {
+  final klasFile = File('${outDir.path}/SyncKlas.csv');
+  if (!klasFile.existsSync()) {
+    stdout.writeln('\n[issue-29] no SyncKlas.csv captured — skipped.');
+    return;
+  }
+  final csv = klasFile.readAsStringSync();
+  if (csv.isEmpty) {
+    stdout.writeln('\n[issue-29] SyncKlas.csv is empty.');
+    return;
+  }
+  final lines = csv.replaceAll('\r\n', '\n').replaceAll('\r', '\n').split('\n');
+  if (lines.length < 2) {
+    stdout.writeln('\n[issue-29] SyncKlas.csv has no data rows.');
+    return;
+  }
+  final headerFields = lines.first.split(',').length;
+  var mismatched = 0;
+  var quoted = 0;
+  var maxFields = headerFields;
+  for (var i = 1; i < lines.length; i++) {
+    final line = lines[i];
+    if (line.isEmpty) continue;
+    final fields = line.split(',').length;
+    if (fields != headerFields) mismatched++;
+    if (fields > maxFields) maxFields = fields;
+    if (line.contains('"')) quoted++;
+  }
+  stdout.writeln('\n[issue-29] SyncKlas verdict');
+  stdout.writeln('  header columns      : $headerFields');
+  stdout.writeln('  data rows           : ${lines.length - 1}');
+  stdout.writeln('  rows w/ mismatch    : $mismatched');
+  stdout.writeln('  max fields observed : $maxFields');
+  stdout.writeln('  rows containing "   : $quoted');
+  if (quoted > 0) {
+    stdout.writeln(
+      '  → WISA appears to QUOTE fields containing commas. '
+      'The new csv parser already handles this; legacy JSON corruption '
+      'is a pre-existing legacy-parser bug.',
+    );
+  } else if (mismatched > 0) {
+    stdout.writeln(
+      '  → WISA does NOT quote and rows with embedded commas mis-split. '
+      'Pick a non-comma separator (issue #29 avenue 1) or switch to '
+      'GetXMLData (avenue 2).',
+    );
+  } else {
+    stdout.writeln(
+      '  → no comma-in-description rows in this capture; question is '
+      'inconclusive from this dataset.',
+    );
+  }
+}
+
+class _RecordingTransport implements WisaSoapTransport {
+  final WisaSoapTransport _inner;
+  final List<({String queryCode, String response})> _records = [];
+
+  _RecordingTransport(this._inner);
+
+  @override
+  Future<String> send({
+    required Uri endpoint,
+    required String soapAction,
+    required String envelope,
+  }) async {
+    final code = _peekQueryCode(envelope);
+    final response = await _inner.send(
+      endpoint: endpoint,
+      soapAction: soapAction,
+      envelope: envelope,
+    );
+    _records.add((queryCode: code, response: response));
+    return response;
+  }
+
+  String _peekQueryCode(String envelope) {
+    final m = RegExp(r'<QueryCode[^>]*>([^<]+)</QueryCode>')
+        .firstMatch(envelope);
+    return m?.group(1)?.trim() ?? 'unknown';
+  }
+
+  /// Writes one `.xml` (raw SOAP) and one `.csv` (decoded payload) per
+  /// captured call. The `.xml` is run through [redactCredentials] in
+  /// case the server echoed the request envelope back in an error path.
+  void dump(Directory outDir) {
+    final counts = <String, int>{};
+    for (final r in _records) {
+      final n = counts.update(r.queryCode, (v) => v + 1, ifAbsent: () => 1);
+      final base = n == 1 ? r.queryCode : '${r.queryCode}-$n';
+      File('${outDir.path}/$base.xml')
+          .writeAsStringSync(redactCredentials(r.response));
+      try {
+        final csv = decodeGetCsvDataResponse(r.response);
+        File('${outDir.path}/$base.csv').writeAsStringSync(csv);
+      } on Exception catch (e) {
+        File('${outDir.path}/$base.csv.error.txt')
+            .writeAsStringSync(redactCredentials(e.toString()));
+      }
+    }
+  }
+}
+
+class _StdoutLog implements core.ILog {
+  @override
+  void addMessage(core.Origin origin, String message) {
+    stdout.writeln('[${origin.name}] $message');
+  }
+
+  @override
+  void addError(core.Origin origin, String message) {
+    stderr.writeln('[${origin.name}] ERROR: $message');
+  }
+}
+
+Directory _findRepoRoot() {
+  var d = Directory.current;
+  while (true) {
+    if (File('${d.path}/pubspec.yaml').existsSync() &&
+        Directory('${d.path}/packages').existsSync() &&
+        Directory('${d.path}/legacy-wpf').existsSync()) {
+      return d;
+    }
+    final parent = d.parent;
+    if (parent.path == d.path) {
+      stderr.writeln('Could not locate repo root from ${Directory.current.path}');
+      exit(2);
+    }
+    d = parent;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Wires `wisa_api` to a live WISA host via six `WISA_*` env vars. `WisaLiveConfig.fromEnvironment()` returns `null` when `WISA_USERNAME` is empty so `dart test` stays offline by default.
- New manual capture script `tool/capture_responses.dart` dumps raw SOAP responses + decoded CSV to a gitignored `packages/wisa_api/captures/` directory and prints an issue-#29 verdict for `SyncKlas`.
- New opt-in integration test `test/integration/wisa_live_test.dart` asserts only structural invariants (`testConnection`, school presence, non-empty `sync`). Logs counts/booleans only — never row contents.
- New workflow `.github/workflows/dart.yml`: offline `test` job (analyze + test) on push & PR, gated `live-test` job (`github.repository == 'yvanvds/AccountManager'`) reading `secrets.WISA_*`.
- Credential-leak hardening: `WisaSoapHttpException.toString()` and captured SOAP XML pass through a new `redactCredentials()` helper that scrubs `<Username>`/`<Password>` contents.
- **Bug fix surfaced by the first live run**: `decodeGetCsvDataResponse` now strips whitespace before base64 decoding. WISA wraps the payload across ~76-char lines separated by CRLF; Dart's strict `base64.decode` rejected it where .NET's `Convert.FromBase64String` tolerated inline whitespace. Regression test added at `test/soap/soap_envelope_test.dart`.

## Issue #29 verdict (side effect)
Capture against school 25 (ISMAA) confirms WISA does **not** quote class-group descriptions containing commas — 2 of 75 rows mis-split (6 fields where header has 5). Fix (separator change or `GetXMLData`) is out of scope for this PR; tracked in #29.

## Test plan
- [x] `dart analyze --fatal-infos --fatal-warnings` clean on the workspace
- [x] `dart test` from `packages/wisa_api/`: 97/97 pass, 3 skipped (live tests self-skip without env)
- [x] With `.wisa.env` populated: `dart test test/integration/` → 3/3 pass (`students=767 staff=202 classGroups=71` against ISMAA)
- [x] Capture script writes `SMATestCon.{xml,csv}`, `SMAGetInst.{xml,csv}`, `SyncKlas.{xml,csv}`, `SmaSyncLln.{xml,csv}`, `SmaSyncPer.{xml,csv}` and prints the issue-#29 diagnostic
- [ ] After secrets are added to the repo, confirm the `live-test` job runs green in Actions

## Notes for the reviewer
- The new `dart.yml` overlaps with the existing `ci.yml` (which currently runs analyze+test+coverage+sonar on PR only). A header comment in `dart.yml` flags this; consolidation is a follow-up if desired.
- Root `pubspec.lock` is currently untracked and not part of this PR. The existing `.gitignore` only excludes `packages/*/pubspec.lock`; happy to ignore the root one too in a follow-up if that matches the workspace policy.

Closes #30