### PR TITLE
Fix WISA SyncKlas mis-parse of comma-bearing class descriptions

### DIFF
--- a/packages/wisa_api/lib/src/csv/row_parsers.dart
+++ b/packages/wisa_api/lib/src/csv/row_parsers.dart
@@ -96,6 +96,17 @@ WisaStaff parseStaffRow(String line) {
 }
 
 /// Parses a `SyncKlas` row into a [WisaClassGroup].
+///
+/// WISA emits `OMSCHRIJVING` (the description) unquoted even when it
+/// contains a literal comma — e.g. `5 Onthaal, organisatie en sales` —
+/// which splits the row into more than the five header columns and, in the
+/// naive parser, shifts `ADMINGROEP` and `INSTELLINGSNUMMER` (issue #29).
+/// `OMSCHRIJVING` is the only free-text column; `KLAS`, `KLASGROEP`,
+/// `ADMINGROEP`, and `INSTELLINGSNUMMER` are codes that never contain a
+/// comma. So we anchor on the first two and last two columns and rejoin
+/// everything in between as the description. A properly quoted description
+/// (should WISA ever quote it) yields exactly five fields and parses
+/// identically.
 WisaClassGroup parseClassGroupRow(String line, {required int schoolId}) {
   try {
     final f = splitCsvLine(line);
@@ -108,9 +119,9 @@ WisaClassGroup parseClassGroupRow(String line, {required int schoolId}) {
     return WisaClassGroup(
       name: f[0].trim(),
       groupName: f[1].trim(),
-      description: f[2].trim(),
-      adminCode: f[3].trim(),
-      schoolCode: f[4].trim(),
+      description: f.sublist(2, f.length - 2).join(',').trim(),
+      adminCode: f[f.length - 2].trim(),
+      schoolCode: f[f.length - 1].trim(),
       schoolId: schoolId,
     );
   } on CsvRowParseException {

--- a/packages/wisa_api/test/csv/row_parsers_test.dart
+++ b/packages/wisa_api/test/csv/row_parsers_test.dart
@@ -134,6 +134,41 @@ void main() {
       final g = parseClassGroupRow('Foo,00,,ASO,123456', schoolId: 25);
       expect(g.year, -1);
     });
+
+    test('rejoins an unquoted comma-bearing description (issue #29)', () {
+      // WISA does not quote OMSCHRIJVING, so the embedded comma splits the
+      // row into six fields. The parser must rejoin the description and
+      // keep adminCode/schoolCode anchored to the trailing columns —
+      // otherwise the institute number is silently dropped.
+      final g = parseClassGroupRow(
+        '5OOS,00,5 Onthaal, organisatie en sales,043117,125252',
+        schoolId: 25,
+      );
+      expect(g.name, '5OOS');
+      expect(g.groupName, '00');
+      expect(g.description, '5 Onthaal, organisatie en sales');
+      expect(g.adminCode, '043117');
+      expect(g.schoolCode, '125252');
+    });
+
+    test('rejoins a description containing multiple commas', () {
+      final g = parseClassGroupRow('7X,00,a, b, c,111,222', schoolId: 25);
+      expect(g.description, 'a, b, c');
+      expect(g.adminCode, '111');
+      expect(g.schoolCode, '222');
+    });
+
+    test('still parses a quoted comma-bearing description', () {
+      // If WISA ever quotes the field, the splitter yields five fields and
+      // the result must be identical to the unquoted path.
+      final g = parseClassGroupRow(
+        '5OOS,00,"5 Onthaal, organisatie en sales",043117,125252',
+        schoolId: 25,
+      );
+      expect(g.description, '5 Onthaal, organisatie en sales');
+      expect(g.adminCode, '043117');
+      expect(g.schoolCode, '125252');
+    });
   });
 
   group('parseSchoolRow', () {

--- a/packages/wisa_api/test/fixtures/sync_klas.csv
+++ b/packages/wisa_api/test/fixtures/sync_klas.csv
@@ -74,7 +74,7 @@ KLAS,KLASGROEP,OMSCHRIJVING,ADMINGROEP,INSTELLINGSNUMMER
 5LWE,00,5 Latijn-wetenschappen,043104,125261
 5M,00,5 Moderealisatie,043112,125252
 5MTWE,00,5 Moderne talen-wetenschappen,043113,125261
-5OOS,00,5 Onthaal, organisatie en sales,043117
+5OOS,00,5 Onthaal, organisatie en sales,043117,125252
 5OPB,00,5 Opvoeding en begeleiding,043119,125252
 5TO,00,5 Toerisme,043147,125252
 5WEWI1,00,5 Wetenschappen-wiskunde 1,043142,125261
@@ -94,7 +94,7 @@ KLAS,KLASGROEP,OMSCHRIJVING,ADMINGROEP,INSTELLINGSNUMMER
 6LWE,00,6 Latijn-wetenschappen,043532,125261
 6M,00,6 Moderealisatie,043540,125252
 6MTWE,00,6 Moderne talen-wetenschappen,043541,125261
-6OOS,00,6 Onthaal, organisatie en sales,043545
+6OOS,00,6 Onthaal, organisatie en sales,043545,125252
 6OPB,00,6 Opvoeding en begeleiding,043547,125252
 6TO,00,6 Toerisme,043575,125252
 6WEWI1,00,6 Wetenschappen-wiskunde 1,043570,125261

--- a/packages/wisa_api/tool/redact_fixtures.dart
+++ b/packages/wisa_api/tool/redact_fixtures.dart
@@ -174,6 +174,27 @@ void _writeStaff(Directory inDir, Directory outDir) {
       .writeAsStringSync(buf.toString(), flush: true);
 }
 
+/// Class groups whose `OMSCHRIJVING` contains a literal comma. WISA emits
+/// these *unquoted*, so the legacy WPF parser mis-split them before caching
+/// to `wisaClasses.json` — shifting `AdminCode` and dropping the institute
+/// number (issue #29). The cache is therefore an unreliable source for
+/// these rows, so we restore WISA's real wire values (captured live against
+/// school 25 / ISMAA) keyed by class name. Keep this map in sync with any
+/// new comma-bearing descriptions a fresh capture turns up.
+const Map<String, ({String description, String adminCode, String schoolCode})>
+    _commaDescriptionRepairs = {
+  '5OOS': (
+    description: '5 Onthaal, organisatie en sales',
+    adminCode: '043117',
+    schoolCode: '125252',
+  ),
+  '6OOS': (
+    description: '6 Onthaal, organisatie en sales',
+    adminCode: '043545',
+    schoolCode: '125252',
+  ),
+};
+
 void _writeClassGroups(Directory inDir, Directory outDir) {
   final json = jsonDecode(
     File('${inDir.path}/wisaClasses.json').readAsStringSync(),
@@ -185,15 +206,20 @@ void _writeClassGroups(Directory inDir, Directory outDir) {
   );
   for (final g in groups) {
     // Class group fields are not PII — class names (`1A`), descriptions
-    // (`1ste leerjaar A`), admin/school codes are institutional. Some
-    // descriptions contain commas (`"Onthaal, organisatie en sales"`),
-    // so each field is CSV-escaped.
-    final name = _csvField(_toAscii(g['Name'] as String? ?? ''));
-    final groupName = _csvField(_toAscii(g['GroupName'] as String? ?? ''));
+    // (`1ste leerjaar A`), admin/school codes are institutional. WISA emits
+    // every field unquoted, including descriptions that contain a literal
+    // comma (`5 Onthaal, organisatie en sales`), so we mirror that exactly
+    // — no CSV quoting — which keeps the fixture exercising the parser's
+    // comma-rejoin path (issue #29).
+    final name = _toAscii(g['Name'] as String? ?? '');
+    final repair = _commaDescriptionRepairs[name];
+    final groupName = _toAscii(g['GroupName'] as String? ?? '');
     final description =
-        _csvField(_toAscii(g['Description'] as String? ?? ''));
-    final adminCode = _csvField(_toAscii(g['AdminCode'] as String? ?? ''));
-    final schoolCode = _csvField(_toAscii(g['SchoolCode'] as String? ?? ''));
+        repair?.description ?? _toAscii(g['Description'] as String? ?? '');
+    final adminCode =
+        repair?.adminCode ?? _toAscii(g['AdminCode'] as String? ?? '');
+    final schoolCode =
+        repair?.schoolCode ?? _toAscii(g['SchoolCode'] as String? ?? '');
     buf.writeln('$name,$groupName,$description,$adminCode,$schoolCode');
   }
   File('${outDir.path}/sync_klas.csv')


### PR DESCRIPTION
## Summary
- WISA's `GetCSVData` emits `OMSCHRIJVING` **unquoted** even when it contains a literal comma (`5 Onthaal, organisatie en sales`), splitting the row into more than five columns. The old parser shifted `ADMINGROEP` and silently dropped `INSTELLINGSNUMMER`, corrupting `schoolCode` and breaking `ReplaceInstitute` matching.
- A live capture (school 25 / ISMAA) **confirmed WISA does not quote** the field: 0 quote characters in the whole payload; `5OOS`/`6OOS` split into 6 fields. This rules out issue #29's avenue 3 ("maybe it's already fine") — a real fix is needed.
- `parseClassGroupRow` now **column-anchors**: `OMSCHRIJVING` is the only free-text column, so it anchors on the first two and last two columns and rejoins everything in between as the description. A quoted field (if WISA ever quotes) yields five fields and parses identically.
- Corrected the redacted `sync_klas.csv` fixture: its `5OOS`/`6OOS` rows carried the *legacy parser's* corruption (institute number already lost) rather than WISA's real wire format. They now mirror the live capture (unquoted, 6-field, institute number `125252`).
- `redact_fixtures.dart` gains a documented known-repair map so regenerating fixtures from the corrupted legacy cache no longer reverts those rows.

## Test plan
- [x] `dart analyze` clean for `wisa_api`
- [x] `dart test` — all pass (live integration tests self-skip offline)
- [x] New unit tests in `row_parsers_test.dart`: unquoted comma row (issue #29), multi-comma row, and quoted-path regression
- [x] Existing `connector_test` `ReplaceInstitute` test still matches institute `125252` (now including the restored OOS rows)

Closes #29