### PR TITLE
Complete the group action family: AddToSmartschool / CreateInSmartschool + Untis-drift (#65)

### DIFF
--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -80,20 +80,43 @@ copy-code.
 legacy `GroupActionParser`. The split is on the WISA/Smartschool **pair** rather
 than all three systems (there is no Azure group action):
 
-- **Missing from WISA or Smartschool** → the lifecycle-style actions:
-  `DoNotImportFromWisa` (WISA-only class; adds a `DontImportClass` rule) and
-  `DoNotImportFromSmartschool` (orphan Smartschool class; informational).
-- **Present in both** → only `ModifySmartschoolData` (sync institute number and
-  description down from WISA).
+- **Missing from WISA or Smartschool** → the lifecycle-style actions, in legacy
+  parser order: `DoNotImportFromWisa` (WISA-only class; adds a `DontImportClass`
+  rule), `AddToSmartschool` (WISA-only class **with students**; creates the
+  official class in Smartschool), `CreateInSmartschool` (WISA-only class with
+  **no** students; informational), and `DoNotImportFromSmartschool` (orphan
+  Smartschool class; informational). A WISA-only class therefore raises
+  `DoNotImportFromWisa` plus exactly one of `AddToSmartschool` /
+  `CreateInSmartschool`.
+- **Present in both** → only `ModifySmartschoolData` (sync institute number,
+  Untis code, and description).
 
 A group action returns its mutated record through `ActionResult.group` (a
 `Group`), not `ActionResult.smartschool` (a `SmartschoolAccount`). It takes no
-config — the shippable group actions derive everything from the WISA/Smartschool
-pair. `DoNotImportFromWisa`, like the staff `DontImportFromWisa`, writes nothing
-and returns a `WisaImportRule` via `ActionResult.wisaRule`.
-`DoNotImportFromSmartschool` is **informational** (`canApply == false`, legacy
-`CanBeApplied == false`): it surfaces a diagnosis and its `apply` throws
+config — the group actions derive everything from the WISA/Smartschool pair plus,
+for the two creation actions, an injected `GroupPlacement` (see below).
+`DoNotImportFromWisa`, like the staff `DontImportFromWisa`, writes nothing and
+returns a `WisaImportRule` via `ActionResult.wisaRule`. `DoNotImportFromSmartschool`
+and `CreateInSmartschool` are **informational** (`canApply == false`, legacy
+`CanBeApplied == false`): they surface a diagnosis and their `apply` throws
 `UnsupportedError`.
+
+### Group placement (#65)
+
+`AddToSmartschool` and `CreateInSmartschool` are **membership-dependent**: both
+branch on whether the WISA class currently holds students (legacy
+`ContainsStudents()`), a signal a `LinkedGroup` does not carry, and
+`AddToSmartschool` also needs the Smartschool group tree to resolve the parent
+the new class hangs under (legacy `GetLogicalParent` → `Root.FindByCode`). They
+take an injected `GroupPlacement` — the group analogue of `ClassPlacement` —
+carrying `containsStudents` and the resolved `parent` group. It is **opt-in**:
+`groupActions` / `groupActionsFor` take a `placementFor` callback invoked only
+for WISA-only classes; without it the dispatch is exactly as it shipped in #54
+(no creation actions). When `AddToSmartschool` cannot resolve a parent it reports
+a failure rather than legacy's silent no-op. `AddToSmartschool` seeds the created
+class's Untis from the class name (legacy `group.Untis = wisa.Name`) and carries
+the institute and admin numbers projected onto the WISA `Group`
+(`schoolCode`/`adminCode`).
 
 ## Configuration
 
@@ -138,18 +161,6 @@ connector leaves that guard to the caller), so an ANS/BNS student whose
   `AddStaffToSmartschool` are **not** ported: they evaluate against Office 365 /
   Smartschool group membership, which `LinkedStaff` does not carry. Same
   membership-aware follow-up.
-- **Group `AddToSmartschool`** / **`CreateInSmartschool`** are **not** ported:
-  both branch on the WISA class's `ContainsStudents()`, and `AddToSmartschool`
-  additionally needs the Smartschool group tree to resolve a parent
-  (`GetLogicalParent`) — neither is carried by the canonical `LinkedGroup`
-  (`Group`), the same membership/tree gap as the student/staff placements above.
-  Tracked in the group follow-up.
-- **Group Untis-drift detection.** Legacy `ModifySmartschoolData` also syncs the
-  Untis id, but the canonical `Group` drops `untis`, so drift on *Untis alone*
-  can't trigger the action. When it *does* fire (institute number / description
-  drift), the `saveClass` write still sets `untis = name` — legacy's own
-  remediation target — so Untis converges. Full detection waits on a `Group.untis`
-  field (group follow-up).
 - **`ChangeEmail`** (legacy) is dead code — not wired into the parser — and is
   intentionally omitted.
 - **`SetStaffCopyCode` idempotency fix.** Legacy `SetCopyCode` compares the

--- a/packages/account_actions/lib/account_actions.dart
+++ b/packages/account_actions/lib/account_actions.dart
@@ -8,9 +8,11 @@
 ///
 /// This package ships the **student**, **staff**, and **group** families and
 /// their dispatchers, mirroring how the linker shipped student/staff/group as
-/// separate slices (#43/#44/#45). The group family ships the subset the
-/// `LinkedGroup` model can express (#54); membership/tree-dependent group
-/// actions are tracked as a follow-up (see the package README).
+/// separate slices (#43/#44/#45). The membership/tree-dependent actions in each
+/// family (student/staff class placement, group `AddToSmartschool` /
+/// `CreateInSmartschool`) take an injected placement value object — a
+/// `ClassPlacement` or `GroupPlacement` — so the action layer stays pure while
+/// still expressing what a `LinkedRecord` alone cannot (#55/#65).
 ///
 /// Pure Dart — no Flutter, no UI coupling. Legacy reference (read-only):
 /// `legacy-wpf/AccountManager/Action/`.
