### PR TITLE
Add the group action family to the action engine (#54)

### DIFF
--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -8,9 +8,11 @@ write APIs.
 
 ## What ships here
 
-This package implements the **student** and **staff** families and their
-dispatchers. The group family is tracked as a follow-up to #46, mirroring how
-the linker shipped student/staff/group as separate slices (#43/#44/#45).
+This package implements the **student**, **staff**, and **group** families and
+their dispatchers, mirroring how the linker shipped student/staff/group as
+separate slices (#43/#44/#45). The group family (#54) ships the subset the
+`LinkedGroup` model can express; the membership/tree-dependent group actions are
+deferred (see **Deferred** below).
 
 ## The shape of an action
 
@@ -74,12 +76,32 @@ the modify set is `UpdateStaffWisaName`, `ModifySmartschoolStaffEmail`,
 into `accountId` (spec §4, OQ-1), while the numeric `wisaId` becomes the
 copy-code.
 
+`groupActions(snapshot)` walks the snapshot's class groups, ported from the
+legacy `GroupActionParser`. The split is on the WISA/Smartschool **pair** rather
+than all three systems (there is no Azure group action):
+
+- **Missing from WISA or Smartschool** → the lifecycle-style actions:
+  `DoNotImportFromWisa` (WISA-only class; adds a `DontImportClass` rule) and
+  `DoNotImportFromSmartschool` (orphan Smartschool class; informational).
+- **Present in both** → only `ModifySmartschoolData` (sync institute number and
+  description down from WISA).
+
+A group action returns its mutated record through `ActionResult.group` (a
+`Group`), not `ActionResult.smartschool` (a `SmartschoolAccount`). It takes no
+config — the shippable group actions derive everything from the WISA/Smartschool
+pair. `DoNotImportFromWisa`, like the staff `DontImportFromWisa`, writes nothing
+and returns a `WisaImportRule` via `ActionResult.wisaRule`.
+`DoNotImportFromSmartschool` is **informational** (`canApply == false`, legacy
+`CanBeApplied == false`): it surfaces a diagnosis and its `apply` throws
+`UnsupportedError`.
+
 ## Configuration
 
 `StudentActionConfig` injects the values legacy hard-coded: `schoolPrefix`, the
 base `azureDomain` and derived `studentDomain`, a password provider for created
 accounts, and a Smartschool `uid` builder. `StaffActionConfig` is the same
-minus `studentDomain` — staff live on the base `azureDomain`.
+minus `studentDomain` — staff live on the base `azureDomain`. The group family
+needs no config.
 
 ## Deferred (documented divergences)
 
@@ -92,6 +114,18 @@ minus `studentDomain` — staff live on the base `azureDomain`.
   `AddStaffToSmartschool` are **not** ported: they evaluate against Office 365 /
   Smartschool group membership, which `LinkedStaff` does not carry. Same
   membership-aware follow-up.
+- **Group `AddToSmartschool`** / **`CreateInSmartschool`** are **not** ported:
+  both branch on the WISA class's `ContainsStudents()`, and `AddToSmartschool`
+  additionally needs the Smartschool group tree to resolve a parent
+  (`GetLogicalParent`) — neither is carried by the canonical `LinkedGroup`
+  (`Group`), the same membership/tree gap as the student/staff placements above.
+  Tracked in the group follow-up.
+- **Group Untis-drift detection.** Legacy `ModifySmartschoolData` also syncs the
+  Untis id, but the canonical `Group` drops `untis`, so drift on *Untis alone*
+  can't trigger the action. When it *does* fire (institute number / description
+  drift), the `saveClass` write still sets `untis = name` — legacy's own
+  remediation target — so Untis converges. Full detection waits on a `Group.untis`
+  field (group follow-up).
 - **`ChangeEmail`** (legacy) is dead code — not wired into the parser — and is
   intentionally omitted.
 - **`SetStaffCopyCode` idempotency fix.** Legacy `SetCopyCode` compares the

--- a/packages/account_actions/lib/account_actions.dart
+++ b/packages/account_actions/lib/account_actions.dart
@@ -6,10 +6,11 @@
 /// `apply()` that returns the **mutated source record** so the State layer can
 /// patch its snapshot without a network re-sync.
 ///
-/// This package currently ships the **student** and **staff** families and
-/// their dispatchers. The group family is tracked as a follow-up to #46,
-/// mirroring how the linker shipped student/staff/group as separate slices
-/// (#43/#44/#45).
+/// This package ships the **student**, **staff**, and **group** families and
+/// their dispatchers, mirroring how the linker shipped student/staff/group as
+/// separate slices (#43/#44/#45). The group family ships the subset the
+/// `LinkedGroup` model can express (#54); membership/tree-dependent group
+/// actions are tracked as a follow-up (see the package README).
 ///
 /// Pure Dart — no Flutter, no UI coupling. Legacy reference (read-only):
 /// `legacy-wpf/AccountManager/Action/`.
@@ -19,6 +20,8 @@ export 'src/action_result.dart';
 export 'src/apply_options.dart';
 export 'src/change_set.dart';
 export 'src/connectors.dart';
+export 'src/group_action.dart';
+export 'src/group_dispatch.dart';
 export 'src/staff_action.dart';
 export 'src/staff_action_config.dart';
 export 'src/staff_dispatch.dart';

--- a/packages/account_actions/lib/src/action_result.dart
+++ b/packages/account_actions/lib/src/action_result.dart
@@ -50,6 +50,13 @@ class ActionResult {
   /// still exists. Null for a delete or a Smartschool-targeted action.
   final AzureUser? azure;
 
+  /// The created/updated Smartschool **group** record, when the action targets
+  /// a class group (the [GroupAction] family) rather than an account. Carried
+  /// separately from [smartschool] because a group is a [Group], not a
+  /// [SmartschoolAccount]. Null for every account-targeted action and for a
+  /// group delete (which sets [removed] instead).
+  final Group? group;
+
   /// True when the action deleted the record from [system] (so the State layer
   /// should drop it from the snapshot rather than patch it).
   final bool removed;
@@ -70,6 +77,7 @@ class ActionResult {
     required this.system,
     this.smartschool,
     this.azure,
+    this.group,
     this.removed = false,
     this.wisaRule,
     this.error,

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -1,0 +1,279 @@
+import 'package:account_core/account_core.dart';
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+import 'action_result.dart';
+import 'apply_options.dart';
+import 'change_set.dart';
+import 'connectors.dart';
+
+/// The group action family (spec `docs/domain-model.md` §3.10). One subclass
+/// per legacy `Action\Group\*` class, mirroring [StudentAction]/[StaffAction].
+///
+/// **Target binding.** Each action is bound to the [LinkedGroup] it acts on at
+/// construction; [evaluate]/[describeChanges] read the bound [group] (exposed
+/// as [target]) and stay pure, while [apply] carries no target of its own.
+///
+/// **Purity boundary (INV-40/41/42).** [evaluate] and [describeChanges] are
+/// pure and deterministic — no I/O, no globals. [apply] is the only impure
+/// operation; it is retry-safe (a transient failure returns
+/// [ActionOutcome.failed] without corrupting state) and never mutates the bound
+/// [group] or its snapshot records.
+///
+/// **Group vs account families.** Three differences shape this family:
+/// - **No config.** Unlike [StudentAction]/[StaffAction], the shippable group
+///   actions derive everything from the WISA/Smartschool group pair — there is
+///   no domain, password, or uid to inject — so there is no `GroupActionConfig`.
+/// - **No Azure and no date.** Legacy has no Azure group action, and the group
+///   `Apply` takes no date; [LinkedGroup.azure] is ignored here.
+/// - **Group record, not account.** A written group flows back through
+///   [ActionResult.group] (a [Group]), not [ActionResult.smartschool] (a
+///   `SmartschoolAccount`).
+///
+/// **Scope (issue #54, "fitting subset").** Only the actions the [LinkedGroup]
+/// model can express ship here: [DoNotImportFromWisa], [DoNotImportFromSmartschool]
+/// (informational), and [ModifySmartschoolData]. The legacy `AddToSmartschool` /
+/// `CreateInSmartschool` actions, and standalone Untis-drift detection, need
+/// data the canonical [Group] does not carry — WISA class membership
+/// (`ContainsStudents`), the Smartschool group tree for parent placement, and a
+/// `untis` field — and are tracked as a follow-up (see the package README),
+/// mirroring how the student/staff slices deferred their class-group placement.
+sealed class GroupAction {
+  /// The linked class group this action targets, bound at construction.
+  final LinkedGroup group;
+
+  const GroupAction(this.group);
+
+  /// Alias for the bound [group] — the "target" the spec's `evaluate(target)`
+  /// refers to.
+  LinkedGroup get target => group;
+
+  /// Whether this action applies to [group]. Pure and deterministic (INV-40).
+  bool evaluate();
+
+  /// The field-level diff this action would make. Pure (INV-40).
+  ChangeSet describeChanges();
+
+  /// Whether [apply] can perform a change. `false` for informational actions
+  /// (the legacy `CanBeApplied == false` case): they surface a diagnosis to the
+  /// operator but have no automated write, so calling [apply] throws. Callers
+  /// (UI / State layer) gate the "apply" affordance on this.
+  bool get canApply => true;
+
+  /// Performs the change on the target system. Impure. With
+  /// [ApplyOptions.dryRun] set, performs **no** writes and returns the
+  /// projected [ActionResult] (PAIN-3). Throws [UnsupportedError] when
+  /// [canApply] is `false`.
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options);
+
+  // --- shared helpers -------------------------------------------------------
+
+  Group get _wisa => group.wisa!;
+  Group get _ss => group.smartschool!;
+
+  ss.SmartschoolConnector _requireSmartschool(Connectors c) =>
+      c.smartschool ??
+      (throw StateError('$runtimeType.apply needs a Smartschool connector'));
+
+  ActionResult _failed(ChangeSet changes, Origin system, Object error) =>
+      ActionResult(
+        outcome: ActionOutcome.failed,
+        changes: changes,
+        system: system,
+        error: error,
+      );
+}
+
+// ---------------------------------------------------------------------------
+// Actions for when the group is missing from one system (§6.3).
+// ---------------------------------------------------------------------------
+
+/// Stop importing a class from WISA. Ported from `Action\Group\DoNotImportFromWisa`:
+/// the class exists in WISA but not Smartschool, and the operator judges it need
+/// not exist downstream, so a [wapi.DontImportClass] rule is added keyed on the
+/// group name.
+///
+/// Like the staff [DontImportStaffFromWisa] this writes nothing: WISA is
+/// read-only, so [apply] returns the rule via [ActionResult.wisaRule] for the
+/// State layer to add to its import-rule set and re-sync (which drops the class
+/// next snapshot).
+///
+/// **Key divergence.** Legacy keys the rule on the raw WISA `Group.Name`; the
+/// canonical [LinkedGroup.wisa] carries only the `fullName` (the cross-system
+/// match key), so the rule is keyed on that. For a single-group class
+/// (`groupName == "00"`) the two are identical; for a subgrouped class they
+/// differ, a limitation of the linked-record model rather than this action.
+class DoNotImportFromWisa extends GroupAction {
+  const DoNotImportFromWisa(super.group);
+
+  @override
+  bool evaluate() => group.wisa != null && group.smartschool == null;
+
+  wapi.DontImportClass _rule() => wapi.DontImportClass(_wisa.name);
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.wisa,
+        summary: 'Negeer deze klas bij het importeren uit WISA',
+        fields: [FieldChange('DontImportClass', after: _wisa.name)],
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    return ActionResult(
+      outcome: options.dryRun ? ActionOutcome.dryRun : ActionOutcome.applied,
+      changes: changes,
+      system: Origin.wisa,
+      wisaRule: _rule(),
+    );
+  }
+}
+
+/// An orphan Smartschool class with no matching WISA class. Ported from
+/// `Action\Group\DoNotImportFromSmartschool`, whose legacy `Apply` throws
+/// `NotImplementedException` — it is **informational only** (legacy
+/// `CanBeApplied == false`): it tells the operator the class exists in
+/// Smartschool but not WISA, and the resolution (keep it, or delete it by hand)
+/// is theirs. There is no automated write, so [canApply] is `false` and [apply]
+/// throws.
+class DoNotImportFromSmartschool extends GroupAction {
+  const DoNotImportFromSmartschool(super.group);
+
+  @override
+  bool evaluate() => group.wisa == null && group.smartschool != null;
+
+  @override
+  bool get canApply => false;
+
+  @override
+  ChangeSet describeChanges() => const ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Deze klas bestaat in Smartschool maar niet in WISA. '
+            'Verwijder ze manueel als ze niet meer nodig is.',
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      throw UnsupportedError(
+        'DoNotImportFromSmartschool is informational and cannot be applied '
+        '(canApply is false)',
+      );
+}
+
+// ---------------------------------------------------------------------------
+// Actions for when the group is present in both systems (§6.3).
+// ---------------------------------------------------------------------------
+
+/// Sync a Smartschool class's data down from its WISA counterpart. Ported from
+/// `Action\Group\ModifySmartschoolData`, evaluated only when both systems carry
+/// the class.
+///
+/// Legacy syncs three fields — institute number, Untis id, and description.
+/// The canonical [Group] does not carry `untis`, so **standalone Untis-drift
+/// detection is deferred** (a follow-up adds `Group.untis`); this action
+/// evaluates on the two representable fields:
+/// - **institute number** (`Group.instituteNumber`): WISA `schoolCode` → Smartschool.
+/// - **description** (`Group.description`): WISA → Smartschool.
+///
+/// **Untis on write.** Smartschool's `saveClass` rewrites the whole class, so
+/// [apply] must supply a `untis` value. Legacy's remediation target is always
+/// `Untis == Name`, so the write passes the class name — the write stays
+/// correct (it converges Untis to its desired value) even though drift on Untis
+/// alone can't yet *trigger* the action.
+class ModifySmartschoolData extends GroupAction {
+  const ModifySmartschoolData(super.group);
+
+  bool get _instituteDiffers => _ss.instituteNumber != _wisa.instituteNumber;
+  bool get _descriptionDiffers => _ss.description != _wisa.description;
+
+  @override
+  bool evaluate() =>
+      group.wisa != null &&
+      group.smartschool != null &&
+      (_instituteDiffers || _descriptionDiffers);
+
+  /// The Smartschool group as it will look once synced. The two drifting fields
+  /// are pulled from WISA; everything else (id/name/type/official/parent/admin
+  /// number) is preserved. Idempotent for a field that already agrees.
+  Group _synced() => Group(
+        id: _ss.id,
+        name: _ss.name,
+        description: _wisa.description,
+        type: _ss.type,
+        official: _ss.official,
+        parentId: _ss.parentId,
+        instituteNumber: _wisa.instituteNumber,
+        adminNumber: _ss.adminNumber,
+        origin: _ss.origin,
+      );
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Werk de klasgegevens bij in Smartschool',
+        fields: [
+          if (_instituteDiffers)
+            FieldChange(
+              'instituteNumber',
+              before: _ss.instituteNumber,
+              after: _wisa.instituteNumber,
+            ),
+          if (_descriptionDiffers)
+            FieldChange(
+              'description',
+              before: _ss.description,
+              after: _wisa.description,
+            ),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    final updated = _synced();
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        group: updated,
+      );
+    }
+
+    try {
+      final ok = await _requireSmartschool(connectors).saveClass(
+        name: updated.name,
+        description: updated.description,
+        code: updated.id.value,
+        parentCode: updated.parentId?.value ?? '',
+        // Legacy's remediation target for Untis is always the class name.
+        untis: updated.name,
+        instituteNumber: updated.instituteNumber ?? '',
+        adminNumber: updated.adminNumber ?? 0,
+      );
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool saveClass returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        group: updated,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}

--- a/packages/account_actions/lib/src/group_dispatch.dart
+++ b/packages/account_actions/lib/src/group_dispatch.dart
@@ -1,0 +1,50 @@
+import 'package:account_core/account_core.dart';
+
+import 'group_action.dart';
+
+/// Derives the applicable [GroupAction]s for one [LinkedGroup], ported from the
+/// legacy `GroupActionParser.AddActions` dispatch (§6.3).
+///
+/// The two action sets are **mutually exclusive**, exactly as in legacy, but
+/// the split is on the WISA/Smartschool pair rather than all three systems
+/// (there is no Azure group action):
+/// - If the class is missing from WISA **or** Smartschool, the lifecycle-style
+///   actions ([DoNotImportFromWisa], [DoNotImportFromSmartschool]) are
+///   considered.
+/// - If it is present in both, only [ModifySmartschoolData] is considered.
+///
+/// The legacy `AddToSmartschool` / `CreateInSmartschool` actions are **not**
+/// dispatched here: they need WISA class membership (`ContainsStudents`) and the
+/// Smartschool group tree, which a [LinkedGroup] does not carry (see the package
+/// README). An Azure-only orphan group (`wisa == null && smartschool == null`,
+/// #52) yields no action.
+///
+/// Each candidate is constructed bound to [group] and kept only when its pure
+/// [GroupAction.evaluate] returns true. Pure and deterministic (INV-40): same
+/// group ⇒ same list.
+List<GroupAction> groupActionsFor(LinkedGroup group) {
+  final both = group.wisa != null && group.smartschool != null;
+
+  final candidates = both
+      ? <GroupAction>[
+          ModifySmartschoolData(group),
+        ]
+      : <GroupAction>[
+          DoNotImportFromWisa(group),
+          DoNotImportFromSmartschool(group),
+        ];
+
+  return [
+    for (final action in candidates)
+      if (action.evaluate()) action,
+  ];
+}
+
+/// Derives every applicable [GroupAction] across a [LinkedSnapshot]'s class
+/// groups, in snapshot order (§6.3). Pure and deterministic.
+///
+/// Only [LinkedSnapshot.groups] are considered; students and staff are handled
+/// by their own families.
+List<GroupAction> groupActions(LinkedSnapshot snapshot) => [
+      for (final group in snapshot.groups) ...groupActionsFor(group),
+    ];

--- a/packages/account_actions/test/group_apply_test.dart
+++ b/packages/account_actions/test/group_apply_test.dart
@@ -1,0 +1,124 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:wisa_api/wisa_api.dart' as wapi;
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+void main() {
+  group('dry run performs no writes (PAIN-3)', () {
+    test(
+        'ModifySmartschoolData dry run: no SOAP call, projected group returned',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = ModifySmartschoolData(
+        linkedGroup(
+          wisa: wisaGroup(instituteNumber: '999999', description: 'Nieuw'),
+          smartschool: ssGroup(instituteNumber: '123456', description: 'Oud'),
+        ),
+      );
+
+      final result = await action.apply(connectors, ApplyOptions.dry);
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(transport.soapActions, isEmpty);
+      expect(result.group?.instituteNumber, '999999');
+      expect(result.group?.description, 'Nieuw');
+    });
+  });
+
+  group('real apply performs the write and returns the mutated group (#40)',
+      () {
+    test('ModifySmartschoolData: calls saveClass, returns synced group',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = ModifySmartschoolData(
+        linkedGroup(
+          wisa: wisaGroup(instituteNumber: '999999', description: 'Nieuw'),
+          smartschool: ssGroup(
+            instituteNumber: '123456',
+            description: 'Oud',
+            adminNumber: 7,
+          ),
+        ),
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.calledMethod('saveClass'), isTrue);
+      expect(result.system, Origin.smartschool);
+      expect(result.group?.instituteNumber, '999999');
+      expect(result.group?.description, 'Nieuw');
+      // Untouched fields are preserved on the mutated record.
+      expect(result.group?.adminNumber, 7);
+      expect(result.group?.name, '3A');
+    });
+
+    test('a failed saveClass leaves the bound record untouched (INV-41)',
+        () async {
+      final transport = RecordingSmartschoolTransport(resultCode: 1);
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final ss = ssGroup(instituteNumber: '123456', description: 'Oud');
+      final action = ModifySmartschoolData(
+        linkedGroup(
+          wisa: wisaGroup(instituteNumber: '999999', description: 'Nieuw'),
+          smartschool: ss,
+        ),
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.failed);
+      expect(result.error, isNotNull);
+      // The source record is untouched — the action can be retried.
+      expect(ss.instituteNumber, '123456');
+      expect(ss.description, 'Oud');
+    });
+  });
+
+  group('DoNotImportFromWisa returns a rule, touches no connector', () {
+    test('apply returns a DontImportClass rule keyed on the group name',
+        () async {
+      final ssTransport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(ssTransport));
+      final action = DoNotImportFromWisa(
+        linkedGroup(wisa: wisaGroup(name: '3A')),
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(result.system, Origin.wisa);
+      final rule = result.wisaRule;
+      expect(rule, isA<wapi.DontImportClass>());
+      expect((rule! as wapi.DontImportClass).className, '3A');
+      // WISA is read-only — no connector was called.
+      expect(ssTransport.soapActions, isEmpty);
+    });
+
+    test('dry run yields the same rule with a dryRun outcome', () async {
+      final action = DoNotImportFromWisa(
+        linkedGroup(wisa: wisaGroup(name: '3A')),
+      );
+      final result = await action.apply(const Connectors(), ApplyOptions.dry);
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect((result.wisaRule! as wapi.DontImportClass).className, '3A');
+    });
+  });
+
+  group('DoNotImportFromSmartschool is informational', () {
+    test('canApply is false and apply throws UnsupportedError', () {
+      final action = DoNotImportFromSmartschool(
+        linkedGroup(smartschool: ssGroup()),
+      );
+      expect(action.canApply, isFalse);
+      expect(
+        () => action.apply(const Connectors(), const ApplyOptions()),
+        throwsUnsupportedError,
+      );
+    });
+  });
+}

