### PR TITLE
Add account_linker: pure student linking + property tests (#43)

### DIFF
--- a/packages/account_linker/lib/account_linker.dart
+++ b/packages/account_linker/lib/account_linker.dart
@@ -1,0 +1,8 @@
+/// Cross-system linker for the Arcadia Account Manager port.
+///
+/// Exposes the pure `link(wisa, smartschool, azure, resolver)` function that
+/// reconciles the WISA, Smartschool, and Azure snapshots into one
+/// `LinkedAccount` per person (spec `docs/domain-model.md` §6.2).
+library;
+
+export 'src/link.dart';

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -1,0 +1,213 @@
+import 'package:account_core/account_core.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+/// Reconciles the three connector snapshots into one [LinkedAccount] per
+/// student, ported from legacy `LinkedAccounts.DoRelink` but extracted from
+/// WPF state and fixed for the known matching bugs.
+///
+/// Pure and deterministic (INV-20): the same snapshots and the same
+/// [resolver] state always yield the same [LinkedSnapshot]. All impurity —
+/// minting and persisting the stable [PersonId] — is delegated to [resolver],
+/// so `link` itself does no I/O.
+///
+/// This issue (#43) links **students** only; [LinkedSnapshot.staff] and
+/// [LinkedSnapshot.groups] are returned empty (staff #44, groups #45).
+///
+/// The bridges used (spec `docs/domain-model.md` §4, §6.2):
+/// - `AzureUser.upn` ≡ `SmartschoolAccount.mail` (case-insensitive, trimmed)
+/// - `SmartschoolAccount.accountId` ≡ `WisaStudent.wisaId` ≡
+///   `AzureUser.employeeId`
+///
+/// Fixes carried over from the legacy linker:
+/// - **INV-12:** every `mail`/`upn`/id comparison is trimmed and
+///   case-insensitive (legacy `.Equals()` was case-sensitive).
+/// - **INV-23:** two Smartschool accounts sharing a `mail` are *both* kept and
+///   a [ResolveDuplicateMail] warning is raised (legacy silently dropped one).
+///
+/// [schoolPrefix] is the Azure `companyName` value the school stamps on its
+/// own users; an Azure-only user carrying it is a former student kept as an
+/// incomplete record so the action engine can flag it for deletion (INV-22).
+LinkedSnapshot link(
+  wapi.WisaSnapshot wisaSnapshot,
+  ss.SmartschoolSnapshot smartschoolSnapshot,
+  az.AzureSnapshot azureSnapshot,
+  PersonIdResolver resolver, {
+  required String schoolPrefix,
+}) {
+  // Records in creation order; the output preserves this order so the result
+  // is a deterministic function of the input lists' order (INV-20).
+  final records = <_Record>[];
+  // Normalized mail -> the records that claim it (usually one; >1 ⇒ INV-23).
+  final byMail = <String, List<_Record>>{};
+  // Normalized wisaId/accountId -> the first record indexed under it.
+  final byWisaId = <String, _Record>{};
+  final warnings = <LinkWarning>[];
+
+  // 1. Seed one record per Smartschool student account, in snapshot order.
+  for (final account in smartschoolSnapshot.accounts) {
+    if (account.accountType != AccountType.student) continue;
+    final rec = _Record(smartschool: account);
+    records.add(rec);
+
+    final mail = _norm(account.mail);
+    if (mail != null) byMail.putIfAbsent(mail, () => []).add(rec);
+
+    final wisaId = _norm(account.accountId);
+    if (wisaId != null) byWisaId.putIfAbsent(wisaId, () => rec);
+  }
+
+  // INV-23: surface every mail shared by two or more accounts.
+  for (final entry in byMail.entries) {
+    if (entry.value.length < 2) continue;
+    warnings.add(
+      ResolveDuplicateMail(
+        mail: entry.key,
+        accounts: <SmartschoolAccount>[
+          for (final rec in entry.value) rec.smartschool!,
+        ],
+      ),
+    );
+  }
+
+  // 2. Attach WISA students by wisaId; unmatched ones become WISA-only
+  //    placeholders. INV-21: every WISA student lands in exactly one record.
+  for (final student in wisaSnapshot.students) {
+    final key = _norm(student.wisaId.value);
+    final match = key == null ? null : byWisaId[key];
+    if (match != null && match.wisa == null) {
+      match.wisa = student;
+    } else {
+      final placeholder = _Record(wisa: student);
+      records.add(placeholder);
+      if (key != null) byWisaId.putIfAbsent(key, () => placeholder);
+    }
+  }
+
+  // 3. Attach Azure users: by upn → mail, else by employeeId → wisaId, else
+  //    keep school-prefix orphans (INV-22), else discard (another school).
+  for (final user in azureSnapshot.users) {
+    final upn = _norm(user.upn);
+    final employeeId = _norm(user.employeeId);
+
+    _Record? target;
+    if (upn != null) {
+      final candidates = byMail[upn];
+      if (candidates != null) {
+        for (final rec in candidates) {
+          if (rec.azure == null) {
+            target = rec;
+            break;
+          }
+        }
+      }
+    }
+    if (target == null && employeeId != null) {
+      final rec = byWisaId[employeeId];
+      if (rec != null && rec.azure == null) target = rec;
+    }
+
+    if (target != null) {
+      target.azure = user;
+    } else if (_matchesPrefix(user.companyName, schoolPrefix)) {
+      records.add(_Record(azure: user));
+    }
+    // else: a user belonging to another school — not our concern, dropped.
+  }
+
+  // 4. Resolve a stable identity and confidence for each record.
+  final accounts = <LinkedAccount>[
+    for (final rec in records)
+      LinkedAccount(
+        id: LinkedAccountId(resolver.resolve(_naturalKey(rec)).value),
+        role: PersonRole.student,
+        wisa: rec.wisa,
+        smartschool: rec.smartschool,
+        azure: rec.azure,
+        confidence: _confidence(rec),
+      ),
+  ];
+
+  return LinkedSnapshot.fromRecords(
+    accounts: accounts,
+    staff: const [],
+    groups: const [],
+    warnings: warnings,
+  );
+}
+
+/// Mutable accumulator for one linked person while the passes run; frozen into
+/// an immutable [LinkedAccount] at the end.
+class _Record {
+  ss.SmartschoolAccount? smartschool;
+  wapi.WisaStudent? wisa;
+  az.AzureUser? azure;
+
+  _Record({this.smartschool, this.wisa, this.azure});
+}
+
+/// Trims and lowercases [value] for case-insensitive, whitespace-tolerant
+/// comparison (INV-12). Returns `null` when [value] is null or blank so empty
+/// keys never match or index anything.
+String? _norm(String? value) {
+  if (value == null) return null;
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed.toLowerCase();
+}
+
+/// Whether an Azure user's [companyName] marks it as one of the school's own
+/// (a current or former student). Trimmed + case-insensitive.
+bool _matchesPrefix(String? companyName, String schoolPrefix) {
+  final company = _norm(companyName);
+  final prefix = _norm(schoolPrefix);
+  return company != null && prefix != null && company == prefix;
+}
+
+/// The natural key handed to the [PersonIdResolver]: `wisaId → mail → upn →
+/// azureId`, normalized and namespaced so the resolver mints a stable, derived
+/// [PersonId]. The wisaId is taken from whichever system carries it.
+String _naturalKey(_Record rec) {
+  final wisaId = _norm(
+    rec.wisa?.wisaId.value ??
+        rec.smartschool?.accountId ??
+        rec.azure?.employeeId,
+  );
+  if (wisaId != null) return 'wisa:$wisaId';
+
+  final mail = _norm(rec.smartschool?.mail);
+  if (mail != null) return 'mail:$mail';
+
+  final upn = _norm(rec.azure?.upn);
+  if (upn != null) return 'upn:$upn';
+
+  final azureId = _norm(rec.azure?.id);
+  if (azureId != null) return 'azure:$azureId';
+
+  // Unreachable: every record carries at least one identifying field.
+  throw StateError('LinkedAccount record has no identifying key: $rec');
+}
+
+/// `high` only when all three systems are present *and* every bridge key
+/// agrees; anything weaker (a missing system, or a forced match where a key
+/// disagrees) is `medium`.
+LinkConfidence _confidence(_Record rec) {
+  final student = rec.wisa;
+  final account = rec.smartschool;
+  final user = rec.azure;
+  if (student == null || account == null || user == null) {
+    return LinkConfidence.medium;
+  }
+
+  final upn = _norm(user.upn);
+  final mail = _norm(account.mail);
+  final mailAgrees = upn != null && upn == mail;
+
+  final wisaId = _norm(student.wisaId.value);
+  final accountId = _norm(account.accountId);
+  final employeeId = _norm(user.employeeId);
+  final idAgrees =
+      wisaId != null && wisaId == accountId && wisaId == employeeId;
+
+  return mailAgrees && idAgrees ? LinkConfidence.high : LinkConfidence.medium;
+}

--- a/packages/account_linker/pubspec.yaml
+++ b/packages/account_linker/pubspec.yaml
@@ -1,0 +1,26 @@
+name: account_linker
+description: >-
+  Cross-system linker for the Arcadia Account Manager port. Implements the
+  pure `link(wisa, smartschool, azure, PersonIdResolver) -> LinkedSnapshot`
+  function that reconciles the three connector snapshots into one record per
+  person. Pure Dart; no Flutter, no I/O — identity minting is delegated to an
+  injected PersonIdResolver.
+version: 0.1.0
+publish_to: none
+repository: https://github.com/yvanvds/AccountManager
+
+environment:
+  sdk: ^3.6.0
+
+resolution: workspace
+
+dependencies:
+  account_core:
+  wisa_api:
+  smartschool_api:
+  azure_api:
+
+dev_dependencies:
+  lints: ^5.1.0
+  test: ^1.25.0
+  glados: ^1.1.7

--- a/packages/account_linker/test/link_properties_test.dart
+++ b/packages/account_linker/test/link_properties_test.dart
@@ -1,0 +1,209 @@
+// Property-based tests for the linker's invariants (INV-12/20/21/22/23).
+//
+// `glados` re-exports `package:test`, so it is the only test import here.
+import 'package:account_core/account_core.dart';
+import 'package:account_linker/account_linker.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:glados/glados.dart';
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+import 'support/fixtures.dart';
+
+const _prefix = 'Arcadia';
+
+/// One synthetic person and how it shows up across the three systems. [tag]
+/// drives the shared keys (`wisaId == 'W$tag'`, `mail == '$tag@s.be'`), so a
+/// repeated tag creates real cross-system links and duplicate mails.
+class PersonSpec {
+  final String tag;
+  final bool inWisa;
+  final bool inSmartschool;
+  final bool inAzure;
+
+  /// When in Azure: `true` links via upn+employeeId; `false` is an orphan.
+  final bool azureMatches;
+
+  /// For an orphan: whether its `companyName` carries the school prefix.
+  final bool azurePrefixed;
+
+  PersonSpec(
+    this.tag,
+    this.inWisa,
+    this.inSmartschool,
+    this.inAzure,
+    this.azureMatches,
+    this.azurePrefixed,
+  );
+}
+
+final Generator<List<PersonSpec>> _scenario = any.list(
+  any.combine6(
+    any.choose(['a', 'b', 'c', 'd', 'e']),
+    any.bool,
+    any.bool,
+    any.bool,
+    any.bool,
+    any.bool,
+    PersonSpec.new,
+  ),
+);
+
+/// The built snapshots plus the source records, so identity-based invariant
+/// checks can find each input record in the output.
+class _Built {
+  final List<wapi.WisaStudent> students;
+  final List<ss.SmartschoolAccount> accounts;
+  final List<az.AzureUser> users;
+  final LinkedSnapshot linked;
+
+  _Built(this.students, this.accounts, this.users, this.linked);
+}
+
+String _noise(String s) => '  ${s.toUpperCase()}  ';
+
+_Built _build(
+  List<PersonSpec> specs,
+  PersonIdResolver resolver, {
+  bool noisy = false,
+}) {
+  final students = <wapi.WisaStudent>[];
+  final accounts = <ss.SmartschoolAccount>[];
+  final users = <az.AzureUser>[];
+
+  for (var i = 0; i < specs.length; i++) {
+    final spec = specs[i];
+    final wisaId = 'W${spec.tag}';
+    final mail = '${spec.tag}@s.be';
+
+    if (spec.inWisa) students.add(wisaStudent(wisaId));
+    if (spec.inSmartschool) {
+      accounts.add(
+        ssAccount(
+          uid: 's$i',
+          accountId: wisaId,
+          mail: noisy ? _noise(mail) : mail,
+        ),
+      );
+    }
+    if (spec.inAzure) {
+      if (spec.azureMatches) {
+        users.add(
+          azureUser(
+            id: 'a$i',
+            upn: noisy ? _noise(mail) : mail,
+            employeeId: noisy ? wisaId.toLowerCase() : wisaId,
+            companyName: _prefix,
+          ),
+        );
+      } else {
+        users.add(
+          azureUser(
+            id: 'a$i',
+            upn: 'orphan$i@x.be',
+            companyName: spec.azurePrefixed ? _prefix : 'OtherSchool',
+          ),
+        );
+      }
+    }
+  }
+
+  final linked = link(
+    wisaSnap(students),
+    ssSnap(accounts),
+    azSnap(users),
+    resolver,
+    schoolPrefix: _prefix,
+  );
+  return _Built(students, accounts, users, linked);
+}
+
+String? _norm(String? s) {
+  if (s == null) return null;
+  final t = s.trim();
+  return t.isEmpty ? null : t.toLowerCase();
+}
+
+void main() {
+  group('link invariants', () {
+    Glados(_scenario).test('INV-20: link is deterministic', (specs) {
+      final first = _build(specs, SeqResolver()).linked;
+      final second = _build(specs, SeqResolver()).linked;
+      expect(structuralSignature(first), structuralSignature(second));
+    });
+
+    Glados(_scenario).test(
+      'INV-21: every WISA student appears in exactly one account',
+      (specs) {
+        final built = _build(specs, SeqResolver());
+        for (final student in built.students) {
+          final hits = built.linked.accounts
+              .where((a) => identical(a.wisa, student))
+              .length;
+          expect(hits, 1, reason: 'student ${student.wisaId} appeared $hits×');
+        }
+      },
+    );
+
+    Glados(_scenario).test(
+      'INV-22: every school-prefixed Azure user appears in exactly one account',
+      (specs) {
+        final built = _build(specs, SeqResolver());
+        final prefix = _norm(_prefix);
+        final owned = built.users.where((u) => _norm(u.companyName) == prefix);
+        for (final user in owned) {
+          final hits = built.linked.accounts
+              .where((a) => identical(a.azure, user))
+              .length;
+          expect(hits, 1, reason: 'azure ${user.id} appeared $hits×');
+        }
+      },
+    );
+
+    Glados(_scenario).test(
+      'INV-23: no Smartschool account is dropped; collisions warn',
+      (specs) {
+        final built = _build(specs, SeqResolver());
+
+        // Retention: every student account appears in exactly one record.
+        for (final account in built.accounts) {
+          final hits = built.linked.accounts
+              .where((a) => identical(a.smartschool, account))
+              .length;
+          expect(hits, 1, reason: 'account ${account.uid} appeared $hits×');
+        }
+
+        // For each mail shared by ≥2 accounts there is exactly one warning
+        // naming all of them.
+        final byMail = <String, List<String>>{};
+        for (final account in built.accounts) {
+          final m = _norm(account.mail);
+          if (m != null) byMail.putIfAbsent(m, () => []).add(account.uid);
+        }
+        final colliding =
+            byMail.entries.where((e) => e.value.length >= 2).toList();
+
+        final warnings =
+            built.linked.warnings.whereType<ResolveDuplicateMail>().toList();
+        expect(warnings, hasLength(colliding.length));
+
+        for (final entry in colliding) {
+          final warning = warnings.firstWhere((w) => w.mail == entry.key);
+          expect(
+            warning.accounts.map((a) => a.uid).toSet(),
+            entry.value.toSet(),
+          );
+        }
+      },
+    );
+
+    Glados(_scenario).test(
+      'INV-12: case/whitespace in mail and upn does not change linking',
+      (specs) {
+        final clean = _build(specs, SeqResolver()).linked;
+        final noisy = _build(specs, SeqResolver(), noisy: true).linked;
+        expect(structuralSignature(noisy), structuralSignature(clean));
+      },
+    );
+  });
+}

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -1,0 +1,197 @@
+import 'package:account_core/account_core.dart';
+import 'package:account_linker/account_linker.dart';
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+const _prefix = 'Arcadia';
+
+void main() {
+  group('link — student scenarios', () {
+    test('fully linked across three systems → high confidence', () {
+      final snapshot = link(
+        wisaSnap([wisaStudent('W1')]),
+        ssSnap([ssAccount(uid: 'jane', accountId: 'W1', mail: 'jane@s.be')]),
+        azSnap([
+          azureUser(
+            id: 'az-1',
+            upn: 'jane@s.be',
+            employeeId: 'W1',
+            companyName: _prefix,
+          ),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      expect(snapshot.accounts, hasLength(1));
+      final a = snapshot.accounts.single;
+      expect(a.confidence, LinkConfidence.high);
+      expect(a.wisa, isNotNull);
+      expect(a.smartschool, isNotNull);
+      expect(a.azure, isNotNull);
+      expect(a.role, PersonRole.student);
+      expect(snapshot.warnings, isEmpty);
+      // Present in all three ⇒ counts toward linked everywhere.
+      expect(snapshot.wisa.linked, 1);
+      expect(snapshot.smartschool.linked, 1);
+      expect(snapshot.azure.linked, 1);
+    });
+
+    test('WISA student not yet in Smartschool → medium placeholder', () {
+      final snapshot = link(
+        wisaSnap([wisaStudent('W2')]),
+        ssSnap(const []),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final a = snapshot.accounts.single;
+      expect(a.wisa, isNotNull);
+      expect(a.smartschool, isNull);
+      expect(a.azure, isNull);
+      expect(a.confidence, LinkConfidence.medium);
+      expect(snapshot.wisa.unlinked, 1);
+    });
+
+    test('Azure-only user with school prefix is kept for later removal', () {
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap(const []),
+        azSnap([
+          azureUser(id: 'az-3', upn: 'gone@s.be', companyName: _prefix),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final a = snapshot.accounts.single;
+      expect(a.azure, isNotNull);
+      expect(a.wisa, isNull);
+      expect(a.smartschool, isNull);
+      expect(a.confidence, LinkConfidence.medium);
+      expect(snapshot.azure.unlinked, 1);
+    });
+
+    test('Azure user from another school is discarded', () {
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap(const []),
+        azSnap([
+          azureUser(
+            id: 'az-4',
+            upn: 'someone@other.be',
+            companyName: 'OtherSchool',
+          ),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      expect(snapshot.accounts, isEmpty);
+    });
+
+    test('INV-12: case and whitespace differences still link', () {
+      final snapshot = link(
+        wisaSnap([wisaStudent('W5')]),
+        ssSnap([ssAccount(uid: 'k', accountId: 'W5', mail: 'Kim@S.BE')]),
+        azSnap([
+          azureUser(
+            id: 'az-5',
+            upn: '  kim@s.be  ',
+            employeeId: 'w5',
+            companyName: _prefix,
+          ),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final a = snapshot.accounts.single;
+      expect(a.wisa, isNotNull);
+      expect(a.smartschool, isNotNull);
+      expect(a.azure, isNotNull);
+      // Keys agree once normalised ⇒ high confidence.
+      expect(a.confidence, LinkConfidence.high);
+    });
+
+    test('INV-23: duplicate-mail Smartschool accounts both kept + warning', () {
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap([
+          ssAccount(uid: 'twin-a', accountId: 'W6', mail: 'twin@s.be'),
+          ssAccount(uid: 'twin-b', accountId: 'W7', mail: 'TWIN@s.be'),
+        ]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      // Both retained — neither silently dropped (PAIN-7).
+      final uids = snapshot.accounts
+          .map((a) => a.smartschool?.uid)
+          .whereType<String>()
+          .toSet();
+      expect(uids, {'twin-a', 'twin-b'});
+
+      final warning = snapshot.warnings.single as ResolveDuplicateMail;
+      expect(warning.mail, 'twin@s.be');
+      expect(
+        warning.accounts.map((a) => a.uid).toSet(),
+        {'twin-a', 'twin-b'},
+      );
+    });
+
+    test('co-account (non-student) Smartschool records are ignored', () {
+      // The concrete model only emits students, but the linker must honour the
+      // accountType filter regardless. A student links normally.
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap([ssAccount(uid: 'kid', accountId: 'W8', mail: 'kid@s.be')]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+      expect(snapshot.accounts.single.smartschool?.uid, 'kid');
+    });
+
+    test('Azure matched by employeeId when UPN differs from mail', () {
+      final snapshot = link(
+        wisaSnap([wisaStudent('W9')]),
+        ssSnap([ssAccount(uid: 'amy', accountId: 'W9', mail: 'amy@s.be')]),
+        azSnap([
+          // UPN was renamed and no longer equals the Smartschool mail, but the
+          // employeeId still bridges to the WISA id.
+          azureUser(
+            id: 'az-9',
+            upn: 'amy.doe@s.be',
+            employeeId: 'W9',
+            companyName: _prefix,
+          ),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final a = snapshot.accounts.single;
+      expect(a.azure?.id, 'az-9');
+      expect(a.wisa, isNotNull);
+      expect(a.smartschool, isNotNull);
+      // upn != mail ⇒ not all keys agree ⇒ medium.
+      expect(a.confidence, LinkConfidence.medium);
+    });
+
+    test('staff and groups stay empty (out of scope for #43)', () {
+      final snapshot = link(
+        wisaSnap([wisaStudent('W10')]),
+        ssSnap(const []),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+      expect(snapshot.staff, isEmpty);
+      expect(snapshot.groups, isEmpty);
+    });
+  });
+}

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -1,0 +1,150 @@
+/// Test helpers for `account_linker`: terse builders for the verbose connector
+/// records, a deterministic [PersonIdResolver], and a structural signature for
+/// comparing [LinkedSnapshot]s (which have no `==`).
+library;
+
+import 'package:account_core/account_core.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+final DateTime _fixedDate = DateTime.utc(2020, 1, 1);
+
+const Address _blankAddress = Address(
+  street: '',
+  houseNumber: '',
+  postalCode: '',
+  city: '',
+  country: '',
+);
+
+/// A WISA student carrying only the fields the linker reads (`wisaId`); the
+/// rest are inert defaults.
+wapi.WisaStudent wisaStudent(String wisaId) => wapi.WisaStudent(
+      wisaId: WisaId(wisaId),
+      classGroup: '',
+      classSubGroup: '',
+      name: 'Doe',
+      firstName: 'Jane',
+      preferredName: '',
+      birthDate: _fixedDate,
+      stemId: '',
+      gender: Gender.female,
+      nationalId: '',
+      birthPlace: '',
+      nationality: '',
+      address: _blankAddress,
+      classChange: _fixedDate,
+      schoolId: 1,
+    );
+
+/// A Smartschool **student** account. [accountId] holds the WISA id by
+/// convention; [mail] is the Azure-UPN bridge.
+ss.SmartschoolAccount ssAccount({
+  required String uid,
+  required String accountId,
+  required String mail,
+}) =>
+    ss.SmartschoolAccount(
+      uid: uid,
+      accountId: accountId,
+      mail: mail,
+      registerId: '',
+      stemId: 0,
+      role: PersonRole.student,
+      givenName: 'Jane',
+      surname: 'Doe',
+      extraNames: '',
+      initials: '',
+      preferredName: '',
+      gender: Gender.female,
+      birthDate: null,
+      birthPlace: '',
+      birthCountry: '',
+      address: _blankAddress,
+      mobilePhone: '',
+      homePhone: '',
+      fax: '',
+      untisId: '',
+      status: 'actief',
+    );
+
+/// An Azure user. [companyName] equal to the school prefix marks one of the
+/// school's own users (INV-22).
+az.AzureUser azureUser({
+  required String id,
+  required String upn,
+  String? employeeId,
+  String? companyName,
+}) =>
+    az.AzureUser(
+      id: id,
+      upn: upn,
+      employeeId: employeeId,
+      companyName: companyName,
+    );
+
+wapi.WisaSnapshot wisaSnap(List<wapi.WisaStudent> students) =>
+    wapi.WisaSnapshot(
+      fetchedAt: _fixedDate,
+      students: students,
+      staff: const [],
+      classGroups: const [],
+      schools: const [],
+    );
+
+ss.SmartschoolSnapshot ssSnap(List<ss.SmartschoolAccount> accounts) =>
+    ss.SmartschoolSnapshot(
+      fetchedAt: _fixedDate,
+      groups: const [],
+      accounts: accounts,
+      memberships: const [],
+    );
+
+az.AzureSnapshot azSnap(List<az.AzureUser> users) => az.AzureSnapshot(
+      fetchedAt: _fixedDate,
+      users: users,
+      groups: const [],
+    );
+
+/// Deterministic [PersonIdResolver]: mints `p0`, `p1`, … in first-seen order
+/// and caches by natural key, so repeated keys return the same id. No I/O.
+class SeqResolver implements PersonIdResolver {
+  final Map<String, String> _seen = {};
+
+  @override
+  PersonId resolve(String naturalKey) {
+    final existing = _seen[naturalKey];
+    if (existing != null) return PersonId(existing);
+    final minted = 'p${_seen.length}';
+    _seen[naturalKey] = minted;
+    return PersonId(minted);
+  }
+}
+
+/// A stable, order-sensitive textual signature of a [LinkedSnapshot] for
+/// equality assertions (the type has no `==`). Captures every account's id,
+/// confidence, and which systems are present (plus their keys), the warnings,
+/// and the per-system counts.
+List<String> structuralSignature(LinkedSnapshot snapshot) {
+  String acc(LinkedAccount a) => [
+        a.id.value,
+        a.confidence.name,
+        'w:${a.wisa?.wisaId.value ?? '-'}',
+        's:${a.smartschool?.uid ?? '-'}',
+        'a:${a.azure?.id ?? '-'}',
+      ].join('|');
+
+  String warning(LinkWarning w) => switch (w) {
+        ResolveDuplicateMail(:final mail, :final accounts) =>
+          'dupmail:$mail:${(accounts.map((x) => x.uid).toList()..sort()).join(',')}',
+      };
+
+  return [
+    for (final a in snapshot.accounts) 'acc:${acc(a)}',
+    for (final w in snapshot.warnings) warning(w),
+    'wisa:${snapshot.wisa.total}/${snapshot.wisa.linked}/${snapshot.wisa.unlinked}',
+    'ss:${snapshot.smartschool.total}/${snapshot.smartschool.linked}/${snapshot.smartschool.unlinked}',
+    'az:${snapshot.azure.total}/${snapshot.azure.linked}/${snapshot.azure.unlinked}',
+  ];
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ workspace:
   - packages/wisa_api
   - packages/smartschool_api
   - packages/azure_api
+  - packages/account_linker
 
 dev_dependencies:
   lints: ^5.1.0


### PR DESCRIPTION
## Summary
- New `packages/account_linker` implementing the pure `link(wisa, smartschool, azure, PersonIdResolver) -> LinkedSnapshot` function, structurally ported from legacy `LinkedAccounts.DoRelink` but extracted from WPF state.
- Seeds from Smartschool students → attaches WISA by `wisaId` (medium placeholder if unmatched) → attaches Azure by `upn` then `employeeId`, keeping school-prefix orphans as Azure-only `medium` records for later removal (INV-22). No alumni state (per #41 / PR #47 rollback).
- **Fix INV-12:** all `mail`/`upn`/id comparisons are trimmed + case-insensitive.
- **Fix INV-23:** duplicate-mail Smartschool accounts are both retained and a `ResolveDuplicateMail` warning is raised.
- `confidence` is `high` only when all three systems are present and the bridge keys agree, otherwise `medium`.
- Stable `PersonId` minted via the injected resolver from a derived natural key (`wisaId → mail → upn → azureId`); `link` itself stays pure (INV-20).
- Added to the workspace; `dart analyze` clean.

## Test plan
- [x] `dart analyze` clean repo-wide
- [x] `glados` property tests for INV-12 / 20 / 21 / 22 / 23 (100 inputs each)
- [x] Scenario tests: fully linked, WISA-only placeholder, Azure-only orphan, foreign-school discard, duplicate mail, employeeId bridge
- [x] All six workspace packages' suites pass

Closes #43