@@ -23,6 +25,7 @@ export 'src/class_placement.dart';
 export 'src/connectors.dart';
 export 'src/group_action.dart';
 export 'src/group_dispatch.dart';
+export 'src/group_placement.dart';
 export 'src/staff_action.dart';
 export 'src/staff_action_config.dart';
 export 'src/staff_dispatch.dart';

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -6,6 +6,7 @@ import 'action_result.dart';
 import 'apply_options.dart';
 import 'change_set.dart';
 import 'connectors.dart';
+import 'group_placement.dart';
 
 /// The group action family (spec `docs/domain-model.md` §3.10). One subclass
 /// per legacy `Action\Group\*` class, mirroring [StudentAction]/[StaffAction].
@@ -30,14 +31,16 @@ import 'connectors.dart';
 ///   [ActionResult.group] (a [Group]), not [ActionResult.smartschool] (a
 ///   `SmartschoolAccount`).
 ///
-/// **Scope (issue #54, "fitting subset").** Only the actions the [LinkedGroup]
-/// model can express ship here: [DoNotImportFromWisa], [DoNotImportFromSmartschool]
-/// (informational), and [ModifySmartschoolData]. The legacy `AddToSmartschool` /
-/// `CreateInSmartschool` actions, and standalone Untis-drift detection, need
-/// data the canonical [Group] does not carry — WISA class membership
+/// **Scope.** The whole family ships here. [DoNotImportFromWisa],
+/// [DoNotImportFromSmartschool] (informational), and [ModifySmartschoolData]
+/// derive everything from the WISA/Smartschool group pair (#54). The remaining
+/// three — [AddToSmartschool], [CreateInSmartschool] (informational), and
+/// standalone Untis-drift inside [ModifySmartschoolData] — need data the
+/// canonical [Group] does not carry on its own: WISA class membership
 /// (`ContainsStudents`), the Smartschool group tree for parent placement, and a
-/// `untis` field — and are tracked as a follow-up (see the package README),
-/// mirroring how the student/staff slices deferred their class-group placement.
+/// `untis` field (#65). The `untis` field now lives on [Group]; the membership
+/// and parent-tree inputs arrive through an injected [GroupPlacement], exactly
+/// as the student/staff class placements arrive through [ClassPlacement].
 sealed class GroupAction {
   /// The linked class group this action targets, bound at construction.
   final LinkedGroup group;
@@ -133,6 +136,164 @@ class DoNotImportFromWisa extends GroupAction {
   }
 }
 
+/// Create an official Smartschool class from a populated WISA class. Ported from
+/// `Action\Group\AddToSmartschool`: the class exists in WISA (with students)
+/// but not Smartschool, so it is created under its logical parent in the
+/// Smartschool group tree.
+///
+/// The membership signal and the resolved parent come from the injected
+/// [GroupPlacement] — a [LinkedGroup] carries neither. [evaluate] mirrors legacy
+/// (`Wisa.Linked && !Smartschool.Linked && ContainsStudents()`); it does not
+/// gate on the parent, matching legacy, which offers the action regardless and
+/// only checks the parent at apply time.
+///
+/// **Key divergence.** Legacy builds the class `Code`/`Name`/`Untis` from the
+/// raw WISA `Group.Name`; the canonical [LinkedGroup.wisa] carries only the
+/// `fullName` (the cross-system match key), so the created class is keyed on
+/// that. Identical for a single-group class (`groupName == "00"`); for a
+/// subgrouped class the two differ — a limitation of the linked-record model,
+/// shared with [DoNotImportFromWisa].
+class AddToSmartschool extends GroupAction {
+  /// The membership + resolved-parent context, injected by the dispatch.
+  final GroupPlacement placement;
+
+  const AddToSmartschool(super.group, this.placement);
+
+  @override
+  bool evaluate() =>
+      group.wisa != null &&
+      group.smartschool == null &&
+      placement.containsStudents;
+
+  /// The official Smartschool class to create, derived from the WISA class and
+  /// the resolved parent. Untis is set to the class name (legacy
+  /// `group.Untis = wisa.Name`); the institute and admin numbers ride in on the
+  /// WISA-projected [Group].
+  Group _created() => Group(
+        id: _wisa.id,
+        name: _wisa.name,
+        description: _wisa.description,
+        type: GroupType.classGroup,
+        official: true,
+        parentId: placement.parent?.id,
+        instituteNumber: _wisa.instituteNumber,
+        adminNumber: _wisa.adminNumber,
+        untis: _wisa.name,
+        origin: Origin.smartschool,
+      );
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Voeg deze klas toe aan Smartschool',
+        fields: [
+          FieldChange('name', after: _wisa.name),
+          FieldChange('description', after: _wisa.description),
+          FieldChange('parent', after: placement.parent?.id.value ?? ''),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+    final created = _created();
+
+    // Legacy silently does nothing when the logical parent can't be resolved;
+    // we surface it as a failure instead (retry-safe, INV-41).
+    if (placement.parent == null) {
+      return _failed(
+        changes,
+        Origin.smartschool,
+        StateError(
+          'cannot resolve a Smartschool parent for class ${_wisa.name}',
+        ),
+      );
+    }
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        group: created,
+      );
+    }
+
+    try {
+      final ok = await _requireSmartschool(connectors).saveClass(
+        name: created.name,
+        description: created.description,
+        code: created.id.value,
+        parentCode: created.parentId!.value,
+        untis: created.untis,
+        instituteNumber: created.instituteNumber ?? '',
+        adminNumber: created.adminNumber ?? 0,
+      );
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool saveClass returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        group: created,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}
+
+/// An empty WISA class with no Smartschool counterpart. Ported from
+/// `Action\Group\CreateInSmartschool`, whose legacy `Apply` throws
+/// `NotImplementedException` — it is **informational only** (legacy
+/// `CanBeApplied == false`): the WISA class holds no students yet, so there is
+/// nothing to create downstream. It tells the operator they may delete the WISA
+/// class by hand or wait until it is populated, at which point
+/// [AddToSmartschool] takes over. There is no automated write, so [canApply] is
+/// `false` and [apply] throws.
+///
+/// Distinguished from [AddToSmartschool] purely by the [GroupPlacement]
+/// membership signal: same WISA-only shape, but `!containsStudents`.
+class CreateInSmartschool extends GroupAction {
+  /// The membership context, injected by the dispatch. Only
+  /// [GroupPlacement.containsStudents] matters here (it must be `false`).
+  final GroupPlacement placement;
+
+  const CreateInSmartschool(super.group, this.placement);
+
+  @override
+  bool evaluate() =>
+      group.wisa != null &&
+      group.smartschool == null &&
+      !placement.containsStudents;
+
+  @override
+  bool get canApply => false;
+
+  @override
+  ChangeSet describeChanges() => const ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Deze WISA-klas bevat nog geen leerlingen. Verwijder ze '
+            'manueel als ze niet meer nodig is, of wacht tot ze leerlingen '
+            'bevat.',
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      throw UnsupportedError(
+        'CreateInSmartschool is informational and cannot be applied '
+        '(canApply is false)',
+      );
+}
+
 /// An orphan Smartschool class with no matching WISA class. Ported from
 /// `Action\Group\DoNotImportFromSmartschool`, whose legacy `Apply` throws
 /// `NotImplementedException` — it is **informational only** (legacy
