### PR TITLE
Build azure_api Dart package with Graph filter/select/delta (PAIN-2)

### DIFF
--- a/.azure.env.example
+++ b/.azure.env.example
@@ -1,0 +1,30 @@
+# Live Azure AD / Microsoft Graph config for the capture script and the
+# read-only integration test.
+#
+# Copy this file to `.azure.env` (gitignored) and fill in the real values,
+# then source it before running:
+#
+#     # PowerShell
+#     Get-Content .azure.env | ForEach-Object {
+#       if ($_ -match '^([^#=]+)=(.*)$') { Set-Item "env:$($matches[1])" $matches[2] }
+#     }
+#
+#     # bash
+#     set -a; source .azure.env; set +a
+#
+# Never commit a populated copy. Real values stay local.
+#
+# AZURE_CLIENT_ID / AZURE_TENANT_ID identify the registered public-client app.
+# AZURE_DOMAIN is the verified domain users live under (e.g. `school.example`).
+# AZURE_SCHOOL_PREFIX scopes the $filter reads and group listing.
+# AZURE_ACCESS_TOKEN is a pre-acquired Graph bearer token — the read-only test
+# skips interactive sign-in. Get one with:
+#
+#     az account get-access-token --resource https://graph.microsoft.com \
+#       --query accessToken -o tsv
+
+AZURE_CLIENT_ID=
+AZURE_TENANT_ID=
+AZURE_DOMAIN=
+AZURE_SCHOOL_PREFIX=
+AZURE_ACCESS_TOKEN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,9 @@ jobs:
         run: |
           dart test --coverage=coverage \
             packages/account_core/test \
-            packages/wisa_api/test
+            packages/wisa_api/test \
+            packages/smartschool_api/test \
+            packages/azure_api/test
           dart pub global activate coverage
           dart pub global run coverage:format_coverage \
             --lcov \

--- a/.gitignore
+++ b/.gitignore
@@ -293,8 +293,15 @@ packages/wisa_api/captures/
 # Local-only diagnostic output; contains real PII straight from Smartschool.
 packages/smartschool_api/captures/
 
+# Raw Graph JSON dumps from packages/azure_api/tool/capture_responses.dart.
+# Local-only diagnostic output; contains real PII straight from Azure AD.
+packages/azure_api/captures/
+
 # Populated .wisa.env (real credentials). Only .wisa.env.example is committed.
 .wisa.env
 
 # Populated .smartschool.env (real accesscode). Only the .example is committed.
 .smartschool.env
+
+# Populated .azure.env (real token/ids). Only .azure.env.example is committed.
+.azure.env

