### PR TITLE
Add membership-dependent Smartschool class placement (#55)

### DIFF
--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -103,12 +103,36 @@ accounts, and a Smartschool `uid` builder. `StaffActionConfig` is the same
 minus `studentDomain` — staff live on the base `azureDomain`. The group family
 needs no config.
 
+## Class placement (#55)
+
+Two student actions are **membership-dependent** — they cannot be expressed as a
+pure function of a `LinkedAccount`, because a `LinkedAccount` carries no
+membership and no group tree (spec §3.7, PAIN-1, INV-31). They take a second
+injectable, `ClassPlacement`, alongside `StudentActionConfig`:
+
+- **`MoveToSmartschoolClassGroup`** (modify branch): fires when the student's
+  target class name differs from their current Smartschool class, and moves them
+  with `saveUserToClass`. The ANS/BNS adult-education classes are excluded here,
+  exactly as legacy `Evaluate` skips them.
+- **The placement step inside `AddStudentToSmartschool`** (lifecycle branch):
+  after creating the account, best-effort-moves it into its class — the WISA
+  `classGroup`, or the "Leerlingen" root for ANS/BNS (legacy `AddToSmartschool`
+  chained `MoveToSmartschoolClassGroup.Move`).
+
+`ClassPlacement` carries the student's `currentClass`, their target `className`
+(the caller computes the sub-group suffix, `Student.ClassName`), and a
+`resolveClass(name)` tree lookup. It is **opt-in**: `studentActions` /
+`studentActionsFor` take a `placementFor` callback; without it the dispatch is
+exactly as it shipped in #46 (account created but not placed, no class move).
+The future State layer builds a `ClassPlacement` per student from the Smartschool
+snapshot's memberships and group tree. Both the standalone move and the create
+placement guard the target the way legacy `MoveUserToClass` does — only an
+**official** class node is a valid destination (the ported `moveUserToClass`
+connector leaves that guard to the caller), so an ANS/BNS student whose
+"Leerlingen" target is non-official is correctly not moved.
+
 ## Deferred (documented divergences)
 
-- **`MoveToSmartschoolClassGroup`** and the class-group placement inside
-  `AddStudentToSmartschool` are **not** ported here: they need the Smartschool
-  group tree / a student's current class membership, which the `LinkedAccount`
-  record does not carry. They belong with a `Membership`-aware input (follow-up).
 - **`AddToAzureStaffGroup`** / **`AddToStaffGroup`** and the `-Personeel` /
   `Leerkrachten` group placements inside `AddStaffToAzure` /
   `AddStaffToSmartschool` are **not** ported: they evaluate against Office 365 /

--- a/packages/account_actions/lib/account_actions.dart
+++ b/packages/account_actions/lib/account_actions.dart
@@ -19,6 +19,7 @@ library;
 export 'src/action_result.dart';
 export 'src/apply_options.dart';
 export 'src/change_set.dart';
+export 'src/class_placement.dart';
 export 'src/connectors.dart';
 export 'src/group_action.dart';
 export 'src/group_dispatch.dart';

--- a/packages/account_actions/lib/src/class_placement.dart
+++ b/packages/account_actions/lib/src/class_placement.dart
@@ -1,0 +1,51 @@
+import 'package:account_core/account_core.dart';
+
+/// The Smartschool class-placement context for one student — the membership +
+/// group-tree data a [LinkedAccount] does not carry (spec
+/// `docs/domain-model.md` §3.7, PAIN-1, INV-31).
+///
+/// Two student actions need it and neither can be expressed as a pure function
+/// of a [LinkedAccount] alone (which is why #46 deferred them):
+/// `MoveToSmartschoolClassGroup` and the class-group placement step inside
+/// `AddStudentToSmartschool`. Both need to know
+/// - which official Smartschool class the student is *currently* in — sourced
+///   from the Smartschool memberships, which the linker does not project onto a
+///   [LinkedAccount] (a `LinkedAccount` has no membership at all); and
+/// - how to resolve a class *name* to its Smartschool group (and code), which
+///   needs the group tree.
+///
+/// This is a plain injectable value object, exactly like [StudentActionConfig]:
+/// the caller (the future State layer, or a test) builds one per student from
+/// the Smartschool snapshot and binds it to the action. Keeping the snapshot
+/// out of the action preserves the package's pure-function boundary — the
+/// action reads the placement, it never walks a tree or a membership list.
+class ClassPlacement {
+  /// The student's current *official* Smartschool class, or `null` when the
+  /// student holds no official class membership (e.g. a freshly created account
+  /// that has not been placed yet). Mirrors legacy `Smartschool.Account.Group`,
+  /// which held the account's class name.
+  final Group? currentClass;
+
+  /// The student's target class name as it should read in Smartschool — the
+  /// WISA `classGroup`, plus the `classSubGroup` when the class uses sub-groups
+  /// (legacy `Student.ClassName` / `ClassGroupManager.UseSubGroups`). The
+  /// sub-group decision needs the class-group admin data, which lives outside
+  /// the student record, so the caller computes it; without sub-groups it is
+  /// just the bare `classGroup`.
+  final String className;
+
+  /// Resolves a Smartschool class group by name across the whole tree,
+  /// including the non-official "Leerlingen" root (legacy
+  /// `GroupManager.Root.Find`). Returns `null` when no group carries that name.
+  final Group? Function(String name) resolveClass;
+
+  const ClassPlacement({
+    required this.className,
+    required this.resolveClass,
+    this.currentClass,
+  });
+
+  /// The current official class name, or `''` when the student is in no
+  /// official class — the value legacy compared against [className].
+  String get currentClassName => currentClass?.name ?? '';
+}

--- a/packages/account_actions/lib/src/student_action.dart
+++ b/packages/account_actions/lib/src/student_action.dart
@@ -6,6 +6,7 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 import 'action_result.dart';
 import 'apply_options.dart';
 import 'change_set.dart';
+import 'class_placement.dart';
 import 'connectors.dart';
 import 'student_action_config.dart';
 
@@ -75,6 +76,12 @@ sealed class StudentAction {
         system: system,
         error: error,
       );
+
+  /// Whether [group] is a valid `saveUserToClass` destination — an *official*
+  /// class node (legacy `MoveUserToClass` guards `Type == Class && Official`;
+  /// the ported `moveUserToClass` connector leaves that guard to the caller).
+  bool _isOfficialClass(Group group) =>
+      group.official && group.type == GroupType.classGroup;
 }
 
 // ---------------------------------------------------------------------------