@@ -172,33 +333,40 @@ class DoNotImportFromSmartschool extends GroupAction {
 /// `Action\Group\ModifySmartschoolData`, evaluated only when both systems carry
 /// the class.
 ///
-/// Legacy syncs three fields — institute number, Untis id, and description.
-/// The canonical [Group] does not carry `untis`, so **standalone Untis-drift
-/// detection is deferred** (a follow-up adds `Group.untis`); this action
-/// evaluates on the two representable fields:
+/// Legacy syncs three fields, and now so does this action:
 /// - **institute number** (`Group.instituteNumber`): WISA `schoolCode` → Smartschool.
+/// - **Untis code** (`Group.untis`): converged to the class `name`.
 /// - **description** (`Group.description`): WISA → Smartschool.
 ///
-/// **Untis on write.** Smartschool's `saveClass` rewrites the whole class, so
-/// [apply] must supply a `untis` value. Legacy's remediation target is always
-/// `Untis == Name`, so the write passes the class name — the write stays
-/// correct (it converges Untis to its desired value) even though drift on Untis
-/// alone can't yet *trigger* the action.
+/// **Untis drift is Smartschool-local.** Legacy triggers on
+/// `Smartschool.Untis != Smartschool.Name` and remediates by setting
+/// `Untis = Name` — it never reads a WISA Untis (WISA has none). Now that
+/// [Group.untis] exists, this action detects that drift directly, so a class
+/// whose only problem is a stale Untis code raises the action on its own.
+/// (Smartschool's `saveClass` rewrites the whole class, so [apply] has always
+/// passed `untis = name`; the change here is that Untis can now *trigger* the
+/// action too.)
 class ModifySmartschoolData extends GroupAction {
   const ModifySmartschoolData(super.group);
 
   bool get _instituteDiffers => _ss.instituteNumber != _wisa.instituteNumber;
   bool get _descriptionDiffers => _ss.description != _wisa.description;
 
+  /// Legacy `Smartschool.Untis != Smartschool.Name`: the class's stored Untis
+  /// code has drifted from its name. Purely a Smartschool-side comparison.
+  bool get _untisDiffers => _ss.untis != _ss.name;
+
   @override
   bool evaluate() =>
       group.wisa != null &&
       group.smartschool != null &&
-      (_instituteDiffers || _descriptionDiffers);
+      (_instituteDiffers || _untisDiffers || _descriptionDiffers);
 
-  /// The Smartschool group as it will look once synced. The two drifting fields
-  /// are pulled from WISA; everything else (id/name/type/official/parent/admin
-  /// number) is preserved. Idempotent for a field that already agrees.
+  /// The Smartschool group as it will look once synced. Institute number and
+  /// description are pulled from WISA; Untis is converged to the class name
+  /// (legacy's fixed remediation target); everything else
+  /// (id/name/type/official/parent/admin number) is preserved. Idempotent for a
+  /// field that already agrees.
   Group _synced() => Group(
         id: _ss.id,
         name: _ss.name,
@@ -208,6 +376,7 @@ class ModifySmartschoolData extends GroupAction {
         parentId: _ss.parentId,
         instituteNumber: _wisa.instituteNumber,
         adminNumber: _ss.adminNumber,
+        untis: _ss.name,
         origin: _ss.origin,
       );
 
@@ -222,6 +391,8 @@ class ModifySmartschoolData extends GroupAction {
               before: _ss.instituteNumber,
               after: _wisa.instituteNumber,
             ),
+          if (_untisDiffers)
+            FieldChange('untis', before: _ss.untis, after: _ss.name),
           if (_descriptionDiffers)
             FieldChange(
               'description',

--- a/packages/account_actions/lib/src/group_dispatch.dart
+++ b/packages/account_actions/lib/src/group_dispatch.dart
@@ -1,6 +1,7 @@
 import 'package:account_core/account_core.dart';
 
 import 'group_action.dart';
+import 'group_placement.dart';
 
 /// Derives the applicable [GroupAction]s for one [LinkedGroup], ported from the
 /// legacy `GroupActionParser.AddActions` dispatch (§6.3).
@@ -9,21 +10,37 @@ import 'group_action.dart';
 /// the split is on the WISA/Smartschool pair rather than all three systems
 /// (there is no Azure group action):
 /// - If the class is missing from WISA **or** Smartschool, the lifecycle-style
-///   actions ([DoNotImportFromWisa], [DoNotImportFromSmartschool]) are
-///   considered.
+///   actions ([DoNotImportFromWisa], [AddToSmartschool], [CreateInSmartschool],
+///   [DoNotImportFromSmartschool]) are considered — in that legacy order, so a
+///   WISA-only class raises both [DoNotImportFromWisa] and exactly one of
+///   [AddToSmartschool] / [CreateInSmartschool].
 /// - If it is present in both, only [ModifySmartschoolData] is considered.
 ///
-/// The legacy `AddToSmartschool` / `CreateInSmartschool` actions are **not**
-/// dispatched here: they need WISA class membership (`ContainsStudents`) and the
-/// Smartschool group tree, which a [LinkedGroup] does not carry (see the package
-/// README). An Azure-only orphan group (`wisa == null && smartschool == null`,
-/// #52) yields no action.
+/// [placementFor] wires the membership-dependent creation actions (#65). When
+/// supplied it is called for each WISA-only class (`wisa != null &&
+/// smartschool == null`) to build its [GroupPlacement]: the membership signal
+/// selects [AddToSmartschool] (class has students) or [CreateInSmartschool]
+/// (empty), and the resolved parent lets [AddToSmartschool] place the new class.
+/// When omitted, the dispatch is exactly as it shipped in #54 — no create
+/// actions — because a [LinkedGroup] alone cannot answer "does the WISA class
+/// have students?". It is only called for WISA-only classes; a both-present or
+/// Smartschool-only class never needs it.
+///
+/// An Azure-only orphan group (`wisa == null && smartschool == null`, #52)
+/// yields no action.
 ///
 /// Each candidate is constructed bound to [group] and kept only when its pure
 /// [GroupAction.evaluate] returns true. Pure and deterministic (INV-40): same
-/// group ⇒ same list.
-List<GroupAction> groupActionsFor(LinkedGroup group) {
+/// group (+ same [placementFor]) ⇒ same list.
+List<GroupAction> groupActionsFor(
+  LinkedGroup group, {
+  GroupPlacement Function(LinkedGroup group)? placementFor,
+}) {
   final both = group.wisa != null && group.smartschool != null;
+  final wisaOnly = group.wisa != null && group.smartschool == null;
+
+  final placement =
+      (placementFor != null && wisaOnly) ? placementFor(group) : null;
 
   final candidates = both
       ? <GroupAction>[
@@ -31,6 +48,8 @@ List<GroupAction> groupActionsFor(LinkedGroup group) {
         ]
       : <GroupAction>[
           DoNotImportFromWisa(group),
+          if (placement != null) AddToSmartschool(group, placement),
+          if (placement != null) CreateInSmartschool(group, placement),
           DoNotImportFromSmartschool(group),
         ];
 
@@ -44,7 +63,13 @@ List<GroupAction> groupActionsFor(LinkedGroup group) {
 /// groups, in snapshot order (§6.3). Pure and deterministic.
 ///
 /// Only [LinkedSnapshot.groups] are considered; students and staff are handled
-/// by their own families.
-List<GroupAction> groupActions(LinkedSnapshot snapshot) => [
-      for (final group in snapshot.groups) ...groupActionsFor(group),
+/// by their own families. [placementFor] is threaded through to
+/// [groupActionsFor] to enable the membership-dependent creation actions (#65).
+List<GroupAction> groupActions(
+  LinkedSnapshot snapshot, {
+  GroupPlacement Function(LinkedGroup group)? placementFor,
+}) =>
+    [
+      for (final group in snapshot.groups)
+        ...groupActionsFor(group, placementFor: placementFor),
     ];

--- a/packages/account_actions/lib/src/group_placement.dart
+++ b/packages/account_actions/lib/src/group_placement.dart
@@ -1,0 +1,40 @@
+import 'package:account_core/account_core.dart';
+
+/// The Smartschool creation context for one WISA class group — the membership
+/// and group-tree data a [LinkedGroup] does not carry (spec
+/// `docs/domain-model.md` §3.7, §6.3, PAIN-1).
+///
+/// Two group actions need it and neither can be expressed as a pure function of
+/// a [LinkedGroup] alone (which is why #54 deferred them):
+/// `AddToSmartschool` and `CreateInSmartschool`. Both branch on whether the
+/// WISA class currently holds students — a signal that lives in the WISA
+/// membership list, not on the [Group] record — and `AddToSmartschool` also
+/// needs the Smartschool group tree to resolve the parent the new class hangs
+/// under.
+///
+/// This is a plain injectable value object, exactly like [ClassPlacement]: the
+/// caller (the future State layer, or a test) builds one per WISA-only class
+/// from the WISA and Smartschool snapshots and binds it to the dispatch.
+/// Keeping the snapshots out of the action preserves the package's pure-function
+/// boundary — the action reads the placement, it never walks a tree or a
+/// membership list.
+class GroupPlacement {
+  /// Whether the WISA class currently holds any students (legacy
+  /// `WisaClassGroup.ContainsStudents()`). Distinguishes `AddToSmartschool`
+  /// (create a populated official class) from `CreateInSmartschool` (an empty
+  /// WISA class, informational only).
+  final bool containsStudents;
+
+  /// The Smartschool parent group the new class should hang under — legacy
+  /// `GroupManager.GetLogicalParent(name)` resolved through
+  /// `Root.FindByCode(...)`. The caller performs that year → grade/path lookup
+  /// against the group tree; the action only reads the result.
+  ///
+  /// `null` when the parent cannot be resolved (the class name's leading digit
+  /// is out of the 1–7 range, or the resolved parent node is absent from the
+  /// tree), in which case `AddToSmartschool.apply` cannot place the class and
+  /// reports a failure rather than legacy's silent no-op.
+  final Group? parent;
+
+  const GroupPlacement({required this.containsStudents, this.parent});
+}

--- a/packages/account_actions/test/group_apply_test.dart
+++ b/packages/account_actions/test/group_apply_test.dart
@@ -121,4 +121,117 @@ void main() {
       );
     });
   });
+
+  group('ModifySmartschoolData converges a drifted Untis code (#65)', () {
+    test('Untis-only drift: applies and sets untis to the class name',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      // Institute + description agree; only Untis has drifted.
+      final action = ModifySmartschoolData(
+        linkedGroup(
+          wisa: wisaGroup(),
+          smartschool: ssGroup(untis: 'stale-untis'),
+        ),
+      );
+
+      expect(action.evaluate(), isTrue);
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.calledMethod('saveClass'), isTrue);
+      // Converged to the class name (legacy's fixed remediation target).
+      expect(result.group?.untis, '3A');
+    });
+  });
+
+  group('AddToSmartschool creates an official class (#65)', () {
+    test('dry run: no SOAP call, projected class returned', () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = AddToSmartschool(
+        linkedGroup(wisa: wisaGroup(name: '3A')),
+        groupPlacement(),
+      );
+
+      final result = await action.apply(connectors, ApplyOptions.dry);
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(transport.soapActions, isEmpty);
+      expect(result.group?.id.value, '3A');
+      expect(result.group?.official, isTrue);
+      expect(result.group?.origin, Origin.smartschool);
+      expect(result.group?.parentId?.value, 'jaar-3');
+      // Untis is seeded from the class name (legacy group.Untis = wisa.Name).
+      expect(result.group?.untis, '3A');
+    });
+
+    test('real apply: calls saveClass and returns the created class', () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = AddToSmartschool(
+        linkedGroup(
+          wisa: wisaGroup(
+            name: '3A',
+            instituteNumber: '123456',
+            adminNumber: 42,
+          ),
+        ),
+        groupPlacement(),
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.calledMethod('saveClass'), isTrue);
+      expect(result.system, Origin.smartschool);
+      expect(result.group?.instituteNumber, '123456');
+      expect(result.group?.adminNumber, 42);
+    });
+
+    test('unresolvable parent: fails instead of legacy silent no-op (INV-41)',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = AddToSmartschool(
+        linkedGroup(wisa: wisaGroup()),
+        groupPlacement(withParent: false),
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.failed);
+      expect(result.error, isNotNull);
+      // No write was attempted.
+      expect(transport.soapActions, isEmpty);
+    });
+
+    test('a failed saveClass surfaces as a failure (INV-41)', () async {
+      final transport = RecordingSmartschoolTransport(resultCode: 1);
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = AddToSmartschool(
+        linkedGroup(wisa: wisaGroup()),
+        groupPlacement(),
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.failed);
+      expect(result.error, isNotNull);
+    });
+  });
+
+  group('CreateInSmartschool is informational (#65)', () {
+    test('canApply is false and apply throws UnsupportedError', () {
+      final action = CreateInSmartschool(
+        linkedGroup(wisa: wisaGroup()),
+        groupPlacement(containsStudents: false),
+      );
+      expect(action.canApply, isFalse);
+      expect(
+        () => action.apply(const Connectors(), const ApplyOptions()),
+        throwsUnsupportedError,
+      );
+    });
+  });
 }

