### PR TITLE
Add staff action family to the action engine (#53)

### DIFF
--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -8,16 +8,17 @@ write APIs.
 
 ## What ships here
 
-This package currently implements the **student** family and its dispatcher.
-Staff and group families are tracked as follow-ups to #46, mirroring how the
-linker shipped student/staff/group as separate slices (#43/#44/#45).
+This package implements the **student** and **staff** families and their
+dispatchers. The group family is tracked as a follow-up to #46, mirroring how
+the linker shipped student/staff/group as separate slices (#43/#44/#45).
 
 ## The shape of an action
 
-`StudentAction` is a `sealed` base with one subclass per legacy
-`Action\StudentAccount\*` class. Each action is **bound to its target**
-`LinkedAccount` at construction (per §6.4's `apply(action, connectors,
-options)`), and exposes three operations with a hard purity boundary:
+`StudentAction` (and its sibling `StaffAction`) is a `sealed` base with one
+subclass per legacy `Action\StudentAccount\*` / `Action\StaffAccount\*` class.
+Each action is **bound to its target** (`LinkedAccount` / `LinkedStaff`) at
+construction (per §6.4's `apply(action, connectors, options)`), and exposes
+three operations with a hard purity boundary:
 
 | Operation | Purity | Purpose |
 |---|---|---|
@@ -35,6 +36,12 @@ record or its snapshot (INV-42: every changed record is a fresh copy).
 or `azure`), or `removed: true` for a delete. This lets the future State layer
 patch its in-memory snapshot and re-run `link()` **without a network re-sync**
 (the incremental-refresh constraint from #40).
+
+The staff `DontImportFromWisa` action is the one exception: WISA is read-only,
+so it performs no write. Instead it returns a `WisaImportRule` via
+`ActionResult.wisaRule` (with `system: Origin.wisa`); the State layer adds the
+rule to its import-rule set and re-syncs, which drops the ignored staff record
+from the next snapshot.
 
 ### Dry run (PAIN-3)
 
@@ -55,11 +62,24 @@ per record, applies the legacy `AccountActionParser` rule:
 
 The two sets never coexist for one record, exactly as in legacy.
 
+`staffActions(snapshot, config)` does the same over the snapshot's staff
+records. The legacy staff parser writes the modify branch as `if (OK)` rather
+than `else`, but sets `OK = false` inside the missing branch, so the two
+branches are mutually exclusive just like the student parser. The staff
+lifecycle set is `AddStaffToAzure`, `AddStaffToSmartschool`,
+`RemoveStaffFromSmartschool`, `DontImportStaffFromWisa`, `RemoveStaffFromAzure`;
+the modify set is `UpdateStaffWisaName`, `ModifySmartschoolStaffEmail`,
+`SetStaffCopyCode`. Staff bridge to Smartschool by `WisaStaff.code` (not
+`wisaId`) — `AddStaffToSmartschool` and `UpdateStaffWisaName` write the code
+into `accountId` (spec §4, OQ-1), while the numeric `wisaId` becomes the
+copy-code.
+
 ## Configuration
 
 `StudentActionConfig` injects the values legacy hard-coded: `schoolPrefix`, the
 base `azureDomain` and derived `studentDomain`, a password provider for created
-accounts, and a Smartschool `uid` builder.
+accounts, and a Smartschool `uid` builder. `StaffActionConfig` is the same
+minus `studentDomain` — staff live on the base `azureDomain`.
 
 ## Deferred (documented divergences)
 
@@ -67,8 +87,20 @@ accounts, and a Smartschool `uid` builder.
   `AddStudentToSmartschool` are **not** ported here: they need the Smartschool
   group tree / a student's current class membership, which the `LinkedAccount`
   record does not carry. They belong with a `Membership`-aware input (follow-up).
+- **`AddToAzureStaffGroup`** / **`AddToStaffGroup`** and the `-Personeel` /
+  `Leerkrachten` group placements inside `AddStaffToAzure` /
+  `AddStaffToSmartschool` are **not** ported: they evaluate against Office 365 /
+  Smartschool group membership, which `LinkedStaff` does not carry. Same
+  membership-aware follow-up.
 - **`ChangeEmail`** (legacy) is dead code — not wired into the parser — and is
   intentionally omitted.
+- **`SetStaffCopyCode` idempotency fix.** Legacy `SetCopyCode` compares the
+  *zero-padded* copy-code against Smartschool's `fax`, but writes back the
+  *unpadded* `wisaId` — so a sub-4-digit id makes the action re-trigger forever.
+  We write the padded code to both `fax` and the `PINCODE CANON` parameter, so
+  the action converges after one apply.
+- **Staff gender on create.** Legacy `AddToSmartschool` hard-codes `Female` for
+  new staff (WISA staff rows carry no gender); preserved verbatim.
 - Smartschool `uid` uniqueness for new accounts is the caller's concern (the
   State layer holds the account set); the default builder is deliberately
   simple.

--- a/packages/account_actions/lib/account_actions.dart
+++ b/packages/account_actions/lib/account_actions.dart
@@ -6,9 +6,9 @@
 /// `apply()` that returns the **mutated source record** so the State layer can
 /// patch its snapshot without a network re-sync.
 ///
-/// This package currently ships the **student** family and its dispatcher.
-/// The staff and group families are tracked as follow-ups to #46, mirroring
-/// how the linker shipped student/staff/group as separate slices
+/// This package currently ships the **student** and **staff** families and
+/// their dispatchers. The group family is tracked as a follow-up to #46,
+/// mirroring how the linker shipped student/staff/group as separate slices
 /// (#43/#44/#45).
 ///
 /// Pure Dart — no Flutter, no UI coupling. Legacy reference (read-only):
@@ -19,6 +19,9 @@ export 'src/action_result.dart';
 export 'src/apply_options.dart';
 export 'src/change_set.dart';
 export 'src/connectors.dart';
+export 'src/staff_action.dart';
+export 'src/staff_action_config.dart';
+export 'src/staff_dispatch.dart';
 export 'src/student_action.dart';
 export 'src/student_action_config.dart';
 export 'src/student_dispatch.dart';

--- a/packages/account_actions/lib/src/action_result.dart
+++ b/packages/account_actions/lib/src/action_result.dart
@@ -1,4 +1,5 @@
 import 'package:account_core/account_core.dart';
+import 'package:wisa_api/wisa_api.dart' show WisaImportRule;
 
 import 'change_set.dart';
 
@@ -27,6 +28,11 @@ enum ActionOutcome {
 ///
 /// The record fields are typed against the `account_core` interfaces; the
 /// concrete connector records ([smartschool_api] / [azure_api]) implement them.
+///
+/// A WISA-targeted action ([wisaRule], e.g. the staff `DontImportFromWisa`)
+/// carries no connector record: WISA is read-only, so the action produces an
+/// import rule for the State layer to add to its rule set and re-sync, rather
+/// than writing anything itself.
 class ActionResult {
   final ActionOutcome outcome;
 
@@ -48,6 +54,13 @@ class ActionResult {
   /// should drop it from the snapshot rather than patch it).
   final bool removed;
 
+  /// The WISA import rule the action produced, when [system] is
+  /// [Origin.wisa]. WISA is read-only, so the action performs no write itself;
+  /// the State layer adds this rule to its import-rule set and re-syncs (which
+  /// drops the ignored staff record from the next snapshot). Null for every
+  /// non-WISA action.
+  final WisaImportRule? wisaRule;
+
   /// The failure cause; non-null only when [outcome] is [ActionOutcome.failed].
   final Object? error;
 
@@ -58,6 +71,7 @@ class ActionResult {
     this.smartschool,
     this.azure,
     this.removed = false,
+    this.wisaRule,
     this.error,
   });
 

--- a/packages/account_actions/lib/src/staff_action.dart
+++ b/packages/account_actions/lib/src/staff_action.dart
@@ -1,0 +1,670 @@
+import 'package:account_core/account_core.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+import 'action_result.dart';
+import 'apply_options.dart';
+import 'change_set.dart';
+import 'connectors.dart';
+import 'staff_action_config.dart';
+
+/// The staff action family (spec `docs/domain-model.md` §3.10). One subclass
+/// per legacy `Action\StaffAccount\*` class, mirroring [StudentAction].
+///
+/// **Target binding.** Each action is bound to the [LinkedStaff] it acts on at
+/// construction; [evaluate]/[describeChanges] read the bound [staff] (exposed
+/// as [target]) and stay pure, while [apply] carries no target of its own.
+///
+/// **Purity boundary (INV-40/41/42).** [evaluate] and [describeChanges] are
+/// pure and deterministic — no I/O, no globals. [apply] is the only impure
+/// operation; it is retry-safe (a transient failure returns
+/// [ActionOutcome.failed] without corrupting state) and never mutates the
+/// bound [staff] or its snapshot records — every changed record is a fresh
+/// copy.
+///
+/// **Staff vs student differences.** Staff bridge to Smartschool by
+/// [wapi.WisaStaff.code] (not `wisaId`) — `AddToSmartschool` and
+/// `UpdateWisaName` write the code into `accountId` (spec §4, OQ-1). Staff live
+/// on the base [StaffActionConfig.azureDomain] (no student sub-domain). The
+/// office-365 / Smartschool **group** placements the legacy add-actions perform
+/// are out of scope here (see the package README) — they need a
+/// membership-aware input, tracked as the `AddToAzureStaffGroup` /
+/// `AddToStaffGroup` follow-up.
+sealed class StaffAction {
+  /// The linked staff record this action targets, bound at construction.
+  final LinkedStaff staff;
+
+  /// Injected configuration (domain, password/uid builders).
+  final StaffActionConfig config;
+
+  const StaffAction(this.staff, this.config);
+
+  /// Alias for the bound [staff] — the "target" the spec's `evaluate(target)`
+  /// refers to.
+  LinkedStaff get target => staff;
+
+  /// Whether this action applies to [staff]. Pure and deterministic (INV-40).
+  bool evaluate();
+
+  /// The field-level diff this action would make. Pure (INV-40).
+  ChangeSet describeChanges();
+
+  /// Performs the change on the target system. Impure. With
+  /// [ApplyOptions.dryRun] set, performs **no** writes and returns the
+  /// projected [ActionResult] (PAIN-3).
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options);
+
+  // --- shared helpers -------------------------------------------------------
+
+  wapi.WisaStaff get _wisa => staff.wisa! as wapi.WisaStaff;
+  ss.SmartschoolAccount get _ss => staff.smartschool! as ss.SmartschoolAccount;
+  az.AzureUser get _az => staff.azure! as az.AzureUser;
+
+  ss.SmartschoolConnector _requireSmartschool(Connectors c) =>
+      c.smartschool ??
+      (throw StateError('$runtimeType.apply needs a Smartschool connector'));
+
+  az.AzureConnector _requireAzure(Connectors c) =>
+      c.azure ??
+      (throw StateError('$runtimeType.apply needs an Azure connector'));
+
+  ActionResult _failed(ChangeSet changes, Origin system, Object error) =>
+      ActionResult(
+        outcome: ActionOutcome.failed,
+        changes: changes,
+        system: system,
+        error: error,
+      );
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle actions — evaluated only when a system is missing (§6.3).
+// ---------------------------------------------------------------------------
+
+/// Create an Office 365 account for a staff member present in WISA but not
+/// Azure. Ported from `Action\StaffAccount\AddToAzure` (the `-Personeel` group
+/// placement is deferred — see the README).
+class AddStaffToAzure extends StaffAction {
+  const AddStaffToAzure(super.staff, super.config);
+
+  @override
+  bool evaluate() => staff.wisa != null && staff.azure == null;
+
+  String get _displayName => '${_wisa.firstName} ${_wisa.lastName}'.trim();
+
+  String _projectedUpn() =>
+      '${_slug(_wisa.firstName)}.${_slug(_wisa.lastName)}@${config.azureDomain}';
+
+  @override
+  ChangeSet describeChanges() {
+    final wisa = _wisa;
+    return ChangeSet(
+      system: Origin.azure,
+      summary: 'Maak een nieuw Office 365 account',
+      fields: [
+        FieldChange('userPrincipalName', after: _projectedUpn()),
+        FieldChange('displayName', after: _displayName),
+        FieldChange('employeeId', after: wisa.wisaId?.value),
+        FieldChange('department', after: config.schoolPrefix),
+      ],
+    );
+  }
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    final wisa = _wisa;
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.azure,
+        azure: az.AzureUser(
+          id: '',
+          upn: _projectedUpn(),
+          employeeId: wisa.wisaId?.value,
+          displayName: _displayName,
+          givenName: wisa.firstName,
+          surname: wisa.lastName,
+          department: config.schoolPrefix,
+        ),
+      );
+    }
+
+    try {
+      final users = _requireAzure(connectors).users;
+      final upn = await users.createPrincipalName(
+        wisa.firstName,
+        wisa.lastName,
+        config.azureDomain,
+        isStudent: false,
+      );
+      final created = await users.createUser(
+        userPrincipalName: upn,
+        displayName: _displayName,
+        password: config.newAccountPassword(),
+        givenName: wisa.firstName,
+        surname: wisa.lastName,
+        employeeId: wisa.wisaId?.value,
+        department: config.schoolPrefix,
+        forceChangePasswordNextSignIn: true,
+      );
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.azure,
+        azure: created,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.azure, e);
+    }
+  }
+}
+
+/// Create a Smartschool account for a staff member present in WISA and Azure
+/// but not Smartschool. Ported from `Action\StaffAccount\AddToSmartschool` —
+/// the account is built from the Azure record with the WISA [wapi.WisaStaff.code]
+/// as its `accountId` (spec §4) and the WISA `wisaId` as its copy-code (`fax`);
+/// the group placement (Leerkrachten / Leerlingen) is deferred (see README).
+class AddStaffToSmartschool extends StaffAction {
+  const AddStaffToSmartschool(super.staff, super.config);
+
+  @override
+  bool evaluate() =>
+      staff.wisa != null && staff.azure != null && staff.smartschool == null;
+
+  ss.SmartschoolAccount _build() {
+    final wisa = _wisa;
+    final azure = _az;
+    return ss.SmartschoolAccount(
+      uid: config.smartschoolUid(azure.givenName, azure.surname),
+      accountId: wisa.code.value,
+      mail: azure.upn,
+      registerId: '',
+      stemId: 0,
+      role: PersonRole.teacher,
+      givenName: azure.givenName,
+      surname: azure.surname,
+      extraNames: '',
+      initials: '',
+      preferredName: '',
+      // Legacy hard-codes Female here; WISA staff rows carry no gender, so
+      // there is nothing better to derive it from. Preserved verbatim.
+      gender: Gender.female,
+      birthDate: null,
+      birthPlace: '',
+      birthCountry: '',
+      address: const Address(
+        street: '',
+        houseNumber: '',
+        postalCode: '',
+        city: '',
+        country: '',
+      ),
+      mobilePhone: '',
+      homePhone: '',
+      fax: wisa.wisaId?.value ?? '',
+      untisId: '',
+      status: 'actief',
+    );
+  }
+
+  @override
+  ChangeSet describeChanges() {
+    final built = _build();
+    return ChangeSet(
+      system: Origin.smartschool,
+      summary: 'Maak een nieuw Smartschool account',
+      fields: [
+        FieldChange('uid', after: built.uid),
+        FieldChange('accountId', after: built.accountId),
+        FieldChange('mail', after: built.mail),
+      ],
+    );
+  }
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    final built = _build();
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: built,
+      );
+    }
+
+    try {
+      final ok = await _requireSmartschool(connectors).saveAccount(
+        built,
+        password: config.newAccountPassword(),
+      );
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool saveAccount returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: built,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}
+
+/// Delete a Smartschool account whose staff member exists in neither WISA nor
+/// Azure. Ported from `Action\StaffAccount\RemoveFromSmartschool`.
+class RemoveStaffFromSmartschool extends StaffAction {
+  const RemoveStaffFromSmartschool(super.staff, super.config);
+
+  @override
+  bool evaluate() =>
+      staff.wisa == null && staff.azure == null && staff.smartschool != null;
+
+  @override
+  ChangeSet describeChanges() => const ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Verwijder dit account uit Smartschool',
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        removed: true,
+      );
+    }
+
+    try {
+      final ok = await _requireSmartschool(connectors).deleteUser(
+        _ss.uid,
+        officialDate: options.deletionDate,
+      );
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool deleteUser returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        removed: true,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}
+
+/// Delete an Azure-only account for a staff member absent from WISA and
+/// Smartschool. Ported from `Action\StaffAccount\RemoveFromAzure` — which, like
+/// legacy, gates only on system presence (the linker already restricts a
+/// [LinkedStaff]'s Azure record to one belonging to the school, INV-22).
+class RemoveStaffFromAzure extends StaffAction {
+  const RemoveStaffFromAzure(super.staff, super.config);
+
+  @override
+  bool evaluate() =>
+      staff.wisa == null && staff.smartschool == null && staff.azure != null;
+
+  @override
+  ChangeSet describeChanges() => const ChangeSet(
+        system: Origin.azure,
+        summary: 'Verwijder Azure account',
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.azure,
+        removed: true,
+      );
+    }
+
+    try {
+      await _requireAzure(connectors).users.deleteUser(_az.id);
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.azure,
+        removed: true,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.azure, e);
+    }
+  }
+}
+
+/// Stop importing a staff member from WISA. Ported from
+/// `Action\StaffAccount\DontImportFromWisa`: the member exists in WISA but not
+/// Smartschool, and the operator judges they are no longer in service, so a
+/// [wapi.DontImportUserFromWisa] rule is added keyed on the WISA code.
+///
+/// Unlike the other actions this writes nothing: WISA is read-only, so [apply]
+/// returns the rule via [ActionResult.wisaRule] for the State layer to add to
+/// its import-rule set and re-sync (which drops the record next snapshot).
+class DontImportStaffFromWisa extends StaffAction {
+  const DontImportStaffFromWisa(super.staff, super.config);
+
+  @override
+  bool evaluate() => staff.wisa != null && staff.smartschool == null;
+
+  wapi.DontImportUserFromWisa _rule() =>
+      wapi.DontImportUserFromWisa(_wisa.code.value);
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.wisa,
+        summary: 'Negeer dit account bij het importeren uit WISA',
+        fields: [
+          FieldChange('DontImportUserFromWisa', after: _wisa.code.value)
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    return ActionResult(
+      outcome: options.dryRun ? ActionOutcome.dryRun : ActionOutcome.applied,
+      changes: changes,
+      system: Origin.wisa,
+      wisaRule: _rule(),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Modify actions — evaluated only when all three systems are present (§6.3).
+// ---------------------------------------------------------------------------
+
+/// Correct the Smartschool internal number to equal the WISA staff
+/// [wapi.WisaStaff.code] (staff bridge to Smartschool, spec §4). Ported from
+/// `Action\StaffAccount\UpdateWisaName`.
+class UpdateStaffWisaName extends StaffAction {
+  const UpdateStaffWisaName(super.staff, super.config);
+
+  @override
+  bool evaluate() =>
+      _wisa.code.value.trim().toLowerCase() !=
+      _ss.accountId.trim().toLowerCase();
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Wijzig het WISA ID in Smartschool',
+        fields: [
+          FieldChange(
+            'accountId',
+            before: _ss.accountId,
+            after: _wisa.code.value,
+          ),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    final updated = _ss.copyWith(accountId: _wisa.code.value);
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: updated,
+      );
+    }
+
+    try {
+      final ok = await _requireSmartschool(connectors)
+          .changeAccountId(_ss.uid, _wisa.code.value);
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool changeAccountId returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: updated,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}
+
+/// Sync the Smartschool mail to the Azure UPN, but only when Smartschool still
+/// holds a base-domain address. Ported from
+/// `Action\StaffAccount\ModifySmartschoolStaffEmail`.
+class ModifySmartschoolStaffEmail extends StaffAction {
+  const ModifySmartschoolStaffEmail(super.staff, super.config);
+
+  @override
+  bool evaluate() =>
+      _domainOf(_ss.mail) == config.azureDomain.toLowerCase() &&
+      !_eq(_ss.mail, _az.upn);
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Wijzig het e-mailadres in Smartschool',
+        fields: [FieldChange('mail', before: _ss.mail, after: _az.upn)],
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      _smartschoolSave(
+        connectors,
+        options,
+        describeChanges(),
+        _ss.copyWith(mail: _az.upn),
+      );
+}
+
+/// Sync the Smartschool copy-code (photocopier PIN) to the WISA `wisaId`.
+/// Ported from `Action\StaffAccount\SetCopyCode`: the code is stored both in
+/// the account's `fax` field and in the `PINCODE CANON` user parameter, and is
+/// left-padded with zeros to at least four digits.
+///
+/// **Divergence from legacy.** Legacy compares the *padded* code against `fax`
+/// but writes the *unpadded* `wisaId`, so a sub-4-digit id makes the action
+/// re-trigger forever (it never converges). We write the padded code to both
+/// targets so the action is idempotent — apply once, and `evaluate` is false
+/// thereafter.
+class SetStaffCopyCode extends StaffAction {
+  const SetStaffCopyCode(super.staff, super.config);
+
+  String get _code => _copyCode(_wisa.wisaId?.value);
+
+  @override
+  bool evaluate() => _code != _ss.fax;
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Wijzig de kopie code in Smartschool',
+        fields: [FieldChange('fax', before: _ss.fax, after: _code)],
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    final code = _code;
+    final updated = _ss.copyWith(fax: code);
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: updated,
+      );
+    }
+
+    try {
+      final smartschool = _requireSmartschool(connectors);
+      // An empty password leaves the holder's existing password unchanged.
+      final saved = await smartschool.saveAccount(updated, password: '');
+      if (!saved) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool saveAccount returned failure'),
+        );
+      }
+      final pinOk = await smartschool.saveUserParameter(
+        updated.uid,
+        _pincodeParameter,
+        code,
+      );
+      if (!pinOk) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool saveUserParameter returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: updated,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared apply helper for the Smartschool modify actions.
+// ---------------------------------------------------------------------------
+
+extension _SmartschoolSave on StaffAction {
+  /// Saves [updated] to Smartschool (`saveUser` with an unchanged password)
+  /// unless dry-run, and returns [updated] as the mutated source record.
+  Future<ActionResult> _smartschoolSave(
+    Connectors connectors,
+    ApplyOptions options,
+    ChangeSet changes,
+    ss.SmartschoolAccount updated,
+  ) async {
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: updated,
+      );
+    }
+    try {
+      final ok = await _requireSmartschool(connectors)
+          .saveAccount(updated, password: '');
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool saveAccount returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: updated,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers.
+// ---------------------------------------------------------------------------
+
+/// The Smartschool user parameter the copy-code (photocopier PIN) is stored
+/// in, alongside the account's `fax` field. Legacy literal: `PINCODE CANON`.
+const String _pincodeParameter = 'PINCODE CANON';
+
+/// Left-pads [wisaId] with zeros to at least four digits — the canonical
+/// copy-code form. Blank/null → `'0000'`.
+String _copyCode(String? wisaId) {
+  var code = wisaId ?? '';
+  while (code.length < 4) {
+    code = '0$code';
+  }
+  return code;
+}
+
+/// Trims + lower-cases for case-insensitive comparison (INV-12); blank → null.
+String? _n(String? v) {
+  if (v == null) return null;
+  final t = v.trim();
+  return t.isEmpty ? null : t.toLowerCase();
+}
+
+/// Case-insensitive, trimmed equality (INV-12).
+bool _eq(String? a, String? b) => _n(a) == _n(b);
+
+/// The normalized domain of an email/UPN (`x.be` from `jane@X.BE`); '' if none.
+String _domainOf(String mail) =>
+    mail.contains('@') ? mail.split('@').last.trim().toLowerCase() : '';
+
+/// A UPN-safe slug for the projected new-account UPN: lower-cased, keeping only
+/// the characters Azure accepts in a local part. Approximates the connector's
+/// own normalization for display/dry-run purposes.
+String _slug(String input) => input
+    .toLowerCase()
+    .split('')
+    .where((c) => RegExp(r'[a-z0-9_.+-]').hasMatch(c))
+    .join();

--- a/packages/account_actions/lib/src/staff_action_config.dart
+++ b/packages/account_actions/lib/src/staff_action_config.dart
@@ -1,0 +1,45 @@
+import 'package:account_core/account_core.dart';
+
+/// Configuration the staff action family needs, holding the values the legacy
+/// code hard-coded (`docs/domain-model.md` §7 lists these as things to
+/// parameterize).
+///
+/// Mirrors [StudentActionConfig] but without a `studentDomain`: staff live on
+/// the base [azureDomain] (legacy `CreateStaffMember` passes `isStudent:
+/// false`), so there is no student sub-domain to move them onto.
+class StaffActionConfig {
+  /// The school prefix stamped on a staff member's Azure `department` when a
+  /// new account is created (legacy `CreateStaffMember` sets
+  /// `Department = Connector.Prefix`).
+  final String schoolPrefix;
+
+  /// The base UPN domain, e.g. `arcadiascholen.be`. New staff UPNs are minted
+  /// under it, and `ModifySmartschoolStaffEmail` only re-syncs a Smartschool
+  /// mail still on this domain.
+  final String azureDomain;
+
+  /// Password for a newly created account. Defaults to the domain [Password]
+  /// generator. (Legacy used `Password.Create()`; the holder resets it when
+  /// the account is handed out.)
+  final String Function() newAccountPassword;
+
+  /// Builds a Smartschool login (`uid`) from a staff member's given name and
+  /// surname. Defaults to `"<given>.<surname>"` lower-cased with spaces
+  /// stripped. Uniqueness against existing accounts is the caller's concern
+  /// (the State layer holds the account set); the default is deliberately
+  /// simple. Mirrors legacy `AccountManager.CreateUID`.
+  final String Function(String givenName, String surname) smartschoolUid;
+
+  StaffActionConfig({
+    required this.schoolPrefix,
+    required this.azureDomain,
+    String Function()? newAccountPassword,
+    String Function(String givenName, String surname)? smartschoolUid,
+  })  : newAccountPassword = newAccountPassword ?? _defaultPassword,
+        smartschoolUid = smartschoolUid ?? _defaultUid;
+
+  static String _defaultPassword() => Password.create();
+
+  static String _defaultUid(String givenName, String surname) =>
+      '${givenName.trim()}.${surname.trim()}'.toLowerCase().replaceAll(' ', '');
+}

--- a/packages/account_actions/lib/src/staff_dispatch.dart
+++ b/packages/account_actions/lib/src/staff_dispatch.dart
@@ -1,0 +1,60 @@
+import 'package:account_core/account_core.dart';
+
+import 'staff_action.dart';
+import 'staff_action_config.dart';
+
+/// Derives the applicable [StaffAction]s for one [LinkedStaff], ported from the
+/// legacy `StaffMemberActionParser.AddActions` dispatch (§6.3).
+///
+/// The two action sets are **mutually exclusive**, exactly as in legacy: the
+/// parser writes the "modify" branch as `if (OK)` rather than `else`, but it
+/// sets `OK = false` inside the "missing" branch, so the semantics are the same
+/// as the student parser — lifecycle actions when a system is missing, modify
+/// actions only when all three are present.
+///
+/// Each candidate is constructed bound to [staff] and kept only when its pure
+/// [StaffAction.evaluate] returns true. Pure and deterministic (INV-40): same
+/// staff + same [config] ⇒ same list.
+///
+/// The legacy `AddToAzureStaffGroup` / `AddToStaffGroup` actions are **not**
+/// dispatched here: they evaluate against Office 365 group membership, which a
+/// [LinkedStaff] does not carry (see the package README).
+List<StaffAction> staffActionsFor(
+  LinkedStaff staff,
+  StaffActionConfig config,
+) {
+  final complete =
+      staff.wisa != null && staff.smartschool != null && staff.azure != null;
+
+  final candidates = complete
+      ? <StaffAction>[
+          UpdateStaffWisaName(staff, config),
+          ModifySmartschoolStaffEmail(staff, config),
+          SetStaffCopyCode(staff, config),
+        ]
+      : <StaffAction>[
+          AddStaffToAzure(staff, config),
+          AddStaffToSmartschool(staff, config),
+          RemoveStaffFromSmartschool(staff, config),
+          DontImportStaffFromWisa(staff, config),
+          RemoveStaffFromAzure(staff, config),
+        ];
+
+  return [
+    for (final action in candidates)
+      if (action.evaluate()) action,
+  ];
+}
+
+/// Derives every applicable [StaffAction] across a [LinkedSnapshot]'s staff
+/// records, in snapshot order (§6.3). Pure and deterministic.
+///
+/// Only [LinkedSnapshot.staff] are considered; students and groups are handled
+/// by their own families.
+List<StaffAction> staffActions(
+  LinkedSnapshot snapshot,
+  StaffActionConfig config,
+) =>
+    [
+      for (final staff in snapshot.staff) ...staffActionsFor(staff, config),
+    ];

--- a/packages/account_actions/test/staff_apply_test.dart
+++ b/packages/account_actions/test/staff_apply_test.dart
@@ -1,0 +1,276 @@
+import 'dart:convert';
+
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+void main() {
+  final cfg = staffConfig();
+
+  group('dry run performs no writes (PAIN-3)', () {
+    test('UpdateStaffWisaName dry run: no SOAP call, projected record returned',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = UpdateStaffWisaName(
+        linkedStaff(
+          wisa: wisaStaff(code: 'SMIT'),
+          smartschool: ssStaff(accountId: 'OLD'),
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, ApplyOptions.dry);
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(transport.soapActions, isEmpty);
+      expect(result.smartschool?.accountId, 'SMIT');
+    });
+
+    test('RemoveStaffFromSmartschool dry run: no write, removed flag set',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = RemoveStaffFromSmartschool(
+        linkedStaff(smartschool: ssStaff()),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, ApplyOptions.dry);
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(result.removed, isTrue);
+      expect(transport.soapActions, isEmpty);
+    });
+
+    test('SetStaffCopyCode dry run: no write, padded fax projected', () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = SetStaffCopyCode(
+        linkedStaff(
+          wisa: wisaStaff(wisaId: '42'),
+          smartschool: ssStaff(fax: '9999'),
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, ApplyOptions.dry);
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(transport.soapActions, isEmpty);
+      expect((result.smartschool! as ss.SmartschoolAccount).fax, '0042');
+    });
+  });
+
+  group('real apply performs the write and returns the mutated record (#40)',
+      () {
+    test(
+        'UpdateStaffWisaName: calls changeInternNumber, returns updated record',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = UpdateStaffWisaName(
+        linkedStaff(
+          wisa: wisaStaff(code: 'SMIT'),
+          smartschool: ssStaff(accountId: 'OLD'),
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.calledMethod('changeInternNumber'), isTrue);
+      expect(result.system, Origin.smartschool);
+      expect(result.smartschool?.accountId, 'SMIT');
+    });
+
+    test('ModifySmartschoolStaffEmail: saves account, mail ← Azure UPN',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = ModifySmartschoolStaffEmail(
+        linkedStaff(
+          wisa: wisaStaff(),
+          smartschool: ssStaff(mail: 'anna.old@school.example'),
+          azure: azureStaff(upn: 'anna.smit@school.example'),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.calledMethod('saveUser'), isTrue);
+      expect(result.smartschool?.mail, 'anna.smit@school.example');
+    });
+
+    test('SetStaffCopyCode: saves account and writes the PINCODE parameter',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = SetStaffCopyCode(
+        linkedStaff(
+          wisa: wisaStaff(wisaId: '42'),
+          smartschool: ssStaff(fax: '9999'),
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.calledMethod('saveUser'), isTrue);
+      expect(transport.calledMethod('saveUserParameter'), isTrue);
+      expect((result.smartschool! as ss.SmartschoolAccount).fax, '0042');
+    });
+
+    test('AddStaffToAzure: creates the user on the base domain, returns it',
+        () async {
+      final transport = RecordingGraphTransport(
+        handler: (req) {
+          if (req.method == 'GET') {
+            // No existing user with the candidate UPN → it is unique.
+            return az.GraphResponse(
+              statusCode: 404,
+              body: jsonEncode({
+                'error': {'code': 'NotFound', 'message': 'no'},
+              }),
+            );
+          }
+          if (req.method == 'POST') {
+            return az.GraphResponse(
+              statusCode: 201,
+              headers: const {'content-type': 'application/json'},
+              body: jsonEncode({
+                'id': 'az-new',
+                'userPrincipalName': 'anna.smit@school.example',
+              }),
+            );
+          }
+          return const az.GraphResponse(statusCode: 204);
+        },
+      );
+      final connectors = Connectors(azure: azureConnector(transport));
+      final action = AddStaffToAzure(
+        linkedStaff(wisa: wisaStaff(wisaId: '42')),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.sent('POST', pathContains: 'users'), isTrue);
+      expect(result.azure?.id, 'az-new');
+      expect(result.azure?.upn, 'anna.smit@school.example');
+      expect(result.azure?.employeeId, '42');
+      expect((result.azure! as az.AzureUser).department, 'SSM');
+    });
+
+    test('AddStaffToSmartschool: saves account, accountId ← WISA code',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = AddStaffToSmartschool(
+        linkedStaff(
+          wisa: wisaStaff(code: 'SMIT', wisaId: '42'),
+          azure: azureStaff(upn: 'anna.smit@school.example'),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.calledMethod('saveUser'), isTrue);
+      expect(result.smartschool?.accountId, 'SMIT');
+      expect(result.smartschool?.mail, 'anna.smit@school.example');
+      // The WISA numeric id becomes the copy-code (fax).
+      expect((result.smartschool! as ss.SmartschoolAccount).fax, '42');
+    });
+
+    test('RemoveStaffFromAzure: deletes the user', () async {
+      final transport = RecordingGraphTransport();
+      final connectors = Connectors(azure: azureConnector(transport));
+      final action = RemoveStaffFromAzure(
+        linkedStaff(azure: azureStaff(id: 'az-gone')),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(result.removed, isTrue);
+      expect(transport.sent('DELETE', pathContains: 'users'), isTrue);
+    });
+  });
+
+  group('DontImportStaffFromWisa returns a rule, touches no connector', () {
+    test('apply returns a DontImportUserFromWisa rule keyed on the code',
+        () async {
+      final ssTransport = RecordingSmartschoolTransport();
+      final azTransport = RecordingGraphTransport();
+      final connectors = Connectors(
+        smartschool: smartschoolConnector(ssTransport),
+        azure: azureConnector(azTransport),
+      );
+      final action = DontImportStaffFromWisa(
+        linkedStaff(wisa: wisaStaff(code: 'SMIT')),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(result.system, Origin.wisa);
+      final rule = result.wisaRule;
+      expect(rule, isA<wapi.DontImportUserFromWisa>());
+      expect((rule! as wapi.DontImportUserFromWisa).userCode, 'SMIT');
+      // WISA is read-only — no connector was called.
+      expect(ssTransport.soapActions, isEmpty);
+      expect(azTransport.requests, isEmpty);
+    });
+
+    test('dry run yields the same rule with a dryRun outcome', () async {
+      final action = DontImportStaffFromWisa(
+        linkedStaff(wisa: wisaStaff(code: 'SMIT')),
+        cfg,
+      );
+      final result = await action.apply(const Connectors(), ApplyOptions.dry);
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(
+          (result.wisaRule! as wapi.DontImportUserFromWisa).userCode, 'SMIT');
+    });
+  });
+
+  group('apply is retry-safe (INV-41): a failed write does not corrupt state',
+      () {
+    test('a non-zero Smartschool result → failed outcome, error captured',
+        () async {
+      final transport = RecordingSmartschoolTransport(resultCode: 1);
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final smartschool = ssStaff(accountId: 'OLD');
+      final action = UpdateStaffWisaName(
+        linkedStaff(
+          wisa: wisaStaff(code: 'SMIT'),
+          smartschool: smartschool,
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.failed);
+      expect(result.error, isNotNull);
+      // The source record is untouched — the action can be retried.
+      expect(smartschool.accountId, 'OLD');
+    });
+  });
+}

--- a/packages/account_actions/test/staff_dispatch_test.dart
+++ b/packages/account_actions/test/staff_dispatch_test.dart
@@ -1,0 +1,121 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+void main() {
+  final cfg = staffConfig();
+
+  List<Type> types(Iterable<StaffAction> actions) =>
+      actions.map((a) => a.runtimeType).toList();
+
+  group('dispatch §6.3 — missing / present branches are mutually exclusive',
+      () {
+    test('a fully-synced staff member yields no actions', () {
+      expect(staffActionsFor(fullySyncedStaff(), cfg), isEmpty);
+    });
+
+    test('WISA-only staff → AddStaffToAzure and DontImportStaffFromWisa', () {
+      final actions = staffActionsFor(linkedStaff(wisa: wisaStaff()), cfg);
+      expect(types(actions), [AddStaffToAzure, DontImportStaffFromWisa]);
+    });
+
+    test('WISA + Azure, no Smartschool → AddStaffToSmartschool and DontImport',
+        () {
+      final actions = staffActionsFor(
+        linkedStaff(wisa: wisaStaff(), azure: azureStaff()),
+        cfg,
+      );
+      expect(types(actions), [AddStaffToSmartschool, DontImportStaffFromWisa]);
+    });
+
+    test('Smartschool-only staff → only RemoveStaffFromSmartschool', () {
+      final actions = staffActionsFor(
+        linkedStaff(smartschool: ssStaff()),
+        cfg,
+      );
+      expect(types(actions), [RemoveStaffFromSmartschool]);
+    });
+
+    test('Azure-only staff → only RemoveStaffFromAzure', () {
+      final actions = staffActionsFor(
+        linkedStaff(azure: azureStaff()),
+        cfg,
+      );
+      expect(types(actions), [RemoveStaffFromAzure]);
+    });
+
+    test('missing-branch never emits a modify action', () {
+      final actions = staffActionsFor(linkedStaff(wisa: wisaStaff()), cfg);
+      expect(actions.whereType<UpdateStaffWisaName>(), isEmpty);
+      expect(actions.whereType<ModifySmartschoolStaffEmail>(), isEmpty);
+      expect(actions.whereType<SetStaffCopyCode>(), isEmpty);
+    });
+  });
+
+  group('dispatch §6.3 — present branch emits only the relevant modify action',
+      () {
+    test('wrong Smartschool internal number → only UpdateStaffWisaName', () {
+      final actions = staffActionsFor(
+        linkedStaff(
+          wisa: wisaStaff(code: 'SMIT'),
+          smartschool: ssStaff(accountId: 'OLD'),
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+      expect(types(actions), [UpdateStaffWisaName]);
+    });
+
+    test('Smartschool mail on the base domain but wrong → only email modify',
+        () {
+      final actions = staffActionsFor(
+        linkedStaff(
+          wisa: wisaStaff(),
+          smartschool: ssStaff(mail: 'anna.old@school.example'),
+          azure: azureStaff(upn: 'anna.smit@school.example'),
+        ),
+        cfg,
+      );
+      expect(types(actions), [ModifySmartschoolStaffEmail]);
+    });
+
+    test('Smartschool mail on another domain → no email modify', () {
+      final actions = staffActionsFor(
+        linkedStaff(
+          wisa: wisaStaff(),
+          smartschool: ssStaff(mail: 'anna.smit@other.example'),
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+      expect(actions, isEmpty);
+    });
+
+    test('wrong copy code → only SetStaffCopyCode', () {
+      final actions = staffActionsFor(
+        linkedStaff(
+          wisa: wisaStaff(wisaId: '42'),
+          smartschool: ssStaff(fax: '9999'),
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+      expect(types(actions), [SetStaffCopyCode]);
+    });
+
+    test('present-branch never emits a lifecycle action', () {
+      final actions = staffActionsFor(
+        linkedStaff(
+          wisa: wisaStaff(code: 'SMIT'),
+          smartschool: ssStaff(accountId: 'OLD'),
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+      expect(actions.whereType<AddStaffToAzure>(), isEmpty);
+      expect(actions.whereType<RemoveStaffFromSmartschool>(), isEmpty);
+      expect(actions.whereType<DontImportStaffFromWisa>(), isEmpty);
+    });
+  });
+}

--- a/packages/account_actions/test/staff_purity_test.dart
+++ b/packages/account_actions/test/staff_purity_test.dart
@@ -1,0 +1,124 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+void main() {
+  final cfg = staffConfig();
+
+  group('evaluate / describeChanges are pure (INV-40)', () {
+    test('describeChanges is deterministic', () {
+      final action = UpdateStaffWisaName(
+        linkedStaff(
+          wisa: wisaStaff(code: 'SMIT'),
+          smartschool: ssStaff(accountId: 'OLD'),
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+      final a = action.describeChanges();
+      final b = action.describeChanges();
+      expect(a.system, b.system);
+      expect(a.summary, b.summary);
+      expect(
+        a.fields.map((f) => '${f.field}:${f.before}>${f.after}'),
+        b.fields.map((f) => '${f.field}:${f.before}>${f.after}'),
+      );
+    });
+
+    test('UpdateStaffWisaName reports the accountId ← WISA code change', () {
+      final action = UpdateStaffWisaName(
+        linkedStaff(
+          wisa: wisaStaff(code: 'SMIT'),
+          smartschool: ssStaff(accountId: 'OLD'),
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+      final change = action.describeChanges();
+      expect(change.system, Origin.smartschool);
+      final field = change.fields.single;
+      expect(field.field, 'accountId');
+      expect(field.before, 'OLD');
+      expect(field.after, 'SMIT');
+    });
+
+    test('SetStaffCopyCode pads the WISA id to four digits', () {
+      final action = SetStaffCopyCode(
+        linkedStaff(
+          wisa: wisaStaff(wisaId: '42'),
+          smartschool: ssStaff(fax: '9999'),
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+      expect(action.evaluate(), isTrue);
+      final field = action.describeChanges().fields.single;
+      expect(field.field, 'fax');
+      expect(field.after, '0042');
+    });
+
+    test(
+        'SetStaffCopyCode is idempotent — an already-padded code re-evaluates '
+        'to false (fixes the legacy non-convergence)', () {
+      final action = SetStaffCopyCode(
+        linkedStaff(
+          wisa: wisaStaff(wisaId: '42'),
+          smartschool: ssStaff(fax: '0042'),
+          azure: azureStaff(),
+        ),
+        cfg,
+      );
+      expect(action.evaluate(), isFalse);
+    });
+
+    test('DontImportStaffFromWisa describes a WISA rule keyed on the code', () {
+      final action = DontImportStaffFromWisa(
+        linkedStaff(wisa: wisaStaff(code: 'SMIT')),
+        cfg,
+      );
+      final change = action.describeChanges();
+      expect(change.system, Origin.wisa);
+      expect(change.fields.single.after, 'SMIT');
+    });
+
+    test('evaluate does not mutate the bound record', () {
+      final ss = ssStaff(accountId: 'OLD');
+      final staff = linkedStaff(
+        wisa: wisaStaff(code: 'SMIT'),
+        smartschool: ss,
+        azure: azureStaff(),
+      );
+      UpdateStaffWisaName(staff, cfg).evaluate();
+      // The bound record is untouched (INV-42).
+      expect(identical(staff.smartschool, ss), isTrue);
+      expect(ss.accountId, 'OLD');
+    });
+  });
+
+  group('staffActions over a LinkedSnapshot', () {
+    test('emits actions per staff record, in snapshot order', () {
+      final snapshot = LinkedSnapshot.fromRecords(
+        accounts: const [],
+        staff: [
+          linkedStaff(wisa: wisaStaff(code: 'A'), id: 'a'), // WISA-only
+          fullySyncedStaff(), // clean → none
+          linkedStaff(
+            wisa: wisaStaff(code: 'C'),
+            smartschool: ssStaff(accountId: 'OLD'),
+            azure: azureStaff(),
+            id: 'c',
+          ), // wrong id → modify
+        ],
+        groups: const [],
+      );
+
+      final actions = staffActions(snapshot, cfg);
+      expect(
+        actions.map((a) => a.runtimeType),
+        [AddStaffToAzure, DontImportStaffFromWisa, UpdateStaffWisaName],
+      );
+    });
+  });
+}

--- a/packages/account_actions/test/support/fixtures.dart
+++ b/packages/account_actions/test/support/fixtures.dart
@@ -149,6 +149,112 @@ LinkedAccount fullySynced() => linked(
     );
 
 // ---------------------------------------------------------------------------
+// Staff fixtures.
+// ---------------------------------------------------------------------------
+
+/// The default staff config: prefix `SSM`, base domain `school.example` (staff
+/// live on the base domain, unlike students), a fixed password, default uid
+/// builder.
+StaffActionConfig staffConfig({
+  String schoolPrefix = 'SSM',
+  String azureDomain = 'school.example',
+}) =>
+    StaffActionConfig(
+      schoolPrefix: schoolPrefix,
+      azureDomain: azureDomain,
+      newAccountPassword: () => 'FakeP4ss!',
+    );
+
+wapi.WisaStaff wisaStaff({
+  String code = 'SMIT',
+  String? wisaId = '42',
+  String firstName = 'Anna',
+  String lastName = 'Smit',
+}) =>
+    wapi.WisaStaff(
+      code: WisaStaffCode(code),
+      wisaId: wisaId == null ? null : WisaId(wisaId),
+      firstName: firstName,
+      lastName: lastName,
+    );
+
+/// A Smartschool staff account (role `teacher`). Defaults line up with
+/// [wisaStaff] / [azureStaff] so a [fullySyncedStaff] triggers no action:
+/// `accountId` == staff code, `fax` == the zero-padded `wisaId`, `mail` == UPN.
+ss.SmartschoolAccount ssStaff({
+  String uid = 'anna.smit',
+  String accountId = 'SMIT',
+  String mail = 'anna.smit@school.example',
+  String fax = '0042',
+  String status = 'actief',
+}) =>
+    ss.SmartschoolAccount(
+      uid: uid,
+      accountId: accountId,
+      mail: mail,
+      registerId: '',
+      stemId: 0,
+      role: PersonRole.teacher,
+      givenName: 'Anna',
+      surname: 'Smit',
+      extraNames: '',
+      initials: '',
+      preferredName: '',
+      gender: Gender.female,
+      birthDate: null,
+      birthPlace: '',
+      birthCountry: '',
+      address: blankAddress,
+      mobilePhone: '',
+      homePhone: '',
+      fax: fax,
+      untisId: '',
+      status: status,
+    );
+
+az.AzureUser azureStaff({
+  String id = 'az-s1',
+  String upn = 'anna.smit@school.example',
+  String? employeeId = '42',
+  String displayName = 'Anna Smit',
+  String? department = 'SSM',
+}) =>
+    az.AzureUser(
+      id: id,
+      upn: upn,
+      employeeId: employeeId,
+      displayName: displayName,
+      givenName: 'Anna',
+      surname: 'Smit',
+      department: department,
+    );
+
+/// Builds a [LinkedStaff] from optional per-system records. Omit a system to
+/// simulate it missing (drives the lifecycle-action branch).
+LinkedStaff linkedStaff({
+  wapi.WisaStaff? wisa,
+  ss.SmartschoolAccount? smartschool,
+  az.AzureUser? azure,
+  String id = 's0',
+}) =>
+    LinkedStaff(
+      id: LinkedAccountId(id),
+      role: PersonRole.teacher,
+      wisa: wisa,
+      smartschool: smartschool,
+      azure: azure,
+      confidence: LinkConfidence.high,
+    );
+
+/// A fully-synced staff member present in all three systems with matching
+/// fields — no staff action should apply to it.
+LinkedStaff fullySyncedStaff() => linkedStaff(
+      wisa: wisaStaff(),
+      smartschool: ssStaff(),
+      azure: azureStaff(),
+    );
+
+// ---------------------------------------------------------------------------
 // Recording fake transports.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Ports the **staff** slice of the action engine (`account_actions`), mirroring the student family from #46. Adds a sealed `StaffAction` base with one concrete action per legacy `Action\StaffAccount\*` class, plus a `staffActions(LinkedSnapshot, ...)` dispatcher over `LinkedSnapshot.staff`.

## Linked issue

Closes #53

## Changes

- **`staff_action.dart`** — sealed `StaffAction` + concrete actions:
  - Lifecycle (missing branch): `AddStaffToAzure`, `AddStaffToSmartschool`, `RemoveStaffFromSmartschool`, `DontImportStaffFromWisa`, `RemoveStaffFromAzure`.
  - Modify (present branch): `UpdateStaffWisaName`, `ModifySmartschoolStaffEmail`, `SetStaffCopyCode`.
- **`staff_action_config.dart`** — `StaffActionConfig` (like `StudentActionConfig`, minus `studentDomain`; staff live on the base `azureDomain`).
- **`staff_dispatch.dart`** — `staffActionsFor` / `staffActions`, preserving the legacy parser's mutually-exclusive missing/present branches (the staff parser writes `if (OK)` but sets `OK = false` in the missing branch, so semantics match the student parser).
- **`action_result.dart`** — new `wisaRule` field: `DontImportFromWisa` writes nothing (WISA is read-only) and returns a `DontImportUserFromWisa` rule (`system: Origin.wisa`) for the State layer to add and re-sync.
- Barrel export, README, and test fixtures updated.

### Documented divergences
- **`SetStaffCopyCode` idempotency fix.** Legacy compares the zero-padded copy-code against `fax` but writes back the unpadded `wisaId`, so a sub-4-digit id re-triggers forever. We write the padded code to both `fax` and the `PINCODE CANON` parameter, so the action converges after one apply.
- **Staff gender on create.** Legacy `AddToSmartschool` hard-codes `Female` for new staff (WISA rows carry no gender); preserved verbatim.
- **Out of scope:** `AddToAzureStaffGroup` / `AddToStaffGroup` — they evaluate against Office 365 / Smartschool group membership, which `LinkedStaff` does not carry (membership-aware follow-up).

Refs `docs/domain-model.md` §3.10, §6.3–6.4, §4 (OQ-1), INV-40/41/42. Parent #40.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` clean (137 files)
- [x] `dart analyze` clean (whole workspace, no issues)
- [x] Unit tests pass — `account_actions`: 54 (30 new staff tests); full workspace: 448 across all 7 packages (`dart test` per package)
- [ ] Integration / e2e — **not applicable**: the change is a pure-Dart data/logic layer with no user-visible surface (the `account_manager` Flutter app is still empty), so it is fully covered by unit tests.