### PR TITLE
Add action engine framework + Student action family (#46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
             packages/account_core/test \
             packages/wisa_api/test \
             packages/smartschool_api/test \
-            packages/azure_api/test
+            packages/azure_api/test \
+            packages/account_linker/test \
+            packages/account_actions/test
           dart pub global activate coverage
           dart pub global run coverage:format_coverage \
             --lcov \

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -78,7 +78,7 @@ jobs:
         # No WISA_USERNAME / SMARTSCHOOL_ACCESSCODE / AZURE_ACCESS_TOKEN in
         # this job — the integration tests self-skip, see each package's
         # test/integration/.
-        run: dart test packages/account_core/test packages/wisa_api/test packages/smartschool_api/test packages/azure_api/test
+        run: dart test packages/account_core/test packages/wisa_api/test packages/smartschool_api/test packages/azure_api/test packages/account_linker/test packages/account_actions/test
 
   live-test:
     name: WISA + Smartschool + Azure live integration

--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -1,0 +1,81 @@
+# account_actions
+
+The **action engine** for the Arcadia Account Manager port (spec
+`docs/domain-model.md` §3.10, §6.3–6.4). Given a `LinkedSnapshot` from
+`account_linker`, it derives the add/remove/modify actions applicable to each
+linked record and applies them — with a dry-run path — against the connector
+write APIs.
+
+## What ships here
+
+This package currently implements the **student** family and its dispatcher.
+Staff and group families are tracked as follow-ups to #46, mirroring how the
+linker shipped student/staff/group as separate slices (#43/#44/#45).
+
+## The shape of an action
+
+`StudentAction` is a `sealed` base with one subclass per legacy
+`Action\StudentAccount\*` class. Each action is **bound to its target**
+`LinkedAccount` at construction (per §6.4's `apply(action, connectors,
+options)`), and exposes three operations with a hard purity boundary:
+
+| Operation | Purity | Purpose |
+|---|---|---|
+| `bool evaluate()` | pure (INV-40) | Does this action apply to the bound record? |
+| `ChangeSet describeChanges()` | pure (INV-40) | The field-level diff, for the detail dialog. |
+| `Future<ActionResult> apply(Connectors, ApplyOptions)` | impure | Perform the write (or, with `dryRun`, don't). |
+
+`apply` is retry-safe (INV-41: a transient failure returns
+`ActionOutcome.failed` without corrupting state) and never mutates the bound
+record or its snapshot (INV-42: every changed record is a fresh copy).
+
+### The mutated source record
+
+`ActionResult` carries the **new or updated connector record** (`smartschool`
+or `azure`), or `removed: true` for a delete. This lets the future State layer
+patch its in-memory snapshot and re-run `link()` **without a network re-sync**
+(the incremental-refresh constraint from #40).
+
+### Dry run (PAIN-3)
+
+`ApplyOptions(dryRun: true)` makes `apply` produce the same `ChangeSet` and the
+same projected record while performing **no** writes. The detail dialog and the
+"apply" button share this one path.
+
+## Dispatch (§6.3)
+
+`studentActions(snapshot, config)` walks the snapshot's student records and,
+per record, applies the legacy `AccountActionParser` rule:
+
+- **Any system missing** → only the lifecycle actions (`AddStudentToAzure`,
+  `AddStudentToSmartschool`, `UnregisterStudentFromSmartschool`,
+  `DeleteStudentFromSmartschool`, `RemoveStudentFromAzure`) are considered.
+- **All three present** → only the modify/sync actions (`ModifyAzure*`,
+  `ModifyAccountId`, `ModifySmartschool*`) are considered.
+
+The two sets never coexist for one record, exactly as in legacy.
+
+## Configuration
+
+`StudentActionConfig` injects the values legacy hard-coded: `schoolPrefix`, the
+base `azureDomain` and derived `studentDomain`, a password provider for created
+accounts, and a Smartschool `uid` builder.
+
+## Deferred (documented divergences)
+
+- **`MoveToSmartschoolClassGroup`** and the class-group placement inside
+  `AddStudentToSmartschool` are **not** ported here: they need the Smartschool
+  group tree / a student's current class membership, which the `LinkedAccount`
+  record does not carry. They belong with a `Membership`-aware input (follow-up).
+- **`ChangeEmail`** (legacy) is dead code — not wired into the parser — and is
+  intentionally omitted.
+- Smartschool `uid` uniqueness for new accounts is the caller's concern (the
+  State layer holds the account set); the default builder is deliberately
+  simple.
+
+## Testing
+
+Pure `evaluate`/`describeChanges`/dispatch tests need no connectors. The
+`apply` tests drive the real connectors backed by recording fake transports, so
+a dry run can assert **zero** writes and a real apply can assert the exact call
+and the returned mutated record.

--- a/packages/account_actions/lib/account_actions.dart
+++ b/packages/account_actions/lib/account_actions.dart
@@ -1,0 +1,24 @@
+/// Action engine for the Arcadia Account Manager port.
+///
+/// A sealed `Action` hierarchy grouped by family (spec
+/// `docs/domain-model.md` §3.10, §6.3–6.4). Each action exposes a pure
+/// `evaluate()` and `describeChanges()` and an impure, dry-run-capable
+/// `apply()` that returns the **mutated source record** so the State layer can
+/// patch its snapshot without a network re-sync.
+///
+/// This package currently ships the **student** family and its dispatcher.
+/// The staff and group families are tracked as follow-ups to #46, mirroring
+/// how the linker shipped student/staff/group as separate slices
+/// (#43/#44/#45).
+///
+/// Pure Dart — no Flutter, no UI coupling. Legacy reference (read-only):
+/// `legacy-wpf/AccountManager/Action/`.
+library;
+
+export 'src/action_result.dart';
+export 'src/apply_options.dart';
+export 'src/change_set.dart';
+export 'src/connectors.dart';
+export 'src/student_action.dart';
+export 'src/student_action_config.dart';
+export 'src/student_dispatch.dart';

--- a/packages/account_actions/lib/src/action_result.dart
+++ b/packages/account_actions/lib/src/action_result.dart
@@ -1,0 +1,69 @@
+import 'package:account_core/account_core.dart';
+
+import 'change_set.dart';
+
+/// How an `apply()` call ended.
+enum ActionOutcome {
+  /// The write was performed successfully.
+  applied,
+
+  /// [ApplyOptions.dryRun] was set — no write was performed; the result
+  /// carries the projected [ChangeSet] and record only (PAIN-3).
+  dryRun,
+
+  /// The write was attempted and failed; [ActionResult.error] holds the cause.
+  /// Per INV-41 the target state is not left corrupted — the action can be
+  /// retried.
+  failed,
+}
+
+/// The outcome of applying an action.
+///
+/// Beyond success/failure and the [changes] that were made, this carries the
+/// **mutated source record** ([smartschool] or [azure]) — the new or updated
+/// connector record — so the State layer can patch its in-memory snapshot and
+/// re-run `link()` without a network re-sync (the incremental-refresh
+/// constraint from #40). A lifecycle delete sets [removed] instead of a record.
+///
+/// The record fields are typed against the `account_core` interfaces; the
+/// concrete connector records ([smartschool_api] / [azure_api]) implement them.
+class ActionResult {
+  final ActionOutcome outcome;
+
+  /// What was changed (or, on a dry run, what would be changed).
+  final ChangeSet changes;
+
+  /// The system the action wrote to.
+  final Origin system;
+
+  /// The created/updated Smartschool record, when [system] is Smartschool and
+  /// the record still exists. Null for a delete or an Azure-targeted action.
+  final SmartschoolAccount? smartschool;
+
+  /// The created/updated Azure record, when [system] is Azure and the record
+  /// still exists. Null for a delete or a Smartschool-targeted action.
+  final AzureUser? azure;
+
+  /// True when the action deleted the record from [system] (so the State layer
+  /// should drop it from the snapshot rather than patch it).
+  final bool removed;
+
+  /// The failure cause; non-null only when [outcome] is [ActionOutcome.failed].
+  final Object? error;
+
+  const ActionResult({
+    required this.outcome,
+    required this.changes,
+    required this.system,
+    this.smartschool,
+    this.azure,
+    this.removed = false,
+    this.error,
+  });
+
+  /// Convenience: the write succeeded or was a dry run (i.e. not failed).
+  bool get ok => outcome != ActionOutcome.failed;
+
+  /// Convenience: a real write happened (not a dry run, not a failure).
+  bool get wrote => outcome == ActionOutcome.applied;
+}

--- a/packages/account_actions/lib/src/apply_options.dart
+++ b/packages/account_actions/lib/src/apply_options.dart
@@ -1,0 +1,21 @@
+/// Options passed to `Action.apply()`.
+///
+/// Spec `docs/domain-model.md` §3.10, §6.4. [dryRun] is the PAIN-3 fix: when
+/// set, `apply` produces the same [ChangeSet] and projected result record but
+/// performs **no writes**.
+class ApplyOptions {
+  /// When true, `apply` performs no side effects — it returns the projected
+  /// outcome only (PAIN-3).
+  final bool dryRun;
+
+  /// The official change date used by the Smartschool lifecycle writes
+  /// (`unregisterStudent`, `deleteUser`); Smartschool records evaluation
+  /// history against it. Ported from the legacy `deletionDate` parameter on
+  /// the student `Apply`. Ignored by actions that don't need a date.
+  final DateTime? deletionDate;
+
+  const ApplyOptions({this.dryRun = false, this.deletionDate});
+
+  /// A dry-run with no deletion date — the common "just describe it" case.
+  static const ApplyOptions dry = ApplyOptions(dryRun: true);
+}

--- a/packages/account_actions/lib/src/change_set.dart
+++ b/packages/account_actions/lib/src/change_set.dart
@@ -1,0 +1,44 @@
+import 'package:account_core/account_core.dart' show Origin;
+
+/// One field-level change an action would make, for the diff UI.
+///
+/// [before] and [after] are the human-readable current and proposed values;
+/// either may be null (a field being set for the first time, or cleared).
+class FieldChange {
+  final String field;
+  final String? before;
+  final String? after;
+
+  const FieldChange(this.field, {this.before, this.after});
+
+  @override
+  String toString() =>
+      'FieldChange($field: ${before ?? '∅'} → ${after ?? '∅'})';
+}
+
+/// A pure description of what an action would change, produced by
+/// `Action.describeChanges()` (spec `docs/domain-model.md` §3.10). Drives the
+/// action-detail diff dialog and the dry-run path (PAIN-3): the same
+/// description is shown whether or not the change is actually applied.
+class ChangeSet {
+  /// The system the change targets.
+  final Origin system;
+
+  /// A short, human-facing summary (Dutch, ported from the legacy action
+  /// `Header`/`Description`).
+  final String summary;
+
+  /// The field-level diff. Empty for pure lifecycle actions (create/delete)
+  /// where a per-field table is not meaningful.
+  final List<FieldChange> fields;
+
+  const ChangeSet({
+    required this.system,
+    required this.summary,
+    this.fields = const [],
+  });
+
+  @override
+  String toString() => 'ChangeSet(${system.name}: $summary, '
+      '${fields.length} field(s))';
+}

--- a/packages/account_actions/lib/src/connectors.dart
+++ b/packages/account_actions/lib/src/connectors.dart
@@ -1,0 +1,16 @@
+import 'package:azure_api/azure_api.dart' show AzureConnector;
+import 'package:smartschool_api/smartschool_api.dart' show SmartschoolConnector;
+
+/// The write-capable connectors an action's `apply()` may call.
+///
+/// WISA is intentionally absent: the WISA connector is read-only (a CSV
+/// export), so no student action writes to it. The `smartschool`/`azure`
+/// connectors are nullable so a caller can wire only the systems it needs; an
+/// action whose target connector is missing throws `StateError` at apply time
+/// (a wiring bug, not a transient failure).
+class Connectors {
+  final SmartschoolConnector? smartschool;
+  final AzureConnector? azure;
+
+  const Connectors({this.smartschool, this.azure});
+}

--- a/packages/account_actions/lib/src/student_action.dart
+++ b/packages/account_actions/lib/src/student_action.dart
@@ -1,0 +1,873 @@
+import 'package:account_core/account_core.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+import 'action_result.dart';
+import 'apply_options.dart';
+import 'change_set.dart';
+import 'connectors.dart';
+import 'student_action_config.dart';
+
+/// The student action family (spec `docs/domain-model.md` §3.10). One subclass
+/// per legacy `Action\StudentAccount\*` class.
+///
+/// **Target binding.** Each action is bound to the [LinkedAccount] it acts on
+/// at construction. The spec draws the operations as `evaluate(account)` /
+/// `describeChanges(account)` (§3.10) but applies as `apply(connectors,
+/// options)` (§6.4, `apply(action, connectors, options)`); binding the target
+/// reconciles the two — [evaluate] and [describeChanges] read the bound
+/// [account] (exposed as [target]) and stay pure, while [apply] carries no
+/// target of its own.
+///
+/// **Purity boundary (INV-40/41/42).** [evaluate] and [describeChanges] are
+/// pure and deterministic — no I/O, no globals. [apply] is the only impure
+/// operation; it is retry-safe (a transient failure returns
+/// [ActionOutcome.failed] without corrupting state) and never mutates the
+/// bound [account] or its snapshot records — every changed record is a fresh
+/// copy.
+sealed class StudentAction {
+  /// The linked record this action targets, bound at construction.
+  final LinkedAccount account;
+
+  /// Injected configuration (domains, password/uid builders).
+  final StudentActionConfig config;
+
+  const StudentAction(this.account, this.config);
+
+  /// Alias for the bound [account] — the "target" the spec's
+  /// `evaluate(target)` refers to.
+  LinkedAccount get target => account;
+
+  /// Whether this action applies to [account]. Pure and deterministic
+  /// (INV-40). The dispatcher constructs one instance per candidate type and
+  /// keeps those returning true.
+  bool evaluate();
+
+  /// The field-level diff this action would make. Pure (INV-40); drives the
+  /// diff UI and the dry-run path.
+  ChangeSet describeChanges();
+
+  /// Performs the change on the target system. Impure. With
+  /// [ApplyOptions.dryRun] set, performs **no** writes and returns the
+  /// projected [ActionResult] (PAIN-3).
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options);
+
+  // --- shared helpers -------------------------------------------------------
+
+  wapi.WisaStudent get _wisa => account.wisa! as wapi.WisaStudent;
+  ss.SmartschoolAccount get _ss =>
+      account.smartschool! as ss.SmartschoolAccount;
+  az.AzureUser get _az => account.azure! as az.AzureUser;
+
+  ss.SmartschoolConnector _requireSmartschool(Connectors c) =>
+      c.smartschool ??
+      (throw StateError('$runtimeType.apply needs a Smartschool connector'));
+
+  az.AzureConnector _requireAzure(Connectors c) =>
+      c.azure ??
+      (throw StateError('$runtimeType.apply needs an Azure connector'));
+
+  ActionResult _failed(ChangeSet changes, Origin system, Object error) =>
+      ActionResult(
+        outcome: ActionOutcome.failed,
+        changes: changes,
+        system: system,
+        error: error,
+      );
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle actions — evaluated only when a system is missing (§6.3).
+// ---------------------------------------------------------------------------
+
+/// Create an Office 365 account for a student present in WISA but not Azure.
+/// Ported from `Action\StudentAccount\AddToAzure`.
+class AddStudentToAzure extends StudentAction {
+  const AddStudentToAzure(super.account, super.config);
+
+  @override
+  bool evaluate() => account.wisa != null && account.azure == null;
+
+  @override
+  ChangeSet describeChanges() {
+    final wisa = _wisa;
+    final given = _givenName(wisa);
+    return ChangeSet(
+      system: Origin.azure,
+      summary: 'Maak een nieuw Office 365 account',
+      fields: [
+        FieldChange(
+          'userPrincipalName',
+          after: _projectedUpn(given, wisa.name),
+        ),
+        FieldChange('displayName', after: wisa.fullName),
+        FieldChange('employeeId', after: wisa.wisaId.value),
+        FieldChange('companyName', after: config.schoolPrefix),
+      ],
+    );
+  }
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    final wisa = _wisa;
+    final given = _givenName(wisa);
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.azure,
+        azure: az.AzureUser(
+          id: '',
+          upn: _projectedUpn(given, wisa.name),
+          employeeId: wisa.wisaId.value,
+          displayName: wisa.fullName,
+          givenName: given,
+          surname: wisa.name,
+          companyName: config.schoolPrefix,
+          department: wisa.classGroup,
+        ),
+      );
+    }
+
+    try {
+      final users = _requireAzure(connectors).users;
+      final upn = await users.createPrincipalName(
+        given,
+        wisa.name,
+        config.azureDomain,
+        isStudent: true,
+      );
+      final created = await users.createUser(
+        userPrincipalName: upn,
+        displayName: wisa.fullName,
+        password: config.newAccountPassword(),
+        givenName: given,
+        surname: wisa.name,
+        employeeId: wisa.wisaId.value,
+        companyName: config.schoolPrefix,
+        department: wisa.classGroup,
+        forceChangePasswordNextSignIn: true,
+      );
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.azure,
+        azure: created,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.azure, e);
+    }
+  }
+
+  String _projectedUpn(String given, String surname) =>
+      '${_slug(given)}.${_slug(surname)}@${config.studentDomain}';
+}
+
+/// Create a Smartschool account for a student present in WISA and Azure but not
+/// Smartschool. Ported from `Action\StudentAccount\AddToSmartschool` — the
+/// account is built from the WISA record with the Azure UPN as its mail; the
+/// class-group placement is a separate action (see the package README's
+/// "deferred" note).
+class AddStudentToSmartschool extends StudentAction {
+  const AddStudentToSmartschool(super.account, super.config);
+
+  @override
+  bool evaluate() =>
+      account.wisa != null &&
+      account.azure != null &&
+      account.smartschool == null;
+
+  ss.SmartschoolAccount _build() {
+    final wisa = _wisa;
+    return ss.SmartschoolAccount(
+      uid: config.smartschoolUid(_givenName(wisa), wisa.name),
+      accountId: wisa.wisaId.value,
+      mail: _az.upn,
+      registerId: wisa.nationalId,
+      stemId: int.tryParse(wisa.stemId) ?? 0,
+      role: PersonRole.student,
+      givenName: wisa.firstName,
+      surname: wisa.name,
+      extraNames: '',
+      initials: '',
+      preferredName: wisa.preferredName,
+      gender: wisa.gender,
+      birthDate: wisa.birthDate,
+      birthPlace: wisa.birthPlace,
+      birthCountry: '',
+      address: wisa.address,
+      mobilePhone: '',
+      homePhone: '',
+      fax: '',
+      untisId: '',
+      status: 'actief',
+    );
+  }
+
+  @override
+  ChangeSet describeChanges() {
+    final built = _build();
+    return ChangeSet(
+      system: Origin.smartschool,
+      summary: 'Maak een nieuw Smartschool account',
+      fields: [
+        FieldChange('uid', after: built.uid),
+        FieldChange('accountId', after: built.accountId),
+        FieldChange('mail', after: built.mail),
+      ],
+    );
+  }
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    final built = _build();
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: built,
+      );
+    }
+
+    try {
+      final ok = await _requireSmartschool(connectors).saveAccount(
+        built,
+        password: config.newAccountPassword(),
+      );
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool saveAccount returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: built,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}
+
+/// Unregister (but keep) a still-active Smartschool account whose student has
+/// left WISA. Ported from `Action\StudentAccount\UnregisterSmartschool`.
+class UnregisterStudentFromSmartschool extends StudentAction {
+  const UnregisterStudentFromSmartschool(super.account, super.config);
+
+  @override
+  bool evaluate() =>
+      account.wisa == null &&
+      account.smartschool != null &&
+      _ss.status == 'actief';
+
+  @override
+  ChangeSet describeChanges() => const ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Schrijf de leerling uit in Smartschool',
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    final account = _ss;
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: account,
+      );
+    }
+
+    try {
+      final ok = await _requireSmartschool(connectors).unregisterStudent(
+        account.uid,
+        options.deletionDate ?? DateTime.now(),
+      );
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool unregisterStudent returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: account,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}
+
+/// Delete a Smartschool account whose student no longer exists in WISA. Ported
+/// from `Action\StudentAccount\DeleteFromSmartschool`.
+class DeleteStudentFromSmartschool extends StudentAction {
+  const DeleteStudentFromSmartschool(super.account, super.config);
+
+  @override
+  bool evaluate() => account.wisa == null && account.smartschool != null;
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: _ss.status == 'actief'
+            ? 'Verwijder dit account uit Smartschool'
+            : 'Verwijder dit account uit Smartschool (al uitgeschakeld)',
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        removed: true,
+      );
+    }
+
+    try {
+      final ok = await _requireSmartschool(connectors).deleteUser(
+        _ss.uid,
+        officialDate: options.deletionDate,
+      );
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool deleteUser returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        removed: true,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}
+
+/// Delete an Azure-only account for a former student (no WISA, no Smartschool)
+/// carrying the school's `companyName`. Ported from
+/// `Action\StudentAccount\RemoveFromAzure`.
+class RemoveStudentFromAzure extends StudentAction {
+  const RemoveStudentFromAzure(super.account, super.config);
+
+  @override
+  bool evaluate() =>
+      account.wisa == null &&
+      account.smartschool == null &&
+      account.azure != null &&
+      _eq(_az.companyName, config.schoolPrefix);
+
+  @override
+  ChangeSet describeChanges() => const ChangeSet(
+        system: Origin.azure,
+        summary: 'Verwijder Azure account',
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.azure,
+        removed: true,
+      );
+    }
+
+    try {
+      await _requireAzure(connectors).users.deleteUser(_az.id);
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.azure,
+        removed: true,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.azure, e);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Modify actions — evaluated only when all three systems are present (§6.3).
+// ---------------------------------------------------------------------------
+
+/// Move a student's Azure UPN onto the student domain. Ported from
+/// `Action\StudentAccount\ModifyAzureStudentEmail`.
+class ModifyAzureStudentEmail extends StudentAction {
+  const ModifyAzureStudentEmail(super.account, super.config);
+
+  @override
+  bool evaluate() {
+    final upn = _n(_az.upn);
+    return upn != null && !upn.endsWith(config.studentDomain.toLowerCase());
+  }
+
+  String get _newUpn => '${_localPart(_az.upn)}@${config.studentDomain}';
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.azure,
+        summary: 'Wijzig het e-mailadres in Azure',
+        fields: [
+          FieldChange('userPrincipalName', before: _az.upn, after: _newUpn),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      _azurePatch(
+        connectors,
+        options,
+        describeChanges(),
+        (users) => users.updateUser(_az.id, userPrincipalName: _newUpn),
+        () => _az.copyWith(upn: _newUpn),
+      );
+}
+
+/// Sync a student's Azure display/given name from WISA. Ported from
+/// `Action\StudentAccount\ModifyAzureName`.
+class ModifyAzureName extends StudentAction {
+  const ModifyAzureName(super.account, super.config);
+
+  @override
+  bool evaluate() => !_eq(_wisa.fullName, _az.displayName);
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.azure,
+        summary: 'Wijzig de naam in Azure',
+        fields: [
+          FieldChange(
+            'displayName',
+            before: _az.displayName,
+            after: _wisa.fullName,
+          ),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) {
+    final wisa = _wisa;
+    final given = _givenName(wisa);
+    return _azurePatch(
+      connectors,
+      options,
+      describeChanges(),
+      (users) => users.updateUser(
+        _az.id,
+        displayName: wisa.fullName,
+        givenName: given,
+        surname: wisa.name,
+      ),
+      () => _az.copyWith(
+        displayName: wisa.fullName,
+        givenName: given,
+        surname: wisa.name,
+      ),
+    );
+  }
+}
+
+/// Correct a student's Azure `companyName` to the school prefix. Ported from
+/// `Action\StudentAccount\ModifyAzureSchool`.
+class ModifyAzureSchool extends StudentAction {
+  const ModifyAzureSchool(super.account, super.config);
+
+  @override
+  bool evaluate() {
+    final company = _az.companyName;
+    return company != null && !_eq(company, config.schoolPrefix);
+  }
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.azure,
+        summary: 'Wijzig de school in Azure',
+        fields: [
+          FieldChange(
+            'companyName',
+            before: _az.companyName,
+            after: config.schoolPrefix,
+          ),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      _azurePatch(
+        connectors,
+        options,
+        describeChanges(),
+        (users) => users.updateUser(_az.id, companyName: config.schoolPrefix),
+        () => _az.copyWith(companyName: config.schoolPrefix),
+      );
+}
+
+/// Correct the Smartschool internal number to equal the WISA id. Ported from
+/// `Action\StudentAccount\ModifyAccountID`.
+class ModifyAccountId extends StudentAction {
+  const ModifyAccountId(super.account, super.config);
+
+  @override
+  bool evaluate() => _wisa.wisaId.value.trim() != _ss.accountId.trim();
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Wijzig het intern nummer in Smartschool',
+        fields: [
+          FieldChange(
+            'accountId',
+            before: _ss.accountId,
+            after: _wisa.wisaId.value,
+          ),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    final updated = _ss.copyWith(accountId: _wisa.wisaId.value);
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: updated,
+      );
+    }
+
+    try {
+      final ok = await _requireSmartschool(connectors)
+          .changeAccountId(_ss.uid, _wisa.wisaId.value);
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool changeAccountId returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: updated,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}
+
+/// Sync the Smartschool mail to the Azure UPN, but only when Smartschool still
+/// holds a base-domain address. Ported from
+/// `Action\StudentAccount\ModifySmartschoolStudentEmail`.
+class ModifySmartschoolStudentEmail extends StudentAction {
+  const ModifySmartschoolStudentEmail(super.account, super.config);
+
+  @override
+  bool evaluate() =>
+      _domainOf(_ss.mail) == config.azureDomain.toLowerCase() &&
+      !_eq(_ss.mail, _az.upn);
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Wijzig het e-mailadres in Smartschool',
+        fields: [FieldChange('mail', before: _ss.mail, after: _az.upn)],
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      _smartschoolSave(
+        connectors,
+        options,
+        describeChanges(),
+        _ss.copyWith(mail: _az.upn),
+      );
+}
+
+/// Sync the Smartschool home address from WISA. Ported from
+/// `Action\StudentAccount\ModifySmartschoolStudentAddress`.
+class ModifySmartschoolStudentAddress extends StudentAction {
+  const ModifySmartschoolStudentAddress(super.account, super.config);
+
+  @override
+  bool evaluate() => _ss.address != _wisa.address;
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Wijzig het adres in Smartschool',
+        fields: [
+          FieldChange(
+            'address',
+            before: _ss.address.streetAddress,
+            after: _wisa.address.streetAddress,
+          ),
+          FieldChange(
+            'city',
+            before: _ss.address.city,
+            after: _wisa.address.city,
+          ),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      _smartschoolSave(
+        connectors,
+        options,
+        describeChanges(),
+        _ss.copyWith(address: _wisa.address),
+      );
+}
+
+/// Sync the Smartschool stamboeknummer from WISA. Ported from
+/// `Action\StudentAccount\ModifySmartschoolStemID`.
+class ModifySmartschoolStemId extends StudentAction {
+  const ModifySmartschoolStemId(super.account, super.config);
+
+  int get _wisaStemId => int.tryParse(_wisa.stemId) ?? 0;
+
+  @override
+  bool evaluate() => _wisaStemId != _ss.stemId;
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Wijzig het stamboeknummer in Smartschool',
+        fields: [
+          FieldChange('stemId', before: '${_ss.stemId}', after: '$_wisaStemId'),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      _smartschoolSave(
+        connectors,
+        options,
+        describeChanges(),
+        _ss.copyWith(stemId: _wisaStemId),
+      );
+}
+
+/// Sync the Smartschool birthplace from WISA. Ported from
+/// `Action\StudentAccount\ModifySmartschoolBirthPlace`.
+class ModifySmartschoolBirthPlace extends StudentAction {
+  const ModifySmartschoolBirthPlace(super.account, super.config);
+
+  @override
+  bool evaluate() => !_eq(_ss.birthPlace, _wisa.birthPlace);
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Wijzig de geboorteplaats in Smartschool',
+        fields: [
+          FieldChange(
+            'birthPlace',
+            before: _ss.birthPlace,
+            after: _wisa.birthPlace,
+          ),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      _smartschoolSave(
+        connectors,
+        options,
+        describeChanges(),
+        _ss.copyWith(birthPlace: _wisa.birthPlace),
+      );
+}
+
+/// Sync the Smartschool preferred name ("Roepnaam") from WISA. Skipped when the
+/// student has no distinct preferred name. Ported from
+/// `Action\StudentAccount\ModifySmartschoolName`.
+class ModifySmartschoolName extends StudentAction {
+  const ModifySmartschoolName(super.account, super.config);
+
+  @override
+  bool evaluate() {
+    final wisa = _wisa;
+    if (wisa.firstName == wisa.preferredName) return false;
+    return wisa.preferredName != _ss.preferredName;
+  }
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Wijzig de roepnaam in Smartschool',
+        fields: [
+          FieldChange(
+            'preferredName',
+            before: _ss.preferredName,
+            after: _wisa.preferredName,
+          ),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      _smartschoolSave(
+        connectors,
+        options,
+        describeChanges(),
+        _ss.copyWith(preferredName: _wisa.preferredName),
+      );
+}
+
+// ---------------------------------------------------------------------------
+// Shared apply helpers for the modify actions.
+// ---------------------------------------------------------------------------
+
+extension _AzurePatch on StudentAction {
+  /// Runs an Azure PATCH ([write]) unless dry-run, and returns the projected
+  /// [record] as the mutated source record.
+  Future<ActionResult> _azurePatch(
+    Connectors connectors,
+    ApplyOptions options,
+    ChangeSet changes,
+    Future<void> Function(az.UserManager users) write,
+    az.AzureUser Function() record,
+  ) async {
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.azure,
+        azure: record(),
+      );
+    }
+    try {
+      await write(_requireAzure(connectors).users);
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.azure,
+        azure: record(),
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.azure, e);
+    }
+  }
+
+  /// Saves [updated] to Smartschool (`saveUser` with an unchanged password)
+  /// unless dry-run, and returns [updated] as the mutated source record.
+  Future<ActionResult> _smartschoolSave(
+    Connectors connectors,
+    ApplyOptions options,
+    ChangeSet changes,
+    ss.SmartschoolAccount updated,
+  ) async {
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: updated,
+      );
+    }
+    try {
+      // An empty password leaves the holder's existing password unchanged.
+      final ok = await _requireSmartschool(connectors)
+          .saveAccount(updated, password: '');
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool saveAccount returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: updated,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers.
+// ---------------------------------------------------------------------------
+
+String _givenName(wapi.WisaStudent wisa) =>
+    wisa.preferredName.isNotEmpty ? wisa.preferredName : wisa.firstName;
+
+/// Trims + lower-cases for case-insensitive comparison (INV-12); blank → null.
+String? _n(String? v) {
+  if (v == null) return null;
+  final t = v.trim();
+  return t.isEmpty ? null : t.toLowerCase();
+}
+
+/// Case-insensitive, trimmed equality (INV-12).
+bool _eq(String? a, String? b) => _n(a) == _n(b);
+
+/// The local part of an email/UPN (`jane.doe` from `jane.doe@x.be`).
+String _localPart(String mail) =>
+    mail.contains('@') ? mail.split('@').first : mail;
+
+/// The normalized domain of an email/UPN (`x.be` from `jane@X.BE`); '' if none.
+String _domainOf(String mail) =>
+    mail.contains('@') ? mail.split('@').last.trim().toLowerCase() : '';
+
+/// A UPN-safe slug for the projected new-account UPN: lower-cased, keeping only
+/// the characters Azure accepts in a local part. Approximates the connector's
+/// own normalization for display/dry-run purposes.
+String _slug(String input) => input
+    .toLowerCase()
+    .split('')
+    .where((c) => RegExp(r'[a-z0-9_.+-]').hasMatch(c))
+    .join();

--- a/packages/account_actions/lib/src/student_action_config.dart
+++ b/packages/account_actions/lib/src/student_action_config.dart
@@ -1,0 +1,50 @@
+import 'package:account_core/account_core.dart';
+
+/// Configuration the student action family needs, holding the values the
+/// legacy code hard-coded (`docs/domain-model.md` §7 lists these as things to
+/// parameterize).
+///
+/// Legacy hard-coded `"arcadiascholen.be"` / `"student.arcadiascholen.be"`, a
+/// `"FakeP4ssword"` placeholder for new Smartschool accounts, and a UID
+/// builder (`AccountManager.CreateUID`). Those become injectable here so the
+/// engine stays testable and reusable.
+class StudentActionConfig {
+  /// The Azure `companyName` value the school stamps on its own students
+  /// (`ModifyAzureSchool` / `RemoveStudentFromAzure` gate on it).
+  final String schoolPrefix;
+
+  /// The base UPN domain, e.g. `arcadiascholen.be`. Used to detect accounts
+  /// still on the staff/base domain that should move to [studentDomain].
+  final String azureDomain;
+
+  /// The student UPN domain, e.g. `student.arcadiascholen.be`. Defaults to
+  /// `student.<azureDomain>`.
+  final String studentDomain;
+
+  /// Password for a newly created account. Defaults to the domain [Password]
+  /// generator. (Legacy used a `"FakeP4ssword"` placeholder that the holder
+  /// resets on first login.)
+  final String Function() newAccountPassword;
+
+  /// Builds a Smartschool login (`uid`) from a student's given name and
+  /// surname. Defaults to `"<given>.<surname>"` lower-cased with spaces
+  /// stripped. Uniqueness against existing accounts is the caller's concern
+  /// (the State layer holds the account set); the default is deliberately
+  /// simple.
+  final String Function(String givenName, String surname) smartschoolUid;
+
+  StudentActionConfig({
+    required this.schoolPrefix,
+    required this.azureDomain,
+    String? studentDomain,
+    String Function()? newAccountPassword,
+    String Function(String givenName, String surname)? smartschoolUid,
+  })  : studentDomain = studentDomain ?? 'student.$azureDomain',
+        newAccountPassword = newAccountPassword ?? _defaultPassword,
+        smartschoolUid = smartschoolUid ?? _defaultUid;
+
+  static String _defaultPassword() => Password.create();
+
+  static String _defaultUid(String givenName, String surname) =>
+      '${givenName.trim()}.${surname.trim()}'.toLowerCase().replaceAll(' ', '');
+}

--- a/packages/account_actions/lib/src/student_dispatch.dart
+++ b/packages/account_actions/lib/src/student_dispatch.dart
@@ -1,0 +1,64 @@
+import 'package:account_core/account_core.dart';
+
+import 'student_action.dart';
+import 'student_action_config.dart';
+
+/// Derives the applicable [StudentAction]s for one [LinkedAccount], ported from
+/// the legacy `AccountActionParser.AddActions` dispatch (§6.3).
+///
+/// The two action sets are **mutually exclusive**, exactly as in legacy:
+/// - If *any* of the three systems is missing the record, only the **lifecycle**
+///   actions (add / unregister / delete / remove) are considered.
+/// - If all three are present, only the **modify / sync** actions are
+///   considered.
+///
+/// Each candidate is constructed bound to [account] and kept only when its
+/// pure [StudentAction.evaluate] returns true. Pure and deterministic
+/// (INV-40): same account + same [config] ⇒ same list.
+List<StudentAction> studentActionsFor(
+  LinkedAccount account,
+  StudentActionConfig config,
+) {
+  final complete = account.wisa != null &&
+      account.smartschool != null &&
+      account.azure != null;
+
+  final candidates = complete
+      ? <StudentAction>[
+          ModifyAzureStudentEmail(account, config),
+          ModifyAzureName(account, config),
+          ModifyAzureSchool(account, config),
+          ModifySmartschoolStudentAddress(account, config),
+          ModifyAccountId(account, config),
+          ModifySmartschoolStemId(account, config),
+          ModifySmartschoolBirthPlace(account, config),
+          ModifySmartschoolStudentEmail(account, config),
+          ModifySmartschoolName(account, config),
+        ]
+      : <StudentAction>[
+          AddStudentToAzure(account, config),
+          AddStudentToSmartschool(account, config),
+          UnregisterStudentFromSmartschool(account, config),
+          DeleteStudentFromSmartschool(account, config),
+          RemoveStudentFromAzure(account, config),
+        ];
+
+  return [
+    for (final action in candidates)
+      if (action.evaluate()) action,
+  ];
+}
+
+/// Derives every applicable [StudentAction] across a [LinkedSnapshot]'s
+/// student records, in snapshot order (§6.3). Pure and deterministic.
+///
+/// Only [LinkedSnapshot.accounts] (students) are considered; staff and groups
+/// are handled by their own families (tracked as follow-ups to #46).
+List<StudentAction> studentActions(
+  LinkedSnapshot snapshot,
+  StudentActionConfig config,
+) =>
+    [
+      for (final account in snapshot.accounts)
+        ...studentActionsFor(account, config),
+    ];

--- a/packages/account_actions/pubspec.yaml
+++ b/packages/account_actions/pubspec.yaml
@@ -1,0 +1,25 @@
+name: account_actions
+description: >-
+  Action engine for the Arcadia Account Manager port. A sealed `Action`
+  hierarchy (student family in this package; staff/group to follow) with pure
+  `evaluate()`/`describeChanges()` and an impure, dry-run-capable `apply()`
+  that returns the mutated source record for incremental snapshot refresh.
+  Pure Dart; no Flutter, no UI coupling.
+version: 0.1.0
+publish_to: none
+repository: https://github.com/yvanvds/AccountManager
+
+environment:
+  sdk: ^3.6.0
+
+resolution: workspace
+
+dependencies:
+  account_core:
+  wisa_api:
+  smartschool_api:
+  azure_api:
+
+dev_dependencies:
+  lints: ^5.1.0
+  test: ^1.25.0

--- a/packages/account_actions/test/student_apply_test.dart
+++ b/packages/account_actions/test/student_apply_test.dart
@@ -1,0 +1,190 @@
+import 'dart:convert';
+
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+void main() {
+  final cfg = config();
+
+  group('dry run performs no writes (PAIN-3)', () {
+    test('ModifyAccountId dry run: no SOAP call, projected record returned',
+        () {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = ModifyAccountId(
+        linked(
+          wisa: wisaStudent(wisaId: 'W1'),
+          smartschool: ssAccount(accountId: 'W9'),
+          azure: azureUser(),
+        ),
+        cfg,
+      );
+
+      return action.apply(connectors, ApplyOptions.dry).then((result) {
+        expect(result.outcome, ActionOutcome.dryRun);
+        expect(transport.soapActions, isEmpty);
+        expect(result.smartschool?.accountId, 'W1');
+      });
+    });
+
+    test('DeleteFromSmartschool dry run: no write, removed flag set', () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = DeleteStudentFromSmartschool(
+        linked(smartschool: ssAccount()),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, ApplyOptions.dry);
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(result.removed, isTrue);
+      expect(transport.soapActions, isEmpty);
+    });
+
+    test('ModifyAzureStudentEmail dry run: no Graph request', () async {
+      final transport = RecordingGraphTransport();
+      final connectors = Connectors(azure: azureConnector(transport));
+      final action = ModifyAzureStudentEmail(
+        linked(
+          wisa: wisaStudent(),
+          smartschool: ssAccount(),
+          azure: azureUser(upn: 'jan.peeters@school.example'),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, ApplyOptions.dry);
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(transport.requests, isEmpty);
+      expect(result.azure?.upn, 'jan.peeters@student.school.example');
+    });
+  });
+
+  group('real apply performs the write and returns the mutated record (#40)',
+      () {
+    test('ModifyAccountId: calls changeInternNumber, returns updated record',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = ModifyAccountId(
+        linked(
+          wisa: wisaStudent(wisaId: 'W1'),
+          smartschool: ssAccount(accountId: 'W9'),
+          azure: azureUser(),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.calledMethod('changeInternNumber'), isTrue);
+      expect(result.system, Origin.smartschool);
+      expect(result.smartschool?.accountId, 'W1');
+    });
+
+    test('ModifyAzureStudentEmail: PATCHes the user, returns new UPN',
+        () async {
+      final transport = RecordingGraphTransport();
+      final connectors = Connectors(azure: azureConnector(transport));
+      final action = ModifyAzureStudentEmail(
+        linked(
+          wisa: wisaStudent(),
+          smartschool: ssAccount(),
+          azure: azureUser(upn: 'jan.peeters@school.example'),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.sent('PATCH', pathContains: 'users'), isTrue);
+      expect(result.azure?.upn, 'jan.peeters@student.school.example');
+    });
+
+    test('AddStudentToAzure: creates the user and returns it', () async {
+      final transport = RecordingGraphTransport(
+        handler: (req) {
+          if (req.method == 'GET') {
+            // No existing user with the candidate UPN → it is unique.
+            return az.GraphResponse(
+              statusCode: 404,
+              body: jsonEncode({
+                'error': {'code': 'NotFound', 'message': 'no'},
+              }),
+            );
+          }
+          if (req.method == 'POST') {
+            return az.GraphResponse(
+              statusCode: 201,
+              headers: const {'content-type': 'application/json'},
+              body: jsonEncode({
+                'id': 'az-new',
+                'userPrincipalName': 'jan.peeters@student.school.example',
+              }),
+            );
+          }
+          return const az.GraphResponse(statusCode: 204);
+        },
+      );
+      final connectors = Connectors(azure: azureConnector(transport));
+      final action = AddStudentToAzure(linked(wisa: wisaStudent()), cfg);
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.sent('POST', pathContains: 'users'), isTrue);
+      expect(result.azure?.id, 'az-new');
+      expect(result.azure?.employeeId, 'W1');
+    });
+
+    test('AddStudentToSmartschool: saves account, mail = Azure UPN', () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = AddStudentToSmartschool(
+        linked(
+          wisa: wisaStudent(wisaId: 'W1'),
+          azure: azureUser(upn: 'jan.peeters@student.school.example'),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.calledMethod('saveUser'), isTrue);
+      expect(result.smartschool?.accountId, 'W1');
+      expect(result.smartschool?.mail, 'jan.peeters@student.school.example');
+    });
+  });
+
+  group('apply is retry-safe (INV-41): a failed write does not corrupt state',
+      () {
+    test('a non-zero Smartschool result → failed outcome, error captured',
+        () async {
+      final transport = RecordingSmartschoolTransport(resultCode: 1);
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final smartschool = ssAccount(accountId: 'W9');
+      final action = ModifyAccountId(
+        linked(
+          wisa: wisaStudent(wisaId: 'W1'),
+          smartschool: smartschool,
+          azure: azureUser(),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.failed);
+      expect(result.error, isNotNull);
+      // The source record is untouched — the action can be retried.
+      expect(smartschool.accountId, 'W9');
+    });
+  });
+}

--- a/packages/account_actions/test/student_dispatch_test.dart
+++ b/packages/account_actions/test/student_dispatch_test.dart
@@ -1,0 +1,127 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+void main() {
+  final cfg = config();
+
+  List<Type> types(Iterable<StudentAction> actions) =>
+      actions.map((a) => a.runtimeType).toList();
+
+  group('dispatch §6.3 — missing / present branches are mutually exclusive',
+      () {
+    test('a fully-synced account yields no actions', () {
+      expect(studentActionsFor(fullySynced(), cfg), isEmpty);
+    });
+
+    test('WISA-only student → only AddStudentToAzure', () {
+      final actions = studentActionsFor(linked(wisa: wisaStudent()), cfg);
+      expect(types(actions), [AddStudentToAzure]);
+    });
+
+    test('WISA + Azure, no Smartschool → only AddStudentToSmartschool', () {
+      final actions = studentActionsFor(
+        linked(wisa: wisaStudent(), azure: azureUser()),
+        cfg,
+      );
+      expect(types(actions), [AddStudentToSmartschool]);
+    });
+
+    test('active Smartschool-only account → Unregister *and* Delete', () {
+      final actions = studentActionsFor(
+        linked(smartschool: ssAccount(status: 'actief')),
+        cfg,
+      );
+      expect(
+        types(actions),
+        [UnregisterStudentFromSmartschool, DeleteStudentFromSmartschool],
+      );
+    });
+
+    test('disabled Smartschool-only account → Delete only (not Unregister)',
+        () {
+      final actions = studentActionsFor(
+        linked(smartschool: ssAccount(status: 'uitgeschakeld')),
+        cfg,
+      );
+      expect(types(actions), [DeleteStudentFromSmartschool]);
+    });
+
+    test('Azure-only account with the school prefix → RemoveStudentFromAzure',
+        () {
+      final actions = studentActionsFor(
+        linked(azure: azureUser(companyName: 'SSM')),
+        cfg,
+      );
+      expect(types(actions), [RemoveStudentFromAzure]);
+    });
+
+    test('Azure-only account for another school → no action', () {
+      final actions = studentActionsFor(
+        linked(azure: azureUser(companyName: 'OTHER')),
+        cfg,
+      );
+      expect(actions, isEmpty);
+    });
+
+    test('missing-branch never emits a modify action', () {
+      final actions = studentActionsFor(linked(wisa: wisaStudent()), cfg);
+      expect(actions.whereType<ModifyAccountId>(), isEmpty);
+      expect(actions.whereType<ModifyAzureStudentEmail>(), isEmpty);
+    });
+  });
+
+  group('dispatch §6.3 — present branch emits only the relevant modify action',
+      () {
+    test('wrong Smartschool internal number → only ModifyAccountId', () {
+      final actions = studentActionsFor(
+        linked(
+          wisa: wisaStudent(wisaId: 'W1'),
+          smartschool: ssAccount(accountId: 'W9'),
+          azure: azureUser(),
+        ),
+        cfg,
+      );
+      expect(types(actions), [ModifyAccountId]);
+    });
+
+    test('Azure UPN still on the base domain → only ModifyAzureStudentEmail',
+        () {
+      final actions = studentActionsFor(
+        linked(
+          wisa: wisaStudent(),
+          smartschool: ssAccount(),
+          azure: azureUser(upn: 'jan.peeters@school.example'),
+        ),
+        cfg,
+      );
+      expect(types(actions), [ModifyAzureStudentEmail]);
+    });
+
+    test('wrong companyName → only ModifyAzureSchool', () {
+      final actions = studentActionsFor(
+        linked(
+          wisa: wisaStudent(),
+          smartschool: ssAccount(),
+          azure: azureUser(companyName: 'WRONG'),
+        ),
+        cfg,
+      );
+      expect(types(actions), [ModifyAzureSchool]);
+    });
+
+    test('present-branch never emits a lifecycle action', () {
+      final actions = studentActionsFor(
+        linked(
+          wisa: wisaStudent(wisaId: 'W1'),
+          smartschool: ssAccount(accountId: 'W9'),
+          azure: azureUser(),
+        ),
+        cfg,
+      );
+      expect(actions.whereType<AddStudentToAzure>(), isEmpty);
+      expect(actions.whereType<DeleteStudentFromSmartschool>(), isEmpty);
+    });
+  });
+}

--- a/packages/account_actions/test/student_purity_test.dart
+++ b/packages/account_actions/test/student_purity_test.dart
@@ -1,0 +1,85 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+void main() {
+  final cfg = config();
+
+  group('evaluate / describeChanges are pure (INV-40)', () {
+    test('describeChanges is deterministic', () {
+      final action = ModifyAccountId(
+        linked(
+          wisa: wisaStudent(wisaId: 'W1'),
+          smartschool: ssAccount(accountId: 'W9'),
+          azure: azureUser(),
+        ),
+        cfg,
+      );
+      final a = action.describeChanges();
+      final b = action.describeChanges();
+      expect(a.system, b.system);
+      expect(a.summary, b.summary);
+      expect(
+        a.fields.map((f) => '${f.field}:${f.before}>${f.after}'),
+        b.fields.map((f) => '${f.field}:${f.before}>${f.after}'),
+      );
+    });
+
+    test('describeChanges reports the before/after of the change', () {
+      final action = ModifyAccountId(
+        linked(
+          wisa: wisaStudent(wisaId: 'W1'),
+          smartschool: ssAccount(accountId: 'W9'),
+          azure: azureUser(),
+        ),
+        cfg,
+      );
+      final change = action.describeChanges();
+      expect(change.system, Origin.smartschool);
+      final field = change.fields.single;
+      expect(field.field, 'accountId');
+      expect(field.before, 'W9');
+      expect(field.after, 'W1');
+    });
+
+    test('evaluate does not mutate the bound record', () {
+      final ss = ssAccount(accountId: 'W9');
+      final account = linked(
+        wisa: wisaStudent(wisaId: 'W1'),
+        smartschool: ss,
+        azure: azureUser(),
+      );
+      ModifyAccountId(account, cfg).evaluate();
+      // The bound record is untouched (INV-42).
+      expect(identical(account.smartschool, ss), isTrue);
+      expect(ss.accountId, 'W9');
+    });
+  });
+
+  group('studentActions over a LinkedSnapshot', () {
+    test('emits actions per student record, in snapshot order', () {
+      final snapshot = LinkedSnapshot.fromRecords(
+        accounts: [
+          linked(wisa: wisaStudent(wisaId: 'A'), id: 'a'), // WISA-only → add
+          fullySynced(), // clean → none
+          linked(
+            wisa: wisaStudent(wisaId: 'C1'),
+            smartschool: ssAccount(accountId: 'C9'),
+            azure: azureUser(),
+            id: 'c',
+          ), // wrong id → modify
+        ],
+        staff: const [],
+        groups: const [],
+      );
+
+      final actions = studentActions(snapshot, cfg);
+      expect(
+        actions.map((a) => a.runtimeType),
+        [AddStudentToAzure, ModifyAccountId],
+      );
+    });
+  });
+}

--- a/packages/account_actions/test/support/fixtures.dart
+++ b/packages/account_actions/test/support/fixtures.dart
@@ -1,0 +1,227 @@
+/// Test helpers for `account_actions`: terse builders for linked records, a
+/// default [StudentActionConfig], and recording fake connector transports so
+/// `apply` can be driven without a network — a dry run asserts **zero** writes
+/// and a real apply asserts the exact call plus the returned mutated record.
+library;
+
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+final DateTime _fixedDate = DateTime.utc(2020, 1, 1);
+
+const Address blankAddress = Address(
+  street: '',
+  houseNumber: '',
+  postalCode: '',
+  city: '',
+  country: '',
+);
+
+const Address sampleAddress = Address(
+  street: 'Kerkstraat',
+  houseNumber: '1',
+  postalCode: '9000',
+  city: 'Gent',
+  country: 'België',
+);
+
+/// The default config used by the tests: prefix `SSM`, base domain
+/// `school.example` (so student UPNs live under `student.school.example`), a
+/// fixed password, and the default uid builder.
+StudentActionConfig config({
+  String schoolPrefix = 'SSM',
+  String azureDomain = 'school.example',
+}) =>
+    StudentActionConfig(
+      schoolPrefix: schoolPrefix,
+      azureDomain: azureDomain,
+      newAccountPassword: () => 'FakeP4ss!',
+    );
+
+wapi.WisaStudent wisaStudent({
+  String wisaId = 'W1',
+  String firstName = 'Jan',
+  String name = 'Peeters',
+  String preferredName = '',
+  String classGroup = '3A',
+  String stemId = '123',
+  String nationalId = '',
+  String birthPlace = 'Gent',
+  Address address = sampleAddress,
+}) =>
+    wapi.WisaStudent(
+      wisaId: WisaId(wisaId),
+      classGroup: classGroup,
+      classSubGroup: '00',
+      name: name,
+      firstName: firstName,
+      preferredName: preferredName,
+      birthDate: _fixedDate,
+      stemId: stemId,
+      gender: Gender.male,
+      nationalId: nationalId,
+      birthPlace: birthPlace,
+      nationality: '',
+      address: address,
+      classChange: _fixedDate,
+      schoolId: 1,
+    );
+
+ss.SmartschoolAccount ssAccount({
+  String uid = 'jan.peeters',
+  String accountId = 'W1',
+  String mail = 'jan.peeters@student.school.example',
+  int stemId = 123,
+  String preferredName = '',
+  String birthPlace = 'Gent',
+  Address address = sampleAddress,
+  String status = 'actief',
+}) =>
+    ss.SmartschoolAccount(
+      uid: uid,
+      accountId: accountId,
+      mail: mail,
+      registerId: '',
+      stemId: stemId,
+      role: PersonRole.student,
+      givenName: 'Jan',
+      surname: 'Peeters',
+      extraNames: '',
+      initials: '',
+      preferredName: preferredName,
+      gender: Gender.male,
+      birthDate: _fixedDate,
+      birthPlace: birthPlace,
+      birthCountry: '',
+      address: address,
+      mobilePhone: '',
+      homePhone: '',
+      fax: '',
+      untisId: '',
+      status: status,
+    );
+
+az.AzureUser azureUser({
+  String id = 'az-1',
+  String upn = 'jan.peeters@student.school.example',
+  String? employeeId = 'W1',
+  String displayName = 'Jan Peeters',
+  String? companyName = 'SSM',
+  String? department = '3A',
+}) =>
+    az.AzureUser(
+      id: id,
+      upn: upn,
+      employeeId: employeeId,
+      displayName: displayName,
+      givenName: 'Jan',
+      surname: 'Peeters',
+      companyName: companyName,
+      department: department,
+    );
+
+/// Builds a [LinkedAccount] from optional per-system records. Omit a system to
+/// simulate it missing (drives the lifecycle-action branch).
+LinkedAccount linked({
+  wapi.WisaStudent? wisa,
+  ss.SmartschoolAccount? smartschool,
+  az.AzureUser? azure,
+  String id = 'p0',
+}) =>
+    LinkedAccount(
+      id: LinkedAccountId(id),
+      role: PersonRole.student,
+      wisa: wisa,
+      smartschool: smartschool,
+      azure: azure,
+      confidence: LinkConfidence.high,
+    );
+
+/// A fully-synced student present in all three systems with matching fields —
+/// no student action should apply to it.
+LinkedAccount fullySynced() => linked(
+      wisa: wisaStudent(),
+      smartschool: ssAccount(),
+      azure: azureUser(),
+    );
+
+// ---------------------------------------------------------------------------
+// Recording fake transports.
+// ---------------------------------------------------------------------------
+
+/// Records every Smartschool SOAP call and replies with a configurable integer
+/// result (default `0` = success), so `apply` can run offline.
+class RecordingSmartschoolTransport implements ss.SmartschoolSoapTransport {
+  /// The `SOAPAction` header of every call, in order (contains the method
+  /// name). Empty after a dry run.
+  final List<String> soapActions = [];
+
+  /// When set, the integer result to return (non-zero = failure). Applied to
+  /// every write.
+  final int resultCode;
+
+  RecordingSmartschoolTransport({this.resultCode = 0});
+
+  bool calledMethod(String method) =>
+      soapActions.any((a) => a.contains(method));
+
+  @override
+  Future<String> send({
+    required Uri endpoint,
+    required String soapAction,
+    required String envelope,
+  }) async {
+    soapActions.add(soapAction);
+    return '<?xml version="1.0" encoding="utf-8"?>'
+        '<soap:Envelope '
+        'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        '<soap:Body><response><return>$resultCode</return></response>'
+        '</soap:Body></soap:Envelope>';
+  }
+}
+
+/// Records every Graph request and replies from an injected [handler] (default:
+/// `204 No Content`, Graph's reply to PATCH/DELETE).
+class RecordingGraphTransport implements az.GraphTransport {
+  final List<az.GraphRequest> requests = [];
+  final az.GraphResponse Function(az.GraphRequest request)? handler;
+
+  RecordingGraphTransport({this.handler});
+
+  bool sent(String method, {String? pathContains}) => requests.any(
+        (r) =>
+            r.method == method &&
+            (pathContains == null || r.url.path.contains(pathContains)),
+      );
+
+  @override
+  Future<az.GraphResponse> send(az.GraphRequest request) async {
+    requests.add(request);
+    if (handler != null) return handler!(request);
+    return const az.GraphResponse(statusCode: 204);
+  }
+}
+
+ss.SmartschoolConnector smartschoolConnector(
+  RecordingSmartschoolTransport transport,
+) =>
+    ss.SmartschoolConnector.fromParts(
+      site: 'demo',
+      accessCode: 'secret',
+      transport: transport,
+    );
+
+az.AzureConnector azureConnector(RecordingGraphTransport transport) =>
+    az.AzureConnector(
+      credentials: az.AzureCredentials(
+        clientId: 'c',
+        tenantId: 't',
+        azureDomain: 'school.example',
+        schoolPrefix: 'SSM',
+      ),
+      authProvider: const az.StaticAuthProvider('token'),
+      transport: transport,
+    );

--- a/packages/smartschool_api/lib/src/models/smartschool_account.dart
+++ b/packages/smartschool_api/lib/src/models/smartschool_account.dart
@@ -99,6 +99,58 @@ class SmartschoolAccount implements core.SmartschoolAccount {
     this.coAccounts = const [],
   });
 
+  /// Returns a copy with the given fields replaced. Used by the action engine
+  /// to project the mutated source record after a successful write, so the
+  /// State layer can patch its snapshot without a re-sync (`account_actions`).
+  SmartschoolAccount copyWith({
+    String? uid,
+    String? accountId,
+    String? mail,
+    String? registerId,
+    int? stemId,
+    core.PersonRole? role,
+    String? givenName,
+    String? surname,
+    String? extraNames,
+    String? initials,
+    String? preferredName,
+    core.Gender? gender,
+    DateTime? birthDate,
+    String? birthPlace,
+    String? birthCountry,
+    core.Address? address,
+    String? mobilePhone,
+    String? homePhone,
+    String? fax,
+    String? untisId,
+    String? status,
+    List<CoAccountSlot>? coAccounts,
+  }) =>
+      SmartschoolAccount(
+        uid: uid ?? this.uid,
+        accountId: accountId ?? this.accountId,
+        mail: mail ?? this.mail,
+        registerId: registerId ?? this.registerId,
+        stemId: stemId ?? this.stemId,
+        role: role ?? this.role,
+        givenName: givenName ?? this.givenName,
+        surname: surname ?? this.surname,
+        extraNames: extraNames ?? this.extraNames,
+        initials: initials ?? this.initials,
+        preferredName: preferredName ?? this.preferredName,
+        gender: gender ?? this.gender,
+        birthDate: birthDate ?? this.birthDate,
+        birthPlace: birthPlace ?? this.birthPlace,
+        birthCountry: birthCountry ?? this.birthCountry,
+        address: address ?? this.address,
+        mobilePhone: mobilePhone ?? this.mobilePhone,
+        homePhone: homePhone ?? this.homePhone,
+        fax: fax ?? this.fax,
+        untisId: untisId ?? this.untisId,
+        status: status ?? this.status,
+        coAccounts: coAccounts ?? this.coAccounts,
+      );
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ workspace:
   - packages/smartschool_api
   - packages/azure_api
   - packages/account_linker
+  - packages/account_actions
 
 dev_dependencies:
   lints: ^5.1.0


### PR DESCRIPTION
## Summary
New `account_actions` package: the action engine per `docs/domain-model.md` §3.10, §6.3–6.4. A sealed `StudentAction` hierarchy (one class per legacy `Action\StudentAccount\*` action) with a hard purity boundary — pure `evaluate()`/`describeChanges()` and an impure, dry-run-capable `apply()` that returns the **mutated source record** so the future State layer can patch its snapshot without a network re-sync (the incremental-refresh constraint from #40).

Scoped to the **student slice**, mirroring how the linker shipped per family (#43/#44/#45). Staff, group, and the membership-dependent class-move actions are tracked as follow-ups #53/#54/#55.

## Linked issue
Closes #46

## Changes
- **New package `packages/account_actions/`**
  - Framework: `ChangeSet`/`FieldChange`, `ActionResult` (mutated Smartschool/Azure record + `removed` flag), `ApplyOptions{dryRun}` (PAIN-3), `Connectors`, `StudentActionConfig` (parameterizes the hard-coded domains / password / uid builder).
  - Sealed `StudentAction` base + 13 actions: 5 lifecycle (`AddStudentToAzure`, `AddStudentToSmartschool`, `UnregisterStudentFromSmartschool`, `DeleteStudentFromSmartschool`, `RemoveStudentFromAzure`) and 8 modify/sync (`ModifyAzureStudentEmail`, `ModifyAzureName`, `ModifyAzureSchool`, `ModifyAccountId`, `ModifySmartschoolStudentEmail`, `ModifySmartschoolStudentAddress`, `ModifySmartschoolStemId`, `ModifySmartschoolBirthPlace`, `ModifySmartschoolName`).
  - `studentActions(LinkedSnapshot, config)` dispatcher: matches the legacy `AccountActionParser` split — any system missing → only lifecycle actions; all three present → only modify actions.
- **`SmartschoolAccount.copyWith`** (enables the mutated-record projection).
- **Workspace + CI**: registered in root `pubspec.yaml`; added `account_actions` to both CI test lists — and filled the pre-existing gap where `account_linker`'s tests were never run in CI.

## Purity / invariants
- `evaluate`/`describeChanges` are pure and never mutate the bound record (INV-40, INV-42).
- `apply` is retry-safe: a failed write returns `ActionOutcome.failed` with the error and leaves the source record untouched (INV-41).
- Dry-run performs **no** writes and returns the projected `ChangeSet` + record (PAIN-3).

## Deferred (documented divergences)
- `MoveToSmartschoolClassGroup` + the class placement inside `AddStudentToSmartschool` need Smartschool group/membership data a `LinkedAccount` doesn't carry → #55.
- `ChangeEmail` (legacy) is dead code (not wired into the parser) → intentionally omitted.
- Smartschool `uid` uniqueness for new accounts is the caller's concern (the State layer holds the account set); the default builder is deliberately simple.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed` clean on all touched files
- [x] `dart analyze --fatal-infos --fatal-warnings` clean (whole workspace)
- [x] unit tests pass — 24 new (`dart test packages/account_actions/test`); full workspace suite **396 pass** / 5 integration self-skips
- [x] `apply` tests drive the **real** `SmartschoolConnector`/`AzureConnector` behind recording fake transports: a dry run asserts **zero** writes; a real apply asserts the exact SOAP/Graph call and the returned mutated record; a non-zero result asserts the retry-safe failed path
- [ ] No Flutter integration test — this is a pure-Dart library with no runtime UI surface (the app under `account_manager/` is still empty), so there is no end-to-end flow to drive. The connector-backed `apply` tests are the end-to-end exercise at this layer, matching how `account_linker` shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)