### PR TITLE
Phase A: Scaffold account_state package + persistence interfaces (#69)

### DIFF
--- a/packages/account_state/CHANGELOG.md
+++ b/packages/account_state/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.1.0 (unreleased)
+
+Initial scaffold of the Layer-5 orchestration package for the Arcadia Account
+Manager port (issue #69). Persistence **seams** only — no orchestration logic.
+
+- `SettingsStore` interface with `InMemorySettingsStore` and
+  `FileSettingsStore`, over the `AppSettings` config model (school prefix,
+  debug flag, and the per-connector import-rule sets). Import-rule JSON codecs
+  keep serialization out of the pure connector rule types.
+- `PasswordQueueStore` interface with `InMemoryPasswordQueueStore` and
+  `FilePasswordQueueStore`, over the `PasswordEntry` model — the port's
+  counterpart of the legacy `PasswordManager`.
+- Re-exports `account_core`'s `PersonIdResolver` and `account_store`'s
+  `FilePersonIdResolver` as the identity seam and its default, so the whole
+  persistence surface is available from one import.

--- a/packages/account_state/LICENSE
+++ b/packages/account_state/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/packages/account_state/README.md
+++ b/packages/account_state/README.md
@@ -1,0 +1,53 @@
+# account_state
+
+Layer-5 orchestration package for the Arcadia Account Manager port.
+
+This is the seam-defining scaffold. It ships the **persistence interfaces**
+the orchestration layer (sync → link → apply, settings, password generation)
+will plug into, each with an in-memory default and a file-backed default — but
+**no orchestration logic yet**. Later slices add the engine on top of these
+seams without changing them.
+
+Pure Dart plus `dart:io`. No Flutter, no UI coupling.
+
+## Persist vs derive
+
+The State layer holds two kinds of data, and only one kind is persisted here:
+
+- **Persisted** — operator input and generated artefacts that must survive a
+  restart and that nothing can recompute:
+  - the **config** (`AppSettings`): school prefix, debug flag, and the
+    per-connector **import-rule sets** — via `SettingsStore`;
+  - the **PersonId map**: natural key → stable UUID — via `account_core`'s
+    `PersonIdResolver` (default `account_store.FilePersonIdResolver`);
+  - the **pending-password queue**: generated sheets awaiting export — via
+    `PasswordQueueStore`.
+- **Derived** — everything the linker and action engine recompute from the
+  connector snapshots: `LinkedAccount`s, per-account/group action lists,
+  dashboard counters. These are **never** stored here; they are a pure function
+  of the snapshots plus the persisted PersonId map (INV-20). Caching a snapshot
+  for fast first paint is a connector concern, not this package's.
+
+Keeping I/O behind these interfaces is the same discipline `account_store`
+applies to `PersonIdResolver`: the orchestration layer stays free of disk and
+format details, so it can be unit-tested against the in-memory adapters with
+zero network and zero infra.
+
+## Seams
+
+| Interface | Model | Defaults | Legacy counterpart |
+|---|---|---|---|
+| `SettingsStore` | `AppSettings` (+ import-rule codecs) | `InMemorySettingsStore`, `FileSettingsStore` | `config.json` / `SettingsState` |
+| `PersonIdResolver` (from `account_core`) | `PersonId` | `FilePersonIdResolver` (from `account_store`) | — |
+| `PasswordQueueStore` | `PasswordEntry` | `InMemoryPasswordQueueStore`, `FilePasswordQueueStore` | `PasswordManager` / `Passwords.json` |
+
+## Scope notes
+
+- `AppSettings` models the global flags and import-rule sets only. Connection
+  credentials and the WISA workdate pair stay with the connectors' own
+  live-config and are folded in by a later slice.
+- `PasswordEntry` models the legacy `AccountPassword` fields; the co-account
+  `Co1..Co6` addresses are deferred until the Passwords page is ported.
+
+Spec: [`docs/domain-model.md`](../../docs/domain-model.md) §7,
+[`PROJECT_OVERVIEW.md`](../../PROJECT_OVERVIEW.md) §5–§7.

--- a/packages/account_state/analysis_options.yaml
+++ b/packages/account_state/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -1,0 +1,31 @@
+/// Layer-5 orchestration package for the Arcadia Account Manager port.
+///
+/// This slice ships only the **persistence seams** the orchestration layer
+/// will plug into — no sync/link/apply logic yet (spec `docs/domain-model.md`
+/// §7, PROJECT_OVERVIEW §5–§7):
+///
+/// - [SettingsStore] — load/save the [AppSettings] config model, including the
+///   per-connector import-rule sets.
+/// - [PasswordQueueStore] — the pending-password queue ([PasswordEntry]).
+/// - `PersonIdResolver` (re-exported from `account_core`) — the identity seam,
+///   with `account_store`'s [FilePersonIdResolver] as the default
+///   implementation.
+///
+/// Every seam has an in-memory default so the layer is testable headlessly
+/// with zero network and zero infra. The persist-vs-derive split — what is
+/// stored here vs recomputed by the linker — is described in the README.
+///
+/// Pure Dart plus `dart:io`. No Flutter.
+library;
+
+// Identity seam: reuse account_core's interface; account_store ships the
+// file-backed default. Re-exported so consumers get the whole persistence
+// surface from one import.
+export 'package:account_core/account_core.dart' show PersonId, PersonIdResolver;
+export 'package:account_store/account_store.dart' show FilePersonIdResolver;
+
+export 'src/passwords/password_entry.dart';
+export 'src/passwords/password_queue_store.dart';
+export 'src/settings/app_settings.dart';
+export 'src/settings/import_rule_codec.dart';
+export 'src/settings/settings_store.dart';

--- a/packages/account_state/lib/src/passwords/password_entry.dart
+++ b/packages/account_state/lib/src/passwords/password_entry.dart
@@ -1,0 +1,95 @@
+import 'package:account_core/account_core.dart';
+
+/// Whether a pending password sheet is for a person's own account or a
+/// co-account (the legacy split between `Passwords.json` and
+/// `CoPasswords.json`, PROJECT_OVERVIEW §6.3).
+enum PasswordAccountKind { account, coAccount }
+
+/// One pending password sheet in the password queue.
+///
+/// When the operator generates a password for a new account, an entry lands
+/// here until a PDF sheet is exported and distributed. It is the port's
+/// counterpart of the legacy `AbstractPassword` hierarchy
+/// (`AccountPassword` / `CoAccountPassword`) that `PasswordManager` persisted.
+///
+/// The fields mirror the legacy `AccountPassword` (the common new-student
+/// case): a login name, display name, mail, class group, and the two backend
+/// passwords. Co-account-specific fields (the `Co1..Co6` addresses) are not
+/// modelled in this scaffold slice — [kind] discriminates the two, and the
+/// extra co-account fields will be added when the Passwords page is ported.
+///
+/// [personId] anchors the entry to a stable [PersonId] so the queue survives a
+/// re-sync that changes a login or mail.
+class PasswordEntry {
+  const PasswordEntry({
+    required this.personId,
+    required this.kind,
+    required this.accountName,
+    required this.displayName,
+    this.mail,
+    this.classGroup,
+    this.smartschoolPassword,
+    this.azurePassword,
+  });
+
+  /// Stable identity of the person this sheet belongs to.
+  final PersonId personId;
+
+  /// Own account vs co-account.
+  final PasswordAccountKind kind;
+
+  /// Login / account name. Legacy `AccountName`.
+  final String accountName;
+
+  /// Human-readable name printed on the sheet. Legacy `Name`.
+  final String displayName;
+
+  /// Contact mail, when known. Legacy `AccountPassword.Mail`.
+  final String? mail;
+
+  /// Class or group label printed on the sheet. Legacy `ClassGroup`.
+  final String? classGroup;
+
+  /// The Smartschool password. Legacy `SSPassword`.
+  final String? smartschoolPassword;
+
+  /// The Azure / Office 365 password. Legacy `AzurePassword`.
+  final String? azurePassword;
+
+  /// Serializes to a JSON-encodable map.
+  Map<String, dynamic> toJson() {
+    return {
+      'personId': personId.value,
+      'kind': kind.name,
+      'accountName': accountName,
+      'displayName': displayName,
+      if (mail != null) 'mail': mail,
+      if (classGroup != null) 'classGroup': classGroup,
+      if (smartschoolPassword != null)
+        'smartschoolPassword': smartschoolPassword,
+      if (azurePassword != null) 'azurePassword': azurePassword,
+    };
+  }
+
+  /// Reconstructs a [PasswordEntry] from a map produced by [toJson].
+  ///
+  /// Throws [FormatException] on an unknown `kind` tag.
+  factory PasswordEntry.fromJson(Map<String, dynamic> json) {
+    final kindName = json['kind'] as String;
+    final kind = PasswordAccountKind.values.firstWhere(
+      (k) => k.name == kindName,
+      orElse: () =>
+          throw FormatException('Unknown PasswordAccountKind: $kindName'),
+    );
+    return PasswordEntry(
+      personId: PersonId(json['personId'] as String),
+      kind: kind,
+      accountName: json['accountName'] as String,
+      displayName: json['displayName'] as String,
+      mail: json['mail'] as String?,
+      classGroup: json['classGroup'] as String?,
+      smartschoolPassword: json['smartschoolPassword'] as String?,
+      azurePassword: json['azurePassword'] as String?,
+    );
+  }
+}

--- a/packages/account_state/lib/src/passwords/password_queue_store.dart
+++ b/packages/account_state/lib/src/passwords/password_queue_store.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'password_entry.dart';
+
+/// The persistence seam for the pending-password queue.
+///
+/// Mirrors the legacy `PasswordManager`, which held two JSON-backed
+/// `Manager<T>` lists (`Passwords.json` / `CoPasswords.json`). One store here
+/// carries both [PasswordAccountKind]s — the [PasswordEntry.kind] tag
+/// distinguishes them — keeping the seam a single injectable interface.
+///
+/// Injected so the orchestration layer neither knows nor cares where the queue
+/// lives: tests use [InMemoryPasswordQueueStore], production uses
+/// [FilePasswordQueueStore].
+abstract interface class PasswordQueueStore {
+  /// Loads all queued entries. An empty or never-persisted queue returns an
+  /// empty list, not an error.
+  Future<List<PasswordEntry>> load();
+
+  /// Persists [entries], replacing the whole queue.
+  Future<void> save(List<PasswordEntry> entries);
+}
+
+/// An in-memory [PasswordQueueStore] holding the queue in a field.
+///
+/// The default for headless tests. [save] copies the incoming list so a
+/// caller mutating its own list afterwards cannot reach into the store.
+class InMemoryPasswordQueueStore implements PasswordQueueStore {
+  InMemoryPasswordQueueStore([List<PasswordEntry> initial = const []])
+      : _entries = List.of(initial);
+
+  List<PasswordEntry> _entries;
+
+  @override
+  Future<List<PasswordEntry>> load() async => List.of(_entries);
+
+  @override
+  Future<void> save(List<PasswordEntry> entries) async =>
+      _entries = List.of(entries);
+}
+
+/// A [PasswordQueueStore] backed by a JSON file on disk.
+///
+/// The file holds a JSON array of entry objects. [load] returns an empty list
+/// when the file is missing or empty; [save] writes the whole array as
+/// pretty-printed JSON, creating parent directories as needed.
+class FilePasswordQueueStore implements PasswordQueueStore {
+  FilePasswordQueueStore(this.path);
+
+  /// The path of the JSON file (legacy: `Passwords.json` / `CoPasswords.json`
+  /// under `%APPDATA%\AccountManager\`).
+  final String path;
+
+  @override
+  Future<List<PasswordEntry>> load() async {
+    final file = File(path);
+    if (!file.existsSync()) return [];
+    final raw = await file.readAsString();
+    if (raw.trim().isEmpty) return [];
+    final decoded = jsonDecode(raw) as List<dynamic>;
+    return [
+      for (final e in decoded)
+        PasswordEntry.fromJson(e as Map<String, dynamic>),
+    ];
+  }
+
+  @override
+  Future<void> save(List<PasswordEntry> entries) async {
+    final file = File(path);
+    file.parent.createSync(recursive: true);
+    const encoder = JsonEncoder.withIndent('  ');
+    final json = entries.map((e) => e.toJson()).toList();
+    await file.writeAsString('${encoder.convert(json)}\n');
+  }
+}

--- a/packages/account_state/lib/src/settings/app_settings.dart
+++ b/packages/account_state/lib/src/settings/app_settings.dart
@@ -1,0 +1,87 @@
+import 'package:smartschool_api/smartschool_api.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+import 'import_rule_codec.dart';
+
+/// The persisted configuration model for the Arcadia Account Manager.
+///
+/// This is the Dart counterpart of the legacy `config.json` (PROJECT_OVERVIEW
+/// §7): the operator-tunable settings that survive across runs. This scaffold
+/// slice models the two pieces the State layer needs first — the global flags
+/// ([schoolPrefix], [debugMode], mirroring the legacy `SettingsState`) and the
+/// per-connector **import-rule sets** applied at snapshot construction (spec
+/// §3.11). Connection credentials and the WISA workdate pair are deliberately
+/// out of scope here; they are the connectors' own live-config concern and
+/// will be folded in by a later slice.
+///
+/// The model is immutable — mutate by [copyWith] and hand the result to a
+/// [SettingsStore]. It carries its own `toJson`/`fromJson` so the file-backed
+/// store never has to know the field layout.
+class AppSettings {
+  const AppSettings({
+    this.schoolPrefix = '',
+    this.debugMode = false,
+    this.wisaRules = const [],
+    this.smartschoolRules = const [],
+  });
+
+  /// The school prefix used by the linker to scope Azure users to this school
+  /// (INV-22). Legacy `SettingsState.SchoolPrefix`.
+  final String schoolPrefix;
+
+  /// Whether verbose diagnostics are enabled. Legacy `SettingsState.DebugMode`.
+  final bool debugMode;
+
+  /// WISA import rules applied at snapshot construction (spec §3.11).
+  final List<WisaImportRule> wisaRules;
+
+  /// Smartschool import rules applied at snapshot construction (spec §3.11).
+  final List<SmartschoolImportRule> smartschoolRules;
+
+  /// Returns a copy with the given fields replaced.
+  AppSettings copyWith({
+    String? schoolPrefix,
+    bool? debugMode,
+    List<WisaImportRule>? wisaRules,
+    List<SmartschoolImportRule>? smartschoolRules,
+  }) {
+    return AppSettings(
+      schoolPrefix: schoolPrefix ?? this.schoolPrefix,
+      debugMode: debugMode ?? this.debugMode,
+      wisaRules: wisaRules ?? this.wisaRules,
+      smartschoolRules: smartschoolRules ?? this.smartschoolRules,
+    );
+  }
+
+  /// Serializes to a JSON-encodable map.
+  Map<String, dynamic> toJson() {
+    return {
+      'schoolPrefix': schoolPrefix,
+      'debugMode': debugMode,
+      'wisaRules': wisaRules.map(encodeWisaRule).toList(),
+      'smartschoolRules': smartschoolRules.map(encodeSmartschoolRule).toList(),
+    };
+  }
+
+  /// Reconstructs an [AppSettings] from a map produced by [toJson].
+  ///
+  /// Missing keys fall back to the constructor defaults so an older or
+  /// partial config still loads. Throws [FormatException] (via the rule
+  /// codecs) if a rule carries an unknown `type` tag.
+  factory AppSettings.fromJson(Map<String, dynamic> json) {
+    final wisa = (json['wisaRules'] as List<dynamic>?) ?? const [];
+    final smartschool =
+        (json['smartschoolRules'] as List<dynamic>?) ?? const [];
+    return AppSettings(
+      schoolPrefix: (json['schoolPrefix'] as String?) ?? '',
+      debugMode: (json['debugMode'] as bool?) ?? false,
+      wisaRules: [
+        for (final r in wisa) decodeWisaRule(r as Map<String, dynamic>),
+      ],
+      smartschoolRules: [
+        for (final r in smartschool)
+          decodeSmartschoolRule(r as Map<String, dynamic>),
+      ],
+    );
+  }
+}

--- a/packages/account_state/lib/src/settings/import_rule_codec.dart
+++ b/packages/account_state/lib/src/settings/import_rule_codec.dart
@@ -1,0 +1,81 @@
+/// JSON codecs for the connector import-rule sealed types.
+///
+/// The rule types ([WisaImportRule], [SmartschoolImportRule]) live in the
+/// connector packages and are intentionally free of any serialization concern
+/// — they model snapshot-time behaviour, nothing more. This package owns the
+/// on-disk representation, so the mapping between a rule and its JSON shape is
+/// quarantined here rather than leaking into the pure domain types.
+///
+/// The wire shape is a tagged object: `{ "type": "<tag>", ... }`. Tags are
+/// stable strings (not enum indices) so reordering the sealed hierarchy never
+/// changes a persisted config.
+library;
+
+import 'package:smartschool_api/smartschool_api.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+/// Encodes a [WisaImportRule] to its tagged-JSON map.
+Map<String, dynamic> encodeWisaRule(WisaImportRule rule) {
+  switch (rule) {
+    case DontImportClass():
+      return {'type': 'dontImportClass', 'className': rule.className};
+    case DontImportUserFromWisa():
+      return {'type': 'dontImportUserFromWisa', 'userCode': rule.userCode};
+    case ReplaceInstitute():
+      return {
+        'type': 'replaceInstitute',
+        'original': rule.original,
+        'replacement': rule.replacement,
+      };
+    case MarkAsVirtual():
+      return {'type': 'markAsVirtual', 'schoolCode': rule.schoolCode};
+  }
+}
+
+/// Decodes a tagged-JSON map produced by [encodeWisaRule].
+///
+/// Throws [FormatException] on an unknown or missing `type` tag so a corrupt
+/// config surfaces loudly rather than silently dropping rules.
+WisaImportRule decodeWisaRule(Map<String, dynamic> json) {
+  final type = json['type'];
+  switch (type) {
+    case 'dontImportClass':
+      return DontImportClass(json['className'] as String);
+    case 'dontImportUserFromWisa':
+      return DontImportUserFromWisa(json['userCode'] as String);
+    case 'replaceInstitute':
+      return ReplaceInstitute(
+        original: json['original'] as String,
+        replacement: json['replacement'] as String,
+      );
+    case 'markAsVirtual':
+      return MarkAsVirtual(json['schoolCode'] as String);
+    default:
+      throw FormatException('Unknown WisaImportRule type: $type');
+  }
+}
+
+/// Encodes a [SmartschoolImportRule] to its tagged-JSON map.
+Map<String, dynamic> encodeSmartschoolRule(SmartschoolImportRule rule) {
+  switch (rule) {
+    case DiscardSmartschoolGroup():
+      return {'type': 'discardSmartschoolGroup', 'groupName': rule.groupName};
+    case NoSmartschoolSubgroups():
+      return {'type': 'noSmartschoolSubgroups', 'groupName': rule.groupName};
+  }
+}
+
+/// Decodes a tagged-JSON map produced by [encodeSmartschoolRule].
+///
+/// Throws [FormatException] on an unknown or missing `type` tag.
+SmartschoolImportRule decodeSmartschoolRule(Map<String, dynamic> json) {
+  final type = json['type'];
+  switch (type) {
+    case 'discardSmartschoolGroup':
+      return DiscardSmartschoolGroup(json['groupName'] as String);
+    case 'noSmartschoolSubgroups':
+      return NoSmartschoolSubgroups(json['groupName'] as String);
+    default:
+      throw FormatException('Unknown SmartschoolImportRule type: $type');
+  }
+}

--- a/packages/account_state/lib/src/settings/settings_store.dart
+++ b/packages/account_state/lib/src/settings/settings_store.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'app_settings.dart';
+
+/// The persistence seam for the [AppSettings] config model.
+///
+/// The orchestration layer loads settings once at startup and saves them when
+/// the operator edits connection details or import rules. Injecting this
+/// interface keeps that layer free of any disk/format concern (the same reason
+/// `account_store` hides UUID minting behind `PersonIdResolver`): tests drive
+/// an in-memory store, production uses [FileSettingsStore].
+abstract interface class SettingsStore {
+  /// Loads the persisted settings. A store with nothing persisted yet returns
+  /// a default [AppSettings] rather than throwing, so first-run has no special
+  /// case.
+  Future<AppSettings> load();
+
+  /// Persists [settings], replacing any previously stored value.
+  Future<void> save(AppSettings settings);
+}
+
+/// An in-memory [SettingsStore] holding a single [AppSettings] in a field.
+///
+/// The default for headless tests: zero disk, zero infra. Seed it with an
+/// initial value to simulate a store that already has content.
+class InMemorySettingsStore implements SettingsStore {
+  InMemorySettingsStore([AppSettings initial = const AppSettings()])
+      : _settings = initial;
+
+  AppSettings _settings;
+
+  @override
+  Future<AppSettings> load() async => _settings;
+
+  @override
+  Future<void> save(AppSettings settings) async => _settings = settings;
+}
+
+/// A [SettingsStore] backed by a JSON file on disk.
+///
+/// [load] returns a default [AppSettings] when the file is missing or empty;
+/// [save] writes the whole model as pretty-printed JSON, creating parent
+/// directories as needed. Whole-file writes are fine — the config is small and
+/// saved only on operator edits.
+class FileSettingsStore implements SettingsStore {
+  FileSettingsStore(this.path);
+
+  /// The path of the JSON file (legacy: `%APPDATA%\AccountManager\config.json`).
+  final String path;
+
+  @override
+  Future<AppSettings> load() async {
+    final file = File(path);
+    if (!file.existsSync()) return const AppSettings();
+    final raw = await file.readAsString();
+    if (raw.trim().isEmpty) return const AppSettings();
+    return AppSettings.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+  }
+
+  @override
+  Future<void> save(AppSettings settings) async {
+    final file = File(path);
+    file.parent.createSync(recursive: true);
+    const encoder = JsonEncoder.withIndent('  ');
+    await file.writeAsString('${encoder.convert(settings.toJson())}\n');
+  }
+}

--- a/packages/account_state/pubspec.yaml
+++ b/packages/account_state/pubspec.yaml
@@ -1,0 +1,29 @@
+name: account_state
+description: >-
+  Layer-5 orchestration package for the Arcadia Account Manager port. Defines
+  the persistence seams (settings, PersonId resolution, password queue) that
+  the sync/link/apply orchestration plugs into, with in-memory and file-backed
+  defaults so the layer is testable headlessly.
+version: 0.1.0
+publish_to: none
+repository: https://github.com/yvanvds/AccountManager
+
+# License: GPL-3.0-or-later. See LICENSE.
+
+environment:
+  sdk: ^3.6.0
+
+resolution: workspace
+
+dependencies:
+  account_core:
+  account_store:
+  wisa_api:
+  smartschool_api:
+  azure_api:
+  account_linker:
+  account_actions:
+
+dev_dependencies:
+  lints: ^5.1.0
+  test: ^1.25.0

--- a/packages/account_state/test/password_queue_store_test.dart
+++ b/packages/account_state/test/password_queue_store_test.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+
+PasswordEntry _accountEntry() => const PasswordEntry(
+      personId: PersonId('p-1'),
+      kind: PasswordAccountKind.account,
+      accountName: 'jan.jansen',
+      displayName: 'Jan Jansen',
+      mail: 'jan.jansen@example.org',
+      classGroup: '1A',
+      smartschoolPassword: 'Sa2b!x',
+      azurePassword: 'Ku9d?y',
+    );
+
+PasswordEntry _coAccountEntry() => const PasswordEntry(
+      personId: PersonId('p-2'),
+      kind: PasswordAccountKind.coAccount,
+      accountName: 'els.peeters',
+      displayName: 'Els Peeters',
+    );
+
+void expectSameEntry(PasswordEntry a, PasswordEntry b) {
+  expect(a.toJson(), equals(b.toJson()));
+}
+
+void main() {
+  group('PasswordEntry JSON', () {
+    test('round-trips a fully-populated account entry', () {
+      final restored = PasswordEntry.fromJson(_accountEntry().toJson());
+      expectSameEntry(restored, _accountEntry());
+      expect(restored.personId, const PersonId('p-1'));
+    });
+
+    test('round-trips a co-account entry with null optionals', () {
+      final restored = PasswordEntry.fromJson(_coAccountEntry().toJson());
+      expectSameEntry(restored, _coAccountEntry());
+      expect(restored.kind, PasswordAccountKind.coAccount);
+      expect(restored.mail, isNull);
+    });
+
+    test('omits null optionals from the serialized map', () {
+      final json = _coAccountEntry().toJson();
+      expect(json.containsKey('mail'), isFalse);
+      expect(json.containsKey('azurePassword'), isFalse);
+    });
+
+    test('throws on an unknown kind tag', () {
+      expect(
+        () => PasswordEntry.fromJson({
+          'personId': 'p',
+          'kind': 'bogus',
+          'accountName': 'a',
+          'displayName': 'b',
+        }),
+        throwsFormatException,
+      );
+    });
+  });
+
+  void queueContract(String name, PasswordQueueStore Function() make) {
+    group('$name (PasswordQueueStore contract)', () {
+      test('load returns an empty queue when nothing is saved', () async {
+        expect(await make().load(), isEmpty);
+      });
+
+      test('save then load round-trips the queue', () async {
+        final store = make();
+        final entries = [_accountEntry(), _coAccountEntry()];
+        await store.save(entries);
+        final loaded = await store.load();
+        expect(loaded, hasLength(2));
+        expectSameEntry(loaded[0], _accountEntry());
+        expectSameEntry(loaded[1], _coAccountEntry());
+      });
+
+      test('save replaces the whole queue', () async {
+        final store = make();
+        await store.save([_accountEntry()]);
+        await store.save([_coAccountEntry()]);
+        final loaded = await store.load();
+        expect(loaded, hasLength(1));
+        expect(loaded.single.personId, const PersonId('p-2'));
+      });
+    });
+  }
+
+  queueContract('InMemoryPasswordQueueStore', InMemoryPasswordQueueStore.new);
+
+  group('InMemoryPasswordQueueStore isolation', () {
+    test('mutating the caller list after save does not affect the store',
+        () async {
+      final store = InMemoryPasswordQueueStore();
+      final entries = [_accountEntry()];
+      await store.save(entries);
+      entries.clear();
+      expect(await store.load(), hasLength(1));
+    });
+
+    test('mutating a loaded list does not affect the store', () async {
+      final store = InMemoryPasswordQueueStore([_accountEntry()]);
+      final loaded = await store.load();
+      loaded.clear();
+      expect(await store.load(), hasLength(1));
+    });
+  });
+
+  group('FilePasswordQueueStore', () {
+    late Directory tmp;
+    late String path;
+
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('account_state_pwq');
+      path = '${tmp.path}/passwords.json';
+    });
+    tearDown(() => tmp.deleteSync(recursive: true));
+
+    queueContract('file-backed', () => FilePasswordQueueStore(path));
+
+    test('persists across a fresh store on the same path', () async {
+      await FilePasswordQueueStore(path).save([_accountEntry()]);
+      final loaded = await FilePasswordQueueStore(path).load();
+      expect(loaded, hasLength(1));
+      expectSameEntry(loaded.single, _accountEntry());
+    });
+
+    test('load treats an empty file as an empty queue', () async {
+      File(path).writeAsStringSync('');
+      expect(await FilePasswordQueueStore(path).load(), isEmpty);
+    });
+
+    test('writes a JSON array', () async {
+      await FilePasswordQueueStore(path).save([_accountEntry()]);
+      final decoded = jsonDecode(File(path).readAsStringSync());
+      expect(decoded, isA<List<dynamic>>());
+      expect(decoded, hasLength(1));
+    });
+  });
+}