--- a/packages/azure_api/CHANGELOG.md
+++ b/packages/azure_api/CHANGELOG.md
@@ -1,0 +1,19 @@
+## 0.1.0 (unreleased)
+
+Initial Microsoft Graph connector for Azure AD / Office 365 (issue #22).
+
+- `AzureConnector.sync({deltaToken})` builds an `AzureSnapshot` using Graph
+  `$filter`, `$select` and `/users/delta` from day one — no full 6000-user
+  bulk pull (PAIN-2).
+- Models: `AzureUser`, `AzureGroup` (implement the `account_core` source-record
+  interfaces), `AzureSnapshot` with a round-trippable on-disk cache.
+- Hand-rolled OAuth2 auth-code-with-PKCE over `package:oauth2`; pluggable
+  encrypted `TokenCache` (the Flutter app supplies a `flutter_secure_storage`
+  backing; an `InMemoryTokenCache` ships for tests).
+- `UserManager`: filtered/$select read, `/users/delta`, and user CRUD
+  (`getUser`, `createUser`, `updateUser`, `deleteUser`) mirroring the legacy
+  `UserManager.cs` surface.
+- `GroupManager`: prefixed group list and membership add/remove, with `$batch`
+  coalescing for multi-write membership operations.
+- Record-and-replay fixture tests over a swappable Graph transport; opt-in,
+  read-only live integration test.

--- a/packages/azure_api/LICENSE
+++ b/packages/azure_api/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/packages/azure_api/README.md
+++ b/packages/azure_api/README.md
@@ -1,0 +1,134 @@
+# azure_api
+
+Microsoft Graph connector for the Arcadia Account Manager port. Reads Azure AD
+/ Office 365 users and groups into an immutable `AzureSnapshot`, and performs
+the user and group-membership writes the action set depends on. Pure Dart — no
+Flutter, no UI coupling — so it is headless-testable and reusable from any Dart
+frontend.
+
+Spec: [`docs/domain-model.md`](../../docs/domain-model.md) §3.6 (`AzureUser`),
+§3.8 (`AzureSnapshot`), §6.1 (sync), §8 (PAIN-2). Legacy reference
+(read-only): [`legacy-wpf/AccountApi/Azure/`](../../legacy-wpf/AccountApi/Azure/).
+
+## The PAIN-2 fix
+
+The legacy connector downloads roughly **6000** tenant users to keep the
+~1000 that belong to the school. This connector never does that:
+
+- **First / full sync** — a `$filter` + `$select` bulk read scoped to the
+  school (`UserManager.load`), so only the school's ~1000 users come down.
+  It also primes a delta token (`$deltatoken=latest`) for next time.
+- **Incremental sync** — `/users/delta` returns only the users that changed
+  since the last token; the connector upserts and removes them on top of the
+  previous snapshot.
+
+`$select` is pinned to exactly the fields the port uses: `id`,
+`userPrincipalName`, `employeeId`, `displayName`, `givenName`, `surname`,
+`companyName`, `department`, `accountEnabled`.
+
+### Server-side filter, and where it falls back
+
+The bulk `$filter` is:
+
+```
+companyName eq '<prefix>' or startswith(department,'<prefix>')
+```
+
+Students carry the prefix in `companyName`; staff carry it at the **start** of
+`department` (the legacy convention sets staff `department` to exactly the
+prefix). Graph supports `eq` and `startswith` server-side on these properties,
+but **not** `contains`. If an installation buries the prefix mid-string in
+`department`, server-side `startswith` would miss those staff — use
+`UserManager.loadClientFiltered`, which pulls with `$select` only and filters
+client-side. The delta path always filters client-side, because `/users/delta`
+does not honour these property filters.
+
+## Authentication
+
+OAuth2 **auth-code with PKCE** against the Microsoft identity platform, built
+on [`package:oauth2`](https://pub.dev/packages/oauth2). This was chosen over
+`msal_auth` / `aad_oauth`: those are Flutter platform plugins (native channels,
+webviews) that are hard to unit-test headlessly and have uncertain Windows
+desktop support. `oauth2` is pure Dart, accepts an injectable `http.Client`
+(so the token exchange and refresh are covered by fakes), handles the S256
+PKCE challenge internally, and sends no client secret — correct for a
+native/desktop **public client**.
+
+Acquisition order mirrors the legacy MSAL flow
+(`AcquireTokenSilent` → `AcquireTokenInteractive`):
+
+1. a valid cached token is returned as-is;
+2. an expired token is refreshed silently;
+3. otherwise an interactive sign-in runs.
+
+The interactive leg is supplied by an `InteractiveAuthorizer` callback — the
+package does not open browsers or bind sockets itself. `LoopbackAuthorizer` is
+the desktop default (RFC 8252 loopback redirect); the Flutter app injects the
+`BrowserLauncher` (`url_launcher` / `Process.start`).
+
+### Token cache (encrypted at rest)
+
+The serialized credentials hold a **refresh token** and must be encrypted at
+rest. The legacy connector used Windows DPAPI (`TokenCacheHelper.cs`). Here the
+package defines a `TokenCache` interface and never writes plaintext to disk:
+
+- the Flutter app supplies a `flutter_secure_storage`-backed implementation
+  (DPAPI on Windows), **or**
+- wraps any `TokenCache` in `EncryptedTokenCache`, which applies an injected
+  cipher so the inner store only ever sees ciphertext.
+
+`InMemoryTokenCache` ships for tests and as a safe non-persistent default.
+
+## Public surface
+
+- `AzureConnector(credentials, authProvider, transport?, log?)` —
+  `sync({deltaToken, previous})` → `AzureSnapshot`.
+- `UserManager` — `load`, `loadClientFiltered`, `delta`, `latestDeltaToken`,
+  `getUser`, `userExists`, `createUser`, `updateUser`, `deleteUser`,
+  `createPrincipalName`.
+- `GroupManager` — `listGroups`, `loadMemberIds`, `addMember`, `removeMember`,
+  and `$batch`-coalesced `addMembers` / `removeMembers`.
+- `GraphClient` / `GraphTransport` — authenticated, paging-aware Graph access
+  over a swappable transport.
+- Auth: `AzureCredentials`, `AzureAuthProvider`, `OAuthAuthProvider`,
+  `LoopbackAuthorizer`, `TokenCache` / `EncryptedTokenCache` /
+  `InMemoryTokenCache`, `StaticAuthProvider`.
+- Models: `AzureUser`, `AzureGroup`, `AzureSnapshot`, `UserDelta`.
+
+## `$batch`
+
+Membership changes are folded into Graph `$batch` calls (`GraphBatch`,
+`GroupManager.addMembers` / `removeMembers`), chunked at Graph's 20-request
+ceiling — something the legacy connector never did (one HTTP call per member).
+
+## Testing
+
+Offline unit tests use a record-and-replay `FakeGraphTransport` (records every
+outgoing request, replays committed fixtures from
+[`test/fixtures/`](test/fixtures/)) and a `StaticAuthProvider`. They assert the
+exact `$filter`/`$select`/`$batch` the connector issues, delta-token
+round-trips, pagination, and the auth flows (cache hit, silent refresh,
+interactive fallback, encrypted-cache round-trip).
+
+Run them:
+
+```
+dart test packages/azure_api/test
+```
+
+Line coverage is **≈88%**. The only deliberately-uncovered code is the real
+interactive browser launch inside `LoopbackAuthorizer.launchBrowser`'s caller
+wiring (the loopback capture itself *is* tested with a fake browser); the
+token-exchange and refresh logic is fully covered.
+
+### Live access
+
+The opt-in [`test/integration/azure_live_test.dart`](test/integration/azure_live_test.dart)
+runs **read-only** against a real tenant (per the project's live-testing
+policy — CI live tests never write). It skips unless the `AZURE_*` env vars are
+present, so `dart test` stays offline by default. See
+[`.azure.env.example`](../../.azure.env.example) for the variables; supply a
+pre-acquired bearer token via `AZURE_ACCESS_TOKEN` to skip interactive
+sign-in. Refresh fixtures with
+[`tool/capture_responses.dart`](tool/capture_responses.dart) (redacts tokens;
+**scrub PII** before committing).

--- a/packages/azure_api/analysis_options.yaml
+++ b/packages/azure_api/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/packages/azure_api/lib/azure_api.dart
+++ b/packages/azure_api/lib/azure_api.dart
@@ -1,0 +1,39 @@
+/// Microsoft Graph connector for the Arcadia Account Manager port.
+///
+/// Reads Azure AD / Office 365 users and groups into an immutable
+/// `AzureSnapshot` using Graph `$filter`, `$select` and `/users/delta`, and
+/// performs the user and group-membership writes the action set depends on.
+/// Pure Dart — no Flutter, no UI coupling. See
+/// `packages/azure_api/README.md` for the auth approach and design notes.
+///
+/// Spec: `docs/domain-model.md` §3.6, §3.8, §6.1, §8 (PAIN-2). Legacy
+/// reference (read-only): `legacy-wpf/AccountApi/Azure/`.
+library;
+
+export 'src/auth/auth_provider.dart'
+    show AzureAuthException, AzureAuthProvider, StaticAuthProvider;
+export 'src/auth/credentials.dart' show AzureCredentials;
+export 'src/auth/loopback_authorizer.dart'
+    show BrowserLauncher, LoopbackAuthorizer;
+export 'src/auth/oauth_auth_provider.dart'
+    show InteractiveAuthorizer, OAuthAuthProvider;
+export 'src/auth/token_cache.dart'
+    show
+        EncryptedTokenCache,
+        InMemoryTokenCache,
+        TokenCache,
+        TokenDecrypt,
+        TokenEncrypt;
+export 'src/config/live_config.dart' show AzureLiveConfig;
+export 'src/connector.dart' show AzureConnector;
+export 'src/graph/graph_batch.dart'
+    show BatchRequest, BatchResponse, GraphBatch;
+export 'src/graph/graph_client.dart' show DeltaResult, GraphClient;
+export 'src/graph/graph_request.dart'
+    show GraphException, GraphRequest, GraphResponse;
+export 'src/graph/graph_transport.dart' show GraphTransport, HttpGraphTransport;
+export 'src/group_manager.dart' show GroupManager;
+export 'src/models/azure_group.dart' show AzureGroup;
+export 'src/models/azure_user.dart' show AzureUser;
+export 'src/snapshot.dart' show AzureSnapshot;
+export 'src/user_manager.dart' show UserDelta, UserManager;

--- a/packages/azure_api/lib/src/auth/auth_provider.dart
+++ b/packages/azure_api/lib/src/auth/auth_provider.dart
@@ -1,0 +1,34 @@
+/// Supplies a bearer token for Graph calls.
+///
+/// The Dart equivalent of the legacy MSAL `IAuthenticationProvider`
+/// (`Connector.cs`): [GraphClient] calls [getAccessToken] before each request
+/// and sets the `Authorization` header. Implementations handle silent
+/// acquisition, refresh, and interactive fallback.
+abstract interface class AzureAuthProvider {
+  /// Returns a valid access token, refreshing or prompting interactively as
+  /// needed. Throws [AzureAuthException] when a token cannot be obtained.
+  Future<String> getAccessToken();
+}
+
+/// Thrown when authentication cannot produce a usable access token.
+class AzureAuthException implements Exception {
+  final String message;
+  final Object? cause;
+
+  const AzureAuthException(this.message, [this.cause]);
+
+  @override
+  String toString() =>
+      'AzureAuthException: $message${cause != null ? ' ($cause)' : ''}';
+}
+
+/// A fixed-token provider. Useful for read-only live tests and for callers
+/// that already hold a token from elsewhere.
+class StaticAuthProvider implements AzureAuthProvider {
+  final String token;
+
+  const StaticAuthProvider(this.token);
+
+  @override
+  Future<String> getAccessToken() async => token;
+}

--- a/packages/azure_api/lib/src/auth/credentials.dart
+++ b/packages/azure_api/lib/src/auth/credentials.dart
@@ -1,0 +1,58 @@
+/// Static configuration for talking to one Azure AD tenant.
+///
+/// Mirrors the arguments the legacy `Connector.Init` took (`clientId`,
+/// `tenantId`, `azureDomain`, `schoolPrefix`); the parent-window handle is
+/// dropped — the interactive browser flow is supplied by an authorizer
+/// callback instead (`docs/domain-model.md` §6.1).
+class AzureCredentials {
+  /// Application (client) id of the registered Azure AD app.
+  final String clientId;
+
+  /// Directory (tenant) id, or a value like `organizations` / `common`.
+  final String tenantId;
+
+  /// The verified domain users live under, e.g. `school.example`. Student
+  /// UPNs are minted under `student.<azureDomain>`; staff under
+  /// `<azureDomain>`.
+  final String azureDomain;
+
+  /// School prefix used to scope the `$filter` reads and group listing — the
+  /// heart of the PAIN-2 fix.
+  final String schoolPrefix;
+
+  /// Redirect URI for the public-client flow. Defaults to a fixed loopback
+  /// address, as Azure requires for native/desktop apps. The port must be
+  /// fixed (not ephemeral) because it is baked into the authorization URL and
+  /// the loopback server has to bind exactly that port.
+  final Uri redirectUri;
+
+  /// Delegated scopes requested. Defaults to the legacy `User.ReadWrite.All`
+  /// plus `offline_access` (needed for refresh tokens) and the OIDC scopes.
+  final List<String> scopes;
+
+  AzureCredentials({
+    required this.clientId,
+    required this.tenantId,
+    required this.azureDomain,
+    required this.schoolPrefix,
+    Uri? redirectUri,
+    List<String>? scopes,
+  })  : redirectUri =
+            redirectUri ?? Uri.parse('http://localhost:8765/auth-redirect'),
+        scopes = scopes ??
+            const [
+              'https://graph.microsoft.com/User.ReadWrite.All',
+              'https://graph.microsoft.com/Group.ReadWrite.All',
+              'offline_access',
+            ];
+
+  /// Microsoft identity-platform authorization endpoint for this tenant.
+  Uri get authorizationEndpoint => Uri.parse(
+        'https://login.microsoftonline.com/$tenantId/oauth2/v2.0/authorize',
+      );
+
+  /// Microsoft identity-platform token endpoint for this tenant.
+  Uri get tokenEndpoint => Uri.parse(
+        'https://login.microsoftonline.com/$tenantId/oauth2/v2.0/token',
+      );
+}

--- a/packages/azure_api/lib/src/auth/loopback_authorizer.dart
+++ b/packages/azure_api/lib/src/auth/loopback_authorizer.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+import 'auth_provider.dart';
+import 'oauth_auth_provider.dart';
+
+/// Opens [url] in the user's browser. The Flutter app wires this to
+/// `url_launcher` (or `Process.start` on desktop); the package stays free of
+/// platform plugins.
+typedef BrowserLauncher = Future<void> Function(Uri url);
+
+/// Desktop [InteractiveAuthorizer]: launches the system browser and captures
+/// the redirect on a loopback HTTP server (RFC 8252).
+///
+/// This is the one code path that genuinely needs a browser and a real socket,
+/// so it is exercised by the live flow rather than unit tests — its untested
+/// status is documented in the README. The pure token-exchange and refresh
+/// logic lives in [OAuthAuthProvider] and is fully covered with a fake
+/// authorizer.
+class LoopbackAuthorizer {
+  final BrowserLauncher launchBrowser;
+
+  /// HTML returned to the browser once the redirect is captured.
+  final String successHtml;
+
+  const LoopbackAuthorizer({
+    required this.launchBrowser,
+    this.successHtml = '<html><body><h2>Signed in.</h2>'
+        'You can close this window and return to the app.</body></html>',
+  });
+
+  /// Implements [InteractiveAuthorizer]. Binds the loopback port from
+  /// [redirectUri], opens [authorizationUrl], and returns the query parameters
+  /// from the single redirect request.
+  Future<Map<String, String>> call(
+    Uri authorizationUrl,
+    Uri redirectUri,
+  ) async {
+    final server = await HttpServer.bind(
+      InternetAddress.loopbackIPv4,
+      redirectUri.port,
+    );
+    try {
+      await launchBrowser(authorizationUrl);
+      final request = await server.first;
+      final params = request.uri.queryParameters;
+      request.response
+        ..statusCode = 200
+        ..headers.contentType = ContentType.html
+        ..write(successHtml);
+      await request.response.close();
+      if (params.containsKey('error')) {
+        throw AzureAuthException(
+          'authorization error: ${params['error']} '
+                  '${params['error_description'] ?? ''}'
+              .trim(),
+        );
+      }
+      return params;
+    } finally {
+      await server.close(force: true);
+    }
+  }
+}

--- a/packages/azure_api/lib/src/auth/oauth_auth_provider.dart
+++ b/packages/azure_api/lib/src/auth/oauth_auth_provider.dart
@@ -1,0 +1,119 @@
+import 'package:http/http.dart' as http;
+import 'package:oauth2/oauth2.dart' as oauth2;
+
+import 'auth_provider.dart';
+import 'credentials.dart';
+import 'token_cache.dart';
+
+/// Drives the interactive leg of the auth-code flow: given the authorization
+/// URL the user must visit, returns the query parameters Azure appended to the
+/// redirect (`code`, `state`, …).
+///
+/// The package does not open browsers or bind sockets itself — that is
+/// platform work. The Flutter app supplies an implementation (e.g.
+/// [LoopbackAuthorizer]); tests supply a fake that returns a canned `code`.
+typedef InteractiveAuthorizer = Future<Map<String, String>> Function(
+  Uri authorizationUrl,
+  Uri redirectUri,
+);
+
+/// Public-client OAuth2 provider using auth-code-with-PKCE against the
+/// Microsoft identity platform, backed by `package:oauth2`.
+///
+/// Acquisition order, mirroring legacy MSAL `AcquireTokenSilent` →
+/// `AcquireTokenInteractive` (`Connector.cs`):
+///   1. valid cached token  → return it;
+///   2. expired but refreshable → silent refresh;
+///   3. otherwise → interactive sign-in via [authorizer].
+///
+/// PKCE (S256) is handled by `oauth2` — no client secret is sent, as required
+/// for a native/desktop public client. The serialized credentials are written
+/// through [cache], which must encrypt at rest (see [EncryptedTokenCache]).
+class OAuthAuthProvider implements AzureAuthProvider {
+  final AzureCredentials credentials;
+  final TokenCache cache;
+  final InteractiveAuthorizer authorizer;
+  final http.Client _httpClient;
+
+  OAuthAuthProvider({
+    required this.credentials,
+    required this.cache,
+    required this.authorizer,
+    http.Client? httpClient,
+  }) : _httpClient = httpClient ?? http.Client();
+
+  @override
+  Future<String> getAccessToken() async {
+    final cached = await _loadCached();
+    if (cached != null) {
+      if (!cached.isExpired) return cached.accessToken;
+      if (cached.canRefresh) {
+        final refreshed = await _tryRefresh(cached);
+        if (refreshed != null) return refreshed;
+      }
+    }
+    return _interactive();
+  }
+
+  Future<oauth2.Credentials?> _loadCached() async {
+    final stored = await cache.read();
+    if (stored == null || stored.isEmpty) return null;
+    try {
+      return oauth2.Credentials.fromJson(stored);
+    } on FormatException {
+      // Corrupt cache — discard and fall back to interactive sign-in.
+      await cache.clear();
+      return null;
+    }
+  }
+
+  /// Silent refresh. Returns the new access token, or `null` when the refresh
+  /// fails (e.g. the refresh token was revoked) so the caller falls back to
+  /// interactive sign-in.
+  Future<String?> _tryRefresh(oauth2.Credentials cached) async {
+    try {
+      final refreshed = await cached.refresh(
+        identifier: credentials.clientId,
+        httpClient: _httpClient,
+      );
+      await cache.write(refreshed.toJson());
+      return refreshed.accessToken;
+    } on oauth2.AuthorizationException {
+      await cache.clear();
+      return null;
+    }
+  }
+
+  Future<String> _interactive() async {
+    final grant = oauth2.AuthorizationCodeGrant(
+      credentials.clientId,
+      credentials.authorizationEndpoint,
+      credentials.tokenEndpoint,
+      httpClient: _httpClient,
+    );
+    final authUrl = grant.getAuthorizationUrl(
+      credentials.redirectUri,
+      scopes: credentials.scopes,
+    );
+
+    final Map<String, String> responseParams;
+    try {
+      responseParams = await authorizer(authUrl, credentials.redirectUri);
+    } catch (e) {
+      throw AzureAuthException('interactive sign-in failed', e);
+    }
+
+    try {
+      final client = await grant.handleAuthorizationResponse(responseParams);
+      await cache.write(client.credentials.toJson());
+      return client.credentials.accessToken;
+    } on oauth2.AuthorizationException catch (e) {
+      throw AzureAuthException('authorization was denied', e);
+    } on FormatException catch (e) {
+      throw AzureAuthException('invalid authorization response', e);
+    }
+  }
+
+  /// Releases the token-endpoint HTTP client.
+  void close() => _httpClient.close();
+}

--- a/packages/azure_api/lib/src/auth/token_cache.dart
+++ b/packages/azure_api/lib/src/auth/token_cache.dart
@@ -1,0 +1,74 @@
+/// Persists the serialized OAuth credentials (access + refresh token) between
+/// runs, so a returning user is not prompted to sign in every time.
+///
+/// The stored payload is opaque to this package (it is whatever
+/// [oauth2.Credentials.toJson] produced). **It contains a refresh token and
+/// must be encrypted at rest.** The legacy connector used Windows DPAPI
+/// (`TokenCacheHelper.cs`); in the port, the Flutter app supplies a
+/// `flutter_secure_storage`-backed implementation (DPAPI on Windows), or wraps
+/// any [TokenCache] in an [EncryptedTokenCache]. The package itself never
+/// writes the cache to disk in plaintext.
+abstract interface class TokenCache {
+  /// Returns the stored payload, or `null` if nothing is cached.
+  Future<String?> read();
+
+  /// Stores [data], replacing any previous payload.
+  Future<void> write(String data);
+
+  /// Removes the stored payload (e.g. on sign-out or unrecoverable refresh
+  /// failure).
+  Future<void> clear();
+}
+
+/// In-memory cache. Holds nothing across process restarts — used by tests and
+/// as a safe default when no persistent, encrypted cache has been wired up.
+class InMemoryTokenCache implements TokenCache {
+  String? _data;
+
+  @override
+  Future<String?> read() async => _data;
+
+  @override
+  Future<void> write(String data) async => _data = data;
+
+  @override
+  Future<void> clear() async => _data = null;
+}
+
+/// Transforms applied to the cache payload at rest. The real app supplies a
+/// platform cipher (DPAPI / secure-storage); tests supply a reversible
+/// transform to exercise the round-trip.
+typedef TokenEncrypt = String Function(String plaintext);
+typedef TokenDecrypt = String Function(String ciphertext);
+
+/// Wraps another [TokenCache], encrypting on write and decrypting on read.
+///
+/// This is how the package keeps the cache "encrypted at rest" without baking
+/// in a platform crypto dependency: the cipher is injected. The inner cache
+/// only ever sees ciphertext.
+class EncryptedTokenCache implements TokenCache {
+  final TokenCache _inner;
+  final TokenEncrypt _encrypt;
+  final TokenDecrypt _decrypt;
+
+  EncryptedTokenCache({
+    required TokenCache inner,
+    required TokenEncrypt encrypt,
+    required TokenDecrypt decrypt,
+  })  : _inner = inner,
+        _encrypt = encrypt,
+        _decrypt = decrypt;
+
+  @override
+  Future<String?> read() async {
+    final stored = await _inner.read();
+    if (stored == null) return null;
+    return _decrypt(stored);
+  }
+
+  @override
+  Future<void> write(String data) => _inner.write(_encrypt(data));
+
+  @override
+  Future<void> clear() => _inner.clear();
+}

--- a/packages/azure_api/lib/src/config/live_config.dart
+++ b/packages/azure_api/lib/src/config/live_config.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+/// Configuration for talking to a live Azure AD tenant.
+///
+/// Used by the capture script (`tool/capture_responses.dart`) and the opt-in,
+/// **read-only** integration test (`test/integration/azure_live_test.dart`).
+/// Offline unit tests never read this; they inject a fake transport and a
+/// [StaticAuthProvider].
+///
+/// See `.azure.env.example` at the repository root for the variable names.
+class AzureLiveConfig {
+  final String clientId;
+  final String tenantId;
+  final String azureDomain;
+  final String schoolPrefix;
+
+  /// A pre-acquired bearer token. The live test is read-only and does not run
+  /// the interactive sign-in, so the token is supplied directly (e.g. from
+  /// `az account get-access-token`).
+  final String accessToken;
+
+  const AzureLiveConfig({
+    required this.clientId,
+    required this.tenantId,
+    required this.azureDomain,
+    required this.schoolPrefix,
+    required this.accessToken,
+  });
+
+  /// Names of the environment variables, in canonical order.
+  static const List<String> envVarNames = [
+    'AZURE_CLIENT_ID',
+    'AZURE_TENANT_ID',
+    'AZURE_DOMAIN',
+    'AZURE_SCHOOL_PREFIX',
+    'AZURE_ACCESS_TOKEN',
+  ];
+
+  /// Reads config from environment variables (defaulting to
+  /// `Platform.environment`). Returns `null` when `AZURE_ACCESS_TOKEN` is
+  /// empty or missing — the integration test uses this as its skip signal, so
+  /// `dart test` stays offline by default.
+  ///
+  /// Throws [ArgumentError] when `AZURE_ACCESS_TOKEN` is set but one of the
+  /// other required variables is missing.
+  static AzureLiveConfig? fromEnvironment([Map<String, String>? env]) {
+    final source = env ?? Platform.environment;
+    final accessToken = (source['AZURE_ACCESS_TOKEN'] ?? '').trim();
+    if (accessToken.isEmpty) return null;
+
+    String required(String name) {
+      final value = (source[name] ?? '').trim();
+      if (value.isEmpty) {
+        throw ArgumentError(
+          'AZURE_ACCESS_TOKEN is set but $name is missing or empty.',
+        );
+      }
+      return value;
+    }
+
+    return AzureLiveConfig(
+      clientId: required('AZURE_CLIENT_ID'),
+      tenantId: required('AZURE_TENANT_ID'),
+      azureDomain: required('AZURE_DOMAIN'),
+      schoolPrefix: required('AZURE_SCHOOL_PREFIX'),
+      accessToken: accessToken,
+    );
+  }
+}

--- a/packages/azure_api/lib/src/connector.dart
+++ b/packages/azure_api/lib/src/connector.dart
@@ -1,0 +1,123 @@
+import 'package:account_core/account_core.dart' as core;
+
+import 'auth/auth_provider.dart';
+import 'auth/credentials.dart';
+import 'graph/graph_client.dart';
+import 'graph/graph_transport.dart';
+import 'group_manager.dart';
+import 'models/azure_user.dart';
+import 'snapshot.dart';
+import 'user_manager.dart';
+
+/// Entry point for the Azure AD / Office 365 connector.
+///
+/// Wires the [AzureAuthProvider], the swappable [GraphTransport], and the
+/// [UserManager]/[GroupManager] together, and builds an [AzureSnapshot] with
+/// [sync]. The PAIN-2 fix lives here: the first sync does a `$filter`-scoped
+/// bulk read and primes a delta token; later syncs apply only the changed set
+/// from `/users/delta`.
+///
+/// Spec: `docs/domain-model.md` §3.6, §3.8, §6.1, §8. Legacy reference
+/// (read-only): `legacy-wpf/AccountApi/Azure/`.
+class AzureConnector {
+  final AzureCredentials credentials;
+  final GraphTransport _transport;
+  final bool _ownsTransport;
+
+  /// User reads and writes.
+  final UserManager users;
+
+  /// Group reads and membership writes.
+  final GroupManager groups;
+
+  AzureConnector._({
+    required this.credentials,
+    required GraphTransport transport,
+    required bool ownsTransport,
+    required this.users,
+    required this.groups,
+  })  : _transport = transport,
+        _ownsTransport = ownsTransport;
+
+  factory AzureConnector({
+    required AzureCredentials credentials,
+    required AzureAuthProvider authProvider,
+    GraphTransport? transport,
+    Uri? baseUrl,
+    core.ILog? log,
+  }) {
+    final ownsTransport = transport == null;
+    final effectiveTransport = transport ?? HttpGraphTransport();
+    final graph = GraphClient(
+      transport: effectiveTransport,
+      auth: authProvider,
+      baseUrl: baseUrl,
+      log: log,
+    );
+    return AzureConnector._(
+      credentials: credentials,
+      transport: effectiveTransport,
+      ownsTransport: ownsTransport,
+      users: UserManager(graph, log: log),
+      groups: GroupManager(graph, log: log),
+    );
+  }
+
+  /// Reads the school's users and groups into a fresh [AzureSnapshot].
+  ///
+  /// - [deltaToken] `null` → first/full sync: `$filter`+`$select` bulk read
+  ///   ([UserManager.load]) plus a primed delta token for next time.
+  /// - [deltaToken] set → incremental: applies `/users/delta` changes and
+  ///   removals on top of [previous] (required for a complete user list; when
+  ///   omitted, only the changed users are returned).
+  Future<AzureSnapshot> sync({
+    String? deltaToken,
+    AzureSnapshot? previous,
+  }) async {
+    final groupList = await groups.listGroups(credentials.schoolPrefix);
+
+    if (deltaToken == null) {
+      final token = await users.latestDeltaToken();
+      final userList = await users.load(credentials.schoolPrefix);
+      return AzureSnapshot(
+        fetchedAt: _now(),
+        deltaToken: token,
+        users: userList,
+        groups: groupList,
+      );
+    }
+
+    final delta = await users.delta(deltaToken, credentials.schoolPrefix);
+    final userList = _applyDelta(previous?.users ?? const [], delta);
+    return AzureSnapshot(
+      fetchedAt: _now(),
+      deltaToken: delta.deltaToken ?? deltaToken,
+      users: userList,
+      groups: groupList,
+    );
+  }
+
+  /// Upserts [delta.changed] and drops [delta.removedIds] over [base], keeping
+  /// the result keyed by Azure object id.
+  static List<AzureUser> _applyDelta(List<AzureUser> base, UserDelta delta) {
+    final byId = {for (final u in base) u.id: u};
+    for (final id in delta.removedIds) {
+      byId.remove(id);
+    }
+    for (final u in delta.changed) {
+      byId[u.id] = u;
+    }
+    return byId.values.toList();
+  }
+
+  /// Releases the HTTP transport when the connector created it. A transport
+  /// the caller injected is the caller's to close.
+  void close() {
+    final transport = _transport;
+    if (_ownsTransport && transport is HttpGraphTransport) {
+      transport.close();
+    }
+  }
+
+  static DateTime _now() => DateTime.now();
+}

--- a/packages/azure_api/lib/src/graph/graph_batch.dart
+++ b/packages/azure_api/lib/src/graph/graph_batch.dart
@@ -1,0 +1,75 @@
+import 'graph_client.dart';
+
+/// One entry in a Graph `$batch` request. [url] is relative to the Graph
+/// version root (e.g. `/groups/{id}/members/$ref`), as `$batch` requires.
+class BatchRequest {
+  final String id;
+  final String method;
+  final String url;
+  final Map<String, String>? headers;
+  final Object? body;
+
+  const BatchRequest({
+    required this.id,
+    required this.method,
+    required this.url,
+    this.headers,
+    this.body,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'method': method,
+        'url': url,
+        if (headers != null && headers!.isNotEmpty) 'headers': headers,
+        if (body != null) 'body': body,
+      };
+}
+
+/// One result from a Graph `$batch` response.
+class BatchResponse {
+  final String id;
+  final int status;
+  final Map<String, dynamic>? body;
+
+  const BatchResponse({required this.id, required this.status, this.body});
+
+  bool get isSuccess => status >= 200 && status < 300;
+}
+
+/// Coalesces multiple writes into Graph `$batch` calls.
+///
+/// Graph caps a batch at 20 sub-requests, so [execute] chunks larger inputs.
+/// Used to fold many membership add/remove operations into few round-trips —
+/// something the legacy connector never did (one HTTP call per member).
+class GraphBatch {
+  /// Microsoft Graph's per-batch sub-request ceiling.
+  static const int maxBatchSize = 20;
+
+  final GraphClient _graph;
+
+  const GraphBatch(this._graph);
+
+  Future<List<BatchResponse>> execute(List<BatchRequest> requests) async {
+    final results = <BatchResponse>[];
+    for (var i = 0; i < requests.length; i += maxBatchSize) {
+      final chunk = requests.sublist(
+        i,
+        i + maxBatchSize > requests.length ? requests.length : i + maxBatchSize,
+      );
+      final payload = {'requests': chunk.map((r) => r.toJson()).toList()};
+      final json = await _graph.postJson(_graph.uri(r'$batch'), payload);
+      final responses = (json['responses'] as List<dynamic>?) ?? const [];
+      for (final r in responses.cast<Map<String, dynamic>>()) {
+        results.add(
+          BatchResponse(
+            id: r['id'] as String,
+            status: (r['status'] as num).toInt(),
+            body: r['body'] as Map<String, dynamic>?,
+          ),
+        );
+      }
+    }
+    return results;
+  }
+}

--- a/packages/azure_api/lib/src/graph/graph_client.dart
+++ b/packages/azure_api/lib/src/graph/graph_client.dart
@@ -1,0 +1,180 @@
+import 'dart:convert';
+
+import 'package:account_core/account_core.dart' as core;
+
+import '../auth/auth_provider.dart';
+import 'graph_request.dart';
+import 'graph_transport.dart';
+
+/// All values from a `/…/delta` walk, plus the token to resume from next time.
+class DeltaResult {
+  final List<Map<String, dynamic>> values;
+
+  /// The `$deltatoken` extracted from the final page's `@odata.deltaLink`.
+  /// `null` if Graph returned no delta link.
+  final String? deltaToken;
+
+  const DeltaResult({required this.values, this.deltaToken});
+}
+
+/// Authenticated, paging-aware Microsoft Graph client.
+///
+/// Sits above the swappable [GraphTransport]: resolves a bearer token from the
+/// [AzureAuthProvider] for every request, follows `@odata.nextLink`
+/// pagination, and surfaces non-2xx replies as [GraphException]. The managers
+/// talk to this, never to the transport directly.
+class GraphClient {
+  /// Microsoft Graph base URL. `v1.0` is the stable endpoint; `/users/delta`
+  /// and `$batch` both live here.
+  static final Uri defaultBaseUrl =
+      Uri.parse('https://graph.microsoft.com/v1.0');
+
+  final GraphTransport _transport;
+  final AzureAuthProvider _auth;
+  final Uri baseUrl;
+  final core.ILog? _log;
+
+  GraphClient({
+    required GraphTransport transport,
+    required AzureAuthProvider auth,
+    Uri? baseUrl,
+    core.ILog? log,
+  })  : _transport = transport,
+        _auth = auth,
+        baseUrl = baseUrl ?? defaultBaseUrl,
+        _log = log;
+
+  /// Builds an absolute Graph URL from a path (e.g. `users`) and query
+  /// parameters. Query values are passed through unescaped keys such as
+  /// `$filter`/`$select`; [Uri] handles percent-encoding of the values.
+  Uri uri(String path, {Map<String, String>? query}) {
+    final trimmedBase = baseUrl.toString().replaceFirst(RegExp(r'/+$'), '');
+    final base = Uri.parse('$trimmedBase/${_trimLeadingSlash(path)}');
+    if (query == null || query.isEmpty) return base;
+    return base.replace(queryParameters: {...base.queryParameters, ...query});
+  }
+
+  /// GET a single resource (or the first page of a collection) and return the
+  /// decoded JSON object.
+  Future<Map<String, dynamic>> getJson(
+    Uri url, {
+    Map<String, String>? headers,
+  }) async {
+    final resp = await _send('GET', url, headers: headers);
+    return resp.json;
+  }
+
+  /// GET every page of a collection at [url], following `@odata.nextLink`.
+  /// Returns the concatenated `value` arrays. [headers] (e.g. the advanced-
+  /// query `ConsistencyLevel: eventual`) are sent on every page.
+  Future<List<Map<String, dynamic>>> getCollection(
+    Uri url, {
+    Map<String, String>? headers,
+  }) async {
+    final items = <Map<String, dynamic>>[];
+    Uri? next = url;
+    while (next != null) {
+      final body = await getJson(next, headers: headers);
+      items.addAll(_values(body));
+      next = _nextLink(body);
+    }
+    return items;
+  }
+
+  /// Walk a delta collection: follows `@odata.nextLink` to gather all changed
+  /// resources, then captures the `$deltatoken` from the terminal
+  /// `@odata.deltaLink` for the next incremental sync.
+  Future<DeltaResult> getDelta(Uri url, {Map<String, String>? headers}) async {
+    final items = <Map<String, dynamic>>[];
+    String? deltaToken;
+    Uri? next = url;
+    while (next != null) {
+      final body = await getJson(next, headers: headers);
+      items.addAll(_values(body));
+      next = _nextLink(body);
+      final deltaLink = body['@odata.deltaLink'] as String?;
+      if (deltaLink != null) deltaToken = _tokenFrom(deltaLink, r'$deltatoken');
+    }
+    return DeltaResult(values: items, deltaToken: deltaToken);
+  }
+
+  /// POST [body] (a JSON-encodable map) to [url]. Returns the decoded response
+  /// (empty map for `204 No Content`).
+  Future<Map<String, dynamic>> postJson(
+    Uri url,
+    Object body, {
+    Map<String, String>? headers,
+  }) async {
+    final resp = await _send(
+      'POST',
+      url,
+      body: jsonEncode(body),
+      headers: {'Content-Type': 'application/json', ...?headers},
+    );
+    return resp.json;
+  }
+
+  /// PATCH [body] to [url] (Graph user/group update). Graph replies `204`.
+  Future<void> patchJson(
+    Uri url,
+    Object body, {
+    Map<String, String>? headers,
+  }) async {
+    await _send(
+      'PATCH',
+      url,
+      body: jsonEncode(body),
+      headers: {'Content-Type': 'application/json', ...?headers},
+    );
+  }
+
+  /// DELETE [url]. Graph replies `204`.
+  Future<void> delete(Uri url, {Map<String, String>? headers}) async {
+    await _send('DELETE', url, headers: headers);
+  }
+
+  Future<GraphResponse> _send(
+    String method,
+    Uri url, {
+    String? body,
+    Map<String, String>? headers,
+  }) async {
+    final token = await _auth.getAccessToken();
+    final request = GraphRequest(
+      method: method,
+      url: url,
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Accept': 'application/json',
+        ...?headers,
+      },
+      body: body,
+    );
+    final resp = await _transport.send(request);
+    if (!resp.isSuccess) {
+      final ex = GraphException(resp.statusCode, resp.body);
+      _log?.addError(core.Origin.azure, '$method $url → $ex');
+      throw ex;
+    }
+    return resp;
+  }
+
+  List<Map<String, dynamic>> _values(Map<String, dynamic> body) {
+    final value = body['value'];
+    if (value is List) return value.cast<Map<String, dynamic>>();
+    return const [];
+  }
+
+  Uri? _nextLink(Map<String, dynamic> body) {
+    final link = body['@odata.nextLink'] as String?;
+    return link == null ? null : Uri.parse(link);
+  }
+
+  /// Extracts the value of a query parameter (e.g. `$deltatoken`) from a full
+  /// Graph link URL.
+  static String? _tokenFrom(String link, String param) =>
+      Uri.parse(link).queryParameters[param];
+
+  static String _trimLeadingSlash(String path) =>
+      path.startsWith('/') ? path.substring(1) : path;
+}

--- a/packages/azure_api/lib/src/graph/graph_request.dart
+++ b/packages/azure_api/lib/src/graph/graph_request.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+
+/// A single Microsoft Graph HTTP request.
+///
+/// Carries everything the transport needs to issue the call, including the
+/// `Authorization` header (set by [GraphClient], not the transport). Kept as a
+/// plain value object so the fake transport in tests can assert on the method,
+/// url and query string (e.g. the `$filter`/`$select` the connector issued).
+class GraphRequest {
+  final String method;
+  final Uri url;
+  final Map<String, String> headers;
+  final String? body;
+
+  const GraphRequest({
+    required this.method,
+    required this.url,
+    this.headers = const {},
+    this.body,
+  });
+
+  GraphRequest copyWith({Map<String, String>? headers}) => GraphRequest(
+        method: method,
+        url: url,
+        headers: headers ?? this.headers,
+        body: body,
+      );
+
+  @override
+  String toString() => '$method ${url.toString()}';
+}
+
+/// A Microsoft Graph HTTP response.
+class GraphResponse {
+  final int statusCode;
+  final Map<String, String> headers;
+  final String body;
+
+  const GraphResponse({
+    required this.statusCode,
+    this.headers = const {},
+    this.body = '',
+  });
+
+  bool get isSuccess => statusCode >= 200 && statusCode < 300;
+
+  /// Decodes the body as a JSON object. Empty bodies (e.g. `204 No Content`
+  /// from a DELETE) decode to an empty map.
+  Map<String, dynamic> get json {
+    if (body.trim().isEmpty) return const {};
+    final decoded = jsonDecode(body);
+    if (decoded is Map<String, dynamic>) return decoded;
+    throw const FormatException('Graph response body was not a JSON object');
+  }
+}
+
+/// Thrown when Graph returns a non-2xx response.
+///
+/// [toString] surfaces Graph's own `error.code`/`error.message` when present,
+/// which is what the operator needs to see in the log.
+class GraphException implements Exception {
+  final int statusCode;
+  final String body;
+
+  const GraphException(this.statusCode, this.body);
+
+  /// Graph's `error.code`, when the body is a standard Graph error envelope.
+  String? get code => _errorField('code');
+
+  /// Graph's `error.message`, when present.
+  String? get message => _errorField('message');
+
+  String? _errorField(String field) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map<String, dynamic>) {
+        final error = decoded['error'];
+        if (error is Map<String, dynamic>) return error[field] as String?;
+      }
+    } on FormatException {
+      // Non-JSON error body; fall through.
+    }
+    return null;
+  }
+
+  @override
+  String toString() {
+    final detail = message ?? body;
+    final codePart = code != null ? ' ($code)' : '';
+    return 'GraphException($statusCode$codePart): $detail';
+  }
+}

