### PR TITLE
Make /cleanup delete remote branches too

### DIFF
--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: cleanup
-description: Post-merge branch tidying for this repo. Run after a PR merges to refresh local `dev`, drop stale remote-tracking refs, delete local branches that have been merged or whose upstream is gone, and close the GitHub issues those branches were tracking. Pairs with the `/issue` skill — `/issue` creates branches, this skill reaps them. Never touches `dev` or `master`, never force-deletes unmerged work. User-invocable as /cleanup.
+description: Post-merge branch tidying for this repo. Run after a PR merges to refresh local `dev`, drop stale remote-tracking refs, delete merged branches both locally and on the remote, and close the GitHub issues those branches were tracking. Pairs with the `/issue` skill — `/issue` creates branches, this skill reaps them. Never touches `dev` or `master`, never force-deletes unmerged work. User-invocable as /cleanup.
 ---
 
 # Post-merge cleanup
 
-Use this after a successful PR merge to keep the local working copy aligned with `dev`, prune stale branches, and close the GitHub issues those branches were tracking. Pairs with the `/issue` skill.
+Use this after a successful PR merge to keep the local working copy aligned with `dev`, prune stale branches (local and remote), and close the GitHub issues those branches were tracking. Pairs with the `/issue` skill.
 
 ## When to use
 
@@ -16,9 +16,9 @@ Do **not** run this proactively during other work. It's a deliberate end-of-iter
 
 ## Hard rules
 