--- a/packages/account_actions/test/group_dispatch_test.dart
+++ b/packages/account_actions/test/group_dispatch_test.dart
@@ -1,0 +1,62 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+void main() {
+  group('groupActionsFor mirrors the legacy GroupActionParser split', () {
+    test('present in both, in sync → no action', () {
+      expect(groupActionsFor(fullySyncedGroup()), isEmpty);
+    });
+
+    test('present in both, data drifts → ModifySmartschoolData', () {
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(description: 'Nieuw'),
+          smartschool: ssGroup(description: 'Oud'),
+        ),
+      );
+      expect(actions.map((a) => a.runtimeType), [ModifySmartschoolData]);
+    });
+
+    test('WISA only → DoNotImportFromWisa', () {
+      final actions = groupActionsFor(linkedGroup(wisa: wisaGroup()));
+      expect(actions.map((a) => a.runtimeType), [DoNotImportFromWisa]);
+    });
+
+    test('Smartschool only → DoNotImportFromSmartschool (informational)', () {
+      final actions = groupActionsFor(linkedGroup(smartschool: ssGroup()));
+      expect(actions.map((a) => a.runtimeType), [DoNotImportFromSmartschool]);
+    });
+
+    test('orphan group with neither WISA nor Smartschool → no action', () {
+      // Neither missing-branch action evaluates (each needs its own system),
+      // and there is no Azure group action.
+      expect(groupActionsFor(linkedGroup()), isEmpty);
+    });
+  });
+
+  group('groupActions over a LinkedSnapshot', () {
+    test('emits actions per group record, in snapshot order', () {
+      final snapshot = LinkedSnapshot.fromRecords(
+        accounts: const [],
+        staff: const [],
+        groups: [
+          linkedGroup(wisa: wisaGroup(name: '1A')), // WISA-only → don't import
+          fullySyncedGroup(), // clean → none
+          linkedGroup(
+            wisa: wisaGroup(description: 'Nieuw'),
+            smartschool: ssGroup(description: 'Oud'),
+          ), // drift → modify
+        ],
+      );
+
+      final actions = groupActions(snapshot);
+      expect(
+        actions.map((a) => a.runtimeType),
+        [DoNotImportFromWisa, ModifySmartschoolData],
+      );
+    });
+  });
+}