@@ -171,11 +178,19 @@ class AddStudentToAzure extends StudentAction {
 
 /// Create a Smartschool account for a student present in WISA and Azure but not
 /// Smartschool. Ported from `Action\StudentAccount\AddToSmartschool` — the
-/// account is built from the WISA record with the Azure UPN as its mail; the
-/// class-group placement is a separate action (see the package README's
-/// "deferred" note).
+/// account is built from the WISA record with the Azure UPN as its mail. When a
+/// [ClassPlacement] is wired (#55), a successful create is followed by a
+/// best-effort move into the student's class group; without one the account is
+/// created but not placed (see [_placeNewAccount]).
 class AddStudentToSmartschool extends StudentAction {
-  const AddStudentToSmartschool(super.account, super.config);
+  /// The class-placement context (#55). When non-null, a successful create is
+  /// followed by a best-effort move into the student's class group (legacy
+  /// chained `MoveToSmartschoolClassGroup.Move` after the create). When null —
+  /// the caller wired no membership context — the account is created but not
+  /// placed, exactly as this action shipped in #46.
+  final ClassPlacement? placement;
+
+  const AddStudentToSmartschool(super.account, super.config, {this.placement});
 
   @override
   bool evaluate() =>
@@ -253,6 +268,7 @@ class AddStudentToSmartschool extends StudentAction {
           StateError('Smartschool saveAccount returned failure'),
         );
       }
+      await _placeNewAccount(connectors, built);
       return ActionResult(
         outcome: ActionOutcome.applied,
         changes: changes,
@@ -262,6 +278,37 @@ class AddStudentToSmartschool extends StudentAction {
     } on Object catch (e) {
       return _failed(changes, Origin.smartschool, e);
     }
+  }
+
+  /// Places a freshly created account into its class group (#55), mirroring the
+  /// `MoveToSmartschoolClassGroup.Move` legacy chained after the create. The
+  /// target is the "Leerlingen" root for the ANS/BNS classes and the WISA
+  /// `classGroup` otherwise (legacy `AddToSmartschool.Add`).
+  ///
+  /// **Best-effort, by design.** The create is this action's success criterion;
+  /// a failed placement must not fail (and so retry) the create (INV-41).
+  /// Legacy likewise logs and continues. An unresolved or non-official target,
+  /// or a failed move, is therefore silently tolerated here — a mis-placed
+  /// *non*-ANS/BNS student is re-caught next pass by [MoveToSmartschoolClassGroup]
+  /// once the account is complete, so only the (rare) ANS/BNS → "Leerlingen"
+  /// case has no safety net. There is no log sink on this path.
+  Future<void> _placeNewAccount(
+    Connectors connectors,
+    ss.SmartschoolAccount built,
+  ) async {
+    final placement = this.placement;
+    if (placement == null) return;
+
+    final classGroup = _wisa.classGroup;
+    final targetName =
+        (classGroup.contains('ANS') || classGroup.contains('BNS'))
+            ? 'Leerlingen'
+            : classGroup;
+    final target = placement.resolveClass(targetName);
+    if (target == null || !_isOfficialClass(target)) return;
+
+    await _requireSmartschool(connectors)
+        .moveUserToClass(built.uid, target.id.value, _wisa.classChange);
   }
 }
 
