### PR TITLE
Live-testing pattern: wire Azure into CI + OIDC token strategy (#32)

### DIFF
--- a/.azure.env.example
+++ b/.azure.env.example
@@ -1,27 +1,26 @@
 # Live Azure AD / Microsoft Graph config for the capture script and the
 # read-only integration test.
 #
-# Copy this file to `.azure.env` (gitignored) and fill in the real values,
-# then source it before running:
+# Copy this file to `.azure.env` (gitignored) and fill in the real values.
+# Then run the live tests via the helper, which loads this file AND mints a
+# fresh token for you:
 #
-#     # PowerShell
-#     Get-Content .azure.env | ForEach-Object {
-#       if ($_ -match '^([^#=]+)=(.*)$') { Set-Item "env:$($matches[1])" $matches[2] }
-#     }
-#
-#     # bash
-#     set -a; source .azure.env; set +a
+#     ./tool/live-tests.ps1 -Only azure
 #
 # Never commit a populated copy. Real values stay local.
 #
-# AZURE_CLIENT_ID / AZURE_TENANT_ID identify the registered public-client app.
+# AZURE_CLIENT_ID / AZURE_TENANT_ID identify the registered app.
 # AZURE_DOMAIN is the verified domain users live under (e.g. `school.example`).
 # AZURE_SCHOOL_PREFIX scopes the $filter reads and group listing.
-# AZURE_ACCESS_TOKEN is a pre-acquired Graph bearer token — the read-only test
-# skips interactive sign-in. Get one with:
 #
-#     az account get-access-token --resource https://graph.microsoft.com \
-#       --query accessToken -o tsv
+# AZURE_ACCESS_TOKEN is a Graph bearer token. It expires in ~1 hour, so do
+# NOT paste a long-lived value here -- leave it blank and let
+# tool/live-tests.ps1 mint a fresh one each run (it calls
+# `az account get-access-token`). CI mints its own via OIDC and never stores
+# one. Only set it by hand for a quick ad-hoc run, e.g.:
+#
+#     $env:AZURE_ACCESS_TOKEN = az account get-access-token `
+#       --resource https://graph.microsoft.com --query accessToken -o tsv
 
 AZURE_CLIENT_ID=
 AZURE_TENANT_ID=

--- a/.claude/skills/live-tests/SKILL.md
+++ b/.claude/skills/live-tests/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: live-tests
+description: Run the opt-in live integration tests against the real WISA, Smartschool, and Azure hosts. Loads the local .*.env credential files and, for Azure, mints a fresh read-only Graph token via the Azure CLI (a stored bearer token expires in ~1h). All live tests are read-only (sync only) per the project's live-testing policy. User-invocable as /live-tests; pass a connector name (wisa, smartschool, azure) to run just one.
+---
+
+# Run live integration tests
+
+Drives each connector's `test/integration/` suite against its real host,
+provisioning credentials from the gitignored `.wisa.env`, `.smartschool.env`,
+and `.azure.env` files. Wraps [`tool/live-tests.ps1`](../../../tool/live-tests.ps1).
+
+## When to use
+
+- The user invokes `/live-tests` (optionally `/live-tests azure`).
+- The user asks to run the live/integration tests against real WISA,
+  Smartschool, or Azure.
+
+These tests hit production school systems. They are **read-only** (sync only)
+by design — never extend them to writes here; write coverage stays manual and
+local per the live-testing policy.
+
+## Prerequisites
+
+1. The relevant `.*.env` file(s) exist at the repo root, populated from the
+   matching `.<name>.env.example`. A missing file just self-skips that
+   connector (its test skips when its trigger var is empty).
+2. **Azure only:** `az login` has been run with an account that can read the
+   directory. The script mints a fresh Graph token via
+   `az account get-access-token`; it does not read a stored token.
+
+## Steps
+
+1. Pick the scope from the argument: `wisa`, `smartschool`, `azure`, or (no
+   argument) all three.
+2. Run the helper from the repo root:
+   ```powershell
+   ./tool/live-tests.ps1            # all connectors
+   ./tool/live-tests.ps1 -Only azure
+   ```
+3. Report the result. The Azure sync takes ~30s (per-group member fetch); the
+   test carries a 3-minute timeout. Each connector logs counts only, never row
+   contents or credentials.
+4. If Azure fails with an auth error (`401`, "JWT is not well formed",
+   "token expired"), the cause is almost always that `az login` is stale —
+   re-run `az login` and try again. Do **not** paste a long-lived token into
+   `.azure.env`.
+
+## Notes
+
+- The script sets credentials into the current process environment; they
+  persist for the rest of the shell session. Open a fresh shell to clear them.
+- CI runs these same tests but authenticates Azure via OIDC federation (no
+  stored secret) — see [.github/workflows/dart.yml](../../../.github/workflows/dart.yml).

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -108,12 +108,15 @@ jobs:
 
       # --- Azure: mint a fresh read-only Graph token via OIDC ---
       # Gated on AZURE_CLIENT_ID so the job still runs (and the Azure test
-      # self-skips) before the Azure app/federation is provisioned. The
-      # federated app holds only User.Read.All + Group.Read.All, so the
-      # minted token cannot write — the read-only guarantee is at the
-      # credential layer, per the live-testing policy.
+      # self-skips) if the Azure secrets are ever cleared. Also gated to the
+      # refs we created federated credentials for — pull requests and the
+      # `dev` branch; on any other ref these steps skip and the Azure test
+      # self-skips on the empty token. The federated app (AccountManager-CI-
+      # ReadOnly) holds only User.Read.All + Group.Read.All, so the minted
+      # token cannot write — the read-only guarantee is at the credential
+      # layer, per the live-testing policy.
       - name: Azure login (OIDC — no stored secret)
-        if: env.AZURE_CLIENT_ID != ''
+        if: env.AZURE_CLIENT_ID != '' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/dev')
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -121,7 +124,7 @@ jobs:
           allow-no-subscriptions: true
 
       - name: Mint read-only Graph token
-        if: env.AZURE_CLIENT_ID != ''
+        if: env.AZURE_CLIENT_ID != '' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/dev')
         run: |
           token=$(az account get-access-token \
             --resource https://graph.microsoft.com \

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -9,15 +9,25 @@
 #                  secrets anyway, the gate is belt-and-suspenders.
 #
 # Operator setup for live-test (one-time):
-#   Add the following repository secrets, all read-only credentials:
+#   WISA + Smartschool authenticate with stored read-only credentials, kept
+#   as repository secrets:
 #     WISA:        WISA_SERVER, WISA_PORT, WISA_DATABASE,
 #                  WISA_USERNAME, WISA_PASSWORD, WISA_SCHOOL_ID
 #     Smartschool: SMARTSCHOOL_SITE, SMARTSCHOOL_ACCESSCODE
-#     Azure:       AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_DOMAIN,
-#                  AZURE_SCHOOL_PREFIX, AZURE_ACCESS_TOKEN
+#   Azure uses OIDC workload-identity federation — NO token or secret is
+#   stored. A short-lived bearer token expires in ~1h, so storing one is
+#   pointless; instead a fresh read-only Graph token is minted per run via
+#   `azure/login` + `az account get-access-token`. Provide:
+#     AZURE_CLIENT_ID, AZURE_TENANT_ID  — the federated read-only app (these
+#                                         are identifiers, not secrets)
+#     AZURE_DOMAIN, AZURE_SCHOOL_PREFIX — tenant config for the read filter
+#   One-time Azure setup — an app registration with User.Read.All +
+#   Group.Read.All *application* permissions (admin-consented) and a
+#   federated credential trusting this repo — is documented in
+#   packages/azure_api/README.md.
 #   See each package's README.md and the matching .<name>.env.example at the
 #   repo root for the variable meanings. Per the live-testing policy, every
-#   one of these is a read-only credential — CI live tests never write.
+#   credential is read-only — CI live tests never write.
 #
 # Overlap note: an older workflow (`ci.yml`) also runs `dart analyze` +
 # `dart test` on pull_request, plus coverage / SonarCloud. The two
@@ -66,6 +76,11 @@ jobs:
     # without this gate, but skipping the job outright keeps the build
     # matrix tidy.
     if: github.repository == 'yvanvds/AccountManager'
+    permissions:
+      # OIDC: let the runner request a federated identity token so
+      # azure/login can mint a read-only Graph token — nothing is stored.
+      id-token: write
+      contents: read
     env:
       WISA_SERVER: ${{ secrets.WISA_SERVER }}
       WISA_PORT: ${{ secrets.WISA_PORT }}
@@ -79,7 +94,8 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_DOMAIN: ${{ secrets.AZURE_DOMAIN }}
       AZURE_SCHOOL_PREFIX: ${{ secrets.AZURE_SCHOOL_PREFIX }}
-      AZURE_ACCESS_TOKEN: ${{ secrets.AZURE_ACCESS_TOKEN }}
+      # AZURE_ACCESS_TOKEN is intentionally absent: it is minted at runtime
+      # by the steps below (OIDC), never stored as a secret.
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -89,6 +105,29 @@ jobs:
 
       - name: dart pub get
         run: dart pub get
+
+      # --- Azure: mint a fresh read-only Graph token via OIDC ---
+      # Gated on AZURE_CLIENT_ID so the job still runs (and the Azure test
+      # self-skips) before the Azure app/federation is provisioned. The
+      # federated app holds only User.Read.All + Group.Read.All, so the
+      # minted token cannot write — the read-only guarantee is at the
+      # credential layer, per the live-testing policy.
+      - name: Azure login (OIDC — no stored secret)
+        if: env.AZURE_CLIENT_ID != ''
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Mint read-only Graph token
+        if: env.AZURE_CLIENT_ID != ''
+        run: |
+          token=$(az account get-access-token \
+            --resource https://graph.microsoft.com \
+            --query accessToken -o tsv)
+          echo "::add-mask::$token"
+          echo "AZURE_ACCESS_TOKEN=$token" >> "$GITHUB_ENV"
 
       - name: Run live integration tests
         # If the credentials are unset (secrets not configured yet) the

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -2,16 +2,22 @@
 #
 # Two jobs:
 #   - test       : offline `dart analyze` + `dart test`. Always runs.
-#   - live-test  : opt-in WISA integration test (`test/integration/`).
+#   - live-test  : opt-in WISA + Smartschool + Azure integration tests
+#                  (each package's `test/integration/`, all read-only).
 #                  Gated to this repository so fork PRs cannot trigger
 #                  secret access — fork pull_request runs do not expose
 #                  secrets anyway, the gate is belt-and-suspenders.
 #
 # Operator setup for live-test (one-time):
-#   Add the following six repository secrets:
-#     WISA_SERVER, WISA_PORT, WISA_DATABASE,
-#     WISA_USERNAME, WISA_PASSWORD, WISA_SCHOOL_ID
-#   See packages/wisa_api/README.md and .wisa.env.example for the names.
+#   Add the following repository secrets, all read-only credentials:
+#     WISA:        WISA_SERVER, WISA_PORT, WISA_DATABASE,
+#                  WISA_USERNAME, WISA_PASSWORD, WISA_SCHOOL_ID
+#     Smartschool: SMARTSCHOOL_SITE, SMARTSCHOOL_ACCESSCODE
+#     Azure:       AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_DOMAIN,
+#                  AZURE_SCHOOL_PREFIX, AZURE_ACCESS_TOKEN
+#   See each package's README.md and the matching .<name>.env.example at the
+#   repo root for the variable meanings. Per the live-testing policy, every
+#   one of these is a read-only credential — CI live tests never write.
 #
 # Overlap note: an older workflow (`ci.yml`) also runs `dart analyze` +
 # `dart test` on pull_request, plus coverage / SonarCloud. The two
@@ -47,13 +53,13 @@ jobs:
         # Dart workspaces don't auto-discover tests from the root; pass
         # each workspace package's test/ directory explicitly. Update
         # this list whenever a new package is added to pubspec.yaml.
-        # No WISA_USERNAME / SMARTSCHOOL_ACCESSCODE in this job — the
-        # integration tests self-skip, see each package's
+        # No WISA_USERNAME / SMARTSCHOOL_ACCESSCODE / AZURE_ACCESS_TOKEN in
+        # this job — the integration tests self-skip, see each package's
         # test/integration/.
-        run: dart test packages/account_core/test packages/wisa_api/test packages/smartschool_api/test
+        run: dart test packages/account_core/test packages/wisa_api/test packages/smartschool_api/test packages/azure_api/test
 
   live-test:
-    name: WISA + Smartschool live integration
+    name: WISA + Smartschool + Azure live integration
     needs: test
     runs-on: ubuntu-latest
     # Only run on the canonical repo. Fork PRs do not get secrets even
@@ -69,6 +75,11 @@ jobs:
       WISA_SCHOOL_ID: ${{ secrets.WISA_SCHOOL_ID }}
       SMARTSCHOOL_SITE: ${{ secrets.SMARTSCHOOL_SITE }}
       SMARTSCHOOL_ACCESSCODE: ${{ secrets.SMARTSCHOOL_ACCESSCODE }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_DOMAIN: ${{ secrets.AZURE_DOMAIN }}
+      AZURE_SCHOOL_PREFIX: ${{ secrets.AZURE_SCHOOL_PREFIX }}
+      AZURE_ACCESS_TOKEN: ${{ secrets.AZURE_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -83,5 +94,6 @@ jobs:
         # If the credentials are unset (secrets not configured yet) the
         # tests self-skip and this still passes — by design, so the
         # workflow can land before secrets are provisioned. The Smartschool
-        # live test is read-only (sync only); see the live-testing policy.
-        run: dart test packages/wisa_api/test/integration/ packages/smartschool_api/test/integration/
+        # and Azure live tests are read-only (sync only); see the
+        # live-testing policy.
+        run: dart test packages/wisa_api/test/integration/ packages/smartschool_api/test/integration/ packages/azure_api/test/integration/

--- a/packages/azure_api/README.md
+++ b/packages/azure_api/README.md
@@ -127,8 +127,46 @@ The opt-in [`test/integration/azure_live_test.dart`](test/integration/azure_live
 runs **read-only** against a real tenant (per the project's live-testing
 policy — CI live tests never write). It skips unless the `AZURE_*` env vars are
 present, so `dart test` stays offline by default. See
-[`.azure.env.example`](../../.azure.env.example) for the variables; supply a
-pre-acquired bearer token via `AZURE_ACCESS_TOKEN` to skip interactive
-sign-in. Refresh fixtures with
+[`.azure.env.example`](../../.azure.env.example) for the variables.
+
+A Graph bearer token expires in ~1 hour, so the token is **never stored** —
+it is minted fresh each run. Both contexts use the same dedicated read-only
+app registration; only the way they authenticate to it differs.
+
+**Locally** — run the helper, which loads `.azure.env` and mints a fresh
+token via the Azure CLI before invoking the test:
+
+```
+./tool/live-tests.ps1 -Only azure   # or omit -Only to run all three connectors
+```
+
+It calls `az account get-access-token` under the hood, so `az login` must
+have been run with an account that can read the directory. The full sync
+fans out a per-group member fetch and takes ~30s; the test carries a 3-minute
+`@Timeout` to suit.
+
+**In CI** — the `live-test` job uses **OIDC workload-identity federation**
+(`azure/login@v2`): GitHub issues a short-lived identity token, Azure trusts
+this repo via a federated credential and mints a Graph token in-job. Nothing
+is stored as a secret. Only `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,
+`AZURE_DOMAIN`, `AZURE_SCHOOL_PREFIX` are configured (identifiers + config,
+not credentials).
+
+#### One-time Azure setup (operator)
+
+1. Register an app (or reuse one) and grant it the **application** Graph
+   permissions `User.Read.All` and `Group.Read.All` — **no write scopes** —
+   then grant admin consent. This makes the credential read-only at the
+   directory level, which is the hard guarantee the live-testing policy
+   requires.
+2. Add a **federated credential** on that app for GitHub Actions: issuer
+   `https://token.actions.githubusercontent.com`, subject matching this repo
+   (e.g. `repo:yvanvds/AccountManager:ref:refs/heads/dev`), audience
+   `api://AzureADTokenExchange`.
+3. In the repo, set `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_DOMAIN`,
+   `AZURE_SCHOOL_PREFIX` (Settings → Secrets and variables → Actions). No
+   token or client secret is ever added.
+
+Refresh record-and-replay fixtures with
 [`tool/capture_responses.dart`](tool/capture_responses.dart) (redacts tokens;
 **scrub PII** before committing).

--- a/packages/azure_api/test/integration/azure_live_test.dart
+++ b/packages/azure_api/test/integration/azure_live_test.dart
@@ -1,7 +1,16 @@
+@Timeout(Duration(minutes: 3))
+library;
+
 import 'package:azure_api/azure_api.dart';
 import 'package:test/test.dart';
 
 /// Opt-in, **read-only** live test against a real Azure AD tenant.
+///
+/// `sync()` fans out a per-group member fetch against the live tenant, so a
+/// full read takes ~30s+ locally — well over the 30s default test timeout.
+/// The generous [Timeout] keeps the live job from failing on duration alone;
+/// a true hang still trips the limit. (The N+1 member pull is the connector's
+/// "Azure bulk pull" concern, tracked separately — not a test bug.)
 ///
 /// Honours the repo live-testing policy: CI live tests never write. The
 /// interactive sign-in is skipped — a pre-acquired bearer token is supplied

--- a/packages/smartschool_api/README.md
+++ b/packages/smartschool_api/README.md
@@ -78,6 +78,16 @@ When `SMARTSCHOOL_ACCESSCODE` is empty the integration test self-skips, so
 `dart test` stays offline by default. The live test is **read-only** (sync
 only) per the project's live-testing policy.
 
+> **Credential caveat.** Smartschool does **not** offer a read-only API
+> tier: the single `SMARTSCHOOL_ACCESSCODE` passphrase is the same
+> credential used for writes (create user, set password, …). So unlike the
+> Azure connector — whose CI credential is read-only at the directory level —
+> the read-only stance here is enforced **client-side** (the test calls only
+> `sync()`), which is weaker than a credential-level guarantee. This is the
+> deliberate, accepted trade-off the live-testing policy flags; it matches how
+> the equally-capable `WISA_*` credential is used in CI. Write coverage stays
+> in offline unit tests against recorded fixtures, never live.
+
 ### Capture script
 
 Run from anywhere inside the repo, after exporting the env vars:

--- a/tool/live-tests.ps1
+++ b/tool/live-tests.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+  Run the opt-in live integration tests against the real WISA / Smartschool /
+  Azure hosts, provisioning credentials from the local .*.env files.
+
+.DESCRIPTION
+  Loads .wisa.env, .smartschool.env and .azure.env (all gitignored) into the
+  process environment, then runs each connector's integration test.
+
+  Azure is special: a stored bearer token is useless because it expires in
+  ~1 hour. So instead of reading AZURE_ACCESS_TOKEN from a file, this script
+  mints a FRESH read-only Graph token via the Azure CLI
+  (az account get-access-token) -- the local mirror of how CI mints one via
+  OIDC workload-identity federation. The other AZURE_* values (client/tenant/
+  domain/prefix) still come from .azure.env.
+
+  Each connector's test self-skips when its trigger var is absent, so a
+  missing .env file just skips that connector rather than failing.
+
+.PARAMETER Only
+  Restrict the run to one connector: wisa, smartschool, or azure.
+  Default: all.
+
+.EXAMPLE
+  ./tool/live-tests.ps1
+  ./tool/live-tests.ps1 -Only azure
+#>
+[CmdletBinding()]
+param(
+  [ValidateSet('all', 'wisa', 'smartschool', 'azure')]
+  [string]$Only = 'all'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+function Import-EnvFile {
+  param([string]$Path)
+  if (-not (Test-Path $Path)) {
+    Write-Host "  (skip) $(Split-Path -Leaf $Path) not found; its tests will self-skip"
+    return
+  }
+  Get-Content $Path | ForEach-Object {
+    if ($_ -match '^([^#=]+)=(.*)$') {
+      Set-Item "env:$($matches[1].Trim())" $matches[2]
+    }
+  }
+  Write-Host "  loaded $(Split-Path -Leaf $Path)"
+}
+
+Push-Location $repoRoot
+try {
+  $dirs = @()
+
+  if ($Only -in @('all', 'wisa')) {
+    Import-EnvFile (Join-Path $repoRoot '.wisa.env')
+    $dirs += 'packages/wisa_api/test/integration/'
+  }
+
+  if ($Only -in @('all', 'smartschool')) {
+    Import-EnvFile (Join-Path $repoRoot '.smartschool.env')
+    $dirs += 'packages/smartschool_api/test/integration/'
+  }
+
+  if ($Only -in @('all', 'azure')) {
+    Import-EnvFile (Join-Path $repoRoot '.azure.env')
+    Write-Host "  minting fresh read-only Azure Graph token via az..."
+    $tok = az account get-access-token --resource https://graph.microsoft.com --query accessToken -o tsv
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($tok)) {
+      throw "az account get-access-token failed. Run 'az login' first (with an account that has directory read access)."
+    }
+    $env:AZURE_ACCESS_TOKEN = $tok
+    $dirs += 'packages/azure_api/test/integration/'
+  }
+
+  $dirList = $dirs -join ' '
+  Write-Host ""
+  Write-Host "dart test $dirList"
+  dart test @dirs
+}
+finally {
+  Pop-Location
+}


### PR DESCRIPTION
## Summary

Completes the live-testing pattern for the Smartschool and Azure connectors (issue #32), which were built after the umbrella issue was filed.

- **CI wiring** — `azure_api` is now in both CI jobs (offline `dart test` + gated `live-test`). All three connectors run in `live-test`.
- **Azure token strategy** — a Graph bearer token expires in ~1h, so it is **never stored**. CI mints one per run via **OIDC workload-identity federation** (`azure/login@v2`, no stored secret) against a dedicated **read-only** app registration (`User.Read.All` + `Group.Read.All`, no write scopes). Locally, `tool/live-tests.ps1` mints one via `az`. The Azure steps are gated to the federated refs (PR + dev).
- **Azure test timeout** — live `sync()` does a per-group member fetch (~34s); added a 3-minute `@Timeout` so it doesn't trip the 30s default.
- **Local ergonomics** — `tool/live-tests.ps1` + a `/live-tests` skill load the `.*.env` files and run the suites.
- **Docs** — azure_api & smartschool_api READMEs, `.azure.env.example`, workflow header. The Smartschool credential caveat (no read-only tier; client-side read-only) and the Azure read-only app are both documented, resolving the issue's two open questions.

## Operator setup done out-of-band
- Entra app `AccountManager-CI-ReadOnly` (read-only, OIDC-only, no client secret) with federated credentials for `pull_request` and `refs/heads/dev`.
- Repo secrets set: `AZURE_CLIENT_ID/TENANT_ID/DOMAIN/SCHOOL_PREFIX`, `SMARTSCHOOL_SITE/ACCESSCODE`.

## Test plan
- [x] Offline `dart test` (all packages) — 335 passed, 5 skipped.
- [x] All three live suites pass locally via `tool/live-tests.ps1`.
- [x] Azure app-only read verified (throwaway secret, then deleted).
- [ ] **This PR's CI run verifies the OIDC federation path end-to-end** (the `github-pr` credential exists for exactly this).

Closes #32