--- a/packages/account_actions/test/group_purity_test.dart
+++ b/packages/account_actions/test/group_purity_test.dart
@@ -1,0 +1,64 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+void main() {
+  group('evaluate / describeChanges are pure (INV-40)', () {
+    test('ModifySmartschoolData.describeChanges is deterministic', () {
+      final action = ModifySmartschoolData(
+        linkedGroup(
+          wisa: wisaGroup(instituteNumber: '999999', description: 'Nieuw'),
+          smartschool: ssGroup(instituteNumber: '123456', description: 'Oud'),
+        ),
+      );
+      final a = action.describeChanges();
+      final b = action.describeChanges();
+      expect(a.system, b.system);
+      expect(a.summary, b.summary);
+      expect(
+        a.fields.map((f) => '${f.field}:${f.before}>${f.after}'),
+        b.fields.map((f) => '${f.field}:${f.before}>${f.after}'),
+      );
+    });
+
+    test('describeChanges reports only the fields that drift', () {
+      // Only the description drifts; the institute number already agrees.
+      final action = ModifySmartschoolData(
+        linkedGroup(
+          wisa: wisaGroup(instituteNumber: '123456', description: 'Nieuw'),
+          smartschool: ssGroup(instituteNumber: '123456', description: 'Oud'),
+        ),
+      );
+      final change = action.describeChanges();
+      expect(change.system, Origin.smartschool);
+      final field = change.fields.single;
+      expect(field.field, 'description');
+      expect(field.before, 'Oud');
+      expect(field.after, 'Nieuw');
+    });
+
+    test('DoNotImportFromWisa describes the rule it would add', () {
+      final change =
+          DoNotImportFromWisa(linkedGroup(wisa: wisaGroup(name: '3A')))
+              .describeChanges();
+      expect(change.system, Origin.wisa);
+      expect(change.fields.single.field, 'DontImportClass');
+      expect(change.fields.single.after, '3A');
+    });
+
+    test('evaluate does not mutate the bound record (INV-42)', () {
+      final ss = ssGroup(instituteNumber: '123456', description: 'Oud');
+      final group = linkedGroup(
+        wisa: wisaGroup(instituteNumber: '999999', description: 'Nieuw'),
+        smartschool: ss,
+      );
+      ModifySmartschoolData(group).evaluate();
+      // The bound record is untouched.
+      expect(identical(group.smartschool, ss), isTrue);
+      expect(ss.instituteNumber, '123456');
+      expect(ss.description, 'Oud');
+    });
+  });
+}

