### PR TITLE
Add group linking to account_linker (#45)

### DIFF
--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -12,8 +12,8 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 /// minting and persisting the stable [PersonId] — is delegated to [resolver],
 /// so `link` itself does no I/O.
 ///
-/// This function links **students** (#43) and **staff** (#44);
-/// [LinkedSnapshot.groups] is still returned empty (groups #45).
+/// This function links **students** (#43), **staff** (#44), and **groups**
+/// (#45).
 ///
 /// The **student** bridges (spec `docs/domain-model.md` §4, §6.2):
 /// - `AzureUser.upn` ≡ `SmartschoolAccount.mail` (case-insensitive, trimmed)
@@ -158,10 +158,12 @@ LinkedSnapshot link(
     warnings: warnings,
   );
 
+  final groups = _linkGroups(wisaSnapshot, smartschoolSnapshot, azureSnapshot);
+
   return LinkedSnapshot.fromRecords(
     accounts: accounts,
     staff: staff,
-    groups: const [],
+    groups: groups,
     warnings: warnings,
   );
 }
@@ -278,6 +280,98 @@ List<LinkedStaff> _linkStaff(
   ];
 }
 
+/// Links the class-group population, ported from legacy
+/// `LinkedGroups.DoRelink`. Groups are matched purely **by name**: a WISA class
+/// group's `fullName` against a Smartschool official class's `name` and an
+/// Azure group's `displayName`. There is no stable cross-system id for a group,
+/// so the name *is* the bridge.
+///
+/// Anchored on WISA: every [LinkedGroup] carries a WISA [Group] ([LinkedGroup]
+/// requires it), so only WISA class groups seed records. A Smartschool or Azure
+/// group that matches no WISA class has no anchor and is dropped — unlike a
+/// person, a group cannot be represented Smartschool-only or Azure-only
+/// (issue #45, "WISA required"). Cleanup of such orphan groups is left to the
+/// action engine, which would need a nullable-WISA record type.
+///
+/// Only `official` Smartschool groups are considered (legacy
+/// `AddSmartschoolChildGroups` walked the "Leerlingen" subtree and linked only
+/// official classes); organisational sub-groups never match.
+///
+/// Confidence mirrors accounts/staff: `high` only when all three systems carry
+/// the group — and because the match key *is* the (normalized) name, presence
+/// in all three implies the keys agree — otherwise `medium`. All comparisons
+/// are trimmed + case-insensitive (INV-12).
+List<LinkedGroup> _linkGroups(
+  wapi.WisaSnapshot wisaSnapshot,
+  ss.SmartschoolSnapshot smartschoolSnapshot,
+  az.AzureSnapshot azureSnapshot,
+) {
+  final records = <_GroupRecord>[];
+  // Normalized fullName -> the record anchored on that WISA class group.
+  final byName = <String, _GroupRecord>{};
+
+  // 1. Seed one record per distinct WISA class group, in snapshot order, keyed
+  //    by its `fullName`. Duplicate fullNames collapse to the first record so
+  //    the output is a deterministic function of the input order (INV-20).
+  for (final group in wisaSnapshot.classGroups) {
+    final key = _norm(group.fullName);
+    if (key == null || byName.containsKey(key)) continue;
+    final rec = _GroupRecord(wisa: group);
+    records.add(rec);
+    byName[key] = rec;
+  }
+
+  // 2. Attach official Smartschool class groups by name. Non-official
+  //    organisational groups never link; an official group matching no WISA
+  //    class is dropped (no WISA anchor).
+  for (final group in smartschoolSnapshot.groups) {
+    if (!group.official) continue;
+    final key = _norm(group.name);
+    if (key == null) continue;
+    final rec = byName[key];
+    if (rec != null && rec.smartschool == null) rec.smartschool = group;
+  }
+
+  // 3. Attach Azure groups by displayName. An Azure group matching no WISA
+  //    class is likewise dropped.
+  for (final group in azureSnapshot.groups) {
+    final key = _norm(group.displayName);
+    if (key == null) continue;
+    final rec = byName[key];
+    if (rec != null && rec.azure == null) rec.azure = group;
+  }
+
+  // 4. Freeze each record into an immutable [LinkedGroup].
+  return <LinkedGroup>[
+    for (final rec in records)
+      LinkedGroup(
+        wisa: _wisaToCoreGroup(rec.wisa),
+        smartschool: rec.smartschool,
+        azure: rec.azure,
+        confidence: rec.smartschool != null && rec.azure != null
+            ? LinkConfidence.high
+            : LinkConfidence.medium,
+      ),
+  ];
+}
+
+/// Projects a [wapi.WisaClassGroup] to the canonical [Group] that
+/// [LinkedGroup.wisa] expects. The group is identified and named by its
+/// `fullName` (the cross-system match key); WISA class groups are always real
+/// classes, hence `official: true` and [GroupType.classGroup]. `schoolCode`
+/// becomes the institute number; WISA exposes no tree edge or numeric admin
+/// number for a class group, so [Group.parentId] and [Group.adminNumber] stay
+/// null.
+Group _wisaToCoreGroup(wapi.WisaClassGroup g) => Group(
+      id: GroupId(g.fullName),
+      name: g.fullName,
+      description: g.description,
+      type: GroupType.classGroup,
+      official: true,
+      instituteNumber: g.schoolCode.isEmpty ? null : g.schoolCode,
+      origin: Origin.wisa,
+    );
+
 /// Mutable accumulator for one linked person while the passes run; frozen into
 /// an immutable [LinkedAccount] at the end.
 class _Record {
@@ -297,6 +391,18 @@ class _StaffRecord {
   az.AzureUser? azure;
 
   _StaffRecord({this.smartschool, this.wisa, this.azure});
+}
+
+/// Mutable accumulator for one linked class group; the group analogue of
+/// [_Record]. Anchored on a required [wapi.WisaClassGroup] (groups seed only
+/// from WISA), gathering the matching Smartschool [Group] and [az.AzureGroup]
+/// as the passes run. Frozen into an immutable [LinkedGroup] at the end.
+class _GroupRecord {
+  final wapi.WisaClassGroup wisa;
+  Group? smartschool;
+  az.AzureGroup? azure;
+
+  _GroupRecord({required this.wisa});
 }
 
 /// Whether a Smartschool [role] marks the account as staff (teacher or

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -183,7 +183,7 @@ void main() {
       expect(a.confidence, LinkConfidence.medium);
     });
 