-- **Never** delete `dev` or `master`. Even if `git branch --merged` lists them, skip.
+- **Never** delete `dev` or `master` — neither the local branch nor the remote branch. Even if `git branch --merged` lists them, skip.
 - **Never** use `git branch -D` (force-delete). Only `git branch -d` (safe — refuses if a branch isn't fully merged).
-- **Never** `git push --delete`. Remote-branch deletion is the PR merge setting's job, not this skill's.
+- **Delete the remote branch only after its local copy was safely deleted.** Remote deletion (`git push origin --delete <branch>`) applies solely to approved candidate branches whose local `git branch -d` succeeded. If the local delete was refused, leave the remote alone.
 - **Never** run on a dirty working tree without explicit user consent — uncommitted work could be lost.
 - **Confirm before deleting or closing.** Print the planned actions (branch deletes + issue closes) in one list and wait for the user's "yes" (or list of exceptions) before anything runs.
 - **Only close issues whose branch you successfully delete.** If `git branch -d` refused (unmerged work), leave the issue open — the user may still be working on it.
@@ -72,53 +72,67 @@ Classify the result:
 
 Branches that don't match `issue-<num>-*` (ad-hoc/experiment branches) are processed for deletion only; there's no issue to close.
 
-**Rule of thumb:** if a branch is merged into `dev` (Step 3 category (a)) and tracks an `OPEN` issue, the plan is always to **delete the branch and close the issue**.
+**Rule of thumb:** if a branch is merged into `dev` (Step 3 category (a)) and tracks an `OPEN` issue, the plan is always to **delete the branch (local + remote) and close the issue**.
 
 ### Step 5 — Confirm with the user
 
 Print one combined plan as a numbered review. For each branch show why it qualifies and what will happen to the linked issue:
 
 ```
-1. issue-23-set-up-ci-with-sonarcloud  (merged into dev) — closes issue #23 "Set up CI with SonarCloud"
-2. issue-19-build-account-core         (upstream gone)   — issue #19 already CLOSED, leave it
-3. experiment-azure-delta-spike        (merged into dev) — no linked issue
+1. issue-23-set-up-ci-with-sonarcloud  (merged into dev) — delete local + remote, close issue #23 "Set up CI with SonarCloud"
+2. issue-19-build-account-core         (upstream gone)   — delete local (remote already gone), issue #19 already CLOSED
+3. experiment-azure-delta-spike        (merged into dev) — delete local + remote, no linked issue
 ```
 
-Then ask:
+Branch deletion covers **both** the local branch and its `origin` counterpart. Then ask:
 
-> "Delete these N branches and close the listed open issues? (yes / no / skip `<numbers>`)"
+> "Delete these N branches (local + remote) and close the listed open issues? (yes / no / skip `<numbers>`)"
 
 - "no" → stop, report nothing deleted/closed.
 - skip `<numbers>` → drop those entries, continue with the rest.
 - "yes" / confirm → proceed.
 
-### Step 6 — Delete branches
+### Step 6 — Delete branches (local, then remote)
 
-For each approved branch:
+For each approved branch, delete the local copy first:
 
 ```
 git branch -d <branch>
 ```
 
-If `git branch -d` refuses (branch is not fully merged), do **not** retry with `-D` and do **not** close the linked issue. Skip and report:
+If `git branch -d` refuses (branch is not fully merged), do **not** retry with `-D`, do **not** delete the remote, and do **not** close the linked issue. Skip and report:
 
 > "Branch `<X>` has unmerged work — skipped (issue #<N> left open). Use `git branch -D <X>` manually if you're sure."
 
+After a **successful** local delete, delete the remote branch:
+
+```
+git push origin --delete <branch>
+```
+
+Handle the result:
+
+- **Deleted** → note it for the report.
+- **`remote ref does not exist`** (the PR merge setting already deleted it, or the branch was in the "upstream gone" category) → treat as already-clean, not a failure.
+- **Any other error** (auth, network, protected branch) → report it and move on; the successful local delete and the issue close (Step 7) still stand.
+
+Never run this for `dev` or `master` — they are excluded from candidates in Step 3.
+
 ### Step 7 — Close issues whose branch deletion succeeded
 
-For each branch that was actually deleted in Step 6 AND has a linked issue still in state `OPEN`:
+For each branch whose **local** delete succeeded in Step 6 AND which has a linked issue still in state `OPEN`:
 
 ```
 gh issue close <num> --comment "Branch <branch> deleted via /cleanup after PR merged to dev."
 ```
 
-If `gh issue close` fails (network, auth, permission), report the failure and leave the issue alone — the branch deletion still stands.
+Gate this on the local delete, not the remote one — a remote-delete hiccup must not block closing the issue. If `gh issue close` fails (network, auth, permission), report the failure and leave the issue alone — the branch deletion still stands.
 
 ### Step 8 — Report
 
 Print a short summary:
 
-- N branches deleted (list them).
+- N branches deleted locally (list them), and which of those were also deleted on `origin` (vs. already gone).
 - M branches skipped (list them with reasons).
 - K issues closed (list `#<num>`s, with the merged-PR context if available).
 - L issues left open (list `#<num>`s — typically because the branch was skipped).
@@ -126,8 +140,8 @@ Print a short summary:
 
 ## What this skill does NOT do
 
-- Does not push anything.
-- Does not delete remote branches.
+- Does not push commits — the only push it makes is `--delete` of an approved, locally-deleted branch.
+- Does not delete the remote `dev` or `master`, nor any remote branch whose local copy was not safely deleted first.
 - Does not rebase, merge, or rewrite history.
 - Does not touch tags, stashes, or worktrees.
 - Does not run tests, CI, or builds.
@@ -143,17 +157,17 @@ Claude: Working tree clean. Switching to dev and pulling...
         Pulled 3 new commits. Pruned 2 stale remote refs.
 
         Cleanup plan:
-          1. issue-23-set-up-ci-with-sonarcloud  (merged into dev) — closes issue #23
-          2. issue-19-build-account-core         (upstream gone)   — issue #19 already CLOSED
-          3. experiment-azure-delta-spike        (merged into dev) — no linked issue
+          1. issue-23-set-up-ci-with-sonarcloud  (merged into dev) — delete local + remote, close issue #23
+          2. issue-19-build-account-core         (upstream gone)   — delete local (remote already gone), issue #19 already CLOSED
+          3. experiment-azure-delta-spike        (merged into dev) — delete local + remote, no linked issue
 
-        Delete all 3 branches and close the listed open issues? (yes / no / skip <numbers>)
+        Delete all 3 branches (local + remote) and close the listed open issues? (yes / no / skip <numbers>)
 
 User: skip 3
 
-Claude: Deleted issue-23-set-up-ci-with-sonarcloud.
+Claude: Deleted issue-23-set-up-ci-with-sonarcloud (local + origin).
         Closed issue #23.
-        Deleted issue-19-build-account-core (issue #19 was already closed).
+        Deleted issue-19-build-account-core locally (origin was already gone; issue #19 was already closed).
         Kept experiment-azure-delta-spike (per your request).
 
         Done. On dev, up to date with origin/dev.


### PR DESCRIPTION
## Summary

Updates the `/cleanup` skill so it also deletes the **remote** branch, instead of leaving it for the PR merge setting.

- After a successful local `git branch -d`, it runs `git push origin --delete <branch>` for each approved candidate.
- Remote deletion is gated on the local delete succeeding — an unmerged branch (where `git branch -d` refused) leaves the remote and the linked issue untouched.
- `remote ref does not exist` (merge setting already deleted it, or the upstream-gone case) is treated as already-clean, not a failure.
- Never deletes the remote `dev` or `master`.
- Issue-closing stays gated on the **local** delete, so a remote-delete hiccup never blocks closing the issue.

Docs updated to match: description, hard rules, Steps 5–8, the "does NOT do" list, and the example session.

## Test plan
- [ ] Next post-merge `/cleanup` run deletes the merged branch on both local and `origin`, and reports which remotes were deleted vs. already gone.

Note: no linked issue — committed directly on a branch per the requested flow.