--- a/packages/account_actions/test/support/fixtures.dart
+++ b/packages/account_actions/test/support/fixtures.dart
@@ -255,6 +255,73 @@ LinkedStaff fullySyncedStaff() => linkedStaff(
     );
 
 // ---------------------------------------------------------------------------
+// Group fixtures.
+// ---------------------------------------------------------------------------
+
+/// A WISA-side canonical [Group], as the linker's `_wisaToCoreGroup` projects a
+/// class group: named by its `fullName`, always an official class, `schoolCode`
+/// as the institute number, and no tree edge or admin number.
+Group wisaGroup({
+  String name = '3A',
+  String description = 'Klas 3A',
+  String? instituteNumber = '123456',
+}) =>
+    Group(
+      id: GroupId(name),
+      name: name,
+      description: description,
+      type: GroupType.classGroup,
+      official: true,
+      instituteNumber: instituteNumber,
+      origin: Origin.wisa,
+    );
+
+/// A Smartschool-side canonical [Group] (an official class), with a tree parent
+/// and admin number the WISA side lacks. Defaults line up with [wisaGroup] so a
+/// [fullySyncedGroup] triggers no action.
+Group ssGroup({
+  String code = '3A',
+  String name = '3A',
+  String description = 'Klas 3A',
+  String? instituteNumber = '123456',
+  int? adminNumber = 7,
+  String? parentId = 'jaar-3',
+}) =>
+    Group(
+      id: GroupId(code),
+      name: name,
+      description: description,
+      type: GroupType.classGroup,
+      official: true,
+      parentId: parentId == null ? null : GroupId(parentId),
+      instituteNumber: instituteNumber,
+      adminNumber: adminNumber,
+      origin: Origin.smartschool,
+    );
+
+/// Builds a [LinkedGroup] from optional per-system records. Omit a system to
+/// simulate the class missing there.
+LinkedGroup linkedGroup({
+  Group? wisa,
+  Group? smartschool,
+  az.AzureGroup? azure,
+  LinkConfidence confidence = LinkConfidence.high,
+}) =>
+    LinkedGroup(
+      wisa: wisa,
+      smartschool: smartschool,
+      azure: azure,
+      confidence: confidence,
+    );
+
+/// A class present and in sync in both WISA and Smartschool — no group action
+/// should apply to it.
+LinkedGroup fullySyncedGroup() => linkedGroup(
+      wisa: wisaGroup(),
+      smartschool: ssGroup(),
+    );
+
+// ---------------------------------------------------------------------------
 // Recording fake transports.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Ports the **group** slice of the action engine (`account_actions`): a sealed
