### PR TITLE
Keep orphan Smartschool/Azure groups for cleanup (#52)

### DIFF
--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -194,11 +194,18 @@ class LinkedAccount {
   final AzureUser? azure;
   final LinkConfidence confidence;   // High | Medium (former-member / WISA-only placeholder)
 }
-class LinkedGroup { ... }
+class LinkedGroup {
+  final Group? wisa;                 // nullable: an orphan may lack a WISA anchor
+  final Group? smartschool;
+  final AzureGroup? azure;
+  final LinkConfidence confidence;
+}
 class LinkedStaff  { ... }
 ```
 
 See INV-5, INV-6. The `confidence` field replaces the implicit "alumni" and "placeholder" states that today are encoded in which fields are null. A former member surfaces as an Azure-only record (confidence `Medium`) so the action engine can raise a remove action for it (§7).
+
+`LinkedGroup` is symmetric (#52): all three systems are optional (at least one is always present). WISA class groups seed records first, but a group that vanished from WISA while still present in Smartschool and/or Azure is kept as an orphan (confidence `Medium`) rather than dropped, so the action engine can raise a delete action for it — the group analogue of the Azure-only former-member record above. Only `official` Smartschool groups seed orphans; on the Azure side — which carries no `official`-style signal — an unmatched group is kept unless its `displayName` ends with a known staff/administrative suffix (`-Personeel`, `-Directie`, `-Secretariaat`, `-Leraren`), a denylist because `securityEnabled` does not separate class groups from staff groups.
 
 The linker bundles its output into a `LinkedSnapshot`:
 

--- a/packages/account_core/lib/src/linked.dart
+++ b/packages/account_core/lib/src/linked.dart
@@ -69,14 +69,21 @@ class LinkedStaff {
 }
 
 /// Output of the linker: one record per identified group.
+///
+/// [wisa] is nullable (#52): a group that vanished from WISA but still exists
+/// in Smartschool and/or Azure is kept as an orphan record — symmetric with
+/// how an Azure-only [LinkedAccount] is kept for a former student — so the
+/// action engine can raise a delete action for it instead of it silently
+/// disappearing. At least one of [wisa], [smartschool], [azure] is always
+/// present.
 class LinkedGroup {
-  final Group wisa;
+  final Group? wisa;
   final Group? smartschool;
   final AzureGroup? azure;
   final LinkConfidence confidence;
 
   const LinkedGroup({
-    required this.wisa,
+    this.wisa,
     this.smartschool,
     this.azure,
     required this.confidence,

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -286,28 +286,35 @@ List<LinkedStaff> _linkStaff(
 /// Azure group's `displayName`. There is no stable cross-system id for a group,
 /// so the name *is* the bridge.
 ///
-/// Anchored on WISA: every [LinkedGroup] carries a WISA [Group] ([LinkedGroup]
-/// requires it), so only WISA class groups seed records. A Smartschool or Azure
-/// group that matches no WISA class has no anchor and is dropped — unlike a
-/// person, a group cannot be represented Smartschool-only or Azure-only
-/// (issue #45, "WISA required"). Cleanup of such orphan groups is left to the
-/// action engine, which would need a nullable-WISA record type.
+/// WISA class groups seed records first, but a Smartschool or Azure group
+/// matching no WISA class is no longer dropped (#52): it becomes an orphan
+/// [LinkedGroup] with `wisa: null`, mirroring how an Azure-only [LinkedAccount]
+/// is kept for a former student. This lets the action engine raise a delete
+/// action for a class that vanished from WISA but still exists downstream.
 ///
 /// Only `official` Smartschool groups are considered (legacy
 /// `AddSmartschoolChildGroups` walked the "Leerlingen" subtree and linked only
-/// official classes); organisational sub-groups never match.
+/// official classes); organisational sub-groups never match or seed orphans.
+///
+/// Azure carries no `official`-style signal — [az.AzureGroup] is just
+/// `{id, displayName, securityEnabled}` — so an unmatched Azure group is kept
+/// as an orphan *unless* its name looks administrative (see
+/// [_looksLikeClassGroup]); staff/directorate/secretariat groups are excluded
+/// by name rather than included by one, since there is no positive
+/// class-group signal to include by.
 ///
 /// Confidence mirrors accounts/staff: `high` only when all three systems carry
 /// the group — and because the match key *is* the (normalized) name, presence
-/// in all three implies the keys agree — otherwise `medium`. All comparisons
-/// are trimmed + case-insensitive (INV-12).
+/// in all three implies the keys agree — otherwise `medium` (including every
+/// orphan record, per #52). All comparisons are trimmed + case-insensitive
+/// (INV-12).
 List<LinkedGroup> _linkGroups(
   wapi.WisaSnapshot wisaSnapshot,
   ss.SmartschoolSnapshot smartschoolSnapshot,
   az.AzureSnapshot azureSnapshot,
 ) {
   final records = <_GroupRecord>[];
-  // Normalized fullName -> the record anchored on that WISA class group.
+  // Normalized fullName/name/displayName -> the record indexed under it.
   final byName = <String, _GroupRecord>{};
 
   // 1. Seed one record per distinct WISA class group, in snapshot order, keyed
@@ -321,38 +328,79 @@ List<LinkedGroup> _linkGroups(
     byName[key] = rec;
   }
 
-  // 2. Attach official Smartschool class groups by name. Non-official
-  //    organisational groups never link; an official group matching no WISA
-  //    class is dropped (no WISA anchor).
+  // 2. Attach official Smartschool class groups by name; non-official
+  //    organisational groups never link or seed orphans. An official group
+  //    matching no WISA class becomes an orphan record (#52) instead of being
+  //    dropped.
   for (final group in smartschoolSnapshot.groups) {
     if (!group.official) continue;
     final key = _norm(group.name);
     if (key == null) continue;
-    final rec = byName[key];
-    if (rec != null && rec.smartschool == null) rec.smartschool = group;
+    final existing = byName[key];
+    if (existing != null) {
+      existing.smartschool ??= group;
+    } else {
+      final rec = _GroupRecord(smartschool: group);
+      records.add(rec);
+      byName[key] = rec;
+    }
   }
 
-  // 3. Attach Azure groups by displayName. An Azure group matching no WISA
-  //    class is likewise dropped.
+  // 3. Attach Azure groups by displayName. An Azure group matching no
+  //    existing record becomes an orphan too (#52), but only when it looks
+  //    like a stale class rather than a staff/administrative group.
   for (final group in azureSnapshot.groups) {
     final key = _norm(group.displayName);
     if (key == null) continue;
-    final rec = byName[key];
-    if (rec != null && rec.azure == null) rec.azure = group;
+    final existing = byName[key];
+    if (existing != null) {
+      existing.azure ??= group;
+    } else if (_looksLikeClassGroup(group.displayName)) {
+      final rec = _GroupRecord(azure: group);
+      records.add(rec);
+      byName[key] = rec;
+    }
   }
 
   // 4. Freeze each record into an immutable [LinkedGroup].
   return <LinkedGroup>[
     for (final rec in records)
       LinkedGroup(
-        wisa: _wisaToCoreGroup(rec.wisa),
+        wisa: rec.wisa == null ? null : _wisaToCoreGroup(rec.wisa!),
         smartschool: rec.smartschool,
         azure: rec.azure,
-        confidence: rec.smartschool != null && rec.azure != null
-            ? LinkConfidence.high
-            : LinkConfidence.medium,
+        confidence:
+            rec.wisa != null && rec.smartschool != null && rec.azure != null
+                ? LinkConfidence.high
+                : LinkConfidence.medium,
       ),
   ];
+}
+
+/// Azure AD group-name suffixes that mark a *staff*/administrative group
+/// rather than a class — ported from the literal names legacy
+/// `AddToAzureStaffGroup`/`AddToStaffGroup` look up via `FindGroupByName`
+/// (`{prefix}-Personeel`, `-Directie`, `-Secretariaat`, `-Leraren`). Checked
+/// as a case-insensitive suffix so it applies regardless of the school's
+/// actual prefix.
+///
+/// This is a denylist, not an allowlist, because [az.AzureGroup] carries no
+/// positive class-group signal: `securityEnabled` doesn't split the
+/// populations either — legacy creates both a security-group and a plain
+/// variant of `{prefix}-Personeel` for the same staff population.
+const List<String> _nonClassGroupSuffixes = [
+  '-personeel',
+  '-directie',
+  '-secretariaat',
+  '-leraren',
+];
+
+/// Whether an unmatched Azure group is plausible as a stale class rather than
+/// a known staff/administrative group. See [_nonClassGroupSuffixes].
+bool _looksLikeClassGroup(String? displayName) {
+  final name = _norm(displayName);
+  if (name == null) return false;
+  return !_nonClassGroupSuffixes.any(name.endsWith);
 }
 
 /// Projects a [wapi.WisaClassGroup] to the canonical [Group] that
@@ -394,15 +442,15 @@ class _StaffRecord {
 }
 
 /// Mutable accumulator for one linked class group; the group analogue of
-/// [_Record]. Anchored on a required [wapi.WisaClassGroup] (groups seed only
-/// from WISA), gathering the matching Smartschool [Group] and [az.AzureGroup]
-/// as the passes run. Frozen into an immutable [LinkedGroup] at the end.
+/// [_Record]. [wisa] is nullable (#52): a record may instead be seeded from an
+/// orphan Smartschool or Azure group with no WISA anchor. Frozen into an
+/// immutable [LinkedGroup] at the end.
 class _GroupRecord {
-  final wapi.WisaClassGroup wisa;
+  wapi.WisaClassGroup? wisa;
   Group? smartschool;
   az.AzureGroup? azure;
 
-  _GroupRecord({required this.wisa});
+  _GroupRecord({this.wisa, this.smartschool, this.azure});
 }
 
 /// Whether a Smartschool [role] marks the account as staff (teacher or

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -208,8 +208,8 @@ void main() {
       expect(snapshot.groups, hasLength(1));
       final g = snapshot.groups.single;
       expect(g.confidence, LinkConfidence.high);
-      expect(g.wisa.name, '5A');
-      expect(g.wisa.origin, Origin.wisa);
+      expect(g.wisa!.name, '5A');
+      expect(g.wisa!.origin, Origin.wisa);
       expect(g.smartschool, isNotNull);
       expect(g.azure, isNotNull);
     });
@@ -224,13 +224,13 @@ void main() {
       );
 
       final g = snapshot.groups.single;
-      expect(g.wisa.name, '3B');
+      expect(g.wisa!.name, '3B');
       expect(g.smartschool, isNull);
       expect(g.azure, isNull);
       expect(g.confidence, LinkConfidence.medium);
     });
 
-    test('Smartschool-only group is dropped (no WISA anchor)', () {
+    test('Smartschool-only orphan group is kept (#52)', () {
       final snapshot = link(
         wisaSnap(const []),
         ssSnap(const [], groups: [ssGroup('6C')]),
@@ -238,10 +238,26 @@ void main() {
         SeqResolver(),
         schoolPrefix: _prefix,
       );
+
+      final g = snapshot.groups.single;
+      expect(g.wisa, isNull);
+      expect(g.smartschool, isNotNull);
+      expect(g.azure, isNull);
+      expect(g.confidence, LinkConfidence.medium);
+    });
+
+    test('non-official Smartschool group does not seed an orphan', () {
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap(const [], groups: [ssGroup('6C', official: false)]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
       expect(snapshot.groups, isEmpty);
     });
 
-    test('Azure-only group is dropped (no WISA anchor)', () {
+    test('Azure-only orphan group is kept (#52)', () {
       final snapshot = link(
         wisaSnap(const []),
         ssSnap(const []),
@@ -249,8 +265,35 @@ void main() {
         SeqResolver(),
         schoolPrefix: _prefix,
       );
-      expect(snapshot.groups, isEmpty);
+
+      final g = snapshot.groups.single;
+      expect(g.wisa, isNull);
+      expect(g.smartschool, isNull);
+      expect(g.azure, isNotNull);
+      expect(g.confidence, LinkConfidence.medium);
     });
+
+    test(
+      'an Azure staff/administrative group is not kept as a class orphan (#52)',
+      () {
+        final snapshot = link(
+          wisaSnap(const []),
+          ssSnap(const []),
+          azSnap(
+            const [],
+            groups: [
+              azureGroup('$_prefix-Personeel'),
+              azureGroup('$_prefix-Directie'),
+              azureGroup('$_prefix-Secretariaat'),
+              azureGroup('$_prefix-Leraren'),
+            ],
+          ),
+          SeqResolver(),
+          schoolPrefix: _prefix,
+        );
+        expect(snapshot.groups, isEmpty);
+      },
+    );
 
     test('WISA + Smartschool but no Azure → medium', () {
       final snapshot = link(
@@ -293,7 +336,7 @@ void main() {
       );
 
       final g = snapshot.groups.single;
-      expect(g.wisa.name, '5A 01');
+      expect(g.wisa!.name, '5A 01');
       expect(g.smartschool, isNotNull);
       expect(g.azure, isNotNull);
       expect(g.confidence, LinkConfidence.high);
@@ -331,7 +374,7 @@ void main() {
       );
 
       expect(snapshot.groups, hasLength(1));
-      expect(snapshot.groups.single.wisa.instituteNumber, '111');
+      expect(snapshot.groups.single.wisa!.instituteNumber, '111');
     });
   });
 

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -243,10 +243,11 @@ List<String> structuralSignature(LinkedSnapshot snapshot) {
         'a:${s.azure?.id ?? '-'}',
       ].join('|');
 
-  // Groups have no linker-minted id; the WISA name anchors the record.
+  // Groups have no linker-minted id; the WISA name anchors the record when
+  // present, else the Smartschool/Azure name of the orphan (#52).
   String grp(LinkedGroup g) => [
         g.confidence.name,
-        'w:${g.wisa.name}',
+        'w:${g.wisa?.name ?? '-'}',
         's:${g.smartschool?.id.value ?? '-'}',
         'a:${g.azure?.id ?? '-'}',
       ].join('|');


### PR DESCRIPTION
## Summary
Group linking (#45) anchored every `LinkedGroup` on WISA, so a Smartschool- or Azure-only class that vanished from WISA had no anchor and was silently dropped — meaning it could never be cleaned up. This makes groups symmetric with accounts: an orphan downstream group is kept (confidence `medium`) so the action engine can raise a delete action for it, the group analogue of the Azure-only former-member record.

## Linked issue
Closes #52

## Changes
- `LinkedGroup.wisa` becomes nullable (`Group?`); `smartschool`/`azure` stay optional. At least one system is always present.
- `_linkGroups` seeds orphan records from unmatched **official** Smartschool groups and from Azure groups, mirroring how the account linker keeps prefixed Azure orphans. WISA-anchored records keep the #45 semantics (`high` only when all three present).
- **Azure class-group filter (the issue's open question):** Azure carries no `official`-style signal, so an unmatched Azure group is kept **unless** its `displayName` ends with a known staff/administrative suffix (`-Personeel`, `-Directie`, `-Secretariaat`, `-Leraren`), ported from the literal legacy `FindGroupByName` lookups. A denylist rather than an allowlist because `securityEnabled` does not separate class groups from staff groups (legacy creates both a security and a plain variant of `{prefix}-Personeel`).
- Docs: updated `docs/domain-model.md` §3.9 group anchoring/confidence note.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `dart analyze --fatal-infos --fatal-warnings` clean
- [x] unit tests pass (`dart test packages/*/test`) — 418 passed, 5 self-skipped (live-integration, no creds), 0 failed
- [ ] integration/e2e — none added: the change is pure domain/linker logic with no UI surface (the `account_manager/` Flutter app is still empty), so there is no end-to-end flow to drive. Covered by the linker unit tests below.

New/updated linker tests: Smartschool-only orphan kept, Azure-only orphan kept, Azure staff-suffix groups NOT kept, non-official Smartschool group does not seed an orphan; all WISA-anchored cases from #45 still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)