--- a/packages/azure_api/lib/src/graph/graph_transport.dart
+++ b/packages/azure_api/lib/src/graph/graph_transport.dart
@@ -1,0 +1,38 @@
+import 'package:http/http.dart' as http;
+
+import 'graph_request.dart';
+
+/// Issues a single Graph HTTP request and returns the raw response.
+///
+/// Abstracted so tests can replace the transport with an in-memory fake that
+/// replays recorded Graph responses and records the outgoing requests (the
+/// `$filter`/`$select`/`$batch` correctness tests assert on those).
+abstract interface class GraphTransport {
+  Future<GraphResponse> send(GraphRequest request);
+}
+
+/// Default transport backed by `package:http`.
+class HttpGraphTransport implements GraphTransport {
+  final http.Client _client;
+
+  HttpGraphTransport({http.Client? client}) : _client = client ?? http.Client();
+
+  @override
+  Future<GraphResponse> send(GraphRequest request) async {
+    final resp = await _client.send(
+      http.Request(request.method, request.url)
+        ..headers.addAll(request.headers)
+        ..body = request.body ?? '',
+    );
+    final body = await resp.stream.bytesToString();
+    return GraphResponse(
+      statusCode: resp.statusCode,
+      headers: resp.headers,
+      body: body,
+    );
+  }
+
+  /// Releases the underlying HTTP client. Cheap no-op if a custom client was
+  /// provided.
+  void close() => _client.close();
+}

--- a/packages/azure_api/lib/src/group_manager.dart
+++ b/packages/azure_api/lib/src/group_manager.dart
@@ -1,0 +1,145 @@
+import 'package:account_core/account_core.dart' as core;
+
+import 'graph/graph_batch.dart';
+import 'graph/graph_client.dart';
+import 'models/azure_group.dart';
+
+/// Reads and writes Azure AD groups and their memberships via Microsoft Graph.
+///
+/// Mirrors the legacy `GroupManager.cs` / `Group.cs` surface: lists the
+/// prefixed groups, loads their members, and adds/removes members. Multi-write
+/// membership changes are coalesced with `$batch`. Legacy reference
+/// (read-only): `legacy-wpf/AccountApi/Azure/GroupManager.cs`,
+/// `legacy-wpf/AccountApi/Azure/Group.cs`.
+class GroupManager {
+  final GraphClient _graph;
+  final core.ILog? _log;
+  final GraphBatch _batch;
+
+  GroupManager(this._graph, {core.ILog? log})
+      : _log = log,
+        _batch = GraphBatch(_graph);
+
+  static final String _select = AzureGroup.graphSelectFields.join(',');
+
+  static const Map<String, String> _advancedQueryHeaders = {
+    'ConsistencyLevel': 'eventual',
+  };
+
+  /// Lists groups whose display name starts with [schoolPrefix] and loads each
+  /// group's member ids. Mirrors legacy `LoadFromAzure` +
+  /// `Group.LoadMembers`.
+  Future<List<AzureGroup>> listGroups(String schoolPrefix) async {
+    final url = _graph.uri(
+      'groups',
+      query: {
+        r'$select': _select,
+        r'$count': 'true',
+        r'$filter':
+            "startswith(displayName,'${_escapeODataString(schoolPrefix)}')",
+      },
+    );
+    final rows =
+        await _graph.getCollection(url, headers: _advancedQueryHeaders);
+    final groups = <AzureGroup>[];
+    for (final row in rows) {
+      final id = (row['id'] as String?) ?? '';
+      final members = await loadMemberIds(id);
+      groups.add(AzureGroup.fromGraphJson(row, members: members));
+    }
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: loaded ${groups.length} groups for "$schoolPrefix".',
+    );
+    return groups;
+  }
+
+  /// Returns the object ids of a group's members, following pagination.
+  Future<List<String>> loadMemberIds(String groupId) async {
+    final url = _graph.uri(
+      'groups/${Uri.encodeComponent(groupId)}/members',
+      query: {r'$select': 'id'},
+    );
+    final rows = await _graph.getCollection(url);
+    return rows.map((m) => m['id'] as String).toList();
+  }
+
+  /// Adds one user to a group. Mirrors legacy `Group.AddMember`.
+  Future<void> addMember(String groupId, String userId) async {
+    await _graph.postJson(
+      _graph.uri('groups/${Uri.encodeComponent(groupId)}/members/\$ref'),
+      {'@odata.id': _directoryObjectRef(userId)},
+    );
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: added $userId to group $groupId.',
+    );
+  }
+
+  /// Removes one user from a group. Mirrors legacy `Group.RemoveMember`.
+  Future<void> removeMember(String groupId, String userId) async {
+    await _graph.delete(
+      _graph.uri(
+        'groups/${Uri.encodeComponent(groupId)}/members/'
+        '${Uri.encodeComponent(userId)}/\$ref',
+      ),
+    );
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: removed $userId from group $groupId.',
+    );
+  }
+
+  /// Adds many users to one group in as few round-trips as possible, via
+  /// `$batch`. Returns the per-user results so the caller can report partial
+  /// failures.
+  Future<List<BatchResponse>> addMembers(
+    String groupId,
+    List<String> userIds,
+  ) async {
+    if (userIds.isEmpty) return const [];
+    final requests = [
+      for (var i = 0; i < userIds.length; i++)
+        BatchRequest(
+          id: '$i',
+          method: 'POST',
+          url: '/groups/$groupId/members/\$ref',
+          headers: const {'Content-Type': 'application/json'},
+          body: {'@odata.id': _directoryObjectRef(userIds[i])},
+        ),
+    ];
+    final results = await _batch.execute(requests);
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: batch-added ${userIds.length} members to group $groupId.',
+    );
+    return results;
+  }
+
+  /// Removes many users from one group via `$batch`.
+  Future<List<BatchResponse>> removeMembers(
+    String groupId,
+    List<String> userIds,
+  ) async {
+    if (userIds.isEmpty) return const [];
+    final requests = [
+      for (var i = 0; i < userIds.length; i++)
+        BatchRequest(
+          id: '$i',
+          method: 'DELETE',
+          url: '/groups/$groupId/members/${userIds[i]}/\$ref',
+        ),
+    ];
+    final results = await _batch.execute(requests);
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: batch-removed ${userIds.length} members from group $groupId.',
+    );
+    return results;
+  }
+
+  static String _directoryObjectRef(String userId) =>
+      'https://graph.microsoft.com/v1.0/directoryObjects/$userId';
+
+  static String _escapeODataString(String value) => value.replaceAll("'", "''");
+}