@@ -762,6 +809,113 @@ class ModifySmartschoolName extends StudentAction {
         describeChanges(),
         _ss.copyWith(preferredName: _wisa.preferredName),
       );
+}
+
+/// Move a student into the official Smartschool class named by their WISA
+/// class, when the two disagree (#55). Ported from
+/// `Action\StudentAccount\MoveToSmartschoolClassGroup`.
+///
+/// This is the membership-dependent action #46 deferred: it reads the student's
+/// current class and resolves the target class through the [ClassPlacement]
+/// companion, neither of which a [LinkedAccount] carries. The ANS/BNS classes
+/// are **excluded** here — legacy `Evaluate` skips them, so their placement
+/// happens only at create time (see [AddStudentToSmartschool]).
+class MoveToSmartschoolClassGroup extends StudentAction {
+  /// The membership + group-tree context this action reads (#55).
+  final ClassPlacement placement;
+
+  const MoveToSmartschoolClassGroup(
+    super.account,
+    super.config,
+    this.placement,
+  );
+
+  bool get _isAdultEducation {
+    final classGroup = _wisa.classGroup;
+    return classGroup.contains('ANS') || classGroup.contains('BNS');
+  }
+
+  @override
+  bool evaluate() =>
+      !_isAdultEducation && placement.className != placement.currentClassName;
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Wijzig de klas in Smartschool',
+        fields: [
+          FieldChange(
+            'class',
+            before: placement.currentClassName,
+            after: placement.className,
+          ),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    final account = _ss;
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: account,
+      );
+    }
+
+    final target = placement.resolveClass(placement.className);
+    if (target == null) {
+      return _failed(
+        changes,
+        Origin.smartschool,
+        StateError(
+          'Smartschool class "${placement.className}" does not exist',
+        ),
+      );
+    }
+    if (!_isOfficialClass(target)) {
+      return _failed(
+        changes,
+        Origin.smartschool,
+        StateError(
+          'Cannot move ${account.uid} to "${target.name}": '
+          'only official classes accept members',
+        ),
+      );
+    }
+
+    try {
+      final ok = await _requireSmartschool(connectors).moveUserToClass(
+        account.uid,
+        target.id.value,
+        _wisa.classChange,
+      );
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool moveUserToClass returned failure'),
+        );
+      }
+      // A move changes membership, not the account's own fields; the account
+      // still exists, so the State layer keeps its record (and updates its
+      // membership index from the target it built into [placement]).
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        smartschool: account,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/account_actions/lib/src/student_dispatch.dart
+++ b/packages/account_actions/lib/src/student_dispatch.dart
@@ -1,5 +1,6 @@
 import 'package:account_core/account_core.dart';
 