-    test('groups stay empty (out of scope for #45)', () {
+    test('a WISA student leaves groups untouched', () {
       final snapshot = link(
         wisaSnap([wisaStudent('W10')]),
         ssSnap(const []),
@@ -192,6 +192,145 @@ void main() {
         schoolPrefix: _prefix,
       );
       expect(snapshot.groups, isEmpty);
+    });
+  });
+
+  group('link — group scenarios', () {
+    test('fully linked across three systems → high confidence', () {
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('5A')]),
+        ssSnap(const [], groups: [ssGroup('5A')]),
+        azSnap(const [], groups: [azureGroup('5A')]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      expect(snapshot.groups, hasLength(1));
+      final g = snapshot.groups.single;
+      expect(g.confidence, LinkConfidence.high);
+      expect(g.wisa.name, '5A');
+      expect(g.wisa.origin, Origin.wisa);
+      expect(g.smartschool, isNotNull);
+      expect(g.azure, isNotNull);
+    });
+
+    test('WISA-only group → medium, no Smartschool/Azure', () {
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('3B')]),
+        ssSnap(const []),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final g = snapshot.groups.single;
+      expect(g.wisa.name, '3B');
+      expect(g.smartschool, isNull);
+      expect(g.azure, isNull);
+      expect(g.confidence, LinkConfidence.medium);
+    });
+
+    test('Smartschool-only group is dropped (no WISA anchor)', () {
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap(const [], groups: [ssGroup('6C')]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+      expect(snapshot.groups, isEmpty);
+    });
+
+    test('Azure-only group is dropped (no WISA anchor)', () {
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap(const []),
+        azSnap(const [], groups: [azureGroup('6C')]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+      expect(snapshot.groups, isEmpty);
+    });
+
+    test('WISA + Smartschool but no Azure → medium', () {
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('5A')]),
+        ssSnap(const [], groups: [ssGroup('5A')]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final g = snapshot.groups.single;
+      expect(g.smartschool, isNotNull);
+      expect(g.azure, isNull);
+      expect(g.confidence, LinkConfidence.medium);
+    });
+
+    test('non-official Smartschool group never links', () {
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('5A')]),
+        ssSnap(const [], groups: [ssGroup('5A', official: false)]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final g = snapshot.groups.single;
+      // The organisational group with the same name is ignored.
+      expect(g.smartschool, isNull);
+      expect(g.confidence, LinkConfidence.medium);
+    });
+
+    test('subgroup fullName (name + groupName) is the match key', () {
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('5A', groupName: '01')]),
+        ssSnap(const [], groups: [ssGroup('5A 01')]),
+        azSnap(const [], groups: [azureGroup('5A 01')]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final g = snapshot.groups.single;
+      expect(g.wisa.name, '5A 01');
+      expect(g.smartschool, isNotNull);
+      expect(g.azure, isNotNull);
+      expect(g.confidence, LinkConfidence.high);
+    });
+
+    test('INV-12: case/whitespace differences still link → high', () {
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('5A')]),
+        ssSnap(const [], groups: [ssGroup('5a')]),
+        azSnap(const [], groups: [azureGroup('  5A  ')]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final g = snapshot.groups.single;
+      expect(g.smartschool, isNotNull);
+      expect(g.azure, isNotNull);
+      expect(g.confidence, LinkConfidence.high);
+    });
+
+    test('duplicate WISA fullName collapses to one record', () {
+      final snapshot = link(
+        wisaSnap(
+          const [],
+          // Same fullName from two schools — one linked group, first wins.
+          classGroups: [
+            wisaClassGroup('5A', schoolCode: '111'),
+            wisaClassGroup('5A', schoolCode: '222'),
+          ],
+        ),
+        ssSnap(const []),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      expect(snapshot.groups, hasLength(1));
+      expect(snapshot.groups.single.wisa.instituteNumber, '111');
     });
   });
 

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -130,30 +130,80 @@ az.AzureUser azureUser({
       department: department,
     );
 
+/// A WISA class group. [name] + [groupName] form the `fullName` the linker
+/// matches on; `groupName == '00'` (the default) means "no subgroup", so
+/// `fullName == name`. [schoolCode] becomes the linked group's institute
+/// number.
+wapi.WisaClassGroup wisaClassGroup(
+  String name, {
+  String groupName = '00',
+  String schoolCode = '123',
+}) =>
+    wapi.WisaClassGroup(
+      name: name,
+      groupName: groupName,
+      description: '',
+      adminCode: '',
+      schoolCode: schoolCode,
+      schoolId: 1,
+    );
+
+/// A Smartschool class group as a [core.Group]. Matched to WISA by [name];
+/// [official] must be `true` for the linker to consider it (non-official
+/// organisational groups never link). [code] defaults to [name].
+Group ssGroup(
+  String name, {
+  String? code,
+  bool official = true,
+}) =>
+    Group(
+      id: GroupId(code ?? name),
+      name: name,
+      description: '',
+      type: GroupType.classGroup,
+      official: official,
+      origin: Origin.smartschool,
+    );
+
+/// An Azure group, matched to WISA by [displayName]. [id] defaults to
+/// [displayName].
+az.AzureGroup azureGroup(String displayName, {String? id}) => az.AzureGroup(
+      id: id ?? displayName,
+      displayName: displayName,
+    );
+
 wapi.WisaSnapshot wisaSnap(
   List<wapi.WisaStudent> students, {
   List<wapi.WisaStaff> staff = const [],
+  List<wapi.WisaClassGroup> classGroups = const [],
 }) =>
     wapi.WisaSnapshot(
       fetchedAt: _fixedDate,
       students: students,
       staff: staff,
-      classGroups: const [],
+      classGroups: classGroups,
       schools: const [],
     );
 
-ss.SmartschoolSnapshot ssSnap(List<ss.SmartschoolAccount> accounts) =>
+ss.SmartschoolSnapshot ssSnap(
+  List<ss.SmartschoolAccount> accounts, {
+  List<Group> groups = const [],
+}) =>
     ss.SmartschoolSnapshot(
       fetchedAt: _fixedDate,
-      groups: const [],
+      groups: groups,
       accounts: accounts,
       memberships: const [],
     );
 
-az.AzureSnapshot azSnap(List<az.AzureUser> users) => az.AzureSnapshot(
+az.AzureSnapshot azSnap(
+  List<az.AzureUser> users, {
+  List<az.AzureGroup> groups = const [],
+}) =>
+    az.AzureSnapshot(
       fetchedAt: _fixedDate,
       users: users,
-      groups: const [],
+      groups: groups,
     );
 
 /// Deterministic [PersonIdResolver]: mints `p0`, `p1`, … in first-seen order
@@ -193,6 +243,14 @@ List<String> structuralSignature(LinkedSnapshot snapshot) {
         'a:${s.azure?.id ?? '-'}',
       ].join('|');
 
+  // Groups have no linker-minted id; the WISA name anchors the record.
+  String grp(LinkedGroup g) => [
+        g.confidence.name,
+        'w:${g.wisa.name}',
+        's:${g.smartschool?.id.value ?? '-'}',
+        'a:${g.azure?.id ?? '-'}',
+      ].join('|');
+
   String warning(LinkWarning w) => switch (w) {
         ResolveDuplicateMail(:final mail, :final accounts) =>
           'dupmail:$mail:${(accounts.map((x) => x.uid).toList()..sort()).join(',')}',
@@ -201,6 +259,7 @@ List<String> structuralSignature(LinkedSnapshot snapshot) {
   return [
     for (final a in snapshot.accounts) 'acc:${acc(a)}',
     for (final s in snapshot.staff) 'stf:${stf(s)}',
+    for (final g in snapshot.groups) 'grp:${grp(g)}',
     for (final w in snapshot.warnings) warning(w),
     'wisa:${snapshot.wisa.total}/${snapshot.wisa.linked}/${snapshot.wisa.unlinked}',
     'ss:${snapshot.smartschool.total}/${snapshot.smartschool.linked}/${snapshot.smartschool.unlinked}',


### PR DESCRIPTION
## Summary
- Adds **group** linking to `account_linker`: `link()` now produces `LinkedGroup` records in `LinkedSnapshot.groups` (previously returned empty).
- Matches **by name**, mirroring the student/staff passes and legacy `LinkedGroups.DoRelink`:
  1. Seed one record per distinct WISA class group, keyed by normalized `fullName` (dedupe first-seen → deterministic, INV-20).
  2. Attach **official** Smartschool groups by `name` (non-official organisational groups never link).
  3. Attach Azure groups by `displayName`.
  4. `confidence` is `high` only when all three systems carry the group, else `medium`. All comparisons trimmed + case-insensitive (INV-12).
- WISA→`core.Group` projection (`_wisaToCoreGroup`) so the required `LinkedGroup.wisa` is satisfied; groups carry no linker-minted id, so the `PersonIdResolver` is untouched.
- No changes to `account_core` or any connector package.

## Design note — orphan groups
`LinkedGroup.wisa` is non-nullable ("WISA required" per the issue), so a **Smartschool-only or Azure-only** group has no anchor and is **dropped**. Legacy allowed Smartschool-only `LinkedGroup`s; cleanup of stale Smartschool/Azure groups (mirroring how Azure-only *accounts* are kept for deletion) would need a nullable-WISA record type **and** an Azure class-group filter (Azure groups carry no `official`-style signal). Deferred to a tracked follow-up.

## Test plan
- [x] `dart analyze` clean
- [x] `dart test` green (32 tests)
- [x] New `link — group scenarios` block covers the three acceptance cases — fully-linked (high), WISA-only (medium), Smartschool-only & Azure-only (dropped) — plus WISA+SS-no-Azure (medium), non-official SS ignored, subgroup `fullName` match, INV-12 case/whitespace, and duplicate-`fullName` collapse.
- [x] Group signature added to `structuralSignature`, so the INV-20 determinism and INV-12 property tests now also cover groups.

Closes #45