--- a/packages/azure_api/lib/src/models/azure_group.dart
+++ b/packages/azure_api/lib/src/models/azure_group.dart
@@ -1,0 +1,111 @@
+import 'dart:collection';
+
+import 'package:account_core/account_core.dart' as core;
+
+/// An Azure AD group, as read from Microsoft Graph.
+///
+/// Implements [core.AzureGroup] (`id`, `displayName`) so the linker can refer
+/// to it without depending on this package (`docs/domain-model.md` §4).
+///
+/// Members are stored as Azure object-id strings — the only thing the linker
+/// and membership writes need. The legacy `Group.cs` wrapped full
+/// `DirectoryObject`s; the port keeps just the ids.
+///
+/// Immutable. Legacy reference (read-only):
+/// `legacy-wpf/AccountApi/Azure/Group.cs`.
+class AzureGroup implements core.AzureGroup {
+  @override
+  final String id;
+
+  @override
+  final String displayName;
+
+  /// Whether this is a security group (vs. a Microsoft 365 group). Mirrors the
+  /// legacy `SecurityEnabled` flag used by `FindGroupByName`.
+  final bool securityEnabled;
+
+  /// Azure object ids of the group's members.
+  final UnmodifiableListView<String> memberIds;
+
+  AzureGroup({
+    required this.id,
+    required this.displayName,
+    this.securityEnabled = false,
+    List<String> memberIds = const [],
+  }) : memberIds = UnmodifiableListView(List.of(memberIds));
+
+  /// Fields the connector requests from Graph (`$select`) when listing groups.
+  static const List<String> graphSelectFields = [
+    'id',
+    'displayName',
+    'securityEnabled',
+  ];
+
+  /// Whether [userId] is a member, by Azure object id.
+  bool hasMember(String userId) => memberIds.contains(userId);
+
+  /// Parses a Graph `group` resource. Members are not part of the group
+  /// resource; [members] is supplied separately (from `/groups/{id}/members`).
+  factory AzureGroup.fromGraphJson(
+    Map<String, dynamic> json, {
+    List<String> members = const [],
+  }) =>
+      AzureGroup(
+        id: (json['id'] as String?) ?? '',
+        displayName: (json['displayName'] as String?) ?? '',
+        securityEnabled: (json['securityEnabled'] as bool?) ?? false,
+        memberIds: members,
+      );
+
+  /// Returns a copy with [memberIds] replaced. Used to apply membership writes
+  /// locally after a successful Graph call.
+  AzureGroup withMembers(List<String> members) => AzureGroup(
+        id: id,
+        displayName: displayName,
+        securityEnabled: securityEnabled,
+        memberIds: members,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'displayName': displayName,
+        'securityEnabled': securityEnabled,
+        'memberIds': memberIds.toList(),
+      };
+
+  factory AzureGroup.fromJson(Map<String, dynamic> json) => AzureGroup(
+        id: json['id'] as String,
+        displayName: (json['displayName'] as String?) ?? '',
+        securityEnabled: (json['securityEnabled'] as bool?) ?? false,
+        memberIds:
+            ((json['memberIds'] as List<dynamic>?) ?? const []).cast<String>(),
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is AzureGroup &&
+      other.id == id &&
+      other.displayName == displayName &&
+      other.securityEnabled == securityEnabled &&
+      _listEquals(other.memberIds, memberIds);
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        displayName,
+        securityEnabled,
+        Object.hashAll(memberIds),
+      );
+
+  @override
+  String toString() =>
+      'AzureGroup($displayName, id: $id, members: ${memberIds.length})';
+}
+
+bool _listEquals(List<String> a, List<String> b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}

--- a/packages/azure_api/lib/src/models/azure_user.dart
+++ b/packages/azure_api/lib/src/models/azure_user.dart
@@ -1,0 +1,175 @@
+import 'package:account_core/account_core.dart' as core;
+
+/// An Azure AD / Office 365 user, as read from Microsoft Graph.
+///
+/// Implements [core.AzureUser] so the linker can refer to it by its linking
+/// keys (`id`, `upn`, `employeeId`) without depending on this package
+/// (`docs/domain-model.md` §3.6, §4). The remaining fields are the ones the
+/// connector reads and writes via Graph `$select`; nothing Graph emits that
+/// the port does not use is carried.
+///
+/// Immutable. Legacy reference (read-only):
+/// `legacy-wpf/AccountApi/Azure/User.cs`.
+class AzureUser implements core.AzureUser {
+  /// Azure object id (GUID). Stable across UPN changes.
+  @override
+  final String id;
+
+  /// `userPrincipalName`. The primary linking key; compared
+  /// case-insensitively and trimmed (INV-12).
+  @override
+  final String upn;
+
+  /// Equals `WisaStudent.wisaId` / `WisaStaff.wisaId` when set — the
+  /// cross-system bridge to WISA. `null`/empty for accounts not provisioned
+  /// from WISA.
+  @override
+  final String? employeeId;
+
+  final String displayName;
+  final String givenName;
+  final String surname;
+
+  /// School prefix; the legacy connector uses it to identify alumni.
+  final String? companyName;
+
+  /// Holds the school prefix for staff; the student class group for students.
+  final String? department;
+
+  /// Whether the account is enabled for sign-in.
+  final bool accountEnabled;
+
+  const AzureUser({
+    required this.id,
+    required this.upn,
+    this.employeeId,
+    this.displayName = '',
+    this.givenName = '',
+    this.surname = '',
+    this.companyName,
+    this.department,
+    this.accountEnabled = true,
+  });
+
+  /// Fields the connector requests from Graph (`$select`). Kept minimal so the
+  /// initial bulk read never pulls more than the port uses (PAIN-2).
+  static const List<String> graphSelectFields = [
+    'id',
+    'userPrincipalName',
+    'employeeId',
+    'displayName',
+    'givenName',
+    'surname',
+    'companyName',
+    'department',
+    'accountEnabled',
+  ];
+
+  /// Parses a single Graph `user` resource (a JSON object as returned by
+  /// `/users`, `/users/{id}` or `/users/delta`). Missing optional fields
+  /// become `null`; missing strings become empty.
+  factory AzureUser.fromGraphJson(Map<String, dynamic> json) {
+    String str(String key) => (json[key] as String?) ?? '';
+    String? nullable(String key) {
+      final v = json[key] as String?;
+      return (v == null || v.isEmpty) ? null : v;
+    }
+
+    return AzureUser(
+      id: str('id'),
+      upn: str('userPrincipalName'),
+      employeeId: nullable('employeeId'),
+      displayName: str('displayName'),
+      givenName: str('givenName'),
+      surname: str('surname'),
+      companyName: nullable('companyName'),
+      department: nullable('department'),
+      accountEnabled: (json['accountEnabled'] as bool?) ?? true,
+    );
+  }
+
+  /// Whether this delta entry marks the user as removed. Graph signals a
+  /// deleted user with an `@removed` annotation on the resource.
+  static bool isRemoved(Map<String, dynamic> json) =>
+      json.containsKey('@removed');
+
+  /// Serializes to the connector's own cache shape (not Graph's). Round-trips
+  /// with [AzureUser.fromJson] for the on-disk "last known good" snapshot.
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'upn': upn,
+        if (employeeId != null) 'employeeId': employeeId,
+        'displayName': displayName,
+        'givenName': givenName,
+        'surname': surname,
+        if (companyName != null) 'companyName': companyName,
+        if (department != null) 'department': department,
+        'accountEnabled': accountEnabled,
+      };
+
+  factory AzureUser.fromJson(Map<String, dynamic> json) => AzureUser(
+        id: json['id'] as String,
+        upn: json['upn'] as String,
+        employeeId: json['employeeId'] as String?,
+        displayName: (json['displayName'] as String?) ?? '',
+        givenName: (json['givenName'] as String?) ?? '',
+        surname: (json['surname'] as String?) ?? '',
+        companyName: json['companyName'] as String?,
+        department: json['department'] as String?,
+        accountEnabled: (json['accountEnabled'] as bool?) ?? true,
+      );
+
+  /// Returns a copy with the given fields replaced. Used to apply writes
+  /// locally after a successful Graph PATCH.
+  AzureUser copyWith({
+    String? id,
+    String? upn,
+    String? employeeId,
+    String? displayName,
+    String? givenName,
+    String? surname,
+    String? companyName,
+    String? department,
+    bool? accountEnabled,
+  }) =>
+      AzureUser(
+        id: id ?? this.id,
+        upn: upn ?? this.upn,
+        employeeId: employeeId ?? this.employeeId,
+        displayName: displayName ?? this.displayName,
+        givenName: givenName ?? this.givenName,
+        surname: surname ?? this.surname,
+        companyName: companyName ?? this.companyName,
+        department: department ?? this.department,
+        accountEnabled: accountEnabled ?? this.accountEnabled,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is AzureUser &&
+      other.id == id &&
+      other.upn == upn &&
+      other.employeeId == employeeId &&
+      other.displayName == displayName &&
+      other.givenName == givenName &&
+      other.surname == surname &&
+      other.companyName == companyName &&
+      other.department == department &&
+      other.accountEnabled == accountEnabled;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        upn,
+        employeeId,
+        displayName,
+        givenName,
+        surname,
+        companyName,
+        department,
+        accountEnabled,
+      );
+
+  @override
+  String toString() => 'AzureUser($upn, id: $id, employeeId: $employeeId)';
+}

--- a/packages/azure_api/lib/src/snapshot.dart
+++ b/packages/azure_api/lib/src/snapshot.dart
@@ -1,0 +1,57 @@
+import 'dart:collection';
+
+import 'package:account_core/account_core.dart' as core;
+
+import 'models/azure_group.dart';
+import 'models/azure_user.dart';
+
+/// Immutable result of one Azure sync.
+///
+/// Spec: `docs/domain-model.md` §3.8. All exposed lists are
+/// [UnmodifiableListView]s — handing the snapshot to the linker is safe.
+///
+/// - [users] holds the school's users, read with Graph `$filter` + `$select`
+///   (or the changed set from `/users/delta`), never the whole tenant.
+/// - [groups] holds the prefixed groups with their member ids.
+/// - [deltaToken] is the opaque `$deltatoken` from the latest
+///   `/users/delta` page. Pass it back to [AzureConnector.sync] for an
+///   incremental next sync. `null` after a full read that produced no token.
+class AzureSnapshot implements core.Snapshot {
+  @override
+  final DateTime fetchedAt;
+
+  @override
+  core.Origin get origin => core.Origin.azure;
+
+  /// Opaque delta token for the next incremental `/users/delta` sync.
+  final String? deltaToken;
+
+  final UnmodifiableListView<AzureUser> users;
+  final UnmodifiableListView<AzureGroup> groups;
+
+  AzureSnapshot({
+    required this.fetchedAt,
+    this.deltaToken,
+    required List<AzureUser> users,
+    required List<AzureGroup> groups,
+  })  : users = UnmodifiableListView(List.of(users)),
+        groups = UnmodifiableListView(List.of(groups));
+
+  Map<String, dynamic> toJson() => {
+        'fetchedAt': fetchedAt.toIso8601String(),
+        if (deltaToken != null) 'deltaToken': deltaToken,
+        'users': users.map((u) => u.toJson()).toList(),
+        'groups': groups.map((g) => g.toJson()).toList(),
+      };
+
+  factory AzureSnapshot.fromJson(Map<String, dynamic> json) => AzureSnapshot(
+        fetchedAt: DateTime.parse(json['fetchedAt'] as String),
+        deltaToken: json['deltaToken'] as String?,
+        users: ((json['users'] as List<dynamic>?) ?? const [])
+            .map((e) => AzureUser.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        groups: ((json['groups'] as List<dynamic>?) ?? const [])
+            .map((e) => AzureGroup.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+}

--- a/packages/azure_api/lib/src/user_manager.dart
+++ b/packages/azure_api/lib/src/user_manager.dart
@@ -1,0 +1,342 @@
+import 'package:account_core/account_core.dart' as core;
+
+import 'graph/graph_client.dart';
+import 'graph/graph_request.dart';
+import 'models/azure_user.dart';
+
+/// Result of a `/users/delta` walk, split into upserts and removals.
+class UserDelta {
+  /// Users created or changed since the last sync, already filtered to the
+  /// school (by `companyName` / `department`).
+  final List<AzureUser> changed;
+
+  /// Azure object ids of users Graph reported as removed (`@removed`). Not
+  /// prefix-filtered — the removed payload carries only the id, so the caller
+  /// reconciles these against the users it already knows.
+  final List<String> removedIds;
+
+  /// Token to resume the next incremental sync from.
+  final String? deltaToken;
+
+  const UserDelta({
+    required this.changed,
+    required this.removedIds,
+    this.deltaToken,
+  });
+}
+
+/// Reads and writes Azure AD users via Microsoft Graph.
+///
+/// Mirrors the legacy `UserManager.cs` surface, but never downloads the whole
+/// tenant: [load] uses `$filter` + `$select`, and [delta] uses `/users/delta`
+/// (PAIN-2). Legacy reference (read-only):
+/// `legacy-wpf/AccountApi/Azure/UserManager.cs`.
+class UserManager {
+  final GraphClient _graph;
+  final core.ILog? _log;
+
+  UserManager(this._graph, {core.ILog? log}) : _log = log;
+
+  static final String _select = AzureUser.graphSelectFields.join(',');
+
+  /// Headers required for advanced directory queries (`$count`,
+  /// `startswith`, `$filter` with `or`). Graph rejects these without
+  /// `ConsistencyLevel: eventual`.
+  static const Map<String, String> _advancedQueryHeaders = {
+    'ConsistencyLevel': 'eventual',
+  };
+
+  /// Server-side `$filter` selecting the school's users: students carry the
+  /// prefix in `companyName`; staff carry it at the start of `department`.
+  ///
+  /// `startswith` matches the legacy convention where staff `department` is set
+  /// to exactly the prefix. Graph does **not** support `contains` server-side
+  /// on these properties, so an installation that buries the prefix mid-string
+  /// in `department` must use [loadClientFiltered] instead (documented in the
+  /// README).
+  static String filterFor(String schoolPrefix) {
+    final p = _escapeODataString(schoolPrefix);
+    return "companyName eq '$p' or startswith(department,'$p')";
+  }
+
+  /// Bulk read of the school's users with `$filter` + `$select`, following
+  /// pagination. This is the first-sync path; subsequent syncs should use
+  /// [delta].
+  Future<List<AzureUser>> load(String schoolPrefix) async {
+    final url = _graph.uri(
+      'users',
+      query: {
+        r'$select': _select,
+        r'$count': 'true',
+        r'$filter': filterFor(schoolPrefix),
+      },
+    );
+    final rows =
+        await _graph.getCollection(url, headers: _advancedQueryHeaders);
+    final users = rows.map(AzureUser.fromGraphJson).toList();
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: loaded ${users.length} users for "$schoolPrefix".',
+    );
+    return users;
+  }
+
+  /// Full read with `$select` only, filtered client-side by [schoolPrefix].
+  /// Fallback for tenants where the prefix is not at the start of
+  /// `department` (so server-side `startswith` would miss staff). Pulls more
+  /// than [load]; use only when [load]'s server-side filter is insufficient.
+  Future<List<AzureUser>> loadClientFiltered(String schoolPrefix) async {
+    final url = _graph.uri('users', query: {r'$select': _select});
+    final rows = await _graph.getCollection(url);
+    final users = rows
+        .map(AzureUser.fromGraphJson)
+        .where((u) => _belongsToSchool(u, schoolPrefix))
+        .toList();
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: loaded ${users.length} users (client-filtered) for '
+      '"$schoolPrefix".',
+    );
+    return users;
+  }
+
+  /// First delta read: walks `/users/delta` to build the initial set and
+  /// returns the resume token.
+  ///
+  /// Note this enumerates the **whole** directory (delta query does not honour
+  /// the `companyName`/`department` filter), so it does not by itself fix
+  /// PAIN-2. The connector primes the first sync with [load] + [latestDeltaToken]
+  /// instead; this method exists for callers that explicitly want a
+  /// data-bearing initial delta.
+  Future<UserDelta> deltaInitial(String schoolPrefix) {
+    final url = _graph.uri('users/delta', query: {r'$select': _select});
+    return _walkDelta(url, schoolPrefix);
+  }
+
+  /// Primes incremental syncs without reading any user data: asks Graph for the
+  /// delta token representing "now" via `$deltatoken=latest`. Paired with
+  /// [load] on the first sync so the bulk read stays `$filter`-scoped (PAIN-2)
+  /// while still establishing a resume point.
+  Future<String?> latestDeltaToken() async {
+    final url = _graph.uri('users/delta', query: {r'$deltatoken': 'latest'});
+    final result = await _graph.getDelta(url);
+    return result.deltaToken;
+  }
+
+  /// Incremental delta read: resumes from a token returned by a previous
+  /// [deltaInitial]/[delta] call. Only changed and removed users come back.
+  Future<UserDelta> delta(String deltaToken, String schoolPrefix) {
+    final url = _graph.uri('users/delta', query: {r'$deltatoken': deltaToken});
+    return _walkDelta(url, schoolPrefix);
+  }
+
+  Future<UserDelta> _walkDelta(Uri url, String schoolPrefix) async {
+    final result = await _graph.getDelta(url);
+    final changed = <AzureUser>[];
+    final removedIds = <String>[];
+    for (final row in result.values) {
+      if (AzureUser.isRemoved(row)) {
+        final id = row['id'] as String?;
+        if (id != null) removedIds.add(id);
+        continue;
+      }
+      final user = AzureUser.fromGraphJson(row);
+      if (_belongsToSchool(user, schoolPrefix)) changed.add(user);
+    }
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: delta for "$schoolPrefix" — ${changed.length} changed, '
+      '${removedIds.length} removed.',
+    );
+    return UserDelta(
+      changed: changed,
+      removedIds: removedIds,
+      deltaToken: result.deltaToken,
+    );
+  }
+
+  /// Fetches one user by object id or UPN. Returns `null` on `404`.
+  Future<AzureUser?> getUser(String idOrUpn) async {
+    final url = _graph.uri(
+      'users/${Uri.encodeComponent(idOrUpn)}',
+      query: {r'$select': _select},
+    );
+    try {
+      final json = await _graph.getJson(url);
+      return AzureUser.fromGraphJson(json);
+    } on GraphException catch (e) {
+      if (e.statusCode == 404) return null;
+      rethrow;
+    }
+  }
+
+  /// Whether a user with [idOrUpn] exists. Mirrors legacy `DoesUserExist`.
+  Future<bool> userExists(String idOrUpn) async =>
+      (await getUser(idOrUpn)) != null;
+
+  /// Creates a user. Mirrors legacy `CreateStudent`/`CreateStaffMember` →
+  /// `CreateUser`. [mailNickname] defaults to the UPN local part. Returns the
+  /// created user projected to [AzureUser].
+  Future<AzureUser> createUser({
+    required String userPrincipalName,
+    required String displayName,
+    required String password,
+    String givenName = '',
+    String surname = '',
+    String? employeeId,
+    String? department,
+    String? companyName,
+    String? jobTitle,
+    String? mailNickname,
+    bool accountEnabled = true,
+    bool forceChangePasswordNextSignIn = false,
+    String userType = 'Member',
+  }) async {
+    final nickname = mailNickname ?? userPrincipalName.split('@').first;
+    final body = <String, dynamic>{
+      'accountEnabled': accountEnabled,
+      'displayName': displayName,
+      'givenName': givenName,
+      'surname': surname,
+      'userPrincipalName': userPrincipalName,
+      'mailNickname': nickname,
+      'userType': userType,
+      'passwordProfile': {
+        'forceChangePasswordNextSignIn': forceChangePasswordNextSignIn,
+        'password': password,
+      },
+      if (employeeId != null) 'employeeId': employeeId,
+      if (department != null) 'department': department,
+      if (companyName != null) 'companyName': companyName,
+      if (jobTitle != null) 'jobTitle': jobTitle,
+    };
+    final json = await _graph.postJson(_graph.uri('users'), body);
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: created user $userPrincipalName.',
+    );
+    // The create response echoes the new resource; fall back to the request
+    // values for any field Graph omitted from its echo.
+    return AzureUser(
+      id: (json['id'] as String?) ?? '',
+      upn: (json['userPrincipalName'] as String?) ?? userPrincipalName,
+      employeeId: employeeId,
+      displayName: displayName,
+      givenName: givenName,
+      surname: surname,
+      companyName: companyName,
+      department: department,
+      accountEnabled: accountEnabled,
+    );
+  }
+
+  /// Patches the mutable fields of a user. Only non-null arguments are sent.
+  /// Pass [id] as the object id or current UPN. Mirrors the legacy
+  /// `Update`/`UpdatePrincipalName`/`Change*` surface.
+  Future<void> updateUser(
+    String id, {
+    String? userPrincipalName,
+    String? displayName,
+    String? givenName,
+    String? surname,
+    String? companyName,
+    String? department,
+    String? employeeId,
+    bool? accountEnabled,
+  }) async {
+    final body = <String, dynamic>{
+      if (userPrincipalName != null) 'userPrincipalName': userPrincipalName,
+      if (displayName != null) 'displayName': displayName,
+      if (givenName != null) 'givenName': givenName,
+      if (surname != null) 'surname': surname,
+      if (companyName != null) 'companyName': companyName,
+      if (department != null) 'department': department,
+      if (employeeId != null) 'employeeId': employeeId,
+      if (accountEnabled != null) 'accountEnabled': accountEnabled,
+    };
+    if (body.isEmpty) return;
+    await _graph.patchJson(
+      _graph.uri('users/${Uri.encodeComponent(id)}'),
+      body,
+    );
+    _log?.addMessage(core.Origin.azure, 'Azure: updated user $id.');
+  }
+
+  /// Deletes a user by object id or UPN. Mirrors legacy `DeleteUser`.
+  Future<void> deleteUser(String idOrUpn) async {
+    await _graph.delete(_graph.uri('users/${Uri.encodeComponent(idOrUpn)}'));
+    _log?.addMessage(core.Origin.azure, 'Azure: deleted user $idOrUpn.');
+  }
+
+  /// Builds a unique UPN from a name, appending a numeric suffix on collision.
+  /// Ports the legacy `CreatePrincipalName`: accents stripped, lower-cased,
+  /// non-`[a-z0-9_.+-]` removed. Students live under `student.<domain>`, staff
+  /// under `<domain>`.
+  Future<String> createPrincipalName(
+    String firstName,
+    String lastName,
+    String azureDomain, {
+    required bool isStudent,
+  }) async {
+    final local = '${_normalize(firstName)}.${_normalize(lastName)}';
+    final domain = isStudent ? 'student.$azureDomain' : azureDomain;
+    var candidate = '$local@$domain';
+    var suffix = 1;
+    while (await userExists(candidate)) {
+      suffix++;
+      candidate = '$local$suffix@$domain';
+    }
+    return candidate;
+  }
+
+  bool _belongsToSchool(AzureUser u, String prefix) {
+    final p = prefix.toLowerCase();
+    final company = u.companyName?.toLowerCase();
+    final dept = u.department?.toLowerCase();
+    return company == p || (dept != null && dept.startsWith(p));
+  }
+
+  /// Lower-cases, strips diacritics, and drops characters Azure rejects in a
+  /// UPN local part. Ports the legacy accent table and `[^a-zA-Z_.+-]` filter.
+  static String _normalize(String input) {
+    final buffer = StringBuffer();
+    for (final ch in input.toLowerCase().split('')) {
+      final mapped = _accents[ch] ?? ch;
+      if (RegExp(r'[a-z0-9_.+-]').hasMatch(mapped)) buffer.write(mapped);
+    }
+    return buffer.toString();
+  }
+
+  static const Map<String, String> _accents = {
+    'à': 'a',
+    'á': 'a',
+    'â': 'a',
+    'ã': 'a',
+    'ä': 'a',
+    'å': 'a',
+    'ç': 'c',
+    'è': 'e',
+    'é': 'e',
+    'ê': 'e',
+    'ë': 'e',
+    'ì': 'i',
+    'í': 'i',
+    'î': 'i',
+    'ï': 'i',
+    'ñ': 'n',
+    'ò': 'o',
+    'ó': 'o',
+    'ô': 'o',
+    'õ': 'o',
+    'ö': 'o',
+    'ù': 'u',
+    'ú': 'u',
+    'û': 'u',
+    'ü': 'u',
+    'ý': 'y',
+    'ÿ': 'y',
+  };
+
+  /// Escapes single quotes in an OData string literal by doubling them.
+  static String _escapeODataString(String value) => value.replaceAll("'", "''");
+}