+import 'class_placement.dart';
 import 'student_action.dart';
 import 'student_action_config.dart';
 
@@ -12,16 +13,31 @@ import 'student_action_config.dart';
 /// - If all three are present, only the **modify / sync** actions are
 ///   considered.
 ///
+/// [placementFor] wires the membership-dependent class-placement actions (#55).
+/// When supplied it is called for each WISA-bearing account to build its
+/// [ClassPlacement]: the class placement flows into [AddStudentToSmartschool]
+/// (so a newly created account lands in its class) and enables
+/// [MoveToSmartschoolClassGroup] in the modify branch. When omitted, the
+/// dispatch is exactly as it shipped in #46 — no placement, no class move —
+/// because a [LinkedAccount] alone cannot answer either. It is only called for
+/// `account.wisa != null` records (the placement's target class comes from the
+/// WISA record); WISA-less lifecycle accounts never need it.
+///
 /// Each candidate is constructed bound to [account] and kept only when its
 /// pure [StudentAction.evaluate] returns true. Pure and deterministic
-/// (INV-40): same account + same [config] ⇒ same list.
+/// (INV-40): same account + same [config] (+ same [placementFor]) ⇒ same list.
 List<StudentAction> studentActionsFor(
   LinkedAccount account,
-  StudentActionConfig config,
-) {
+  StudentActionConfig config, {
+  ClassPlacement Function(LinkedAccount account)? placementFor,
+}) {
   final complete = account.wisa != null &&
       account.smartschool != null &&
       account.azure != null;
+
+  final placement = (placementFor != null && account.wisa != null)
+      ? placementFor(account)
+      : null;
 
   final candidates = complete
       ? <StudentAction>[
@@ -32,12 +48,14 @@ List<StudentAction> studentActionsFor(
           ModifyAccountId(account, config),
           ModifySmartschoolStemId(account, config),
           ModifySmartschoolBirthPlace(account, config),
+          if (placement != null)
+            MoveToSmartschoolClassGroup(account, config, placement),
           ModifySmartschoolStudentEmail(account, config),
           ModifySmartschoolName(account, config),
         ]
       : <StudentAction>[
           AddStudentToAzure(account, config),
-          AddStudentToSmartschool(account, config),
+          AddStudentToSmartschool(account, config, placement: placement),
           UnregisterStudentFromSmartschool(account, config),
           DeleteStudentFromSmartschool(account, config),
           RemoveStudentFromAzure(account, config),
@@ -56,9 +74,10 @@ List<StudentAction> studentActionsFor(
 /// are handled by their own families (tracked as follow-ups to #46).
 List<StudentAction> studentActions(
   LinkedSnapshot snapshot,
-  StudentActionConfig config,
-) =>
+  StudentActionConfig config, {
+  ClassPlacement Function(LinkedAccount account)? placementFor,
+}) =>
     [
       for (final account in snapshot.accounts)
-        ...studentActionsFor(account, config),
+        ...studentActionsFor(account, config, placementFor: placementFor),
     ];

--- a/packages/account_actions/test/class_placement_test.dart
+++ b/packages/account_actions/test/class_placement_test.dart
@@ -1,0 +1,340 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+void main() {
+  final cfg = config();
+
+  List<Type> types(Iterable<StudentAction> actions) =>
+      actions.map((a) => a.runtimeType).toList();
+
+  LinkedAccount completeStudent({
+    ss.SmartschoolAccount? smartschool,
+    az.AzureUser? azure,
+    String classGroup = '3A',
+  }) =>
+      linked(
+        wisa: wisaStudent(classGroup: classGroup),
+        smartschool: smartschool ?? ssAccount(),
+        azure: azure ?? azureUser(),
+      );
+
+  // -------------------------------------------------------------------------
+  // Dispatch (#55): MoveToSmartschoolClassGroup is opt-in via placementFor.
+  // -------------------------------------------------------------------------
+  group('dispatch — MoveToSmartschoolClassGroup gated on placementFor', () {
+    test('no placementFor → no class move (backward-compatible with #46)', () {
+      final actions = studentActionsFor(completeStudent(), cfg);
+      expect(actions.whereType<MoveToSmartschoolClassGroup>(), isEmpty);
+    });
+
+    test('placement whose target differs from the current class → move fires',
+        () {
+      final actions = studentActionsFor(
+        completeStudent(),
+        cfg,
+        placementFor: (_) => classPlacement(
+          className: '3A',
+          currentClass: ssGroup(code: '3B', name: '3B'),
+        ),
+      );
+      expect(types(actions), [MoveToSmartschoolClassGroup]);
+    });
+
+    test('placement whose target equals the current class → no move', () {
+      final actions = studentActionsFor(
+        completeStudent(),
+        cfg,
+        placementFor: (_) => classPlacement(
+          className: '3A',
+          currentClass: ssGroup(code: '3A', name: '3A'),
+        ),
+      );
+      expect(actions.whereType<MoveToSmartschoolClassGroup>(), isEmpty);
+    });
+
+    test('student in no class yet (currentClass null) → move fires', () {
+      final actions = studentActionsFor(
+        completeStudent(),
+        cfg,
+        placementFor: (_) => classPlacement(className: '3A'),
+      );
+      expect(types(actions), [MoveToSmartschoolClassGroup]);
+    });
+
+    test('ANS/BNS student is excluded even when the class differs', () {
+      for (final cg in ['ANS1', 'BNS2']) {
+        final actions = studentActionsFor(
+          completeStudent(classGroup: cg),
+          cfg,
+          placementFor: (_) => classPlacement(
+            className: cg,
+            currentClass: ssGroup(code: '3B', name: '3B'),
+          ),
+        );
+        expect(
+          actions.whereType<MoveToSmartschoolClassGroup>(),
+          isEmpty,
+          reason: '$cg must not raise a standalone class move',
+        );
+      }
+    });
+
+    test('the move sits between BirthPlace and StudentEmail (legacy order)',
+        () {
+      final actions = studentActionsFor(
+        completeStudent(
+          smartschool: ssAccount(
+            birthPlace: 'Antwerpen', // ≠ WISA 'Gent' → BirthPlace fires
+            mail: 'jan.peeters@school.example', // base domain → StudentEmail
+          ),
+        ),
+        cfg,
+        placementFor: (_) => classPlacement(
+          className: '3A',
+          currentClass: ssGroup(code: '3B', name: '3B'),
+        ),
+      );
+      expect(types(actions), [
+        ModifySmartschoolBirthPlace,
+        MoveToSmartschoolClassGroup,
+        ModifySmartschoolStudentEmail,
+      ]);
+    });
+
+    test('placementFor is not consulted for a WISA-less lifecycle account', () {
+      var called = false;
+      studentActionsFor(
+        linked(smartschool: ssAccount(status: 'actief')),
+        cfg,
+        placementFor: (_) {
+          called = true;
+          return classPlacement();
+        },
+      );
+      expect(called, isFalse);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Purity (INV-40/42).
+  // -------------------------------------------------------------------------
+  group('MoveToSmartschoolClassGroup — evaluate / describeChanges are pure',
+      () {
+    MoveToSmartschoolClassGroup move({
+      Group? currentClass,
+      String className = '3A',
+    }) =>
+        MoveToSmartschoolClassGroup(
+          completeStudent(),
+          cfg,
+          classPlacement(className: className, currentClass: currentClass),
+        );
+
+    test('describeChanges reports the class before/after', () {
+      final change =
+          move(currentClass: ssGroup(code: '3B', name: '3B')).describeChanges();
+      expect(change.system, Origin.smartschool);
+      final field = change.fields.single;
+      expect(field.field, 'class');
+      expect(field.before, '3B');
+      expect(field.after, '3A');
+    });
+
+    test('a student in no class reports an empty "before"', () {
+      final change = move().describeChanges();
+      expect(change.fields.single.before, '');
+      expect(change.fields.single.after, '3A');
+    });
+
+    test('evaluate does not mutate the bound record', () {
+      final ss = ssAccount();
+      final action = MoveToSmartschoolClassGroup(
+        linked(wisa: wisaStudent(), smartschool: ss, azure: azureUser()),
+        cfg,
+        classPlacement(currentClass: ssGroup(code: '3B', name: '3B')),
+      );
+      action.evaluate();
+      expect(identical(action.account.smartschool, ss), isTrue);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Apply — MoveToSmartschoolClassGroup.
+  // -------------------------------------------------------------------------
+  group('MoveToSmartschoolClassGroup — apply', () {
+    MoveToSmartschoolClassGroup move({
+      List<Group> tree = const [],
+      String className = '3A',
+    }) =>
+        MoveToSmartschoolClassGroup(
+          linked(
+            wisa: wisaStudent(),
+            smartschool: ssAccount(uid: 'jan.peeters'),
+            azure: azureUser(),
+          ),
+          cfg,
+          classPlacement(
+            className: className,
+            currentClass: ssGroup(code: '3B', name: '3B'),
+            tree: tree,
+          ),
+        );
+
+    test('dry run: no SOAP call, returns the (still-existing) account',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+
+      final result = await move().apply(connectors, ApplyOptions.dry);
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(transport.soapActions, isEmpty);
+      expect(result.smartschool?.uid, 'jan.peeters');
+    });
+
+    test('real apply: calls saveUserToClass, returns applied + record',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+
+      final result = await move().apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.calledMethod('saveUserToClass'), isTrue);
+      expect(result.system, Origin.smartschool);
+      expect(result.smartschool?.uid, 'jan.peeters');
+    });
+
+    test('unresolved target class → failed, no write', () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+
+      final result = await move(className: '9Z', tree: [ssGroup()])
+          .apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.failed);
+      expect(result.error.toString(), contains('does not exist'));
+      expect(transport.soapActions, isEmpty);
+    });
+
+    test('non-official target (e.g. Leerlingen) → failed, no write', () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+
+      final result = await move(
+        className: 'Leerlingen',
+        tree: [ssGroupNode(name: 'Leerlingen')],
+      ).apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.failed);
+      expect(result.error.toString(), contains('only official classes'));
+      expect(transport.soapActions, isEmpty);
+    });
+
+    test('saveUserToClass returns a non-zero code → failed (retry-safe)',
+        () async {
+      final transport = RecordingSmartschoolTransport(resultCode: 1);
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+
+      final result = await move().apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.failed);
+      expect(transport.calledMethod('saveUserToClass'), isTrue);
+      expect(result.error, isNotNull);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Apply — AddStudentToSmartschool class placement step.
+  // -------------------------------------------------------------------------
+  group('AddStudentToSmartschool — class placement on add', () {
+    AddStudentToSmartschool add({
+      ClassPlacement? placement,
+      String classGroup = '3A',
+    }) =>
+        AddStudentToSmartschool(
+          linked(
+            wisa: wisaStudent(
+              firstName: 'Jan',
+              name: 'Peeters',
+              classGroup: classGroup,
+            ),
+            azure: azureUser(upn: 'jan.peeters@student.school.example'),
+          ),
+          cfg,
+          placement: placement,
+        );
+
+    test('no placement → account created but not placed (as in #46)', () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+
+      final result = await add().apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(result.smartschool, isNotNull);
+      expect(transport.calledMethod('saveUserToClass'), isFalse);
+    });
+
+    test('placement → account created then moved into its class', () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+
+      final result = await add(
+        placement: classPlacement(tree: [ssGroup(code: '3A', name: '3A')]),
+      ).apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.calledMethod('saveUserToClass'), isTrue);
+    });
+
+    test('dry run with placement → no writes at all', () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+
+      final result = await add(
+        placement: classPlacement(tree: [ssGroup(code: '3A', name: '3A')]),
+      ).apply(connectors, ApplyOptions.dry);
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(transport.soapActions, isEmpty);
+    });
+
+    test('ANS/BNS student targets the (non-official) Leerlingen root → no move',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+
+      final result = await add(
+        classGroup: 'ANS1',
+        placement: classPlacement(tree: [ssGroupNode(name: 'Leerlingen')]),
+      ).apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      // Leerlingen is not an official class, so the move is (correctly) skipped.
+      expect(transport.calledMethod('saveUserToClass'), isFalse);
+    });
+
+    test('a failed placement move does not fail the create (best-effort)',
+        () async {
+      // saveUser (+ QR parameter) succeed; only saveUserToClass fails.
+      final transport = RecordingSmartschoolTransport(
+        resultFor: (action) => action.contains('saveUserToClass') ? 1 : null,
+      );
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+
+      final result = await add(
+        placement: classPlacement(tree: [ssGroup(code: '3A', name: '3A')]),
+      ).apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(result.smartschool, isNotNull);
+      expect(transport.calledMethod('saveUserToClass'), isTrue);
+    });
+  });
+}

--- a/packages/account_actions/test/support/fixtures.dart
+++ b/packages/account_actions/test/support/fixtures.dart
@@ -149,6 +149,43 @@ LinkedAccount fullySynced() => linked(
     );
 
 // ---------------------------------------------------------------------------
+// Class-placement fixtures (#55).
+// ---------------------------------------------------------------------------
+
+/// A non-official Smartschool group node (e.g. the "Leerlingen" student root),
+/// which `saveUserToClass` rejects as a move target.
+Group ssGroupNode({
+  String code = 'leerlingen',
+  String name = 'Leerlingen',
+}) =>
+    Group(
+      id: GroupId(code),
+      name: name,
+      description: '',
+      type: GroupType.group,
+      official: false,
+      origin: Origin.smartschool,
+    );
+
+/// A [ClassPlacement] for a student. [tree] is the set of Smartschool groups
+/// [ClassPlacement.resolveClass] searches by name (default: the official `3A`
+/// class). [currentClass] is the student's current official class — omit for a
+/// student in no class yet (a fresh account).
+ClassPlacement classPlacement({
+  String className = '3A',
+  Group? currentClass,
+  List<Group> tree = const [],
+}) {
+  final resolved = tree.isEmpty ? [ssGroup(code: '3A', name: '3A')] : tree;
+  final byName = {for (final g in resolved) g.name: g};
+  return ClassPlacement(
+    className: className,
+    currentClass: currentClass,
+    resolveClass: (name) => byName[name],
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Staff fixtures.
 // ---------------------------------------------------------------------------
 
@@ -333,10 +370,16 @@ class RecordingSmartschoolTransport implements ss.SmartschoolSoapTransport {
   final List<String> soapActions = [];
 
   /// When set, the integer result to return (non-zero = failure). Applied to
-  /// every write.
+  /// every write for which [resultFor] returns null.
   final int resultCode;
 
-  RecordingSmartschoolTransport({this.resultCode = 0});
+  /// Optional per-call override: given a `SOAPAction` header, returns the
+  /// integer result for that call (non-zero = failure), or null to fall back to
+  /// [resultCode]. Lets a test make one method succeed and another fail (e.g.
+  /// `saveAccount` ok but `saveUserToClass` failing).
+  final int? Function(String soapAction)? resultFor;
+
+  RecordingSmartschoolTransport({this.resultCode = 0, this.resultFor});
 
   bool calledMethod(String method) =>
       soapActions.any((a) => a.contains(method));
@@ -348,10 +391,11 @@ class RecordingSmartschoolTransport implements ss.SmartschoolSoapTransport {
     required String envelope,
   }) async {
     soapActions.add(soapAction);
+    final code = resultFor?.call(soapAction) ?? resultCode;
     return '<?xml version="1.0" encoding="utf-8"?>'
         '<soap:Envelope '
         'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
-        '<soap:Body><response><return>$resultCode</return></response>'
+        '<soap:Body><response><return>$code</return></response>'
         '</soap:Body></soap:Envelope>';
   }
 }


### PR DESCRIPTION
## Summary

Ports the two student actions #46 deferred because they depend on Smartschool group/membership data a `LinkedAccount` does not carry:

- **`MoveToSmartschoolClassGroup`** (modify branch) — moves a student into the official class named by their WISA class when it differs from their current Smartschool class (`saveUserToClass`). The ANS/BNS adult-education classes are excluded, exactly as legacy `Evaluate` skips them.
- **The class-placement step inside `AddStudentToSmartschool`** (lifecycle branch) — after creating the account, best-effort moves it into its class: the WISA `classGroup`, or the "Leerlingen" root for ANS/BNS (legacy `AddToSmartschool` chained `MoveToSmartschoolClassGroup.Move`).

Both actions take a new `ClassPlacement` companion (`currentClass`, target `className`, and a `resolveClass(name)` tree lookup), injected alongside `StudentActionConfig`.

## Linked issue
Closes #55

## Changes
- **New `ClassPlacement`** companion (`lib/src/class_placement.dart`, exported) — a plain injectable, like `StudentActionConfig`, carrying the membership + group-tree data a `LinkedAccount` lacks (spec §3.7, PAIN-1, INV-31).
- **`student_action.dart`** — added `MoveToSmartschoolClassGroup`; extended `AddStudentToSmartschool` with an optional `placement` + best-effort `_placeNewAccount` move; added an `_isOfficialClass` guard on the base class.
- **`student_dispatch.dart`** — `studentActions` / `studentActionsFor` take an **opt-in** `placementFor` callback; the move slots into the legacy dispatch order (between `ModifySmartschoolBirthPlace` and `ModifySmartschoolStudentEmail`).
- **README** — moved the item out of "Deferred" into a new "Class placement (#55)" section.
- **Tests + fixtures** — 20 new tests; `ClassPlacement` / non-official-group fixtures and a per-method result-code hook on the recording Smartschool transport.

## Design notes
- **Companion, not a widened `LinkedAccount`.** The linker never projects `SmartschoolMembership` onto a `LinkedAccount`, so the current class and the group tree genuinely aren't available on the record. The companion keeps the snapshot out of the pure actions.
- **Opt-in / backward-compatible.** Without `placementFor`, dispatch is exactly the #46 behaviour (account created but not placed, no class move).
- **Faithful ANS/BNS split.** The standalone move excludes ANS/BNS; only the create-time placement routes them to the non-official "Leerlingen" root — which the official-class guard then (correctly) declines to move into, mirroring legacy `MoveUserToClass` (`Type == Class && Official`), a guard the ported `moveUserToClass` connector leaves to the caller.
- **Best-effort placement in Add.** A failed move must not fail (and so re-trigger) the create (INV-41); the standalone action is the safety net for the non-ANS/BNS case.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed` clean
- [x] `dart analyze` (workspace) clean
- [x] unit tests pass — **90/90** (`dart test` in `packages/account_actions`: 70 existing + 20 new)
- [ ] integration/e2e — **not applicable**: pure engine/data-layer logic with no runtime UI surface (the `account_manager` Flutter app is empty), fully covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)