`GroupAction` base with the actions the `LinkedGroup` model can express, plus a
`groupActions(LinkedSnapshot)` dispatcher mirroring the legacy
`GroupActionParser` WISA/Smartschool split. Completes the student/staff/group
trio of families (after #46), the way the linker shipped #43/#44/#45.

## Linked issue
Closes #54

## Changes
- **`group_action.dart`** — `sealed GroupAction` (bound to a `LinkedGroup`, no
  config, no Azure/date) with:
  - `DoNotImportFromWisa` — WISA-only class; returns a `DontImportClass` rule via
    `ActionResult.wisaRule` and writes nothing (WISA is read-only), like the
    staff `DontImportFromWisa`.
  - `DoNotImportFromSmartschool` — orphan Smartschool class; **informational**
    (`canApply == false`, `apply` throws `UnsupportedError`), matching legacy
    `CanBeApplied == false`.
  - `ModifySmartschoolData` — syncs institute number + description down from WISA
    via `saveClass`.
- **`group_dispatch.dart`** — `groupActionsFor` / `groupActions`; the two action
  sets are mutually exclusive, split on the WISA/Smartschool pair.
- **`action_result.dart`** — new `ActionResult.group` (a `Group`) so a written
  class flows back to the State layer for incremental refresh (#40), since a
  group is a `Group`, not a `SmartschoolAccount`.
- Exports, README (dispatch + Deferred sections), group test fixtures.

## Deferred → #65
`AddToSmartschool`, `CreateInSmartschool`, and standalone Untis-drift detection
need data the canonical `LinkedGroup` / `Group` does not carry — WISA class
membership (`ContainsStudents`), the Smartschool group tree for parent placement
(`GetLogicalParent`), and a `Group.untis` field. This is the same
membership/tree gap that deferred the student/staff class-group placements;
filed as #65 with the prerequisite model work. `ModifySmartschoolData`'s write
still converges `untis = name` (legacy's own remediation target) when it fires.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `dart analyze` clean (whole workspace)
- [x] unit tests pass — `dart test` in `account_actions`: **70 pass** (16 new:
  group apply/dispatch/purity covering dry-run/no-write, real `saveClass` +
  mutated-record return, the WISA rule, the informational throw, and INV-41
  retry-safety)
- [ ] integration/e2e — **not applicable**: `account_actions` is a pure-Dart
  library with no UI or runtime surface; this is model/data-layer logic fully
  covered by unit tests (same basis as the #46 student/staff slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)