--- a/packages/azure_api/pubspec.yaml
+++ b/packages/azure_api/pubspec.yaml
@@ -1,0 +1,25 @@
+name: azure_api
+description: >-
+  Microsoft Graph connector for the Arcadia Account Manager port. Reads Azure
+  AD / Office 365 users and groups into an immutable AzureSnapshot using Graph
+  $filter, $select and /users/delta, and performs the user and group-membership
+  writes the action set depends on. Pure Dart, headless-testable.
+version: 0.1.0
+publish_to: none
+repository: https://github.com/yvanvds/AccountManager
+
+# License: GPL-3.0-or-later. See LICENSE.
+
+environment:
+  sdk: ^3.6.0
+
+resolution: workspace
+
+dependencies:
+  account_core:
+  http: ^1.2.0
+  oauth2: ^2.0.0
+
+dev_dependencies:
+  lints: ^5.1.0
+  test: ^1.25.0

--- a/packages/azure_api/test/connector_test.dart
+++ b/packages/azure_api/test/connector_test.dart
@@ -1,0 +1,127 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:azure_api/azure_api.dart';
+import 'package:test/test.dart';
+
+import 'support/fake_graph_transport.dart';
+
+void main() {
+  final credentials = AzureCredentials(
+    clientId: 'c',
+    tenantId: 't',
+    azureDomain: 'school.example',
+    schoolPrefix: 'GBS',
+  );
+
+  GraphResponse route(GraphRequest req) {
+    final path = req.url.path;
+    if (path.contains('/members')) {
+      return jsonOk(readFixture('group_members_3a.json'));
+    }
+    if (path.contains('groups')) {
+      return jsonOk(readFixture('groups.json'));
+    }
+    if (path.contains('users/delta')) {
+      if (req.url.queryParameters[r'$deltatoken'] == 'latest') {
+        return jsonOk(readFixture('delta_latest.json'));
+      }
+      if (req.url.queryParameters[r'$skiptoken'] == 'DELTA2') {
+        return jsonOk(readFixture('users_delta_final.json'));
+      }
+      return jsonOk(readFixture('users_delta_page1.json'));
+    }
+    // plain /users bulk read
+    if (req.url.queryParameters[r'$skiptoken'] == 'PAGE2') {
+      return jsonOk(readFixture('users_page2.json'));
+    }
+    return jsonOk(readFixture('users_page1.json'));
+  }
+
+  AzureConnector connectorWith(FakeGraphTransport transport) => AzureConnector(
+        credentials: credentials,
+        authProvider: const StaticAuthProvider('T'),
+        transport: transport,
+      );
+
+  group('first/full sync', () {
+    test(
+        'uses \$filter bulk read + primes a delta token, never an unfiltered '
+        'delta', () async {
+      final transport = FakeGraphTransport(route);
+      final connector = connectorWith(transport);
+
+      final snapshot = await connector.sync();
+
+      expect(snapshot.origin, core.Origin.azure);
+      expect(snapshot.deltaToken, 'PRIMEDTOKEN123');
+      expect(snapshot.users.map((u) => u.upn), [
+        'ann.peeters@student.school.example',
+        'bram.janssens@student.school.example',
+        'carla.maes@school.example',
+      ]);
+      expect(snapshot.groups, hasLength(2));
+
+      // The bulk read went to /users with a $filter (the PAIN-2 contract),
+      // not to an unfiltered /users/delta enumerating the whole tenant.
+      final bulk = transport.requests.firstWhere(
+        (r) => r.url.path.endsWith('/users'),
+      );
+      expect(bulk.url.queryParameters[r'$filter'], isNotNull);
+    });
+  });
+
+  group('incremental sync', () {
+    test('applies delta changes and removals on top of the previous snapshot',
+        () async {
+      final transport = FakeGraphTransport(route);
+      final connector = connectorWith(transport);
+
+      final previous = AzureSnapshot(
+        fetchedAt: DateTime.utc(2026, 6, 1),
+        deltaToken: 'OLDTOKEN',
+        users: const [
+          AzureUser(id: '00000000-0000-0000-0000-000000000001', upn: 'ann@x'),
+          AzureUser(
+            id: '00000000-0000-0000-0000-000000000002',
+            upn: 'bram@x',
+            department: '3A',
+          ),
+          AzureUser(id: '00000000-0000-0000-0000-000000000003', upn: 'carla@x'),
+        ],
+        groups: const [],
+      );
+
+      final snapshot =
+          await connector.sync(deltaToken: 'OLDTOKEN', previous: previous);
+
+      final byId = {for (final u in snapshot.users) u.id: u};
+      // 0001 removed.
+      expect(byId.containsKey('00000000-0000-0000-0000-000000000001'), isFalse);
+      // 0002 updated (department 3A → 4A).
+      expect(byId['00000000-0000-0000-0000-000000000002']?.department, '4A');
+      // 0003 untouched.
+      expect(byId.containsKey('00000000-0000-0000-0000-000000000003'), isTrue);
+      // 0009 added.
+      expect(byId.containsKey('00000000-0000-0000-0000-000000000009'), isTrue);
+      // out-of-prefix 0050 never enters the snapshot.
+      expect(byId.containsKey('00000000-0000-0000-0000-000000000050'), isFalse);
+      expect(snapshot.deltaToken, 'NEWDELTA456');
+    });
+
+    test('delta sync issues /users/delta with the supplied token', () async {
+      final transport = FakeGraphTransport(route);
+      final connector = connectorWith(transport);
+      await connector.sync(
+        deltaToken: 'OLDTOKEN',
+        previous: AzureSnapshot(
+          fetchedAt: DateTime.utc(2026),
+          users: const [],
+          groups: const [],
+        ),
+      );
+      final deltaCall = transport.requests.firstWhere(
+        (r) => r.url.path.contains('users/delta'),
+      );
+      expect(deltaCall.url.queryParameters[r'$deltatoken'], 'OLDTOKEN');
+    });
+  });
+}

--- a/packages/azure_api/test/fixtures/README.md
+++ b/packages/azure_api/test/fixtures/README.md
@@ -1,0 +1,21 @@
+# azure_api test fixtures
+
+Synthetic Microsoft Graph payloads — no real PII. They drive the
+record-and-replay tests via `FakeGraphTransport`, which routes by request path
+and `$skiptoken`/`$deltatoken`.
+
+The synthetic school prefix is `GBS`; the verified domain is `school.example`.
+
+| Fixture | Represents | Exercises |
+|---|---|---|
+| `users_page1.json` | first `/users` page, with `@odata.nextLink` | pagination, `$filter`/`$select` read |
+| `users_page2.json` | final `/users` page (staff via `department`) | pagination terminates |
+| `users_delta_page1.json` | first `/users/delta` page, with `@odata.nextLink` | delta pagination |
+| `users_delta_final.json` | final delta page: in-prefix change, out-of-prefix change, and an `@removed` entry | delta token capture, client-side prefix filter, removals |
+| `delta_latest.json` | `$deltatoken=latest` reply (empty value, fresh `@odata.deltaLink`) | priming the first sync's resume token |
+| `groups.json` | prefixed `/groups` collection | group list, `startswith(displayName,…)` |
+| `group_members_3a.json` | `/groups/{id}/members` collection | member-id loading |
+| `user_single.json` | single `/users/{id}` resource | `getUser` |
+
+Capture new fixtures with `tool/capture_responses.dart` (redacts tokens) and
+trim them to the minimum the test needs.

--- a/packages/azure_api/test/fixtures/delta_latest.json
+++ b/packages/azure_api/test/fixtures/delta_latest.json
@@ -1,0 +1,5 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users",
+  "@odata.deltaLink": "https://graph.microsoft.com/v1.0/users/delta?$deltatoken=PRIMEDTOKEN123",
+  "value": []
+}

--- a/packages/azure_api/test/fixtures/group_members_3a.json
+++ b/packages/azure_api/test/fixtures/group_members_3a.json
@@ -1,0 +1,11 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#directoryObjects",
+  "value": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001"
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000002"
+    }
+  ]
+}

--- a/packages/azure_api/test/fixtures/groups.json
+++ b/packages/azure_api/test/fixtures/groups.json
@@ -1,0 +1,16 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups",
+  "@odata.count": 2,
+  "value": [
+    {
+      "id": "g0000000-0000-0000-0000-0000000000a1",
+      "displayName": "GBS-3A",
+      "securityEnabled": true
+    },
+    {
+      "id": "g0000000-0000-0000-0000-0000000000a2",
+      "displayName": "GBS-Staff",
+      "securityEnabled": false
+    }
+  ]
+}

--- a/packages/azure_api/test/fixtures/user_single.json
+++ b/packages/azure_api/test/fixtures/user_single.json
@@ -1,0 +1,12 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
+  "id": "00000000-0000-0000-0000-000000000001",
+  "userPrincipalName": "ann.peeters@student.school.example",
+  "employeeId": "W1001",
+  "displayName": "Ann Peeters",
+  "givenName": "Ann",
+  "surname": "Peeters",
+  "companyName": "GBS",
+  "department": "3A",
+  "accountEnabled": true
+}

--- a/packages/azure_api/test/fixtures/users_delta_final.json
+++ b/packages/azure_api/test/fixtures/users_delta_final.json
@@ -1,0 +1,34 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users",
+  "@odata.deltaLink": "https://graph.microsoft.com/v1.0/users/delta?$deltatoken=NEWDELTA456",
+  "value": [
+    {
+      "id": "00000000-0000-0000-0000-000000000009",
+      "userPrincipalName": "dirk.nieuw@student.school.example",
+      "employeeId": "W1009",
+      "displayName": "Dirk Nieuw",
+      "givenName": "Dirk",
+      "surname": "Nieuw",
+      "companyName": "GBS",
+      "department": "1A",
+      "accountEnabled": true
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000050",
+      "userPrincipalName": "evy.extern@other.example",
+      "employeeId": "X9999",
+      "displayName": "Evy Extern",
+      "givenName": "Evy",
+      "surname": "Extern",
+      "companyName": "OTHER",
+      "department": "ZZ",
+      "accountEnabled": true
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "@removed": {
+        "reason": "deleted"
+      }
+    }
+  ]
+}

--- a/packages/azure_api/test/fixtures/users_delta_page1.json
+++ b/packages/azure_api/test/fixtures/users_delta_page1.json
@@ -1,0 +1,17 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users",
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/users/delta?$skiptoken=DELTA2",
+  "value": [
+    {
+      "id": "00000000-0000-0000-0000-000000000002",
+      "userPrincipalName": "bram.janssens@student.school.example",
+      "employeeId": "W1002",
+      "displayName": "Bram Janssens",
+      "givenName": "Bram",
+      "surname": "Janssens",
+      "companyName": "GBS",
+      "department": "4A",
+      "accountEnabled": true
+    }
+  ]
+}

--- a/packages/azure_api/test/fixtures/users_page1.json
+++ b/packages/azure_api/test/fixtures/users_page1.json
@@ -1,0 +1,29 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users",
+  "@odata.count": 3,
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/users?$skiptoken=PAGE2",
+  "value": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "userPrincipalName": "ann.peeters@student.school.example",
+      "employeeId": "W1001",
+      "displayName": "Ann Peeters",
+      "givenName": "Ann",
+      "surname": "Peeters",
+      "companyName": "GBS",
+      "department": "3A",
+      "accountEnabled": true
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000002",
+      "userPrincipalName": "bram.janssens@student.school.example",
+      "employeeId": "W1002",
+      "displayName": "Bram Janssens",
+      "givenName": "Bram",
+      "surname": "Janssens",
+      "companyName": "GBS",
+      "department": "3A",
+      "accountEnabled": true
+    }
+  ]
+}