--- a/packages/account_state/test/person_id_seam_test.dart
+++ b/packages/account_state/test/person_id_seam_test.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+
+/// The identity seam is re-exported from `account_state`, so a consumer gets
+/// `PersonIdResolver` and its file-backed default without a second import.
+void main() {
+  test('FilePersonIdResolver is reachable via the barrel and resolves ids',
+      () async {
+    final tmp = Directory.systemTemp.createTempSync('account_state_pid');
+    addTearDown(() => tmp.deleteSync(recursive: true));
+
+    final PersonIdResolver resolver =
+        await FilePersonIdResolver.load('${tmp.path}/person_ids.json');
+    final id = resolver.resolve('wisa:123');
+
+    expect(id, isA<PersonId>());
+    expect(id.value, isNotEmpty);
+    expect(resolver.resolve('wisa:123'), equals(id));
+  });
+}

--- a/packages/account_state/test/settings_store_test.dart
+++ b/packages/account_state/test/settings_store_test.dart
@@ -1,0 +1,138 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:account_state/account_state.dart';
+import 'package:smartschool_api/smartschool_api.dart';
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+/// A representative config exercising both flags and every import-rule variant.
+AppSettings _sampleSettings() => const AppSettings(
+      schoolPrefix: 'SMA',
+      debugMode: true,
+      wisaRules: [
+        DontImportClass('1A'),
+        DontImportUserFromWisa('U42'),
+        ReplaceInstitute(original: '001', replacement: '002'),
+        MarkAsVirtual('VIRT'),
+      ],
+      smartschoolRules: [
+        DiscardSmartschoolGroup('Archief'),
+        NoSmartschoolSubgroups('Klassen'),
+      ],
+    );
+
+void expectSameSettings(AppSettings a, AppSettings b) {
+  expect(a.schoolPrefix, b.schoolPrefix);
+  expect(a.debugMode, b.debugMode);
+  expect(encodeRules(a.wisaRules, encodeWisaRule),
+      equals(encodeRules(b.wisaRules, encodeWisaRule)));
+  expect(encodeRules(a.smartschoolRules, encodeSmartschoolRule),
+      equals(encodeRules(b.smartschoolRules, encodeSmartschoolRule)));
+}
+
+List<Map<String, dynamic>> encodeRules<T>(
+        List<T> rules, Map<String, dynamic> Function(T) enc) =>
+    rules.map(enc).toList();
+
+void main() {
+  group('AppSettings JSON', () {
+    test('round-trips every field and rule variant', () {
+      final original = _sampleSettings();
+      final restored = AppSettings.fromJson(original.toJson());
+      expectSameSettings(restored, original);
+    });
+
+    test('defaults fill in for a partial / older config', () {
+      final settings = AppSettings.fromJson({'schoolPrefix': 'X'});
+      expect(settings.schoolPrefix, 'X');
+      expect(settings.debugMode, isFalse);
+      expect(settings.wisaRules, isEmpty);
+      expect(settings.smartschoolRules, isEmpty);
+    });
+
+    test('throws on an unknown rule type tag', () {
+      expect(
+        () => AppSettings.fromJson({
+          'wisaRules': [
+            {'type': 'bogus'}
+          ],
+        }),
+        throwsFormatException,
+      );
+    });
+
+    test('copyWith replaces only the given fields', () {
+      const base = AppSettings(schoolPrefix: 'A', debugMode: true);
+      final copy = base.copyWith(schoolPrefix: 'B');
+      expect(copy.schoolPrefix, 'B');
+      expect(copy.debugMode, isTrue);
+    });
+  });
+
+  // The interface contract, run against both adapters.
+  void settingsStoreContract(String name, SettingsStore Function() make) {
+    group('$name (SettingsStore contract)', () {
+      test('load returns defaults when nothing has been saved', () async {
+        final settings = await make().load();
+        expect(settings.schoolPrefix, isEmpty);
+        expect(settings.debugMode, isFalse);
+        expect(settings.wisaRules, isEmpty);
+        expect(settings.smartschoolRules, isEmpty);
+      });
+
+      test('save then load round-trips the config', () async {
+        final store = make();
+        await store.save(_sampleSettings());
+        expectSameSettings(await store.load(), _sampleSettings());
+      });
+
+      test('save replaces the previously stored value', () async {
+        final store = make();
+        await store.save(const AppSettings(schoolPrefix: 'first'));
+        await store.save(const AppSettings(schoolPrefix: 'second'));
+        expect((await store.load()).schoolPrefix, 'second');
+      });
+    });
+  }
+
+  settingsStoreContract('InMemorySettingsStore', InMemorySettingsStore.new);
+
+  group('FileSettingsStore', () {
+    late Directory tmp;
+    late String path;
+
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('account_state_settings');
+      path = '${tmp.path}/config.json';
+    });
+    tearDown(() => tmp.deleteSync(recursive: true));
+
+    settingsStoreContract('file-backed', () => FileSettingsStore(path));
+
+    test('persists across a fresh store on the same path', () async {
+      await FileSettingsStore(path).save(_sampleSettings());
+      expectSameSettings(
+          await FileSettingsStore(path).load(), _sampleSettings());
+    });
+
+    test('load treats an empty file as defaults', () async {
+      File(path).writeAsStringSync('');
+      expect((await FileSettingsStore(path).load()).schoolPrefix, isEmpty);
+    });
+
+    test('creates parent directories on save', () async {
+      final nested = '${tmp.path}/a/b/config.json';
+      await FileSettingsStore(nested).save(const AppSettings());
+      expect(File(nested).existsSync(), isTrue);
+    });
+
+    test('writes a human-readable JSON object', () async {
+      await FileSettingsStore(path)
+          .save(const AppSettings(schoolPrefix: 'SMA'));
+      final decoded =
+          jsonDecode(File(path).readAsStringSync()) as Map<String, dynamic>;
+      expect(decoded['schoolPrefix'], 'SMA');
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ workspace:
   - packages/azure_api
   - packages/account_linker
   - packages/account_actions
+  - packages/account_state
 
 dev_dependencies:
   lints: ^5.1.0


### PR DESCRIPTION
## Summary

Adds `packages/account_state/` — the Layer-5 orchestration package — as a
workspace member and defines its **persistence seams**. Interfaces plus
in-memory/file defaults only; **no sync/link/apply orchestration yet**. This
establishes the seams so later slices plug in without changing them.

## Linked issue

Closes #69

## Changes

- **New workspace package** `packages/account_state/`, added to the root
  `pubspec.yaml`, depending on `account_core`, the three connectors,
  `account_linker`, `account_actions`, and `account_store`.
- **`SettingsStore`** (`InMemorySettingsStore` / `FileSettingsStore`) over the
  `AppSettings` config model — school prefix, debug flag, and the per-connector
  **import-rule sets**. Import-rule JSON codecs (`import_rule_codec.dart`) own
  the on-disk shape so the pure connector rule types stay serialization-free.
- **`PasswordQueueStore`** (`InMemoryPasswordQueueStore` /
  `FilePasswordQueueStore`) over the `PasswordEntry` model — the port's
  counterpart of the legacy `PasswordManager` (`Passwords.json`).
- **PersonId seam:** re-exports `account_core`'s `PersonIdResolver` and
  `account_store`'s `FilePersonIdResolver` (the default) so consumers get the
  whole persistence surface from one import.
- Barrel export, README (persist-vs-derive split), CHANGELOG, LICENSE.

Every seam has an in-memory default, so the layer is testable headlessly with
zero network and zero infra — mirroring how `account_store` quarantines I/O
behind `PersonIdResolver` to keep `link()` pure.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed packages/account_state` — clean
- [x] `dart analyze` — clean across all 8 workspace packages
- [x] Unit tests pass — `dart test` in `packages/account_state`: **30 passing**.
  Cover both adapters (in-memory + file) for `SettingsStore` and
  `PasswordQueueStore`, `AppSettings`/`PasswordEntry` JSON round-trips including
  every import-rule variant, unknown-tag `FormatException` paths, empty/missing
  file handling, parent-dir creation, and in-memory copy isolation.
- [ ] Integration / e2e — **not applicable**: this is a pure-Dart
  data/persistence library with no UI or runtime flow to drive (the Flutter app
  is still empty). Not user-visible; fully covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
