### PR TITLE
Derive CI test dirs from a glob so no package is skipped (#60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,17 +71,12 @@ jobs:
 
       - name: dart test (with coverage)
         if: steps.workspace.outputs.exists == 'true'
-        # Dart workspaces don't auto-discover tests from the root; pass
-        # each workspace package's test/ directory explicitly. Update
-        # this list whenever a new package is added to pubspec.yaml.
+        # Dart workspaces don't auto-discover tests from the root; the shell
+        # glob expands to every workspace package's test/ directory, so new
+        # packages are picked up automatically (#60 — a hand-maintained list
+        # silently skipped account_store).
         run: |
-          dart test --coverage=coverage \
-            packages/account_core/test \
-            packages/wisa_api/test \
-            packages/smartschool_api/test \
-            packages/azure_api/test \
-            packages/account_linker/test \
-            packages/account_actions/test
+          dart test --coverage=coverage packages/*/test
           dart pub global activate coverage
           dart pub global run coverage:format_coverage \
             --lcov \

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -84,13 +84,14 @@ jobs:
         run: dart analyze --fatal-infos --fatal-warnings
 
       - name: dart test
-        # Dart workspaces don't auto-discover tests from the root; pass
-        # each workspace package's test/ directory explicitly. Update
-        # this list whenever a new package is added to pubspec.yaml.
+        # Dart workspaces don't auto-discover tests from the root; the shell
+        # glob expands to every workspace package's test/ directory, so new
+        # packages are picked up automatically (#60 — a hand-maintained list
+        # silently skipped account_store).
         # No WISA_USERNAME / SMARTSCHOOL_ACCESSCODE / AZURE_ACCESS_TOKEN in
         # this job — the integration tests self-skip, see each package's
         # test/integration/.
-        run: dart test packages/account_core/test packages/wisa_api/test packages/smartschool_api/test packages/azure_api/test packages/account_linker/test packages/account_actions/test
+        run: dart test packages/*/test
 
   live-test:
     name: WISA + Smartschool + Azure live integration


### PR DESCRIPTION
## Summary
The `dart test` steps in `dart.yml` and `ci.yml` hand-maintained the list of workspace package `test/` directories, and both missed `packages/account_store/test` — so `file_person_id_resolver_test.dart` never ran in CI. Rather than appending to two lists that already proved easy to forget, both steps now use a `packages/*/test` shell glob (both jobs run bash on `ubuntu-latest`), so every existing package test directory is picked up automatically and a future package cannot be silently skipped the same way.

## Linked issue
Closes #60

## Changes
- `.github/workflows/dart.yml` — test job's `dart test` step now runs `dart test packages/*/test`; comment updated to explain the glob and reference #60.
- `.github/workflows/ci.yml` — coverage test step now runs `dart test --coverage=coverage packages/*/test`; same comment update.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` clean (0 files changed)
- [x] `dart analyze --fatal-infos --fatal-warnings` clean
- [x] Full suite via the exact new command (`dart test packages/*/test`, run in bash so the glob expands as on CI): 416 tests pass, 5 live-integration tests self-skip as designed
- [x] Confirmed the glob expands to all 7 package test dirs including `packages/account_store/test`, and the previously-skipped `file_person_id_resolver_test.dart` runs (8 tests pass)
- No integration/e2e test added: the change is CI configuration with no user-visible app surface; verification was executing the real CI commands locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)