--- a/packages/azure_api/test/fixtures/users_page2.json
+++ b/packages/azure_api/test/fixtures/users_page2.json
@@ -1,0 +1,16 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users",
+  "value": [
+    {
+      "id": "00000000-0000-0000-0000-000000000003",
+      "userPrincipalName": "carla.maes@school.example",
+      "employeeId": "S2001",
+      "displayName": "Carla Maes",
+      "givenName": "Carla",
+      "surname": "Maes",
+      "companyName": null,
+      "department": "GBS",
+      "accountEnabled": true
+    }
+  ]
+}

--- a/packages/azure_api/test/graph_client_test.dart
+++ b/packages/azure_api/test/graph_client_test.dart
@@ -1,0 +1,118 @@
+import 'package:azure_api/azure_api.dart';
+import 'package:test/test.dart';
+
+import 'support/fake_graph_transport.dart';
+
+void main() {
+  GraphClient clientWith(FakeGraphTransport transport) => GraphClient(
+        transport: transport,
+        auth: const StaticAuthProvider('TEST-TOKEN'),
+      );
+
+  group('GraphClient.uri', () {
+    test('joins base + path without dropping the version segment', () {
+      final client = clientWith(FakeGraphTransport.constant(noContent()));
+      expect(
+        client.uri('users').toString(),
+        'https://graph.microsoft.com/v1.0/users',
+      );
+    });
+
+    test('attaches query parameters, percent-encoding values', () {
+      final client = clientWith(FakeGraphTransport.constant(noContent()));
+      final uri = client.uri(
+        'users',
+        query: {
+          r'$select': 'id,displayName',
+          r'$filter': "companyName eq 'GBS'",
+        },
+      );
+      expect(uri.queryParameters[r'$select'], 'id,displayName');
+      expect(uri.queryParameters[r'$filter'], "companyName eq 'GBS'");
+    });
+  });
+
+  group('authentication', () {
+    test('sets a Bearer token from the auth provider on every request',
+        () async {
+      final transport =
+          FakeGraphTransport.constant(jsonOk({'value': <dynamic>[]}));
+      final client = clientWith(transport);
+      await client.getJson(client.uri('users'));
+      expect(transport.last.headers['Authorization'], 'Bearer TEST-TOKEN');
+      expect(transport.last.headers['Accept'], 'application/json');
+    });
+
+    test('non-2xx ⇒ GraphException carrying Graph error code/message',
+        () async {
+      final transport = FakeGraphTransport.constant(
+        graphError(
+          403,
+          'Authorization_RequestDenied',
+          'Insufficient privileges',
+        ),
+      );
+      final client = clientWith(transport);
+      expect(
+        () => client.getJson(client.uri('users')),
+        throwsA(
+          isA<GraphException>()
+              .having((e) => e.statusCode, 'statusCode', 403)
+              .having((e) => e.code, 'code', 'Authorization_RequestDenied')
+              .having((e) => e.message, 'message', 'Insufficient privileges'),
+        ),
+      );
+    });
+  });
+
+  group('pagination', () {
+    test('getCollection follows @odata.nextLink across all pages', () async {
+      final transport = FakeGraphTransport((req) {
+        if (req.url.queryParameters[r'$skiptoken'] == 'PAGE2') {
+          return jsonOk(readFixture('users_page2.json'));
+        }
+        return jsonOk(readFixture('users_page1.json'));
+      });
+      final client = clientWith(transport);
+      final rows = await client.getCollection(client.uri('users'));
+      expect(rows, hasLength(3));
+      expect(transport.requests, hasLength(2));
+      // Page-1 headers are forwarded to the next page too.
+    });
+
+    test('getCollection forwards headers on every page', () async {
+      final transport = FakeGraphTransport((req) {
+        if (req.url.queryParameters[r'$skiptoken'] == 'PAGE2') {
+          return jsonOk(readFixture('users_page2.json'));
+        }
+        return jsonOk(readFixture('users_page1.json'));
+      });
+      final client = clientWith(transport);
+      await client.getCollection(
+        client.uri('users'),
+        headers: const {'ConsistencyLevel': 'eventual'},
+      );
+      expect(
+        transport.requests.every(
+          (r) => r.headers['ConsistencyLevel'] == 'eventual',
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('delta', () {
+    test('getDelta gathers all pages and extracts the \$deltatoken', () async {
+      final transport = FakeGraphTransport((req) {
+        if (req.url.queryParameters[r'$skiptoken'] == 'DELTA2') {
+          return jsonOk(readFixture('users_delta_final.json'));
+        }
+        return jsonOk(readFixture('users_delta_page1.json'));
+      });
+      final client = clientWith(transport);
+      final result = await client.getDelta(client.uri('users/delta'));
+      expect(result.values, hasLength(4)); // 1 + (2 changed + 1 removed)
+      expect(result.deltaToken, 'NEWDELTA456');
+    });
+  });
+}

--- a/packages/azure_api/test/graph_request_test.dart
+++ b/packages/azure_api/test/graph_request_test.dart
@@ -1,0 +1,43 @@
+import 'package:azure_api/azure_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GraphResponse', () {
+    test('json decodes an object body', () {
+      const resp = GraphResponse(statusCode: 200, body: '{"a":1}');
+      expect(resp.json['a'], 1);
+      expect(resp.isSuccess, isTrue);
+    });
+
+    test('json on an empty body (204) is an empty map', () {
+      expect(const GraphResponse(statusCode: 204).json, isEmpty);
+    });
+
+    test('json throws when the body is not a JSON object', () {
+      expect(
+        () => const GraphResponse(statusCode: 200, body: '[]').json,
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('GraphException', () {
+    test('exposes Graph error code/message and renders them', () {
+      const ex = GraphException(
+        403,
+        '{"error":{"code":"Forbidden","message":"no access"}}',
+      );
+      expect(ex.code, 'Forbidden');
+      expect(ex.message, 'no access');
+      expect(ex.toString(), contains('Forbidden'));
+      expect(ex.toString(), contains('no access'));
+    });
+
+    test('tolerates a non-JSON error body', () {
+      const ex = GraphException(500, 'Internal Server Error');
+      expect(ex.code, isNull);
+      expect(ex.message, isNull);
+      expect(ex.toString(), contains('Internal Server Error'));
+    });
+  });
+}

--- a/packages/azure_api/test/graph_transport_test.dart
+++ b/packages/azure_api/test/graph_transport_test.dart
@@ -1,0 +1,39 @@
+import 'package:azure_api/azure_api.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HttpGraphTransport', () {
+    test('forwards method, url, headers and body, and maps the response',
+        () async {
+      late http.BaseRequest seen;
+      final transport = HttpGraphTransport(
+        client: MockClient((req) async {
+          seen = req;
+          return http.Response(
+            '{"value":1}',
+            201,
+            headers: {'request-id': 'abc'},
+          );
+        }),
+      );
+
+      final resp = await transport.send(
+        GraphRequest(
+          method: 'POST',
+          url: Uri.parse('https://graph.microsoft.com/v1.0/users'),
+          headers: const {'Authorization': 'Bearer t'},
+          body: '{"displayName":"x"}',
+        ),
+      );
+
+      expect(seen.method, 'POST');
+      expect(seen.url.path, '/v1.0/users');
+      expect(seen.headers['Authorization'], 'Bearer t');
+      expect(resp.statusCode, 201);
+      expect(resp.headers['request-id'], 'abc');
+      expect(resp.json['value'], 1);
+    });
+  });
+}

--- a/packages/azure_api/test/group_manager_test.dart
+++ b/packages/azure_api/test/group_manager_test.dart
@@ -1,0 +1,162 @@
+import 'dart:convert';
+
+import 'package:azure_api/azure_api.dart';
+import 'package:test/test.dart';
+
+import 'support/fake_graph_transport.dart';
+
+void main() {
+  GraphClient clientWith(FakeGraphTransport transport) => GraphClient(
+        transport: transport,
+        auth: const StaticAuthProvider('T'),
+      );
+
+  group('listGroups', () {
+    late FakeGraphTransport transport;
+    late GroupManager groups;
+
+    setUp(() {
+      transport = FakeGraphTransport((req) {
+        if (req.url.path.contains('/members')) {
+          return jsonOk(readFixture('group_members_3a.json'));
+        }
+        return jsonOk(readFixture('groups.json'));
+      });
+      groups = GroupManager(clientWith(transport));
+    });
+
+    test('filters by startswith(displayName, prefix) with \$select', () async {
+      await groups.listGroups('GBS');
+      final groupCall = transport.requests.first;
+      expect(
+        groupCall.url.queryParameters[r'$filter'],
+        "startswith(displayName,'GBS')",
+      );
+      expect(
+        groupCall.url.queryParameters[r'$select'],
+        'id,displayName,securityEnabled',
+      );
+      expect(groupCall.headers['ConsistencyLevel'], 'eventual');
+    });
+
+    test('loads member ids for each group', () async {
+      final result = await groups.listGroups('GBS');
+      expect(result, hasLength(2));
+      expect(result.first.displayName, 'GBS-3A');
+      expect(result.first.memberIds, [
+        '00000000-0000-0000-0000-000000000001',
+        '00000000-0000-0000-0000-000000000002',
+      ]);
+    });
+  });
+
+  group('membership writes', () {
+    test('addMember POSTs an @odata.id directoryObjects ref', () async {
+      final transport = FakeGraphTransport.constant(noContent());
+      final groups = GroupManager(clientWith(transport));
+      await groups.addMember('g1', 'u1');
+      expect(transport.last.method, 'POST');
+      expect(transport.last.url.path, endsWith(r'/members/$ref'));
+      final body = jsonDecode(transport.last.body!) as Map<String, dynamic>;
+      expect(
+        body['@odata.id'],
+        'https://graph.microsoft.com/v1.0/directoryObjects/u1',
+      );
+    });
+
+    test('removeMember DELETEs the member ref', () async {
+      final transport = FakeGraphTransport.constant(noContent());
+      final groups = GroupManager(clientWith(transport));
+      await groups.removeMember('g1', 'u1');
+      expect(transport.last.method, 'DELETE');
+      expect(transport.last.url.path, endsWith(r'/members/u1/$ref'));
+    });
+  });
+
+  group('\$batch', () {
+    test('coalesces many adds into one \$batch POST with relative urls',
+        () async {
+      final transport = FakeGraphTransport((req) {
+        final body = jsonDecode(req.body!) as Map<String, dynamic>;
+        final requests = body['requests'] as List<dynamic>;
+        return jsonOk({
+          'responses': [
+            for (final r in requests.cast<Map<String, dynamic>>())
+              {'id': r['id'], 'status': 204},
+          ],
+        });
+      });
+      final groups = GroupManager(clientWith(transport));
+
+      final results = await groups.addMembers('g1', ['u1', 'u2', 'u3']);
+
+      expect(transport.requests, hasLength(1));
+      expect(transport.last.url.path, endsWith(r'/$batch'));
+      final body = jsonDecode(transport.last.body!) as Map<String, dynamic>;
+      final reqs = (body['requests'] as List).cast<Map<String, dynamic>>();
+      expect(reqs, hasLength(3));
+      expect(reqs.first['method'], 'POST');
+      expect(reqs.first['url'], r'/groups/g1/members/$ref');
+      expect(results.every((r) => r.isSuccess), isTrue);
+    });
+
+    test('chunks batches larger than 20 sub-requests', () async {
+      var batches = 0;
+      final transport = FakeGraphTransport((req) {
+        batches++;
+        final body = jsonDecode(req.body!) as Map<String, dynamic>;
+        final requests = body['requests'] as List<dynamic>;
+        return jsonOk({
+          'responses': [
+            for (final r in requests.cast<Map<String, dynamic>>())
+              {'id': r['id'], 'status': 204},
+          ],
+        });
+      });
+      final groups = GroupManager(clientWith(transport));
+
+      final userIds = List.generate(45, (i) => 'u$i');
+      final results = await groups.addMembers('g1', userIds);
+
+      expect(batches, 3); // 20 + 20 + 5
+      expect(results, hasLength(45));
+    });
+
+    test('empty member list short-circuits without a call', () async {
+      final transport = FakeGraphTransport.constant(noContent());
+      final groups = GroupManager(clientWith(transport));
+      expect(await groups.addMembers('g1', const []), isEmpty);
+      expect(transport.requests, isEmpty);
+    });
+
+    test('removeMembers batches DELETE \$ref sub-requests', () async {
+      final transport = FakeGraphTransport((req) {
+        final body = jsonDecode(req.body!) as Map<String, dynamic>;
+        final requests =
+            (body['requests'] as List).cast<Map<String, dynamic>>();
+        return jsonOk({
+          'responses': [
+            for (final r in requests) {'id': r['id'], 'status': 204},
+          ],
+        });
+      });
+      final groups = GroupManager(clientWith(transport));
+
+      final results = await groups.removeMembers('g1', ['u1', 'u2']);
+
+      final reqs = (jsonDecode(transport.last.body!)
+          as Map<String, dynamic>)['requests'] as List;
+      expect(reqs, hasLength(2));
+      expect((reqs.first as Map)['method'], 'DELETE');
+      expect((reqs.first as Map)['url'], r'/groups/g1/members/u1/$ref');
+      expect(results.every((r) => r.isSuccess), isTrue);
+    });
+
+    test('removeMembers short-circuits on an empty list', () async {
+      final transport = FakeGraphTransport.constant(noContent());
+      final groups = GroupManager(clientWith(transport));
+      expect(await groups.removeMembers('g1', const []), isEmpty);
+      expect(transport.requests, isEmpty);
+    });
+  });
+}

--- a/packages/azure_api/test/integration/azure_live_test.dart
+++ b/packages/azure_api/test/integration/azure_live_test.dart
@@ -1,0 +1,56 @@
+import 'package:azure_api/azure_api.dart';
+import 'package:test/test.dart';
+
+/// Opt-in, **read-only** live test against a real Azure AD tenant.
+///
+/// Honours the repo live-testing policy: CI live tests never write. The
+/// interactive sign-in is skipped — a pre-acquired bearer token is supplied
+/// via `AZURE_ACCESS_TOKEN` (e.g. `az account get-access-token
+/// --resource https://graph.microsoft.com`).
+///
+/// Runs only when the Azure env vars are present; otherwise it is skipped, so
+/// `dart test` stays offline by default.
+void main() {
+  final config = AzureLiveConfig.fromEnvironment();
+
+  group(
+    'Azure live (read-only)',
+    () {
+      late AzureConnector connector;
+
+      setUp(() {
+        connector = AzureConnector(
+          credentials: AzureCredentials(
+            clientId: config!.clientId,
+            tenantId: config.tenantId,
+            azureDomain: config.azureDomain,
+            schoolPrefix: config.schoolPrefix,
+          ),
+          authProvider: StaticAuthProvider(config.accessToken),
+        );
+      });
+
+      tearDown(() => connector.close());
+
+      test('sync() returns a filtered, non-empty snapshot', () async {
+        final prefix = config!.schoolPrefix.toLowerCase();
+        final snapshot = await connector.sync();
+        // Filtered read should not return the whole tenant; sanity-bound it.
+        expect(snapshot.users, isNotEmpty);
+        expect(
+          snapshot.users.every(
+            (u) =>
+                (u.companyName?.toLowerCase() == prefix) ||
+                (u.department?.toLowerCase().startsWith(prefix) ?? false),
+          ),
+          isTrue,
+        );
+        // A delta token must be primed for the next incremental sync.
+        expect(snapshot.deltaToken, isNotNull);
+      });
+    },
+    skip: config == null
+        ? 'Set AZURE_ACCESS_TOKEN (+ client/tenant/domain/prefix) to run.'
+        : false,
+  );
+}

--- a/packages/azure_api/test/live_config_test.dart
+++ b/packages/azure_api/test/live_config_test.dart
@@ -1,0 +1,44 @@
+import 'package:azure_api/azure_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AzureLiveConfig.fromEnvironment', () {
+    test('returns null when AZURE_ACCESS_TOKEN is absent (offline default)',
+        () {
+      expect(AzureLiveConfig.fromEnvironment(const {}), isNull);
+    });
+
+    test('returns null when the token is blank', () {
+      expect(
+        AzureLiveConfig.fromEnvironment(const {'AZURE_ACCESS_TOKEN': '  '}),
+        isNull,
+      );
+    });
+
+    test('parses a complete environment', () {
+      final config = AzureLiveConfig.fromEnvironment(const {
+        'AZURE_ACCESS_TOKEN': 'tok',
+        'AZURE_CLIENT_ID': 'cid',
+        'AZURE_TENANT_ID': 'tid',
+        'AZURE_DOMAIN': 'school.example',
+        'AZURE_SCHOOL_PREFIX': 'GBS',
+      });
+      expect(config, isNotNull);
+      expect(config!.accessToken, 'tok');
+      expect(config.clientId, 'cid');
+      expect(config.tenantId, 'tid');
+      expect(config.azureDomain, 'school.example');
+      expect(config.schoolPrefix, 'GBS');
+    });
+
+    test('throws when the token is set but a required field is missing', () {
+      expect(
+        () => AzureLiveConfig.fromEnvironment(const {
+          'AZURE_ACCESS_TOKEN': 'tok',
+          'AZURE_CLIENT_ID': 'cid',
+        }),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/packages/azure_api/test/loopback_authorizer_test.dart
+++ b/packages/azure_api/test/loopback_authorizer_test.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'package:azure_api/azure_api.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+void main() {
+  group('LoopbackAuthorizer', () {
+    test('captures the redirect query parameters from the loopback server',
+        () async {
+      final redirect = Uri.parse('http://localhost:8762/auth-redirect');
+      final authorizer = LoopbackAuthorizer(
+        launchBrowser: (authUrl) async {
+          // Simulate the browser bouncing back to the loopback server. Fire and
+          // forget — the server only answers once call() reaches `server.first`.
+          unawaited(
+            http.get(
+              redirect.replace(queryParameters: {'code': 'abc', 'state': 's'}),
+            ),
+          );
+        },
+      );
+
+      final params = await authorizer.call(
+        Uri.parse('https://login.microsoftonline.com/t/oauth2/v2.0/authorize'),
+        redirect,
+      );
+
+      expect(params['code'], 'abc');
+      expect(params['state'], 's');
+    });
+
+    test('throws AzureAuthException when the redirect carries an error',
+        () async {
+      final redirect = Uri.parse('http://localhost:8763/auth-redirect');
+      final authorizer = LoopbackAuthorizer(
+        launchBrowser: (authUrl) async {
+          unawaited(
+            http.get(
+              redirect.replace(
+                queryParameters: {
+                  'error': 'access_denied',
+                  'error_description': 'user declined',
+                },
+              ),
+            ),
+          );
+        },
+      );
+
+      expect(
+        () => authorizer.call(
+          Uri.parse(
+            'https://login.microsoftonline.com/t/oauth2/v2.0/authorize',
+          ),
+          redirect,
+        ),
+        throwsA(isA<AzureAuthException>()),
+      );
+    });
+  });
+}

--- a/packages/azure_api/test/models_test.dart
+++ b/packages/azure_api/test/models_test.dart
@@ -1,0 +1,135 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:azure_api/azure_api.dart';
+import 'package:test/test.dart';
+
+import 'support/fake_graph_transport.dart';
+
+void main() {
+  group('AzureUser', () {
+    test('implements core.AzureUser linking interface', () {
+      const core.AzureUser user =
+          AzureUser(id: 'i', upn: 'a@b', employeeId: 'W1');
+      expect(user.id, 'i');
+      expect(user.upn, 'a@b');
+      expect(user.employeeId, 'W1');
+    });
+
+    test('fromGraphJson maps Graph fields ⇒ model fields', () {
+      final json = readJsonFixture('user_single.json');
+      final user = AzureUser.fromGraphJson(json);
+      expect(user.id, '00000000-0000-0000-0000-000000000001');
+      expect(user.upn, 'ann.peeters@student.school.example');
+      expect(user.employeeId, 'W1001');
+      expect(user.displayName, 'Ann Peeters');
+      expect(user.givenName, 'Ann');
+      expect(user.surname, 'Peeters');
+      expect(user.companyName, 'GBS');
+      expect(user.department, '3A');
+      expect(user.accountEnabled, isTrue);
+    });
+
+    test('fromGraphJson treats empty/absent employeeId & companyName as null',
+        () {
+      final user = AzureUser.fromGraphJson({
+        'id': 'x',
+        'userPrincipalName': 'u@d',
+        'employeeId': '',
+      });
+      expect(user.employeeId, isNull);
+      expect(user.companyName, isNull);
+      expect(user.department, isNull);
+      expect(user.displayName, '');
+    });
+
+    test('isRemoved detects @removed delta entries', () {
+      expect(
+        AzureUser.isRemoved({
+          'id': 'x',
+          '@removed': {'reason': 'deleted'},
+        }),
+        isTrue,
+      );
+      expect(AzureUser.isRemoved({'id': 'x'}), isFalse);
+    });
+
+    test('graphSelectFields holds exactly the fields the port reads', () {
+      expect(AzureUser.graphSelectFields, [
+        'id',
+        'userPrincipalName',
+        'employeeId',
+        'displayName',
+        'givenName',
+        'surname',
+        'companyName',
+        'department',
+        'accountEnabled',
+      ]);
+    });
+
+    test('toJson/fromJson round-trip', () {
+      const user = AzureUser(
+        id: 'i',
+        upn: 'a@b',
+        employeeId: 'W1',
+        displayName: 'A B',
+        givenName: 'A',
+        surname: 'B',
+        companyName: 'GBS',
+        department: '3A',
+        accountEnabled: false,
+      );
+      expect(AzureUser.fromJson(user.toJson()), user);
+    });
+
+    test('copyWith replaces only named fields', () {
+      const user = AzureUser(id: 'i', upn: 'a@b', department: '3A');
+      final moved = user.copyWith(department: '4A');
+      expect(moved.department, '4A');
+      expect(moved.id, 'i');
+      expect(moved.upn, 'a@b');
+    });
+
+    test('equality is value-based', () {
+      const a = AzureUser(id: 'i', upn: 'a@b');
+      const b = AzureUser(id: 'i', upn: 'a@b');
+      const c = AzureUser(id: 'i', upn: 'x@y');
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+    });
+  });
+
+  group('AzureGroup', () {
+    test('implements core.AzureGroup and carries members + securityEnabled',
+        () {
+      final json = readJsonFixture('groups.json');
+      final row = (json['value'] as List).first as Map<String, dynamic>;
+      final group = AzureGroup.fromGraphJson(
+        row,
+        members: const ['m1', 'm2'],
+      );
+      expect(group, isA<core.AzureGroup>());
+      expect(group.id, 'g0000000-0000-0000-0000-0000000000a1');
+      expect(group.displayName, 'GBS-3A');
+      expect(group.securityEnabled, isTrue);
+      expect(group.memberIds, ['m1', 'm2']);
+      expect(group.hasMember('m1'), isTrue);
+      expect(group.hasMember('zzz'), isFalse);
+    });
+
+    test('memberIds is unmodifiable', () {
+      final group = AzureGroup(id: 'g', displayName: 'n', memberIds: ['a']);
+      expect(() => group.memberIds.add('b'), throwsUnsupportedError);
+    });
+
+    test('toJson/fromJson round-trip', () {
+      final group = AzureGroup(
+        id: 'g',
+        displayName: 'GBS-3A',
+        securityEnabled: true,
+        memberIds: const ['m1', 'm2'],
+      );
+      expect(AzureGroup.fromJson(group.toJson()), group);
+    });
+  });
+}

--- a/packages/azure_api/test/oauth_auth_provider_test.dart
+++ b/packages/azure_api/test/oauth_auth_provider_test.dart
@@ -1,0 +1,199 @@
+import 'dart:convert';
+
+import 'package:azure_api/azure_api.dart';
+import 'package:http/testing.dart';
+import 'package:http/http.dart' as http;
+import 'package:oauth2/oauth2.dart' as oauth2;
+import 'package:test/test.dart';
+
+void main() {
+  final credentials = AzureCredentials(
+    clientId: 'client-123',
+    tenantId: 'tenant-abc',
+    azureDomain: 'school.example',
+    schoolPrefix: 'GBS',
+  );
+
+  /// Builds a serialized oauth2 credentials payload as the cache would hold it.
+  String cachedCredentials({
+    required String accessToken,
+    String refreshToken = 'refresh-1',
+    required DateTime expiration,
+  }) =>
+      oauth2.Credentials(
+        accessToken,
+        refreshToken: refreshToken,
+        tokenEndpoint: credentials.tokenEndpoint,
+        scopes: credentials.scopes,
+        expiration: expiration,
+      ).toJson();
+
+  String tokenResponse(
+    String accessToken, {
+    String refreshToken = 'refresh-2',
+  }) =>
+      jsonEncode({
+        'token_type': 'Bearer',
+        'access_token': accessToken,
+        'expires_in': 3600,
+        'refresh_token': refreshToken,
+        'scope': credentials.scopes.join(' '),
+      });
+
+  // oauth2 requires the token endpoint to declare a JSON content type.
+  http.Response jsonResp(String body, int status) => http.Response(
+        body,
+        status,
+        headers: {'content-type': 'application/json'},
+      );
+
+  // An authorizer that must never run (asserts the silent path was taken).
+  Future<Map<String, String>> failIfCalled(Uri url, Uri redirect) async {
+    fail('interactive sign-in should not have been triggered');
+  }
+
+  group('silent acquisition', () {
+    test('returns a valid cached token without HTTP or interaction', () async {
+      final cache = InMemoryTokenCache();
+      await cache.write(
+        cachedCredentials(
+          accessToken: 'CACHED-AT',
+          expiration: DateTime.now().add(const Duration(hours: 1)),
+        ),
+      );
+      final provider = OAuthAuthProvider(
+        credentials: credentials,
+        cache: cache,
+        authorizer: failIfCalled,
+        httpClient: MockClient((_) async {
+          fail('no token endpoint call expected');
+        }),
+      );
+      expect(await provider.getAccessToken(), 'CACHED-AT');
+    });
+
+    test('refreshes an expired token silently and re-caches it', () async {
+      final cache = InMemoryTokenCache();
+      await cache.write(
+        cachedCredentials(
+          accessToken: 'OLD-AT',
+          expiration: DateTime.now().subtract(const Duration(minutes: 1)),
+        ),
+      );
+      Uri? refreshUrl;
+      final provider = OAuthAuthProvider(
+        credentials: credentials,
+        cache: cache,
+        authorizer: failIfCalled,
+        httpClient: MockClient((req) async {
+          refreshUrl = req.url;
+          expect(req.bodyFields['grant_type'], 'refresh_token');
+          expect(req.bodyFields['client_id'], 'client-123');
+          return jsonResp(tokenResponse('FRESH-AT'), 200);
+        }),
+      );
+
+      expect(await provider.getAccessToken(), 'FRESH-AT');
+      expect(refreshUrl, credentials.tokenEndpoint);
+      // New credentials were written back to the cache.
+      expect(await cache.read(), contains('FRESH-AT'));
+    });
+  });
+
+  group('interactive acquisition', () {
+    test('requests the right tenant, scopes, and PKCE challenge', () async {
+      Uri? seenAuthUrl;
+      final provider = OAuthAuthProvider(
+        credentials: credentials,
+        cache: InMemoryTokenCache(),
+        authorizer: (authUrl, redirect) async {
+          seenAuthUrl = authUrl;
+          return {'code': 'auth-code-xyz'};
+        },
+        httpClient: MockClient((req) async {
+          expect(req.bodyFields['grant_type'], 'authorization_code');
+          expect(req.bodyFields['code'], 'auth-code-xyz');
+          expect(req.bodyFields['code_verifier'], isNotNull);
+          return jsonResp(tokenResponse('INTERACTIVE-AT'), 200);
+        }),
+      );
+
+      expect(await provider.getAccessToken(), 'INTERACTIVE-AT');
+      expect(
+        seenAuthUrl!.origin + seenAuthUrl!.path,
+        'https://login.microsoftonline.com/tenant-abc/oauth2/v2.0/authorize',
+      );
+      expect(
+        seenAuthUrl!.queryParameters['scope'],
+        contains('User.ReadWrite.All'),
+      );
+      expect(seenAuthUrl!.queryParameters['code_challenge_method'], 'S256');
+      expect(seenAuthUrl!.queryParameters['code_challenge'], isNotNull);
+    });
+
+    test('falls back to interactive when the refresh token is rejected',
+        () async {
+      final cache = InMemoryTokenCache();
+      await cache.write(
+        cachedCredentials(
+          accessToken: 'OLD-AT',
+          expiration: DateTime.now().subtract(const Duration(minutes: 1)),
+        ),
+      );
+      var authorizerCalled = false;
+      final provider = OAuthAuthProvider(
+        credentials: credentials,
+        cache: cache,
+        authorizer: (authUrl, redirect) async {
+          authorizerCalled = true;
+          return {'code': 'new-code'};
+        },
+        httpClient: MockClient((req) async {
+          if (req.bodyFields['grant_type'] == 'refresh_token') {
+            return jsonResp(jsonEncode({'error': 'invalid_grant'}), 400);
+          }
+          return jsonResp(tokenResponse('RECOVERED-AT'), 200);
+        }),
+      );
+
+      expect(await provider.getAccessToken(), 'RECOVERED-AT');
+      expect(authorizerCalled, isTrue);
+    });
+
+    test('wraps a failing authorizer in AzureAuthException', () async {
+      final provider = OAuthAuthProvider(
+        credentials: credentials,
+        cache: InMemoryTokenCache(),
+        authorizer: (authUrl, redirect) async {
+          throw StateError('user closed the window');
+        },
+        httpClient: MockClient((_) async => http.Response('{}', 200)),
+      );
+      expect(
+        () => provider.getAccessToken(),
+        throwsA(isA<AzureAuthException>()),
+      );
+    });
+  });
+
+  group('corrupt cache', () {
+    test('is discarded and the flow falls back to interactive', () async {
+      final cache = InMemoryTokenCache();
+      await cache.write('not-valid-json');
+      var authorizerCalled = false;
+      final provider = OAuthAuthProvider(
+        credentials: credentials,
+        cache: cache,
+        authorizer: (authUrl, redirect) async {
+          authorizerCalled = true;
+          return {'code': 'c'};
+        },
+        httpClient: MockClient(
+          (_) async => jsonResp(tokenResponse('AT-AFTER-CORRUPT'), 200),
+        ),
+      );
+      expect(await provider.getAccessToken(), 'AT-AFTER-CORRUPT');
+      expect(authorizerCalled, isTrue);
+    });
+  });
+}

--- a/packages/azure_api/test/snapshot_test.dart
+++ b/packages/azure_api/test/snapshot_test.dart
@@ -1,0 +1,42 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:azure_api/azure_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AzureSnapshot', () {
+    final snapshot = AzureSnapshot(
+      fetchedAt: DateTime.utc(2026, 6, 5, 9),
+      deltaToken: 'TOKEN123',
+      users: const [
+        AzureUser(id: 'i1', upn: 'a@b', employeeId: 'W1', department: '3A'),
+      ],
+      groups: [
+        AzureGroup(id: 'g1', displayName: 'GBS-3A', memberIds: const ['i1']),
+      ],
+    );
+
+    test('origin is azure', () {
+      expect(snapshot.origin, core.Origin.azure);
+      expect(snapshot, isA<core.Snapshot>());
+    });
+
+    test('exposed lists are unmodifiable', () {
+      expect(
+        () => snapshot.users.add(const AzureUser(id: 'x', upn: 'y')),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => snapshot.groups.add(AzureGroup(id: 'x', displayName: 'y')),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('toJson/fromJson round-trip preserves users, groups, token, time', () {
+      final restored = AzureSnapshot.fromJson(snapshot.toJson());
+      expect(restored.fetchedAt, snapshot.fetchedAt);
+      expect(restored.deltaToken, 'TOKEN123');
+      expect(restored.users, snapshot.users);
+      expect(restored.groups, snapshot.groups);
+    });
+  });
+}

--- a/packages/azure_api/test/support/fake_graph_transport.dart
+++ b/packages/azure_api/test/support/fake_graph_transport.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:azure_api/azure_api.dart';
+
+/// A [GraphTransport] that records every outgoing [GraphRequest] and replays a
+/// response from an injected handler. The recorded requests let tests assert
+/// on the exact `$filter`/`$select`/`$batch` the connector issued.
+class FakeGraphTransport implements GraphTransport {
+  final List<GraphRequest> requests = [];
+  final FutureOr<GraphResponse> Function(GraphRequest request) _handler;
+
+  FakeGraphTransport(this._handler);
+
+  /// Convenience: always replies with [response], recording calls.
+  FakeGraphTransport.constant(GraphResponse response)
+      : _handler = ((_) => response);
+
+  @override
+  Future<GraphResponse> send(GraphRequest request) async {
+    requests.add(request);
+    return _handler(request);
+  }
+
+  GraphRequest get last => requests.last;
+}
+
+/// A `200 OK` JSON response.
+GraphResponse jsonOk(Object body) => GraphResponse(
+      statusCode: 200,
+      headers: const {'content-type': 'application/json'},
+      body: body is String ? body : jsonEncode(body),
+    );
+
+/// A `204 No Content` response (Graph's reply to PATCH/DELETE and member
+/// `$ref` writes).
+GraphResponse noContent() => const GraphResponse(statusCode: 204);
+
+/// An error response with a Graph error envelope.
+GraphResponse graphError(int status, String code, String message) =>
+    GraphResponse(
+      statusCode: status,
+      body: jsonEncode({
+        'error': {'code': code, 'message': message},
+      }),
+    );
+
+/// Reads a committed fixture from `test/fixtures/`. Tolerates being run from
+/// the package root or the workspace root.
+String readFixture(String name) {
+  final candidates = <String>[
+    'test/fixtures/$name',
+    'packages/azure_api/test/fixtures/$name',
+    Uri.base.resolve('test/fixtures/$name').toFilePath(),
+  ];
+  for (final path in candidates) {
+    final file = File(path);
+    if (file.existsSync()) return file.readAsStringSync();
+  }
+  throw FileSystemException('fixture not found', name);
+}
+
+/// Reads and decodes a JSON fixture object.
+Map<String, dynamic> readJsonFixture(String name) =>
+    jsonDecode(readFixture(name)) as Map<String, dynamic>;

--- a/packages/azure_api/test/token_cache_test.dart
+++ b/packages/azure_api/test/token_cache_test.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+import 'package:azure_api/azure_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('InMemoryTokenCache', () {
+    test('read/write/clear lifecycle', () async {
+      final cache = InMemoryTokenCache();
+      expect(await cache.read(), isNull);
+      await cache.write('payload');
+      expect(await cache.read(), 'payload');
+      await cache.clear();
+      expect(await cache.read(), isNull);
+    });
+  });
+
+  group('EncryptedTokenCache', () {
+    test('inner cache only ever sees ciphertext; read decrypts it', () async {
+      final inner = InMemoryTokenCache();
+      // A trivial reversible cipher stands in for the platform DPAPI /
+      // secure-storage transform the Flutter app supplies.
+      final cache = EncryptedTokenCache(
+        inner: inner,
+        encrypt: (p) => base64.encode(utf8.encode(p)),
+        decrypt: (c) => utf8.decode(base64.decode(c)),
+      );
+
+      await cache.write('{"access_token":"secret"}');
+
+      // At rest, the inner store holds ciphertext, not the plaintext token.
+      final atRest = await inner.read();
+      expect(atRest, isNot(contains('access_token')));
+      expect(atRest, base64.encode(utf8.encode('{"access_token":"secret"}')));
+
+      // Round-trip restores the original.
+      expect(await cache.read(), '{"access_token":"secret"}');
+    });
+
+    test('read returns null when nothing is stored', () async {
+      final cache = EncryptedTokenCache(
+        inner: InMemoryTokenCache(),
+        encrypt: (p) => p,
+        decrypt: (c) => c,
+      );
+      expect(await cache.read(), isNull);
+    });
+
+    test('clear wipes the inner store', () async {
+      final inner = InMemoryTokenCache();
+      final cache = EncryptedTokenCache(
+        inner: inner,
+        encrypt: (p) => p,
+        decrypt: (c) => c,
+      );
+      await cache.write('x');
+      await cache.clear();
+      expect(await inner.read(), isNull);
+    });
+  });
+}

--- a/packages/azure_api/test/user_manager_test.dart
+++ b/packages/azure_api/test/user_manager_test.dart
@@ -1,0 +1,242 @@
+import 'dart:convert';
+
+import 'package:azure_api/azure_api.dart';
+import 'package:test/test.dart';
+
+import 'support/fake_graph_transport.dart';
+
+void main() {
+  GraphClient clientWith(FakeGraphTransport transport) => GraphClient(
+        transport: transport,
+        auth: const StaticAuthProvider('T'),
+      );
+
+  group('load (\$filter + \$select bulk read)', () {
+    late FakeGraphTransport transport;
+    late UserManager users;
+
+    setUp(() {
+      transport = FakeGraphTransport((req) {
+        if (req.url.queryParameters[r'$skiptoken'] == 'PAGE2') {
+          return jsonOk(readFixture('users_page2.json'));
+        }
+        return jsonOk(readFixture('users_page1.json'));
+      });
+      users = UserManager(clientWith(transport));
+    });
+
+    test('issues the expected \$filter and \$select query strings', () async {
+      await users.load('GBS');
+      final first = transport.requests.first;
+      expect(first.method, 'GET');
+      expect(
+        first.url.queryParameters[r'$filter'],
+        "companyName eq 'GBS' or startswith(department,'GBS')",
+      );
+      expect(
+        first.url.queryParameters[r'$select'],
+        'id,userPrincipalName,employeeId,displayName,givenName,surname,'
+        'companyName,department,accountEnabled',
+      );
+      expect(first.url.queryParameters[r'$count'], 'true');
+    });
+
+    test('sends ConsistencyLevel: eventual for the advanced query', () async {
+      await users.load('GBS');
+      expect(
+        transport.requests.first.headers['ConsistencyLevel'],
+        'eventual',
+      );
+    });
+
+    test('follows pagination and maps every page to AzureUser', () async {
+      final result = await users.load('GBS');
+      expect(result.map((u) => u.upn), [
+        'ann.peeters@student.school.example',
+        'bram.janssens@student.school.example',
+        'carla.maes@school.example',
+      ]);
+    });
+
+    test('escapes single quotes in the prefix', () async {
+      await users.load("O'Brien");
+      expect(
+        transport.requests.first.url.queryParameters[r'$filter'],
+        "companyName eq 'O''Brien' or startswith(department,'O''Brien')",
+      );
+    });
+  });
+
+  group('delta', () {
+    test(
+        'uses the supplied token, filters by prefix, captures removals + token',
+        () async {
+      final transport = FakeGraphTransport((req) {
+        if (req.url.queryParameters[r'$skiptoken'] == 'DELTA2') {
+          return jsonOk(readFixture('users_delta_final.json'));
+        }
+        return jsonOk(readFixture('users_delta_page1.json'));
+      });
+      final users = UserManager(clientWith(transport));
+
+      final delta = await users.delta('OLDTOKEN', 'GBS');
+
+      expect(
+        transport.requests.first.url.queryParameters[r'$deltatoken'],
+        'OLDTOKEN',
+      );
+      // bram (GBS) + dirk (GBS) are in prefix; evy (OTHER) is filtered out.
+      expect(
+        delta.changed.map((u) => u.upn),
+        containsAll(<String>[
+          'bram.janssens@student.school.example',
+          'dirk.nieuw@student.school.example',
+        ]),
+      );
+      expect(
+        delta.changed.any((u) => u.upn.endsWith('@other.example')),
+        isFalse,
+      );
+      expect(delta.removedIds, ['00000000-0000-0000-0000-000000000001']);
+      expect(delta.deltaToken, 'NEWDELTA456');
+    });
+
+    test('latestDeltaToken primes a token via \$deltatoken=latest', () async {
+      final transport = FakeGraphTransport((req) {
+        expect(req.url.queryParameters[r'$deltatoken'], 'latest');
+        return jsonOk(readFixture('delta_latest.json'));
+      });
+      final users = UserManager(clientWith(transport));
+      expect(await users.latestDeltaToken(), 'PRIMEDTOKEN123');
+    });
+  });
+
+  group('getUser', () {
+    test('returns the parsed user', () async {
+      final transport =
+          FakeGraphTransport.constant(jsonOk(readFixture('user_single.json')));
+      final users = UserManager(clientWith(transport));
+      final user = await users.getUser('ann.peeters@student.school.example');
+      expect(user?.employeeId, 'W1001');
+    });
+
+    test('returns null on 404', () async {
+      final transport = FakeGraphTransport.constant(
+        graphError(404, 'Request_ResourceNotFound', 'not found'),
+      );
+      final users = UserManager(clientWith(transport));
+      expect(await users.getUser('ghost@school.example'), isNull);
+    });
+  });
+
+  group('createUser', () {
+    test('POSTs the Graph body with passwordProfile and default nickname',
+        () async {
+      final transport = FakeGraphTransport.constant(
+        jsonOk({
+          'id': 'new-id',
+          'userPrincipalName': 'k.l@student.school.example',
+        }),
+      );
+      final users = UserManager(clientWith(transport));
+
+      final created = await users.createUser(
+        userPrincipalName: 'k.l@student.school.example',
+        displayName: 'K L',
+        password: 'Secret123!',
+        givenName: 'K',
+        surname: 'L',
+        employeeId: 'W2',
+        department: '3A',
+        companyName: 'GBS',
+        jobTitle: 'LeerlingSec',
+      );
+
+      final body = jsonDecode(transport.last.body!) as Map<String, dynamic>;
+      expect(transport.last.method, 'POST');
+      expect(body['userPrincipalName'], 'k.l@student.school.example');
+      expect(body['mailNickname'], 'k.l');
+      expect(body['accountEnabled'], true);
+      expect(body['employeeId'], 'W2');
+      expect(body['jobTitle'], 'LeerlingSec');
+      expect(
+        (body['passwordProfile'] as Map)['password'],
+        'Secret123!',
+      );
+      expect(
+        (body['passwordProfile'] as Map)['forceChangePasswordNextSignIn'],
+        false,
+      );
+      expect(created.id, 'new-id');
+    });
+  });
+
+  group('updateUser', () {
+    test('PATCHes only the provided fields', () async {
+      final transport = FakeGraphTransport.constant(noContent());
+      final users = UserManager(clientWith(transport));
+      await users.updateUser('id-1', department: '4A', employeeId: 'W9');
+      final body = jsonDecode(transport.last.body!) as Map<String, dynamic>;
+      expect(transport.last.method, 'PATCH');
+      expect(body.keys, containsAll(<String>['department', 'employeeId']));
+      expect(body.containsKey('displayName'), isFalse);
+    });
+
+    test('no-op when nothing to change (no request issued)', () async {
+      final transport = FakeGraphTransport.constant(noContent());
+      final users = UserManager(clientWith(transport));
+      await users.updateUser('id-1');
+      expect(transport.requests, isEmpty);
+    });
+  });
+
+  group('deleteUser', () {
+    test('issues DELETE on the user resource', () async {
+      final transport = FakeGraphTransport.constant(noContent());
+      final users = UserManager(clientWith(transport));
+      await users.deleteUser('ann.peeters@student.school.example');
+      expect(transport.last.method, 'DELETE');
+      // The UPN is percent-encoded into the path segment.
+      expect(transport.last.url.path, contains('ann.peeters'));
+      expect(
+        Uri.decodeComponent(transport.last.url.pathSegments.last),
+        'ann.peeters@student.school.example',
+      );
+    });
+  });
+
+  group('createPrincipalName', () {
+    test('strips accents, lowercases, suffixes on collision', () async {
+      var calls = 0;
+      final transport = FakeGraphTransport((req) {
+        calls++;
+        // First candidate exists, second is free.
+        if (calls == 1) return jsonOk(readFixture('user_single.json'));
+        return graphError(404, 'Request_ResourceNotFound', 'not found');
+      });
+      final users = UserManager(clientWith(transport));
+
+      final upn = await users.createPrincipalName(
+        'Désiré',
+        'Müller',
+        'school.example',
+        isStudent: true,
+      );
+      expect(upn, 'desire.muller2@student.school.example');
+    });
+
+    test('staff land under the bare domain', () async {
+      final transport = FakeGraphTransport.constant(
+        graphError(404, 'Request_ResourceNotFound', 'not found'),
+      );
+      final users = UserManager(clientWith(transport));
+      final upn = await users.createPrincipalName(
+        'Jan',
+        'Peeters',
+        'school.example',
+        isStudent: false,
+      );
+      expect(upn, 'jan.peeters@school.example');
+    });
+  });
+}

--- a/packages/azure_api/tool/capture_responses.dart
+++ b/packages/azure_api/tool/capture_responses.dart
@@ -1,0 +1,135 @@
+/// Manual capture script: hits a real Azure AD tenant via Microsoft Graph and
+/// dumps raw JSON responses under `packages/azure_api/captures/` (gitignored,
+/// local-only).
+///
+/// Run from anywhere inside the repo, after exporting the env vars:
+///
+///     dart run packages/azure_api/tool/capture_responses.dart
+///
+/// Requires the `AZURE_*` vars (see `.azure.env.example` at the repo root).
+/// **Read-only**: it lists the school's users and groups and never writes.
+/// Uses the pre-acquired `AZURE_ACCESS_TOKEN`, so no interactive sign-in.
+///
+/// Output, per Graph call:
+///
+///     captures/<timestamp>/<name>.json   — raw Graph JSON (tokens redacted)
+///
+/// Use the captures to refresh the record-and-replay fixtures under
+/// `test/fixtures/`. **Scrub PII** (names, mails, employeeIds, object ids)
+/// before committing anything derived from a capture.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:account_core/account_core.dart' as core;
+import 'package:azure_api/azure_api.dart';
+
+Future<int> main(List<String> args) async {
+  final config = AzureLiveConfig.fromEnvironment();
+  if (config == null) {
+    stderr.writeln(
+      'AZURE_ACCESS_TOKEN is not set. Source .azure.env first '
+      '(see .azure.env.example).',
+    );
+    return 2;
+  }
+
+  final repoRoot = _findRepoRoot();
+  final stamp =
+      DateTime.now().toIso8601String().replaceAll(':', '-').split('.').first;
+  final outDir = Directory(
+    '${repoRoot.path}/packages/azure_api/captures/$stamp',
+  )..createSync(recursive: true);
+
+  final log = _StderrLog();
+  final transport = _CapturingTransport(HttpGraphTransport(), outDir);
+  final connector = AzureConnector(
+    credentials: AzureCredentials(
+      clientId: config.clientId,
+      tenantId: config.tenantId,
+      azureDomain: config.azureDomain,
+      schoolPrefix: config.schoolPrefix,
+    ),
+    authProvider: StaticAuthProvider(config.accessToken),
+    transport: transport,
+    log: log,
+  );
+
+  try {
+    final snapshot = await connector.sync();
+    stderr.writeln(
+      'Captured ${snapshot.users.length} users, ${snapshot.groups.length} '
+      'groups → ${outDir.path}',
+    );
+    return 0;
+  } on GraphException catch (e) {
+    stderr.writeln('Graph error: $e');
+    return 1;
+  } finally {
+    connector.close();
+  }
+}
+
+/// Wraps a transport, writing each response body to a numbered JSON file with
+/// bearer tokens redacted.
+class _CapturingTransport implements GraphTransport {
+  final GraphTransport _inner;
+  final Directory _outDir;
+  int _seq = 0;
+
+  _CapturingTransport(this._inner, this._outDir);
+
+  @override
+  Future<GraphResponse> send(GraphRequest request) async {
+    final resp = await _inner.send(request);
+    final name = _nameFor(request.url);
+    File('${_outDir.path}/${_seq++}-$name.json')
+        .writeAsStringSync(_pretty(resp.body));
+    return resp;
+  }
+
+  String _nameFor(Uri url) {
+    final segments = url.pathSegments.where((s) => s.isNotEmpty).toList();
+    final base = segments.isEmpty ? 'root' : segments.join('-');
+    return base.replaceAll(RegExp(r'[^a-zA-Z0-9_-]'), '_');
+  }
+
+  String _pretty(String body) {
+    try {
+      return const JsonEncoder.withIndent('  ')
+          .convert(jsonDecode(_redact(body)));
+    } on FormatException {
+      return _redact(body);
+    }
+  }
+
+  /// Redacts anything that looks like a bearer token from the captured text.
+  String _redact(String input) => input.replaceAllMapped(
+        RegExp(r'(Bearer\s+)[A-Za-z0-9._-]+'),
+        (m) => '${m.group(1)}[REDACTED]',
+      );
+}
+
+class _StderrLog implements core.ILog {
+  @override
+  void addMessage(core.Origin origin, String message) =>
+      stderr.writeln('[${origin.name}] $message');
+
+  @override
+  void addError(core.Origin origin, String message) =>
+      stderr.writeln('[${origin.name}] ERROR $message');
+}
+
+Directory _findRepoRoot() {
+  var dir = Directory.current;
+  while (true) {
+    if (File('${dir.path}/pubspec.yaml').existsSync() &&
+        Directory('${dir.path}/packages').existsSync()) {
+      return dir;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) return Directory.current;
+    dir = parent;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ workspace:
   - packages/account_core
   - packages/wisa_api
   - packages/smartschool_api
+  - packages/azure_api
 
 dev_dependencies:
   lints: ^5.1.0


### PR DESCRIPTION
## Summary

Pure-Dart `azure_api` package: a Microsoft Graph connector for Azure AD / Office 365 that fixes **PAIN-2** — the legacy "download ~6000 users to keep ~1000" anti-pattern.

- **`AzureConnector.sync({deltaToken, previous})`** — first/full sync does a `$filter`+`$select` bulk read scoped to the school and primes a delta token (`$deltatoken=latest`); subsequent syncs apply only the changed/removed set from `/users/delta` on top of the previous snapshot.
- **`UserManager`** — filtered read, `loadClientFiltered` fallback, delta, and CRUD (`getUser`, `createUser`, `updateUser`, `deleteUser`, `createPrincipalName`) mirroring legacy `UserManager.cs`.
- **`GroupManager`** — prefixed group listing + membership add/remove, with `$batch` coalescing (`addMembers`/`removeMembers`, chunked at Graph's 20-request ceiling).
- **Auth** — hand-rolled OAuth2 auth-code + PKCE over `package:oauth2` (public client, no secret); silent refresh with interactive fallback; pluggable **encrypted** `TokenCache` (`EncryptedTokenCache` decorator + `InMemoryTokenCache`; the Flutter app wires `flutter_secure_storage`). `LoopbackAuthorizer` is the desktop default. Rationale for choosing `oauth2` over `msal_auth`/`aad_oauth` is documented in the README.
- **Models** implement the `account_core` source-record interfaces (`AzureUser`, `AzureGroup`); `AzureSnapshot` is immutable and round-trips to disk.
- **`$select`** is pinned to exactly the fields the port uses; the server-side `startswith(department,…)`/`companyName eq` filter and its client-side `contains` fallback are documented.

### Out of scope / left open
- License/Teams/SharePoint provisioning and action evaluation (per the issue).
- OQ-3b (detecting an Azure user transferred to another school) — left open; current behaviour surfaces the action regardless.

## Notable extras
- Wires `azure_api` **and** the previously-omitted `smartschool_api` into the CI `dart test` list (CI only ran `account_core` + `wisa_api`).
- Adds `.azure.env.example` and `.gitignore` entries for the env file + captures dir.

## Test plan
- [x] `dart analyze --fatal-infos --fatal-warnings` clean across the workspace
- [x] `dart test packages/azure_api/test` — 69 tests pass (1 opt-in live test skipped offline)
- [x] Record-and-replay fixture tests with a swappable `GraphTransport`: `$filter`/`$select` string assertions, delta-token round-trip, pagination, `$batch` coalescing/chunking, CRUD request shapes
- [x] Auth tests with fakes: cache hit, silent refresh, interactive fallback, corrupt-cache recovery, token-cache encrypt/decrypt round-trip, PKCE/scope/tenant assertions
- [x] Line coverage ≈88% (≥80% target; only the real browser-launch wiring is intentionally uncovered)
- [ ] Opt-in read-only live test against a real tenant (`AZURE_*` env vars) — manual, honours the live-testing policy

Closes #22