--- a/packages/account_actions/test/group_dispatch_test.dart
+++ b/packages/account_actions/test/group_dispatch_test.dart
@@ -20,9 +20,47 @@ void main() {
       expect(actions.map((a) => a.runtimeType), [ModifySmartschoolData]);
     });
 
-    test('WISA only → DoNotImportFromWisa', () {
+    test('WISA only, no placement → DoNotImportFromWisa only (#54 behaviour)',
+        () {
       final actions = groupActionsFor(linkedGroup(wisa: wisaGroup()));
       expect(actions.map((a) => a.runtimeType), [DoNotImportFromWisa]);
+    });
+
+    test('WISA only with students → DoNotImportFromWisa + AddToSmartschool',
+        () {
+      final actions = groupActionsFor(
+        linkedGroup(wisa: wisaGroup()),
+        placementFor: (_) => groupPlacement(containsStudents: true),
+      );
+      expect(
+        actions.map((a) => a.runtimeType),
+        [DoNotImportFromWisa, AddToSmartschool],
+      );
+    });
+
+    test('WISA only, empty class → DoNotImportFromWisa + CreateInSmartschool',
+        () {
+      final actions = groupActionsFor(
+        linkedGroup(wisa: wisaGroup()),
+        placementFor: (_) => groupPlacement(containsStudents: false),
+      );
+      expect(
+        actions.map((a) => a.runtimeType),
+        [DoNotImportFromWisa, CreateInSmartschool],
+      );
+    });
+
+    test('placement is not consulted for a both-present class', () {
+      var called = false;
+      final actions = groupActionsFor(
+        fullySyncedGroup(),
+        placementFor: (_) {
+          called = true;
+          return groupPlacement();
+        },
+      );
+      expect(actions, isEmpty);
+      expect(called, isFalse, reason: 'only WISA-only classes need placement');
     });
 
     test('Smartschool only → DoNotImportFromSmartschool (informational)', () {
@@ -56,6 +94,26 @@ void main() {
       expect(
         actions.map((a) => a.runtimeType),
         [DoNotImportFromWisa, ModifySmartschoolData],
+      );
+    });
+
+    test('threads placementFor so WISA-only classes gain a create action', () {
+      final snapshot = LinkedSnapshot.fromRecords(
+        accounts: const [],
+        staff: const [],
+        groups: [
+          linkedGroup(wisa: wisaGroup(name: '1A')), // WISA-only, has students
+          fullySyncedGroup(), // clean → none, placement untouched
+        ],
+      );
+
+      final actions = groupActions(
+        snapshot,
+        placementFor: (_) => groupPlacement(containsStudents: true),
+      );
+      expect(
+        actions.map((a) => a.runtimeType),
+        [DoNotImportFromWisa, AddToSmartschool],
       );
     });
   });

--- a/packages/account_actions/test/group_purity_test.dart
+++ b/packages/account_actions/test/group_purity_test.dart
@@ -39,6 +39,69 @@ void main() {
       expect(field.after, 'Nieuw');
     });
 
