### PR TITLE
Add LinkedSnapshot and LinkWarning to account_core (#41)

### DIFF
--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -119,7 +119,7 @@ The flat shape mirrors Smartschool's SOAP contract. It must **not** leak past th
 | `displayName` | `String` | |
 | `givenName` | `String` | |
 | `surname` | `String` | |
-| `companyName` | `String?` | School prefix; used to identify alumni |
+| `companyName` | `String?` | School prefix; used to identify former members to remove |
 | `department` | `String?` | Holds school prefix for staff |
 
 ### 3.7 `Group` and `Membership` — major redesign
@@ -185,13 +185,27 @@ class LinkedAccount {
   final WisaStudent? wisa;
   final SmartschoolAccount? smartschool;
   final AzureUser? azure;
-  final LinkConfidence confidence;   // High | Medium (alumni / WISA-only placeholder)
+  final LinkConfidence confidence;   // High | Medium (former-member / WISA-only placeholder)
 }
 class LinkedGroup { ... }
 class LinkedStaff  { ... }
 ```
 
-See INV-5, INV-6. The `confidence` field replaces the implicit "alumni" and "placeholder" states that today are encoded in which fields are null.
+See INV-5, INV-6. The `confidence` field replaces the implicit "alumni" and "placeholder" states that today are encoded in which fields are null. A former member surfaces as an Azure-only record (confidence `Medium`) so the action engine can raise a remove action for it (§7).
+
+The linker bundles its output into a `LinkedSnapshot`:
+
+```dart
+class LinkedSnapshot {
+  final List<LinkedAccount> accounts;
+  final List<LinkedStaff>   staff;
+  final List<LinkedGroup>   groups;
+  final LinkCounts wisa, smartschool, azure;   // total/linked/unlinked per system
+  final List<LinkWarning> warnings;            // e.g. ResolveDuplicateMail (INV-23)
+}
+```
+
+`LinkCounts` mirrors the legacy `LinkedAccounts` counters: a person counts toward a system's `linked` only when present in all three systems, otherwise `unlinked`. `LinkWarning` is a sealed type; its `ResolveDuplicateMail` variant carries the shared `mail` and every colliding Smartschool account (INV-23, PAIN-7).
 
 ### 3.10 `Action`
 
@@ -263,7 +277,7 @@ Rules are applied **at snapshot construction time** (inside the connector or jus
 
 - **INV-20 [D]:** `link` is a **pure function**: `(WisaSnapshot, SmartschoolSnapshot, AzureSnapshot) → LinkedSnapshot`. Same input ⇒ same output.
 - **INV-21 [D]:** Every WISA student appears in **exactly one** `LinkedAccount`.
-- **INV-22 [D]:** Every Azure user with `companyName == schoolPrefix` (students) or `department contains schoolPrefix` (staff) appears in **exactly one** `LinkedAccount`, even when alumni.
+- **INV-22 [D]:** Every Azure user with `companyName == schoolPrefix` (students) or `department contains schoolPrefix` (staff) appears in **exactly one** `LinkedAccount`, even after the person has left the school (so the engine can raise a remove action).
 - **INV-23 [D]:** When two Smartschool accounts collide on `mail`, **both** end up in some `LinkedAccount`, never silently dropped. A `ResolveDuplicateMail` warning action is raised.
 
 ### Membership
@@ -312,7 +326,7 @@ Rules are applied **at snapshot construction time** (inside the connector or jus
 
 | Case | Legacy behaviour | New behaviour | Rationale |
 |---|---|---|---|
-| Alumni (Azure-only w/ school prefix) | Preserved as Azure-only `LinkedAccount` | **Keep**, mark `confidence: Medium` + `alumni: true` | Operator needs visibility |
+| Former member (Azure-only w/ school prefix) | Preserved as Azure-only `LinkedAccount` | **Fix**: surface as Azure-only `LinkedAccount` (`confidence: Medium`); the action engine raises a remove action — we don't keep alumni | Students who leave are deleted, not retained |
 | WISA-only student (no SS, no Azure) | Placeholder keyed by `WisaID` | **Keep**; surfaces "add" actions naturally | Drives onboarding |
 | Two Smartschool accounts share `mail` | First wins, second lost silently | **Fix**: both retained, raise `ResolveDuplicateMail` warning | INV-23 |
 | Case-sensitive mail/UPN comparison | `.Equals()` | **Fix**: case-insensitive + trim | INV-12 — latent bug |

--- a/packages/account_core/lib/src/linked.dart
+++ b/packages/account_core/lib/src/linked.dart
@@ -12,9 +12,10 @@ enum LinkConfidence {
   /// All linking keys agreed (e.g. `upn == mail` AND `employeeId == wisaId`).
   high,
 
-  /// Some signal is missing or weak — typically an Azure-only alumni record
-  /// or a WISA-only placeholder for a student who hasn't been provisioned in
-  /// Smartschool yet.
+  /// Some signal is missing or weak — typically an Azure-only record for a
+  /// person who has left the school (the action engine raises a remove
+  /// action for these) or a WISA-only placeholder for a student who hasn't
+  /// been provisioned in Smartschool yet.
   medium,
   ;
 
@@ -80,4 +81,142 @@ class LinkedGroup {
     this.azure,
     required this.confidence,
   });
+}
+
+/// A non-fatal anomaly the linker surfaces for operator attention.
+///
+/// Collected into [LinkedSnapshot.warnings]. Sealed so the action engine
+/// can dispatch exhaustively over the concrete variants.
+sealed class LinkWarning {
+  const LinkWarning();
+}
+
+/// INV-23: two or more Smartschool accounts claim the same [mail].
+///
+/// The legacy linker silently kept the first and dropped the rest (PAIN-7).
+/// We retain every colliding account in the [LinkedSnapshot] and raise this
+/// warning so the operator can resolve the collision (typically a stray
+/// co-account; see INV-13).
+class ResolveDuplicateMail extends LinkWarning {
+  /// The address the colliding accounts share. Compared case-insensitively
+  /// and trimmed per INV-12.
+  final String mail;
+
+  /// Every Smartschool account that claims [mail]; at least two.
+  final List<SmartschoolAccount> accounts;
+
+  const ResolveDuplicateMail({required this.mail, required this.accounts});
+}
+
+/// Per-system tally for one [LinkedSnapshot], mirroring the counters legacy
+/// `LinkedAccounts.DoRelink` exposed.
+///
+/// A record counts toward [linked] when it is present in *every* system, and
+/// toward [unlinked] when it is present in this system but missing from at
+/// least one other. [total] == [linked] + [unlinked].
+class LinkCounts {
+  final int total;
+  final int linked;
+  final int unlinked;
+
+  const LinkCounts({
+    required this.total,
+    required this.linked,
+    required this.unlinked,
+  });
+
+  static const empty = LinkCounts(total: 0, linked: 0, unlinked: 0);
+}
+
+/// The complete output of one `link(wisa, smartschool, azure)` run.
+///
+/// Spec §6.2. Holds the reconciled [accounts], [staff], and [groups], the
+/// per-system [LinkCounts], and any [warnings] raised while linking
+/// (e.g. [ResolveDuplicateMail]). Pure data — produced by the linker (#43)
+/// and consumed by the action engine (#46).
+class LinkedSnapshot {
+  final List<LinkedAccount> accounts;
+  final List<LinkedStaff> staff;
+  final List<LinkedGroup> groups;
+
+  /// Account/staff tallies for WISA, Smartschool, and Azure respectively.
+  final LinkCounts wisa;
+  final LinkCounts smartschool;
+  final LinkCounts azure;
+
+  final List<LinkWarning> warnings;
+
+  const LinkedSnapshot({
+    required this.accounts,
+    required this.staff,
+    required this.groups,
+    required this.wisa,
+    required this.smartschool,
+    required this.azure,
+    this.warnings = const [],
+  });
+
+  /// Builds a snapshot and derives the per-system [LinkCounts] from the
+  /// [accounts] and [staff] records, replicating legacy
+  /// `LinkedAccounts.DoRelink`: a person counts toward a system's [total]
+  /// when present there, and toward that system's [linked] only when present
+  /// in all three systems. Groups are listed but not counted.
+  factory LinkedSnapshot.fromRecords({
+    required List<LinkedAccount> accounts,
+    required List<LinkedStaff> staff,
+    required List<LinkedGroup> groups,
+    List<LinkWarning> warnings = const [],
+  }) {
+    var wisaTotal = 0, wisaLinked = 0;
+    var ssTotal = 0, ssLinked = 0;
+    var azTotal = 0, azLinked = 0;
+
+    void tally({
+      required bool inWisa,
+      required bool inSmartschool,
+      required bool inAzure,
+    }) {
+      final complete = inWisa && inSmartschool && inAzure;
+      if (inWisa) {
+        wisaTotal++;
+        if (complete) wisaLinked++;
+      }
+      if (inSmartschool) {
+        ssTotal++;
+        if (complete) ssLinked++;
+      }
+      if (inAzure) {
+        azTotal++;
+        if (complete) azLinked++;
+      }
+    }
+
+    for (final a in accounts) {
+      tally(
+        inWisa: a.wisa != null,
+        inSmartschool: a.smartschool != null,
+        inAzure: a.azure != null,
+      );
+    }
+    for (final s in staff) {
+      tally(
+        inWisa: s.wisa != null,
+        inSmartschool: s.smartschool != null,
+        inAzure: s.azure != null,
+      );
+    }
+
+    LinkCounts counts(int total, int linked) =>
+        LinkCounts(total: total, linked: linked, unlinked: total - linked);
+
+    return LinkedSnapshot(
+      accounts: accounts,
+      staff: staff,
+      groups: groups,
+      warnings: warnings,
+      wisa: counts(wisaTotal, wisaLinked),
+      smartschool: counts(ssTotal, ssLinked),
+      azure: counts(azTotal, azLinked),
+    );
+  }
 }

--- a/packages/account_core/test/linked_test.dart
+++ b/packages/account_core/test/linked_test.dart
@@ -119,4 +119,124 @@ void main() {
     expect(lg.azure?.displayName, equals('5A'));
     expect(lg.smartschool, isNull);
   });
+
+  test('ResolveDuplicateMail is a LinkWarning carrying the colliding accounts '
+      '(INV-23)', () {
+    const a = _FakeSmartschoolAccount(
+      uid: 'janssens.anna',
+      mail: 'anna@school.be',
+      accountId: 'w-1',
+      accountType: AccountType.student,
+    );
+    const b = _FakeSmartschoolAccount(
+      uid: 'janssens.anna2',
+      mail: 'anna@school.be',
+      accountId: 'w-2',
+      accountType: AccountType.coAccount1,
+    );
+    const warning =
+        ResolveDuplicateMail(mail: 'anna@school.be', accounts: [a, b]);
+    expect(warning, isA<LinkWarning>());
+    expect(warning.mail, equals('anna@school.be'));
+    expect(warning.accounts, hasLength(2));
+    expect(
+      warning.accounts.map((s) => s.uid),
+      containsAll(<String>['janssens.anna', 'janssens.anna2']),
+    );
+  });
+
+  test('LinkedSnapshot stores records, counts, and warnings (spec §6.2)', () {
+    const snapshot = LinkedSnapshot(
+      accounts: [],
+      staff: [],
+      groups: [],
+      wisa: LinkCounts.empty,
+      smartschool: LinkCounts.empty,
+      azure: LinkCounts.empty,
+    );
+    expect(snapshot.accounts, isEmpty);
+    expect(snapshot.warnings, isEmpty);
+    expect(snapshot.wisa, equals(LinkCounts.empty));
+  });
+
+  test('LinkedSnapshot.fromRecords derives per-system counts like legacy', () {
+    // Fully linked student: present in all three systems.
+    const full = LinkedAccount(
+      id: LinkedAccountId('la-full'),
+      role: PersonRole.student,
+      wisa: _FakeWisaStudent(WisaId('w-1')),
+      smartschool: _FakeSmartschoolAccount(
+        uid: 'a',
+        mail: 'a@school.be',
+        accountId: 'w-1',
+        accountType: AccountType.student,
+      ),
+      azure: _FakeAzureUser(id: 'az-1', upn: 'a@school.be', employeeId: 'w-1'),
+      confidence: LinkConfidence.high,
+    );
+    // WISA-only placeholder.
+    const wisaOnly = LinkedAccount(
+      id: LinkedAccountId('la-wisa'),
+      role: PersonRole.student,
+      wisa: _FakeWisaStudent(WisaId('w-2')),
+      confidence: LinkConfidence.medium,
+    );
+    // Azure-only record for someone who has left (the engine will remove it).
+    const azureOnly = LinkedAccount(
+      id: LinkedAccountId('la-az'),
+      role: PersonRole.student,
+      azure: _FakeAzureUser(id: 'az-2', upn: 'old@school.be'),
+      confidence: LinkConfidence.medium,
+    );
+    // Fully linked staff member contributes to every system total too.
+    const staff = LinkedStaff(
+      id: LinkedAccountId('ls-1'),
+      role: PersonRole.teacher,
+      wisa: _FakeWisaStaff(WisaStaffCode('s-1'), WisaId('w-100')),
+      smartschool: _FakeSmartschoolAccount(
+        uid: 'staff',
+        mail: 'staff@school.be',
+        accountId: 'w-100',
+        accountType: AccountType.student,
+      ),
+      azure: _FakeAzureUser(
+        id: 'az-100',
+        upn: 'staff@school.be',
+        employeeId: 'w-100',
+      ),
+      confidence: LinkConfidence.high,
+    );
+
+    final snapshot = LinkedSnapshot.fromRecords(
+      accounts: const [full, wisaOnly, azureOnly],
+      staff: const [staff],
+      groups: const [],
+      warnings: const [
+        ResolveDuplicateMail(mail: 'dup@school.be', accounts: []),
+      ],
+    );
+
+    // WISA: full, wisaOnly, staff present (3); only full + staff complete (2).
+    expect(snapshot.wisa.total, equals(3));
+    expect(snapshot.wisa.linked, equals(2));
+    expect(snapshot.wisa.unlinked, equals(1));
+
+    // Smartschool: full + staff present (2), both complete.
+    expect(snapshot.smartschool.total, equals(2));
+    expect(snapshot.smartschool.linked, equals(2));
+    expect(snapshot.smartschool.unlinked, equals(0));
+
+    // Azure: full, azureOnly, staff present (3); full + staff complete (2).
+    expect(snapshot.azure.total, equals(3));
+    expect(snapshot.azure.linked, equals(2));
+    expect(snapshot.azure.unlinked, equals(1));
+
+    // total always equals linked + unlinked.
+    for (final c in [snapshot.wisa, snapshot.smartschool, snapshot.azure]) {
+      expect(c.total, equals(c.linked + c.unlinked));
+    }
+
+    expect(snapshot.warnings, hasLength(1));
+    expect(snapshot.warnings.single, isA<ResolveDuplicateMail>());
+  });
 }


### PR DESCRIPTION
## Summary
- Add `LinkedSnapshot` to `account_core`: lists of `LinkedAccount`/`LinkedStaff`/`LinkedGroup`, per-system `LinkCounts` (total/linked/unlinked, mirroring legacy `LinkedAccounts`), and a `List<LinkWarning>`. A `fromRecords` factory derives the counts the legacy way.
- Add sealed `LinkWarning` with a `ResolveDuplicateMail` variant (INV-23): both colliding Smartschool accounts are retained, never silently dropped (fixes PAIN-7's design at the type level).
- Unit tests + `dart analyze` clean.

## Deviation from the issue: no `alumni` flag
Acceptance criterion #2 asked for an `alumni: bool`. We deliberately **dropped it**. The school does not want to keep accounts for people who have left — they should be **deleted**. A leaver now surfaces as an Azure-only `LinkedAccount` (`confidence: Medium`), which is exactly the signal the action engine (#46) uses to raise a remove action (spec §6.3). Spec §3.9, §7, INV-22, and the `companyName` row were updated to reflect "delete, don't retain."

## Test plan
- [x] `dart analyze` — no issues
- [x] `dart test` (account_core) — 60 tests pass, incl. new coverage for `ResolveDuplicateMail`, `LinkedSnapshot`, and `fromRecords` count derivation

Closes #41