### PR TITLE
Pin WISA live-test Werkdatum; default to 30 June, override via WISA_WERKDATUM (#57)

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -13,6 +13,10 @@
 #   as repository secrets:
 #     WISA:        WISA_SERVER, WISA_PORT, WISA_DATABASE,
 #                  WISA_USERNAME, WISA_PASSWORD, WISA_SCHOOL_ID
+#                  Optional repository *variable* WISA_WERKDATUM (ISO date,
+#                  not a secret) pins the export Werkdatum; when unset the
+#                  live test defaults to 30 June of the current year so the
+#                  export is non-empty in summer too (#57).
 #     Smartschool: SMARTSCHOOL_SITE, SMARTSCHOOL_ACCESSCODE
 #   Azure uses OIDC workload-identity federation — NO token or secret is
 #   stored. A short-lived bearer token expires in ~1h, so storing one is
@@ -100,6 +104,10 @@ jobs:
       WISA_USERNAME: ${{ secrets.WISA_USERNAME }}
       WISA_PASSWORD: ${{ secrets.WISA_PASSWORD }}
       WISA_SCHOOL_ID: ${{ secrets.WISA_SCHOOL_ID }}
+      # Optional; a plain date, so a repository variable rather than a
+      # secret. Empty when unconfigured — the live test then defaults to
+      # 30 June of the current year.
+      WISA_WERKDATUM: ${{ vars.WISA_WERKDATUM }}
       SMARTSCHOOL_SITE: ${{ secrets.SMARTSCHOOL_SITE }}
       SMARTSCHOOL_ACCESSCODE: ${{ secrets.SMARTSCHOOL_ACCESSCODE }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.wisa.env.example
+++ b/.wisa.env.example
@@ -20,3 +20,8 @@ WISA_DATABASE=
 WISA_USERNAME=
 WISA_PASSWORD=
 WISA_SCHOOL_ID=
+
+# Optional: Werkdatum for the live-test export, as an ISO date
+# (e.g. 2026-01-15). When unset the live test uses 30 June of the
+# current year, so the export has enrolled students even in summer (#57).
+#WISA_WERKDATUM=

--- a/packages/wisa_api/lib/src/config/live_config.dart
+++ b/packages/wisa_api/lib/src/config/live_config.dart
@@ -4,7 +4,8 @@ import 'package:account_core/account_core.dart' as core;
 
 import '../connector.dart';
 
-/// Six-variable configuration for talking to a live WISA host.
+/// Six-variable configuration for talking to a live WISA host, plus the
+/// optional `WISA_WERKDATUM` override for the export Werkdatum.
 ///
 /// Used by both the capture script (`tool/capture_responses.dart`) and
 /// the opt-in integration test (`test/integration/wisa_live_test.dart`).
@@ -19,6 +20,11 @@ class WisaLiveConfig {
   final String password;
   final int schoolId;
 
+  /// Explicit Werkdatum for the export, from `WISA_WERKDATUM`. `null`
+  /// when the variable is unset; use [resolveWorkDate] to fall back to
+  /// the end-of-school-year default.
+  final DateTime? workDate;
+
   const WisaLiveConfig({
     required this.server,
     required this.port,
@@ -26,6 +32,7 @@ class WisaLiveConfig {
     required this.username,
     required this.password,
     required this.schoolId,
+    this.workDate,
   });
 
   /// Names of the six environment variables, in canonical order.
@@ -44,8 +51,8 @@ class WisaLiveConfig {
   /// signal, so `dart test` stays offline by default.
   ///
   /// Throws [ArgumentError] when `WISA_USERNAME` is set but one of the
-  /// other five variables is missing/empty or a numeric variable cannot
-  /// be parsed.
+  /// other five variables is missing/empty, a numeric variable cannot
+  /// be parsed, or `WISA_WERKDATUM` is set but not an ISO-8601 date.
   static WisaLiveConfig? fromEnvironment([Map<String, String>? env]) {
     final source = env ?? Platform.environment;
     final username = (source['WISA_USERNAME'] ?? '').trim();
@@ -81,6 +88,17 @@ class WisaLiveConfig {
       );
     }
 
+    DateTime? workDate;
+    final workDateRaw = (source['WISA_WERKDATUM'] ?? '').trim();
+    if (workDateRaw.isNotEmpty) {
+      workDate = DateTime.tryParse(workDateRaw);
+      if (workDate == null) {
+        throw ArgumentError(
+          'WISA_WERKDATUM is not an ISO-8601 date: "$workDateRaw"',
+        );
+      }
+    }
+
     return WisaLiveConfig(
       server: source['WISA_SERVER']!.trim(),
       port: port,
@@ -88,8 +106,17 @@ class WisaLiveConfig {
       username: username,
       password: source['WISA_PASSWORD']!.trim(),
       schoolId: schoolId,
+      workDate: workDate,
     );
   }
+
+  /// The Werkdatum the live test should use: the explicit [workDate]
+  /// when `WISA_WERKDATUM` was set, otherwise 30 June of [now]'s year —
+  /// the end of the Belgian school year, so the export has enrolled
+  /// students regardless of the calendar date (issue #57: `DateTime.now()`
+  /// yields an empty export all summer).
+  DateTime resolveWorkDate(DateTime now) =>
+      workDate ?? DateTime(now.year, 6, 30);
 
   /// Builds a connector from this config. The connector uses the default
   /// HTTP transport unless [log] is provided to capture diagnostics.

--- a/packages/wisa_api/test/config/live_config_test.dart
+++ b/packages/wisa_api/test/config/live_config_test.dart
@@ -1,0 +1,150 @@
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+const Map<String, String> _completeEnv = {
+  'WISA_SERVER': '  wisa.example.be  ',
+  'WISA_PORT': ' 443 ',
+  'WISA_DATABASE': ' SCHOOLDB ',
+  'WISA_USERNAME': ' user ',
+  'WISA_PASSWORD': ' secret ',
+  'WISA_SCHOOL_ID': ' 42 ',
+};
+
+void main() {
+  group('WisaLiveConfig.fromEnvironment', () {
+    test('returns null when the username is empty or missing', () {
+      expect(WisaLiveConfig.fromEnvironment(const {}), isNull);
+      expect(
+        WisaLiveConfig.fromEnvironment(
+          {..._completeEnv, 'WISA_USERNAME': '  '},
+        ),
+        isNull,
+      );
+    });
+
+    test('throws when the username is set but another variable is missing', () {
+      expect(
+        () => WisaLiveConfig.fromEnvironment(const {
+          'WISA_USERNAME': 'user',
+        }),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws when a numeric variable cannot be parsed', () {
+      expect(
+        () => WisaLiveConfig.fromEnvironment(
+          {..._completeEnv, 'WISA_PORT': 'not-a-number'},
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => WisaLiveConfig.fromEnvironment(
+          {..._completeEnv, 'WISA_SCHOOL_ID': 'not-a-number'},
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('parses and trims a complete environment', () {
+      final config = WisaLiveConfig.fromEnvironment(_completeEnv);
+      expect(config, isNotNull);
+      expect(config!.server, 'wisa.example.be');
+      expect(config.port, 443);
+      expect(config.database, 'SCHOOLDB');
+      expect(config.username, 'user');
+      expect(config.password, 'secret');
+      expect(config.schoolId, 42);
+      expect(config.workDate, isNull);
+    });
+
+    test('parses WISA_WERKDATUM as an ISO date', () {
+      final config = WisaLiveConfig.fromEnvironment(
+        {..._completeEnv, 'WISA_WERKDATUM': ' 2026-01-15 '},
+      );
+      expect(config!.workDate, DateTime(2026, 1, 15));
+    });
+
+    test('treats a blank WISA_WERKDATUM as unset', () {
+      final config = WisaLiveConfig.fromEnvironment(
+        {..._completeEnv, 'WISA_WERKDATUM': '   '},
+      );
+      expect(config!.workDate, isNull);
+    });
+
+    test('throws when WISA_WERKDATUM is not an ISO date', () {
+      expect(
+        () => WisaLiveConfig.fromEnvironment(
+          {..._completeEnv, 'WISA_WERKDATUM': '30/06/2026'},
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('exposes the canonical env var names', () {
+      expect(WisaLiveConfig.envVarNames, [
+        'WISA_SERVER',
+        'WISA_PORT',
+        'WISA_DATABASE',
+        'WISA_USERNAME',
+        'WISA_PASSWORD',
+        'WISA_SCHOOL_ID',
+      ]);
+    });
+  });
+
+  group('WisaLiveConfig.resolveWorkDate', () {
+    const base = WisaLiveConfig(
+      server: 's',
+      port: 1,
+      database: 'd',
+      username: 'u',
+      password: 'p',
+      schoolId: 1,
+    );
+
+    test('returns the explicit workDate when WISA_WERKDATUM was set', () {
+      final config = WisaLiveConfig(
+        server: 's',
+        port: 1,
+        database: 'd',
+        username: 'u',
+        password: 'p',
+        schoolId: 1,
+        workDate: DateTime(2025, 10, 1),
+      );
+      expect(
+        config.resolveWorkDate(DateTime(2026, 7, 15)),
+        DateTime(2025, 10, 1),
+      );
+    });
+
+    test('defaults to 30 June of the current year in the summer holiday', () {
+      expect(
+        base.resolveWorkDate(DateTime(2026, 8, 3)),
+        DateTime(2026, 6, 30),
+      );
+    });
+
+    test('defaults to 30 June of the current year during the school year', () {
+      expect(
+        base.resolveWorkDate(DateTime(2026, 2, 10)),
+        DateTime(2026, 6, 30),
+      );
+    });
+  });
+
+  group('WisaLiveConfig.connector', () {
+    test('builds a connector from the config', () {
+      const config = WisaLiveConfig(
+        server: 's',
+        port: 1,
+        database: 'd',
+        username: 'u',
+        password: 'p',
+        schoolId: 1,
+      );
+      expect(config.connector(), isA<WisaConnector>());
+    });
+  });
+}

--- a/packages/wisa_api/test/integration/wisa_live_test.dart
+++ b/packages/wisa_api/test/integration/wisa_live_test.dart
@@ -60,8 +60,7 @@ void main() {
       expect(
         ids,
         contains(config!.schoolId),
-        reason:
-            'WISA_SCHOOL_ID=${config.schoolId} not present in schools '
+        reason: 'WISA_SCHOOL_ID=${config.schoolId} not present in schools '
             '(${schools.length} returned)',
       );
     });
@@ -82,11 +81,18 @@ void main() {
         reason: 'WISA_SCHOOL_ID not in schools list',
       );
 
+      // Not DateTime.now(): with a summer Werkdatum the export is
+      // legitimately empty and the test false-fails all holiday (#57).
+      final workDate = config!.resolveWorkDate(DateTime.now());
+      stdout.writeln(
+        '  workDate=${workDate.toIso8601String().split('T').first}',
+      );
+
       WisaSnapshot snapshot;
       try {
         snapshot = await connector.sync(
           schools: target,
-          workDate: DateTime.now(),
+          workDate: workDate,
         );
       } on Exception catch (e) {
         throw Exception(


### PR DESCRIPTION
## Summary
The WISA live sync test derived its Werkdatum from `DateTime.now()`, so the export was legitimately empty all summer holiday and the test false-failed for months (red `Dart` workflow on `dev` since 2026-07-02). `WisaLiveConfig` now accepts an optional `WISA_WERKDATUM` env var (ISO date) and otherwise defaults to 30 June of the current year — the end of the Belgian school year — so the export has enrolled students year-round. Test/CI change only; the connector already accepted `workDate`.

## Linked issue
Closes #57

## Changes
- `packages/wisa_api/lib/src/config/live_config.dart` — optional `workDate` field parsed from `WISA_WERKDATUM` (`ArgumentError` on a non-ISO value, blank treated as unset) + `resolveWorkDate(now)` with the 30-June fallback.
- `packages/wisa_api/test/integration/wisa_live_test.dart` — sync test uses `config.resolveWorkDate(DateTime.now())` and logs the chosen date (date only).
- `packages/wisa_api/test/config/live_config_test.dart` — new unit tests (11) for the six-var parsing, Werkdatum parsing/errors, and both `resolveWorkDate` paths.
- `.wisa.env.example` — documents the optional `WISA_WERKDATUM`.
- `.github/workflows/dart.yml` — live-test job reads `vars.WISA_WERKDATUM` (a plain date, so a repository variable rather than a secret; empty/unset means "use the default").

## Test plan
- [x] `dart format` — files touched by this branch formatted; repo-wide pre-existing drift (27 files under Dart 3.12, no CI format gate) filed separately as #58
- [x] `dart analyze --fatal-infos --fatal-warnings` clean
- [x] 408 offline unit tests pass (`dart test` over all six workspace packages), incl. 11 new `WisaLiveConfig` tests
- [x] live integration test against the real WISA host on 2026-07-02 — inside the failing summer window, where unpatched `dev` fails with `Actual: []`: `workDate=2026-06-30` → 764 students / 203 staff / 71 class groups, all assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)