+    test('ModifySmartschoolData reports Untis drift converging to the name',
+        () {
+      // Institute + description agree; only the Untis code drifted.
+      final action = ModifySmartschoolData(
+        linkedGroup(
+          wisa: wisaGroup(),
+          smartschool: ssGroup(untis: 'stale-untis'),
+        ),
+      );
+      final field = action.describeChanges().fields.single;
+      expect(field.field, 'untis');
+      expect(field.before, 'stale-untis');
+      expect(field.after, '3A');
+    });
+
+    test(
+        'AddToSmartschool.describeChanges is deterministic and names the parent',
+        () {
+      final action = AddToSmartschool(
+        linkedGroup(wisa: wisaGroup(name: '3A')),
+        groupPlacement(),
+      );
+      final a = action.describeChanges();
+      final b = action.describeChanges();
+      expect(a.system, Origin.smartschool);
+      expect(
+        a.fields.map((f) => '${f.field}:${f.after}'),
+        b.fields.map((f) => '${f.field}:${f.after}'),
+      );
+      expect(
+        a.fields.firstWhere((f) => f.field == 'parent').after,
+        'jaar-3',
+      );
+    });
+
+    test('AddToSmartschool.evaluate keys on the membership signal', () {
+      final group = linkedGroup(wisa: wisaGroup());
+      expect(
+        AddToSmartschool(group, groupPlacement(containsStudents: true))
+            .evaluate(),
+        isTrue,
+      );
+      expect(
+        AddToSmartschool(group, groupPlacement(containsStudents: false))
+            .evaluate(),
+        isFalse,
+      );
+    });
+
+    test('CreateInSmartschool.evaluate is the empty-class complement', () {
+      final group = linkedGroup(wisa: wisaGroup());
+      expect(
+        CreateInSmartschool(group, groupPlacement(containsStudents: false))
+            .evaluate(),
+        isTrue,
+      );
+      expect(
+        CreateInSmartschool(group, groupPlacement(containsStudents: true))
+            .evaluate(),
+        isFalse,
+      );
+    });
+
     test('DoNotImportFromWisa describes the rule it would add', () {
       final change =
           DoNotImportFromWisa(linkedGroup(wisa: wisaGroup(name: '3A')))

--- a/packages/account_actions/test/support/fixtures.dart
+++ b/packages/account_actions/test/support/fixtures.dart
@@ -297,11 +297,13 @@ LinkedStaff fullySyncedStaff() => linkedStaff(
 
 /// A WISA-side canonical [Group], as the linker's `_wisaToCoreGroup` projects a
 /// class group: named by its `fullName`, always an official class, `schoolCode`
-/// as the institute number, and no tree edge or admin number.
+/// as the institute number, `adminCode` as the admin number, no tree edge and
+/// no Untis code.
 Group wisaGroup({
   String name = '3A',
   String description = 'Klas 3A',
   String? instituteNumber = '123456',
+  int? adminNumber = 7,
 }) =>
     Group(
       id: GroupId(name),
@@ -310,12 +312,14 @@ Group wisaGroup({
       type: GroupType.classGroup,
       official: true,
       instituteNumber: instituteNumber,
+      adminNumber: adminNumber,
       origin: Origin.wisa,
     );
 
 /// A Smartschool-side canonical [Group] (an official class), with a tree parent
 /// and admin number the WISA side lacks. Defaults line up with [wisaGroup] so a
-/// [fullySyncedGroup] triggers no action.
+/// [fullySyncedGroup] triggers no action — including [untis], which defaults to
+/// [name] (no Untis drift); pass a different value to force drift.
 Group ssGroup({
   String code = '3A',
   String name = '3A',
@@ -323,6 +327,7 @@ Group ssGroup({
   String? instituteNumber = '123456',
   int? adminNumber = 7,
   String? parentId = 'jaar-3',
+  String? untis,
 }) =>
     Group(
       id: GroupId(code),
@@ -333,7 +338,35 @@ Group ssGroup({
       parentId: parentId == null ? null : GroupId(parentId),
       instituteNumber: instituteNumber,
       adminNumber: adminNumber,
+      untis: untis ?? name,
       origin: Origin.smartschool,
+    );
+
+/// The logical parent [AddToSmartschool] hangs a new class under — legacy
+/// `GroupManager.GetLogicalParent` resolved through `Root.FindByCode`. A
+/// non-official year/grade node in the Smartschool tree.
+Group ssParentGroup({String code = 'jaar-3', String name = 'Derde jaar'}) =>
+    Group(
+      id: GroupId(code),
+      name: name,
+      description: '',
+      type: GroupType.group,
+      official: false,
+      origin: Origin.smartschool,
+    );
+
+/// A [GroupPlacement] for a WISA-only class. Defaults to a populated class
+/// (`containsStudents: true`) with a resolvable parent — the [AddToSmartschool]
+/// happy path. Pass `containsStudents: false` for the [CreateInSmartschool]
+/// case, or `withParent: false` to simulate an unresolvable parent.
+GroupPlacement groupPlacement({
+  bool containsStudents = true,
+  Group? parent,
+  bool withParent = true,
+}) =>
+    GroupPlacement(
+      containsStudents: containsStudents,
+      parent: parent ?? (withParent ? ssParentGroup() : null),
     );
 
 /// Builds a [LinkedGroup] from optional per-system records. Omit a system to

--- a/packages/account_core/lib/src/group.dart
+++ b/packages/account_core/lib/src/group.dart
@@ -22,6 +22,13 @@ class Group {
 
   final String? instituteNumber;
   final int? adminNumber;
+
+  /// The Untis timetable code Smartschool stores for the class. Empty when the
+  /// system carries none: WISA exposes no Untis value, and a freshly imported
+  /// Smartschool class has it blank until it is set to the class [name]. Legacy
+  /// `IGroup.Untis`; `ModifySmartschoolData` converges a drifted value to [name].
+  final String untis;
+
   final Origin origin;
 
   const Group({
@@ -33,6 +40,7 @@ class Group {
     this.parentId,
     this.instituteNumber,
     this.adminNumber,
+    this.untis = '',
     required this.origin,
   });
 
@@ -45,6 +53,7 @@ class Group {
         if (parentId != null) 'parentId': parentId!.toJson(),
         if (instituteNumber != null) 'instituteNumber': instituteNumber,
         if (adminNumber != null) 'adminNumber': adminNumber,
+        if (untis.isNotEmpty) 'untis': untis,
         'origin': origin.toJson(),
       };
 
@@ -59,6 +68,7 @@ class Group {
             : GroupId(json['parentId'] as String),
         instituteNumber: json['instituteNumber'] as String?,
         adminNumber: json['adminNumber'] as int?,
+        untis: json['untis'] as String? ?? '',
         origin: Origin.fromJson(json['origin'] as String),
       );
 
@@ -74,6 +84,7 @@ class Group {
           parentId == other.parentId &&
           instituteNumber == other.instituteNumber &&
           adminNumber == other.adminNumber &&
+          untis == other.untis &&
           origin == other.origin;
 
   @override
@@ -86,6 +97,7 @@ class Group {
         parentId,
         instituteNumber,
         adminNumber,
+        untis,
         origin,
       );
 }

--- a/packages/account_core/test/group_test.dart
+++ b/packages/account_core/test/group_test.dart
@@ -8,6 +8,7 @@ Group _group({
   String? parent,
   String? institute,
   int? admin,
+  String untis = '',
   GroupType type = GroupType.classGroup,
   bool official = true,
 }) =>
@@ -20,6 +21,7 @@ Group _group({
       parentId: parent == null ? null : GroupId(parent),
       instituteNumber: institute,
       adminNumber: admin,
+      untis: untis,
       origin: Origin.wisa,
     );
 
@@ -30,25 +32,33 @@ void main() {
       expect(Group.fromJson(g.toJson()), equals(g));
     });
 
-    test('full (parent, institute, admin)', () {
-      final g = _group(parent: 'root', institute: '12345', admin: 7);
+    test('full (parent, institute, admin, untis)', () {
+      final g =
+          _group(parent: 'root', institute: '12345', admin: 7, untis: '5A');
       expect(Group.fromJson(g.toJson()), equals(g));
     });
 
     test('survives encode/decode through dart:convert', () {
-      final g = _group(parent: 'root', institute: '12345', admin: 7);
+      final g =
+          _group(parent: 'root', institute: '12345', admin: 7, untis: '5A');
       final encoded = jsonEncode(g.toJson());
       final decoded =
           Group.fromJson(jsonDecode(encoded) as Map<String, dynamic>);
       expect(decoded, equals(g));
     });
 
-    test('omits null optionals from JSON', () {
+    test('omits null optionals and empty untis from JSON', () {
       final g = _group();
       final json = g.toJson();
       expect(json.containsKey('parentId'), isFalse);
       expect(json.containsKey('instituteNumber'), isFalse);
       expect(json.containsKey('adminNumber'), isFalse);
+      expect(json.containsKey('untis'), isFalse);
+    });
+
+    test('legacy JSON without untis decodes to an empty untis', () {
+      final json = _group(institute: '12345').toJson()..remove('untis');
+      expect(Group.fromJson(json).untis, '');
     });
   });
 
@@ -57,6 +67,7 @@ void main() {
       expect(_group(), equals(_group()));
       expect(_group().hashCode, equals(_group().hashCode));
       expect(_group(official: true), isNot(equals(_group(official: false))));
+      expect(_group(untis: '5A'), isNot(equals(_group(untis: 'stale'))));
       expect(
         _group(type: GroupType.group),
         isNot(equals(_group(type: GroupType.classGroup))),

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -407,9 +407,11 @@ bool _looksLikeClassGroup(String? displayName) {
 /// [LinkedGroup.wisa] expects. The group is identified and named by its
 /// `fullName` (the cross-system match key); WISA class groups are always real
 /// classes, hence `official: true` and [GroupType.classGroup]. `schoolCode`
-/// becomes the institute number; WISA exposes no tree edge or numeric admin
-/// number for a class group, so [Group.parentId] and [Group.adminNumber] stay
-/// null.
+/// becomes the institute number and `adminCode` the numeric admin number (both
+/// feed `AddToSmartschool` when it creates the Smartschool class). WISA exposes
+/// no tree edge, so [Group.parentId] stays null, and no Untis code, so
+/// [Group.untis] is empty — the created Smartschool class derives its Untis
+/// from the class name instead.
 Group _wisaToCoreGroup(wapi.WisaClassGroup g) => Group(
       id: GroupId(g.fullName),
       name: g.fullName,
@@ -417,6 +419,7 @@ Group _wisaToCoreGroup(wapi.WisaClassGroup g) => Group(
       type: GroupType.classGroup,
       official: true,
       instituteNumber: g.schoolCode.isEmpty ? null : g.schoolCode,
+      adminNumber: int.tryParse(g.adminCode),
       origin: Origin.wisa,
     );
 

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -230,6 +230,28 @@ void main() {
       expect(g.confidence, LinkConfidence.medium);
     });
 
+    test('WISA projection carries adminCode as adminNumber, empty untis (#65)',
+        () {
+      final snapshot = link(
+        wisaSnap(
+          const [],
+          classGroups: [
+            wisaClassGroup('3B', schoolCode: '456', adminCode: '42'),
+          ],
+        ),
+        ssSnap(const []),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final wisa = snapshot.groups.single.wisa!;
+      expect(wisa.instituteNumber, '456');
+      expect(wisa.adminNumber, 42);
+      // WISA carries no Untis code; AddToSmartschool seeds it from the name.
+      expect(wisa.untis, '');
+    });
+
     test('Smartschool-only orphan group is kept (#52)', () {
       final snapshot = link(
         wisaSnap(const []),

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -138,12 +138,13 @@ wapi.WisaClassGroup wisaClassGroup(
   String name, {
   String groupName = '00',
   String schoolCode = '123',
+  String adminCode = '',
 }) =>
     wapi.WisaClassGroup(
       name: name,
       groupName: groupName,
       description: '',
-      adminCode: '',
+      adminCode: adminCode,
       schoolCode: schoolCode,
       schoolId: 1,
     );

--- a/packages/smartschool_api/lib/src/models/smartschool_group.dart
+++ b/packages/smartschool_api/lib/src/models/smartschool_group.dart
@@ -58,7 +58,8 @@ class SmartschoolGroup {
         children = children ?? <SmartschoolGroup>[];
 
   /// Projects this node to an immutable [core.Group]. `parentId` is set from
-  /// [parentCode] when it is non-empty.
+  /// [parentCode] when it is non-empty. [untis] is carried through so the
+  /// action engine can detect Untis-only drift (`ModifySmartschoolData`).
   core.Group toCoreGroup() => core.Group(
         id: core.GroupId(code),
         name: name,
@@ -70,6 +71,7 @@ class SmartschoolGroup {
             : null,
         instituteNumber: instituteNumber.isEmpty ? null : instituteNumber,
         adminNumber: adminNumber == 0 ? null : adminNumber,
+        untis: untis,
         origin: core.Origin.smartschool,
       );
 }

--- a/packages/smartschool_api/test/parsing/group_tree_test.dart
+++ b/packages/smartschool_api/test/parsing/group_tree_test.dart
@@ -67,6 +67,7 @@ void main() {
       expect(g.official, isTrue);
       expect(g.adminNumber, 12345);
       expect(g.instituteNumber, '30024');
+      expect(g.untis, '1A');
       expect(g.origin, core.Origin.smartschool);
 
       final root = forest.first.toCoreGroup();


### PR DESCRIPTION
## Summary

Completes the **group** action family started in #54 by porting the three actions it deferred, together with the model work they depended on. All three needed data the canonical `LinkedGroup` / `Group` model could not express: WISA class membership (`ContainsStudents`), the Smartschool group tree for parent placement, and a `Group.untis` field.

## Linked issue

Closes #65

## Changes

**Model prerequisites**
- Add `Group.untis` to `account_core` (field, ctor, JSON, equality/hashCode). Empty `untis` is omitted from JSON and legacy JSON without the key decodes to `''` — backward compatible.
- Carry `untis` through `SmartschoolGroup.toCoreGroup()`.
- Carry `untis` (empty — WISA has none) and `adminCode → adminNumber` through the linker's `_wisaToCoreGroup`, so a created official class carries its institute and admin numbers.
- New `GroupPlacement` injectable — the group analogue of `ClassPlacement` (#55): carries the WISA `ContainsStudents()` signal and the resolved Smartschool `parent`, keeping the action layer pure.

**Actions**
- **`AddToSmartschool`** — WISA-only class *with students* → creates the official Smartschool class under its logical parent. Reports a failure when the parent can't be resolved (legacy silently no-oped).
- **`CreateInSmartschool`** — WISA-only *empty* class → informational (`canApply == false`, `apply` throws).
- **`ModifySmartschoolData`** — now detects standalone Untis drift (`smartschool.untis != name`) and converges it to the class name; institute/Untis/description all sync.
- `groupActions` / `groupActionsFor` gain an opt-in `placementFor` callback (mirroring the student family's #55 wiring). A WISA-only class raises `DoNotImportFromWisa` plus exactly one of `AddToSmartschool` / `CreateInSmartschool`; omitting the callback leaves the dispatch identical to #54.

**Docs**
- `account_actions` README: documents the group-placement pattern and removes the two now-resolved "Deferred" bullets.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `dart analyze` (whole workspace) — **No issues found**
- [x] Unit tests pass across every package (account_core, smartschool_api, account_linker, account_actions, account_store, wisa_api, azure_api). New coverage: `Group.untis` JSON/equality; `toCoreGroup` untis; linker `adminNumber`/`untis` projection; dispatch order + placement gating; `AddToSmartschool` apply (dry-run, real, unresolvable-parent, `saveClass` failure); `CreateInSmartschool` informational; Untis-drift apply + `describeChanges`.
- [ ] No integration test — these are pure-Dart library packages with no UI (the `account_manager/` Flutter app is still empty). The change is data-layer/model logic fully covered by unit tests, so there is no end-to-end flow to drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
