### PR TITLE
Add account_linker staff linking + resolve OQ-1 (code vs wisaId)

### DIFF
--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -92,7 +92,14 @@ Immutable. Much smaller than `WisaStudent` ([legacy-wpf/AccountApi/Wisa/Staff.cs
 | `firstName` | `String` | |
 | `lastName` | `String` | |
 
-> **OQ-1:** Are `code` and `wisaId` ever genuinely different identifiers, or always the same value? The linker uses `wisaId` to match Azure (`EmployeeId`), but the "AddToSmartschool" staff action uses `code` as Smartschool `AccountID`. If they're always equal in real data, we collapse to one field.
+> **OQ-1 (RESOLVED — keep both fields):** `code` and `wisaId` are genuinely
+> different identifiers. Verified against a real 194-row WISA staff export: they
+> differ in 194/194 records (`wisaId` numeric, `code` an alphabetic
+> surname-mnemonic; `wisaId` may also be empty while `code` never is). Each
+> bridges a different system — the "AddToSmartschool" staff action writes `code`
+> as the Smartschool `AccountID`, while `wisaId` equals Azure's `EmployeeId`.
+> The linker matches staff to Smartschool on `code` and to Azure on `wisaId`.
+> See `packages/account_linker/README.md` for the data and method.
 
 ### 3.5 `SmartschoolAccount` (source record)
 
@@ -251,7 +258,7 @@ Rules are applied **at snapshot construction time** (inside the connector or jus
 |---|---|---|---|
 | `PersonId` | `Person` | Opaque local UUID | Internal stable key. See OQ-3. |
 | `WisaId` | WisaStudent, WisaStaff, AzureUser.employeeId | String | WISA primary; cross-system bridge to Azure |
-| `WisaStaffCode` | WisaStaff | String | Staff-scope key; possibly equal to `WisaId` (OQ-1) |
+| `WisaStaffCode` | WisaStaff | String | Staff-scope key; **distinct** from `WisaId` (OQ-1 resolved). Bridges staff to Smartschool (`accountId`) |
 | `nationalId` | Person, WisaStudent | String (rijksregisternr) | Identity attribute; **not** used for linking |
 | `stemId` | Person/Wisa/Smartschool | String/int | Attribute; not a primary key |
 | `upn` | AzureUser | Email-format | Azure primary; also the legacy linker key |
@@ -262,7 +269,8 @@ Rules are applied **at snapshot construction time** (inside the connector or jus
 
 - `AzureUser.upn` ≡ `SmartschoolAccount.mail` (when both exist) — **case-insensitive, trimmed** (INV-12)
 - `AzureUser.employeeId` ≡ `WisaStudent.wisaId` (or `WisaStaff.wisaId`)
-- `SmartschoolAccount.accountId` ≡ `WisaStudent.wisaId` (a `ModifyAccountID` action enforces this)
+- `SmartschoolAccount.accountId` ≡ `WisaStudent.wisaId` for **students** (a `ModifyAccountID` action enforces this)
+- `SmartschoolAccount.accountId` ≡ `WisaStaff.code` for **staff** (the "AddToSmartschool" staff action writes the code, not the wisaId — OQ-1)
 
 ## 5. Invariants
 
@@ -348,7 +356,7 @@ Rules are applied **at snapshot construction time** (inside the connector or jus
 
 ## 9. Open questions (decide before coding)
 
-- **OQ-1:** `WisaStaff.code` vs `WisaStaff.wisaId` — same identifier in different costume, or genuinely two IDs? Inspect real data to decide.
+- **OQ-1 (RESOLVED):** `WisaStaff.code` vs `WisaStaff.wisaId` — **genuinely two IDs.** Real data (194/194 staff differ) shows `code` is an alphabetic surname-mnemonic bridging Smartschool and `wisaId` is the numeric WISA key bridging Azure. Both fields are kept. See §3.4 and `packages/account_linker/README.md`.
 - **OQ-2:** `Address` — strictly Belgian-format or free-form per country? Legacy assumes Belgian (street/house/box).
 - **OQ-3:** `PersonId` lifecycle — derived (e.g. `wisaId` if present, `upn` otherwise) or freshly minted on first observation and stored in a local persistence layer? Affects the upgrade story when an alumni's only ID changes.
 - **OQ-4:** Co-accounts (parents) — first-class `Person` linked via a `ParentOf` relation, or attribute-only as in legacy? Affects the Passwords feature.

--- a/packages/account_linker/README.md
+++ b/packages/account_linker/README.md
@@ -1,0 +1,74 @@
+# account_linker
+
+Pure, deterministic cross-system linker for the Arcadia Account Manager port.
+Exposes a single function:
+
+```dart
+LinkedSnapshot link(
+  WisaSnapshot wisa,
+  SmartschoolSnapshot smartschool,
+  AzureSnapshot azure,
+  PersonIdResolver resolver, {
+  required String schoolPrefix,
+});
+```
+
+It reconciles the three connector snapshots into one record per person —
+`LinkedAccount` for students, `LinkedStaff` for staff — plus per-system counts
+and any non-fatal warnings. The function is a pure function of its inputs and
+the `resolver` state (INV-20): all impurity (minting/persisting the stable
+`PersonId`) is delegated to the injected `PersonIdResolver`, so `link` itself
+does no I/O. It is the WPF-free, test-covered port of legacy
+`LinkedAccounts.DoRelink` + `LinkedStaffMembers.DoRelink`.
+
+## Linking keys
+
+Students and staff are split out of Smartschool's single flat account list by
+`SmartschoolAccount.role`: `teacher`/`director` ⇒ staff, everything else ⇒
+student (`accountType` is always `student` for a primary record, so it cannot
+discriminate). The two populations are linked by **different** Smartschool
+bridges.
+
+| Pair | Student bridge | Staff bridge |
+|---|---|---|
+| Smartschool ↔ WISA | `accountId` ≡ `WisaStudent.wisaId` | `accountId` ≡ **`WisaStaff.code`** |
+| Azure ↔ WISA | `employeeId` ≡ `WisaStudent.wisaId` | `employeeId` ≡ `WisaStaff.wisaId` |
+| Smartschool ↔ Azure | `mail` ≡ `upn` | `mail` ≡ `upn` |
+
+All comparisons are trimmed and case-insensitive (INV-12).
+
+Azure "orphans" — users present only in Azure, kept so the action engine can
+raise a removal — are split per INV-22: a student carries `companyName ==
+schoolPrefix`; a staff member carries a `department` that **contains** the
+prefix.
+
+## OQ-1 — `WisaStaff.code` vs `WisaStaff.wisaId` (RESOLVED)
+
+> **Question:** Are a staff member's `code` and `wisaId` ever genuinely
+> different identifiers, or always the same value? If always equal we could
+> collapse them to one field.
+
+**Finding: they are genuinely distinct — keep both fields.**
+
+Inspected against a real production WISA staff export (194 staff members, the
+gitignored `artifacts/wisaStaff.json` redacted into
+`packages/wisa_api/test/fixtures/sma_sync_per.csv`):
+
+- `code == wisaId` in **0 / 194** records; they differ in **all** of them.
+- `wisaId` is purely numeric in 194 / 194 (e.g. `493`, `426`, `309`).
+- `code` is a short alphabetic surname-mnemonic in 184 / 194 (e.g. `ARNAU`,
+  `BEECK`, `BENSC`); the remainder add a disambiguating digit on collision.
+
+The two identifiers are not interchangeable and each bridges a different
+system: `code` is what the staff "AddToSmartschool" action writes as the
+Smartschool internal number (so it bridges Smartschool), while `wisaId` is the
+numeric WISA primary key that equals Azure's `employeeId` (so it bridges
+Azure). `wisaId` may additionally be empty for some staff, whereas `code` is
+always present — another reason they cannot collapse.
+
+Consequence for the linker: staff match Smartschool on `code` and Azure on
+`wisaId`. A staff record reaches `high` confidence only when all three systems
+are present **and** `upn == mail`, `accountId == code`, and `employeeId ==
+wisaId` all agree; anything weaker is `medium`.
+
+See `docs/domain-model.md` §3.4, §4, and §9 (OQ-1).

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -12,13 +12,30 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 /// minting and persisting the stable [PersonId] — is delegated to [resolver],
 /// so `link` itself does no I/O.
 ///
-/// This issue (#43) links **students** only; [LinkedSnapshot.staff] and
-/// [LinkedSnapshot.groups] are returned empty (staff #44, groups #45).
+/// This function links **students** (#43) and **staff** (#44);
+/// [LinkedSnapshot.groups] is still returned empty (groups #45).
 ///
-/// The bridges used (spec `docs/domain-model.md` §4, §6.2):
+/// The **student** bridges (spec `docs/domain-model.md` §4, §6.2):
 /// - `AzureUser.upn` ≡ `SmartschoolAccount.mail` (case-insensitive, trimmed)
 /// - `SmartschoolAccount.accountId` ≡ `WisaStudent.wisaId` ≡
 ///   `AzureUser.employeeId`
+///
+/// The **staff** bridges differ on the Smartschool side. Staff carry two WISA
+/// identifiers — `WisaStaff.code` (an alphabetic surname-mnemonic) and
+/// `WisaStaff.wisaId` (a numeric id) — that are *genuinely distinct* (OQ-1,
+/// resolved from real data; see the package README). Each bridges a different
+/// system:
+/// - `AzureUser.upn` ≡ `SmartschoolAccount.mail` (as for students)
+/// - `SmartschoolAccount.accountId` ≡ `WisaStaff.code` — the staff
+///   "AddToSmartschool" action stores the *code*, not the wisaId, as the
+///   Smartschool internal number (legacy `FindAccountByWisaID(account.CODE)`).
+/// - `AzureUser.employeeId` ≡ `WisaStaff.wisaId`
+///
+/// Students and staff are partitioned out of the single flat Smartschool
+/// account list by [SmartschoolAccount] `role`: teacher/director ⇒ staff,
+/// everything else ⇒ student. Azure orphans split per INV-22:
+/// `companyName == schoolPrefix` keeps a former *student*, `department`
+/// containing the prefix keeps a former *staff* member.
 ///
 /// Fixes carried over from the legacy linker:
 /// - **INV-12:** every `mail`/`upn`/id comparison is trimmed and
@@ -46,8 +63,11 @@ LinkedSnapshot link(
   final warnings = <LinkWarning>[];
 
   // 1. Seed one record per Smartschool student account, in snapshot order.
+  //    Staff (teacher/director role) are linked separately below, so they are
+  //    skipped here — otherwise a staff account would be linked twice.
   for (final account in smartschoolSnapshot.accounts) {
     if (account.accountType != AccountType.student) continue;
+    if (_isStaffRole(account.role)) continue;
     final rec = _Record(smartschool: account);
     records.add(rec);
 
@@ -129,12 +149,133 @@ LinkedSnapshot link(
       ),
   ];
 
+  final staff = _linkStaff(
+    wisaSnapshot,
+    smartschoolSnapshot,
+    azureSnapshot,
+    resolver,
+    schoolPrefix: schoolPrefix,
+    warnings: warnings,
+  );
+
   return LinkedSnapshot.fromRecords(
     accounts: accounts,
-    staff: const [],
+    staff: staff,
     groups: const [],
     warnings: warnings,
   );
+}
+
+/// Links the staff population, mirroring the student passes above but using
+/// the staff-specific bridges (see the `link` doc-comment): WISA staff match
+/// Smartschool by `code` (≡ `accountId`) and Azure by `wisaId` (≡
+/// `employeeId`). Appends any duplicate-mail warnings to [warnings].
+List<LinkedStaff> _linkStaff(
+  wapi.WisaSnapshot wisaSnapshot,
+  ss.SmartschoolSnapshot smartschoolSnapshot,
+  az.AzureSnapshot azureSnapshot,
+  PersonIdResolver resolver, {
+  required String schoolPrefix,
+  required List<LinkWarning> warnings,
+}) {
+  final records = <_StaffRecord>[];
+  // Normalized mail -> the staff records that claim it (>1 ⇒ INV-23).
+  final byMail = <String, List<_StaffRecord>>{};
+  // Normalized Smartschool accountId (≡ WISA staff `code`) -> first record.
+  final byCode = <String, _StaffRecord>{};
+  // Normalized WISA staff `wisaId` -> the record holding that staff member,
+  // for the Azure `employeeId` bridge.
+  final byWisaId = <String, _StaffRecord>{};
+
+  // 1. Seed one record per Smartschool staff account, in snapshot order.
+  for (final account in smartschoolSnapshot.accounts) {
+    if (!_isStaffRole(account.role)) continue;
+    final rec = _StaffRecord(smartschool: account);
+    records.add(rec);
+
+    final mail = _norm(account.mail);
+    if (mail != null) byMail.putIfAbsent(mail, () => []).add(rec);
+
+    final code = _norm(account.accountId);
+    if (code != null) byCode.putIfAbsent(code, () => rec);
+  }
+
+  // INV-23: surface every mail shared by two or more staff accounts.
+  for (final entry in byMail.entries) {
+    if (entry.value.length < 2) continue;
+    warnings.add(
+      ResolveDuplicateMail(
+        mail: entry.key,
+        accounts: <SmartschoolAccount>[
+          for (final rec in entry.value) rec.smartschool!,
+        ],
+      ),
+    );
+  }
+
+  // 2. Attach WISA staff by `code`; unmatched ones become WISA-only
+  //    placeholders. Every WISA staff member lands in exactly one record, and
+  //    that record is indexed by `wisaId` for the Azure bridge in pass 3.
+  for (final member in wisaSnapshot.staff) {
+    final codeKey = _norm(member.code.value);
+    final match = codeKey == null ? null : byCode[codeKey];
+    final _StaffRecord target;
+    if (match != null && match.wisa == null) {
+      match.wisa = member;
+      target = match;
+    } else {
+      target = _StaffRecord(wisa: member);
+      records.add(target);
+      if (codeKey != null) byCode.putIfAbsent(codeKey, () => target);
+    }
+    final wisaIdKey = _norm(member.wisaId?.value);
+    if (wisaIdKey != null) byWisaId.putIfAbsent(wisaIdKey, () => target);
+  }
+
+  // 3. Attach Azure users: by upn → mail, else by employeeId → wisaId, else
+  //    keep school-prefix orphans (INV-22 staff variant: `department` contains
+  //    the prefix), else discard (belongs to another school / population).
+  for (final user in azureSnapshot.users) {
+    final upn = _norm(user.upn);
+    final employeeId = _norm(user.employeeId);
+
+    _StaffRecord? target;
+    if (upn != null) {
+      final candidates = byMail[upn];
+      if (candidates != null) {
+        for (final rec in candidates) {
+          if (rec.azure == null) {
+            target = rec;
+            break;
+          }
+        }
+      }
+    }
+    if (target == null && employeeId != null) {
+      final rec = byWisaId[employeeId];
+      if (rec != null && rec.azure == null) target = rec;
+    }
+
+    if (target != null) {
+      target.azure = user;
+    } else if (_departmentMatchesPrefix(user.department, schoolPrefix)) {
+      records.add(_StaffRecord(azure: user));
+    }
+    // else: a user belonging to another school/population — dropped.
+  }
+
+  // 4. Resolve a stable identity, role, and confidence for each record.
+  return <LinkedStaff>[
+    for (final rec in records)
+      LinkedStaff(
+        id: LinkedAccountId(resolver.resolve(_naturalStaffKey(rec)).value),
+        role: rec.smartschool?.role ?? PersonRole.teacher,
+        wisa: rec.wisa,
+        smartschool: rec.smartschool,
+        azure: rec.azure,
+        confidence: _staffConfidence(rec),
+      ),
+  ];
 }
 
 /// Mutable accumulator for one linked person while the passes run; frozen into
@@ -146,6 +287,25 @@ class _Record {
 
   _Record({this.smartschool, this.wisa, this.azure});
 }
+
+/// Mutable accumulator for one linked staff member; the staff analogue of
+/// [_Record], carrying [wapi.WisaStaff] (with its `code`) instead of a
+/// [wapi.WisaStudent]. Frozen into an immutable [LinkedStaff] at the end.
+class _StaffRecord {
+  ss.SmartschoolAccount? smartschool;
+  wapi.WisaStaff? wisa;
+  az.AzureUser? azure;
+
+  _StaffRecord({this.smartschool, this.wisa, this.azure});
+}
+
+/// Whether a Smartschool [role] marks the account as staff (teacher or
+/// director) rather than a student. A `null` role (unrecognised Basisrol) is
+/// treated as non-staff so it stays in the student population, matching the
+/// pre-staff behaviour. The staff/student split derives from `role` because
+/// [SmartschoolAccount.accountType] is always `student` for a primary record.
+bool _isStaffRole(PersonRole? role) =>
+    role == PersonRole.teacher || role == PersonRole.director;
 
 /// Trims and lowercases [value] for case-insensitive, whitespace-tolerant
 /// comparison (INV-12). Returns `null` when [value] is null or blank so empty
@@ -162,6 +322,16 @@ bool _matchesPrefix(String? companyName, String schoolPrefix) {
   final company = _norm(companyName);
   final prefix = _norm(schoolPrefix);
   return company != null && prefix != null && company == prefix;
+}
+
+/// Whether an Azure user's [department] marks it as one of the school's own
+/// staff (a current or former staff member). Per INV-22 the staff signal is a
+/// *substring* match (`department` contains the prefix), unlike the student
+/// signal which is an exact `companyName` equality. Trimmed + case-insensitive.
+bool _departmentMatchesPrefix(String? department, String schoolPrefix) {
+  final dept = _norm(department);
+  final prefix = _norm(schoolPrefix);
+  return dept != null && prefix != null && dept.contains(prefix);
 }
 
 /// The natural key handed to the [PersonIdResolver]: `wisaId → mail → upn →
@@ -210,4 +380,56 @@ LinkConfidence _confidence(_Record rec) {
       wisaId != null && wisaId == accountId && wisaId == employeeId;
 
   return mailAgrees && idAgrees ? LinkConfidence.high : LinkConfidence.medium;
+}
+
+/// The natural key for a staff member: `wisaId → code → mail → upn → azureId`,
+/// normalized and namespaced under `staff:` so a staff member never collides
+/// with a student who happens to share a numeric id. `wisaId` (the Azure
+/// bridge) is preferred, then the Smartschool-side `code`.
+String _naturalStaffKey(_StaffRecord rec) {
+  final wisaId = _norm(rec.wisa?.wisaId?.value ?? rec.azure?.employeeId);
+  if (wisaId != null) return 'staff:wisa:$wisaId';
+
+  final code = _norm(rec.wisa?.code.value ?? rec.smartschool?.accountId);
+  if (code != null) return 'staff:code:$code';
+
+  final mail = _norm(rec.smartschool?.mail);
+  if (mail != null) return 'staff:mail:$mail';
+
+  final upn = _norm(rec.azure?.upn);
+  if (upn != null) return 'staff:upn:$upn';
+
+  final azureId = _norm(rec.azure?.id);
+  if (azureId != null) return 'staff:azure:$azureId';
+
+  // Unreachable: every record carries at least one identifying field.
+  throw StateError('LinkedStaff record has no identifying key: $rec');
+}
+
+/// `high` only when all three systems are present *and* both staff bridges
+/// agree: `upn == mail`, `accountId == code` (Smartschool ↔ WISA), and
+/// `employeeId == wisaId` (Azure ↔ WISA). Anything weaker is `medium`.
+LinkConfidence _staffConfidence(_StaffRecord rec) {
+  final member = rec.wisa;
+  final account = rec.smartschool;
+  final user = rec.azure;
+  if (member == null || account == null || user == null) {
+    return LinkConfidence.medium;
+  }
+
+  final upn = _norm(user.upn);
+  final mail = _norm(account.mail);
+  final mailAgrees = upn != null && upn == mail;
+
+  final code = _norm(member.code.value);
+  final accountId = _norm(account.accountId);
+  final codeAgrees = code != null && code == accountId;
+
+  final wisaId = _norm(member.wisaId?.value);
+  final employeeId = _norm(user.employeeId);
+  final idAgrees = wisaId != null && wisaId == employeeId;
+
+  return mailAgrees && codeAgrees && idAgrees
+      ? LinkConfidence.high
+      : LinkConfidence.medium;
 }

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -144,8 +144,9 @@ void main() {
     });
 
     test('co-account (non-student) Smartschool records are ignored', () {
-      // The concrete model only emits students, but the linker must honour the
-      // accountType filter regardless. A student links normally.
+      // The concrete model only emits primary student accounts via
+      // `accountType`; staff are filtered by role (see staff scenarios). A
+      // plain student links normally here.
       final snapshot = link(
         wisaSnap(const []),
         ssSnap([ssAccount(uid: 'kid', accountId: 'W8', mail: 'kid@s.be')]),
@@ -182,7 +183,7 @@ void main() {
       expect(a.confidence, LinkConfidence.medium);
     });
 
-    test('staff and groups stay empty (out of scope for #43)', () {
+    test('groups stay empty (out of scope for #45)', () {
       final snapshot = link(
         wisaSnap([wisaStudent('W10')]),
         ssSnap(const []),
@@ -190,8 +191,222 @@ void main() {
         SeqResolver(),
         schoolPrefix: _prefix,
       );
-      expect(snapshot.staff, isEmpty);
       expect(snapshot.groups, isEmpty);
+    });
+  });
+
+  group('link — staff scenarios', () {
+    test('fully linked across three systems → high confidence', () {
+      // Staff bridge Smartschool by `code` (≡ accountId) and Azure by `wisaId`
+      // (≡ employeeId): the two WISA identifiers are distinct (OQ-1).
+      final snapshot = link(
+        wisaSnap(const [], staff: [wisaStaff('DOEJA', wisaId: '493')]),
+        ssSnap([ssStaffAccount(uid: 'jdoe', accountId: 'DOEJA', mail: 'j@s.be')]),
+        azSnap([
+          azureUser(
+            id: 'az-s1',
+            upn: 'j@s.be',
+            employeeId: '493',
+            department: 'Arcadia - Wiskunde',
+          ),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      // No student records; one fully-linked staff record.
+      expect(snapshot.accounts, isEmpty);
+      expect(snapshot.staff, hasLength(1));
+      final s = snapshot.staff.single;
+      expect(s.confidence, LinkConfidence.high);
+      expect(s.wisa, isNotNull);
+      expect(s.smartschool, isNotNull);
+      expect(s.azure, isNotNull);
+      expect(s.role, PersonRole.teacher);
+      expect(snapshot.warnings, isEmpty);
+      // Present in all three ⇒ counts toward linked everywhere.
+      expect(snapshot.wisa.linked, 1);
+      expect(snapshot.smartschool.linked, 1);
+      expect(snapshot.azure.linked, 1);
+    });
+
+    test('director role is preserved on the linked staff record', () {
+      final snapshot = link(
+        wisaSnap(const [], staff: [wisaStaff('BIGBO', wisaId: '1')]),
+        ssSnap([
+          ssStaffAccount(
+            uid: 'boss',
+            accountId: 'BIGBO',
+            mail: 'boss@s.be',
+            role: PersonRole.director,
+          ),
+        ]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+      expect(snapshot.staff.single.role, PersonRole.director);
+    });
+
+    test('WISA staff not yet in Smartschool → medium placeholder', () {
+      final snapshot = link(
+        wisaSnap(const [], staff: [wisaStaff('NEWBI', wisaId: '900')]),
+        ssSnap(const []),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final s = snapshot.staff.single;
+      expect(s.wisa, isNotNull);
+      expect(s.smartschool, isNull);
+      expect(s.azure, isNull);
+      expect(s.confidence, LinkConfidence.medium);
+      expect(snapshot.wisa.unlinked, 1);
+    });
+
+    test('staff present only in Smartschool + Azure (no WISA) → medium', () {
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap([ssStaffAccount(uid: 't', accountId: 'TEACH', mail: 't@s.be')]),
+        azSnap([
+          azureUser(
+            id: 'az-s2',
+            upn: 't@s.be',
+            employeeId: '777',
+            department: 'Arcadia',
+          ),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      expect(snapshot.accounts, isEmpty);
+      final s = snapshot.staff.single;
+      expect(s.wisa, isNull);
+      expect(s.smartschool, isNotNull);
+      expect(s.azure, isNotNull);
+      expect(s.confidence, LinkConfidence.medium);
+    });
+
+    test('Azure-only staff with school prefix in department is kept', () {
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap(const []),
+        azSnap([
+          azureUser(
+            id: 'az-s3',
+            upn: 'gone@s.be',
+            department: 'Arcadia - Talen',
+          ),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final s = snapshot.staff.single;
+      expect(s.azure, isNotNull);
+      expect(s.wisa, isNull);
+      expect(s.smartschool, isNull);
+      expect(s.confidence, LinkConfidence.medium);
+      expect(snapshot.azure.unlinked, 1);
+    });
+
+    test('Azure staff matched by employeeId when UPN differs from mail', () {
+      final snapshot = link(
+        wisaSnap(const [], staff: [wisaStaff('AMYTE', wisaId: '321')]),
+        ssSnap([ssStaffAccount(uid: 'amy', accountId: 'AMYTE', mail: 'amy@s.be')]),
+        azSnap([
+          azureUser(
+            id: 'az-s4',
+            upn: 'amy.renamed@s.be',
+            employeeId: '321',
+            department: 'Arcadia',
+          ),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final s = snapshot.staff.single;
+      expect(s.azure?.id, 'az-s4');
+      expect(s.wisa, isNotNull);
+      expect(s.smartschool, isNotNull);
+      // upn != mail ⇒ not all keys agree ⇒ medium.
+      expect(s.confidence, LinkConfidence.medium);
+    });
+
+    test('staff and students partition cleanly from one Smartschool list', () {
+      // A teacher and a student share neither key; each must land in exactly
+      // one population, never both.
+      final snapshot = link(
+        wisaSnap([wisaStudent('W1')], staff: [wisaStaff('TEACH', wisaId: '5')]),
+        ssSnap([
+          ssAccount(uid: 'pupil', accountId: 'W1', mail: 'pupil@s.be'),
+          ssStaffAccount(uid: 'teach', accountId: 'TEACH', mail: 'teach@s.be'),
+        ]),
+        azSnap([
+          azureUser(
+            id: 'az-stud',
+            upn: 'pupil@s.be',
+            employeeId: 'W1',
+            companyName: _prefix,
+          ),
+          azureUser(
+            id: 'az-staff',
+            upn: 'teach@s.be',
+            employeeId: '5',
+            department: 'Arcadia',
+          ),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      expect(snapshot.accounts.single.smartschool?.uid, 'pupil');
+      expect(snapshot.staff.single.smartschool?.uid, 'teach');
+      expect(snapshot.accounts.single.confidence, LinkConfidence.high);
+      expect(snapshot.staff.single.confidence, LinkConfidence.high);
+    });
+
+    test('INV-23: duplicate-mail staff accounts both kept + warning', () {
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap([
+          ssStaffAccount(uid: 'twin-a', accountId: 'TWINA', mail: 'twin@s.be'),
+          ssStaffAccount(uid: 'twin-b', accountId: 'TWINB', mail: 'TWIN@s.be'),
+        ]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final uids = snapshot.staff
+          .map((s) => s.smartschool?.uid)
+          .whereType<String>()
+          .toSet();
+      expect(uids, {'twin-a', 'twin-b'});
+
+      final warning = snapshot.warnings.single as ResolveDuplicateMail;
+      expect(warning.mail, 'twin@s.be');
+      expect(warning.accounts.map((a) => a.uid).toSet(), {'twin-a', 'twin-b'});
+    });
+
+    test('staff member with no wisaId still links via code + mail', () {
+      // OQ-1: wisaId may be empty; code remains the Smartschool bridge.
+      final snapshot = link(
+        wisaSnap(const [], staff: [wisaStaff('NOIDS')]),
+        ssSnap([ssStaffAccount(uid: 'n', accountId: 'NOIDS', mail: 'n@s.be')]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final s = snapshot.staff.single;
+      expect(s.wisa, isNotNull);
+      expect(s.smartschool?.uid, 'n');
+      // No Azure (and no wisaId to bridge it) ⇒ medium.
+      expect(s.confidence, LinkConfidence.medium);
     });
   });
 }

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -69,26 +69,75 @@ ss.SmartschoolAccount ssAccount({
       status: 'actief',
     );
 
+/// A WISA staff member. [code] is the alphabetic surname-mnemonic that bridges
+/// to Smartschool (`accountId`); [wisaId] is the distinct numeric id that
+/// bridges to Azure (`employeeId`) and may be null (OQ-1).
+wapi.WisaStaff wisaStaff(String code, {String? wisaId}) => wapi.WisaStaff(
+      code: WisaStaffCode(code),
+      wisaId: wisaId == null ? null : WisaId(wisaId),
+      firstName: 'Jane',
+      lastName: 'Doe',
+    );
+
+/// A Smartschool **staff** account. Unlike [ssAccount], [accountId] holds the
+/// WISA staff `code` (not the wisaId) and [role] is a staff role so the linker
+/// routes it to the staff population.
+ss.SmartschoolAccount ssStaffAccount({
+  required String uid,
+  required String accountId,
+  required String mail,
+  PersonRole role = PersonRole.teacher,
+}) =>
+    ss.SmartschoolAccount(
+      uid: uid,
+      accountId: accountId,
+      mail: mail,
+      registerId: '',
+      stemId: 0,
+      role: role,
+      givenName: 'Jane',
+      surname: 'Doe',
+      extraNames: '',
+      initials: '',
+      preferredName: '',
+      gender: Gender.female,
+      birthDate: null,
+      birthPlace: '',
+      birthCountry: '',
+      address: _blankAddress,
+      mobilePhone: '',
+      homePhone: '',
+      fax: '',
+      untisId: '',
+      status: 'actief',
+    );
+
 /// An Azure user. [companyName] equal to the school prefix marks one of the
-/// school's own users (INV-22).
+/// school's own *students*; a [department] containing the prefix marks a
+/// *staff* member (INV-22).
 az.AzureUser azureUser({
   required String id,
   required String upn,
   String? employeeId,
   String? companyName,
+  String? department,
 }) =>
     az.AzureUser(
       id: id,
       upn: upn,
       employeeId: employeeId,
       companyName: companyName,
+      department: department,
     );
 
-wapi.WisaSnapshot wisaSnap(List<wapi.WisaStudent> students) =>
+wapi.WisaSnapshot wisaSnap(
+  List<wapi.WisaStudent> students, {
+  List<wapi.WisaStaff> staff = const [],
+}) =>
     wapi.WisaSnapshot(
       fetchedAt: _fixedDate,
       students: students,
-      staff: const [],
+      staff: staff,
       classGroups: const [],
       schools: const [],
     );
@@ -135,6 +184,15 @@ List<String> structuralSignature(LinkedSnapshot snapshot) {
         'a:${a.azure?.id ?? '-'}',
       ].join('|');
 
+  String stf(LinkedStaff s) => [
+        s.id.value,
+        s.role.name,
+        s.confidence.name,
+        'w:${s.wisa?.code.value ?? '-'}',
+        's:${s.smartschool?.uid ?? '-'}',
+        'a:${s.azure?.id ?? '-'}',
+      ].join('|');
+
   String warning(LinkWarning w) => switch (w) {
         ResolveDuplicateMail(:final mail, :final accounts) =>
           'dupmail:$mail:${(accounts.map((x) => x.uid).toList()..sort()).join(',')}',
@@ -142,6 +200,7 @@ List<String> structuralSignature(LinkedSnapshot snapshot) {
 
   return [
     for (final a in snapshot.accounts) 'acc:${acc(a)}',
+    for (final s in snapshot.staff) 'stf:${stf(s)}',
     for (final w in snapshot.warnings) warning(w),
     'wisa:${snapshot.wisa.total}/${snapshot.wisa.linked}/${snapshot.wisa.unlinked}',
     'ss:${snapshot.smartschool.total}/${snapshot.smartschool.linked}/${snapshot.smartschool.unlinked}',


### PR DESCRIPTION
## Summary
- Link the **staff** population (`LinkedStaff`) alongside students, completing the second of the three linker scopes (students #43, staff #44, groups #45).
- Staff use **different bridges** than students: WISA staff match Smartschool on `code` (≡ `accountId`) and Azure on `wisaId` (≡ `employeeId`); `mail` ≡ `upn` as before. Azure staff orphans are kept when `department` contains the school prefix (INV-22 staff variant).
- Students and staff are partitioned out of Smartschool's single flat account list by `role` (`teacher`/`director` ⇒ staff). Staff-role accounts are now skipped in the student seed so a staff member is never linked into both populations.

## OQ-1 resolved (from real data)
Inspected the real 194-row WISA staff export (`artifacts/wisaStaff.json`, gitignored): `code` and `wisaId` differ in **194/194** records — `wisaId` is numeric, `code` an alphabetic surname-mnemonic, and `wisaId` may be empty while `code` never is. **They are genuinely distinct identifiers; both fields are kept.** Each bridges a different system (code→Smartschool, wisaId→Azure). Documented in the new `packages/account_linker/README.md` and `docs/domain-model.md` (§3.4, §4, §9).

## Note on scope
The student seed previously filtered on `accountType` (always `student`, a no-op), so staff-role Smartschool accounts were incorrectly linked as students. Correcting this to a `role`-based skip was necessary to partition the two populations; it only affects teacher/director accounts and does not change linking for student-role accounts (all existing student tests still pass unchanged).

## Test plan
- [x] `dart analyze` clean across the workspace
- [x] All package test suites pass (`account_core`, `wisa_api`, `smartschool_api`, `azure_api`, `account_linker`)
- [x] New staff scenarios: fully linked (high), director role preserved, WISA-only placeholder, SS+Azure-only (medium), Azure-only department orphan, employeeId fallback, clean student/staff partition, duplicate-mail INV-23, no-wisaId staff member
- [ ] CI green

Closes #44