### PR TITLE
Phase A: State link + placement construction (#71)

### DIFF
--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -22,6 +22,13 @@
 /// - [ApplicationState] — the three [SystemState]s plus a `sync(Origin)` entry
 ///   point. [azureSyncer] wires the delta-from-day-one behaviour (PAIN-2).
 ///
+/// On top of the snapshots, the linked view is **derived** (never persisted):
+///
+/// - [LinkedState] — re-runs the pure `link()` over the current snapshots and
+///   the three action dispatchers, with the membership/tree-dependent actions
+///   wired through a [PlacementResolver] built from the injected
+///   [SmartschoolClassTree] (#55 / #65).
+///
 /// Pure Dart plus `dart:io`. No Flutter.
 library;
 
@@ -31,6 +38,8 @@ library;
 export 'package:account_core/account_core.dart' show PersonId, PersonIdResolver;
 export 'package:account_store/account_store.dart' show FilePersonIdResolver;
 
+export 'src/link/linked_state.dart';
+export 'src/link/placement.dart';
 export 'src/passwords/password_entry.dart';
 export 'src/passwords/password_queue_store.dart';
 export 'src/settings/app_settings.dart';

--- a/packages/account_state/lib/src/link/linked_state.dart
+++ b/packages/account_state/lib/src/link/linked_state.dart
@@ -1,0 +1,132 @@
+import 'package:account_actions/account_actions.dart' as actions;
+import 'package:account_core/account_core.dart';
+import 'package:account_linker/account_linker.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+import '../sync/application_state.dart';
+import 'placement.dart';
+
+/// The State layer's **derived** view of one link+dispatch pass: the pure
+/// [LinkedSnapshot] plus the per-family action lists the UI renders.
+///
+/// Ties the three layers together (spec `docs/domain-model.md` §6.2–§6.4):
+/// the pure `link()` reconciles the current connector snapshots, then the
+/// action dispatchers derive the applicable actions — with the membership- and
+/// tree-dependent ones wired through a [PlacementResolver] so
+/// `MoveToSmartschoolClassGroup`, the placement step in `AddStudentToSmartschool`,
+/// and the group `AddToSmartschool` / `CreateInSmartschool` actions are
+/// considered (#55 / #65).
+///
+/// **Never persisted.** This is recomputed from the snapshots on demand, never
+/// written to disk — legacy `LinkedState.SaveContent` deliberately threw, and
+/// the port keeps that by giving the linked view no persistence seam at all
+/// (README "persist vs derive"). Rebuild it with [LinkedState.fromApplication]
+/// (or [LinkedState.recompute]) whenever a sync replaces a snapshot.
+class LinkedState {
+  const LinkedState({
+    required this.snapshot,
+    required this.studentActions,
+    required this.staffActions,
+    required this.groupActions,
+  });
+
+  /// The reconciled output of `link()` over the three current snapshots.
+  final LinkedSnapshot snapshot;
+
+  /// Applicable student actions, in snapshot order, with class placement wired.
+  final List<actions.StudentAction> studentActions;
+
+  /// Applicable staff actions, in snapshot order. Staff carry no placement
+  /// (their Office 365 group actions are out of the port's scope), so this is a
+  /// plain dispatch — included here so [LinkedState] is the one derived view of
+  /// every family, not just the placement-bearing two.
+  final List<actions.StaffAction> staffActions;
+
+  /// Applicable group actions, in snapshot order, with group placement wired.
+  final List<actions.GroupAction> groupActions;
+
+  /// Recomputes the linked view from three concrete snapshots.
+  ///
+  /// Runs the pure `link()` (scoped by the shared `schoolPrefix` the
+  /// [studentConfig] / [staffConfig] carry) and then the three dispatchers,
+  /// binding a [PlacementResolver] built from the WISA + Smartschool snapshots
+  /// and the injected [classTree] to the student and group `placementFor`
+  /// callbacks.
+  factory LinkedState.recompute({
+    required wapi.WisaSnapshot wisa,
+    required ss.SmartschoolSnapshot smartschool,
+    required az.AzureSnapshot azure,
+    required PersonIdResolver resolver,
+    required actions.StudentActionConfig studentConfig,
+    required actions.StaffActionConfig staffConfig,
+    SmartschoolClassTree classTree = const SmartschoolClassTree(),
+  }) {
+    assert(
+      studentConfig.schoolPrefix == staffConfig.schoolPrefix,
+      'student/staff configs must share the school prefix the linker scopes by',
+    );
+
+    final snapshot = link(
+      wisa,
+      smartschool,
+      azure,
+      resolver,
+      schoolPrefix: studentConfig.schoolPrefix,
+    );
+
+    final placements = PlacementResolver(
+      wisa: wisa,
+      smartschool: smartschool,
+      classTree: classTree,
+    );
+
+    return LinkedState(
+      snapshot: snapshot,
+      studentActions: actions.studentActions(
+        snapshot,
+        studentConfig,
+        placementFor: placements.classPlacementFor,
+      ),
+      staffActions: actions.staffActions(snapshot, staffConfig),
+      groupActions: actions.groupActions(
+        snapshot,
+        placementFor: placements.groupPlacementFor,
+      ),
+    );
+  }
+
+  /// Recomputes the linked view from an [ApplicationState]'s current snapshots.
+  ///
+  /// Throws a [StateError] when any system has not synced yet (its snapshot is
+  /// still `null`): linking needs all three views, mirroring how the legacy
+  /// dashboard only re-linked after the syncs had run.
+  factory LinkedState.fromApplication(
+    ApplicationState app, {
+    required PersonIdResolver resolver,
+    required actions.StudentActionConfig studentConfig,
+    required actions.StaffActionConfig staffConfig,
+    SmartschoolClassTree classTree = const SmartschoolClassTree(),
+  }) {
+    final wisa = app.wisa.snapshot;
+    final smartschool = app.smartschool.snapshot;
+    final azure = app.azure.snapshot;
+    if (wisa == null || smartschool == null || azure == null) {
+      throw StateError(
+        'Cannot link before every system has synced at least once '
+        '(wisa: ${wisa != null}, smartschool: ${smartschool != null}, '
+        'azure: ${azure != null}).',
+      );
+    }
+    return LinkedState.recompute(
+      wisa: wisa,
+      smartschool: smartschool,
+      azure: azure,
+      resolver: resolver,
+      studentConfig: studentConfig,
+      staffConfig: staffConfig,
+      classTree: classTree,
+    );
+  }
+}

--- a/packages/account_state/lib/src/link/placement.dart
+++ b/packages/account_state/lib/src/link/placement.dart
@@ -1,0 +1,224 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+/// The Smartschool class-tree configuration used to resolve a new class's
+/// *logical parent* — the group a freshly created official class hangs under.
+///
+/// Ported from legacy `Connector.StudentYear` / `StudentGrade` / `StudentPath`
+/// and the `GroupManager.GetLogicalParent` switch on them
+/// (`legacy-wpf/AccountApi/Smartschool/GroupManager.cs`). A school configures
+/// **one** of two schemes:
+/// - [years]: seven group codes, one per school year (`1..7`); or
+/// - [grades]: three group codes, one per grade (years 1–2, 3–4, 5–7).
+///
+/// [path] is the fallback root code used when neither scheme is fully
+/// configured. All three default to empty, matching a not-yet-configured
+/// Smartschool tenant.
+///
+/// This is Smartschool live-config, deferred out of `AppSettings` like the
+/// connection credentials; the State layer injects it into [PlacementResolver]
+/// when it recomputes derived state, so the placement builder never reaches
+/// into connector config itself.
+class SmartschoolClassTree {
+  const SmartschoolClassTree({
+    this.years = const [],
+    this.grades = const [],
+    this.path = '',
+  });
+
+  /// Seven group codes, one per school year, or empty when the school
+  /// configures grades instead. Legacy `Connector.StudentYear`.
+  final List<String> years;
+
+  /// Three group codes, one per grade, or empty when the school configures
+  /// years instead. Legacy `Connector.StudentGrade`.
+  final List<String> grades;
+
+  /// Fallback root group code used when neither [years] nor [grades] is fully
+  /// configured. Legacy `Connector.StudentPath`.
+  final String path;
+
+  /// The logical-parent group *code* for a class whose name starts with
+  /// [year] (the class's first digit, `1..7`). Mirrors legacy
+  /// `GetLogicalParent`: prefer the per-year code, then the per-grade code,
+  /// then the flat [path].
+  ///
+  /// Returns `null` when [year] is out of the `1..7` range — legacy returned an
+  /// empty string there, which `FindByCode` never resolved; `null` makes the
+  /// "no parent" outcome explicit so [GroupPlacement.parent] is left unset.
+  String? parentCodeForYear(int year) {
+    if (year < 1 || year > 7) return null;
+    if (years.length == 7) return years[year - 1];
+    if (grades.length == 3) {
+      switch (year) {
+        case 1:
+        case 2:
+          return grades[0];
+        case 3:
+        case 4:
+          return grades[1];
+        default:
+          return grades[2];
+      }
+    }
+    return path;
+  }
+}
+
+/// Builds the [ClassPlacement] / [GroupPlacement] inputs the action engine's
+/// membership- and tree-dependent actions need, from the WISA and Smartschool
+/// snapshots (spec `docs/domain-model.md` §3.7, PAIN-1).
+///
+/// A [LinkedAccount] / [LinkedGroup] alone cannot answer "which official class
+/// is this student currently in?" or "does this WISA class hold students, and
+/// what Smartschool parent does it hang under?" — those live in the
+/// Smartschool memberships / group tree and the WISA class roster, which the
+/// linker does not project onto a linked record (which is why #55 / #65
+/// deferred the actions that need them). This resolver walks those snapshots
+/// **once** in its constructor and exposes two tear-off-friendly methods,
+/// [classPlacementFor] and [groupPlacementFor], that the State layer passes as
+/// the dispatchers' `placementFor` callbacks.
+///
+/// Keeping the walk here preserves `account_actions`' pure-function boundary:
+/// an action reads the placement it is handed, it never touches a snapshot.
+class PlacementResolver {
+  PlacementResolver({
+    required wapi.WisaSnapshot wisa,
+    required ss.SmartschoolSnapshot smartschool,
+    this.classTree = const SmartschoolClassTree(),
+  }) {
+    // Index the Smartschool tree by name (for resolveClass) and by code (for
+    // the current-class and logical-parent lookups). First wins on a
+    // collision, keeping the result a deterministic function of snapshot order.
+    for (final group in smartschool.groups) {
+      final name = _norm(group.name);
+      if (name != null) _groupsByName.putIfAbsent(name, () => group);
+      _groupsByCode.putIfAbsent(group.id.value, () => group);
+    }
+
+    // A student's current official class, keyed by Smartschool uid. Legacy
+    // `Smartschool.Account.Group` held a single class name; with first-class
+    // memberships (INV-30) we take the first membership that resolves to an
+    // official class group.
+    for (final membership in smartschool.memberships) {
+      final uid = _norm(membership.uid);
+      if (uid == null) continue;
+      final group = _groupsByCode[membership.groupId.value];
+      if (group == null ||
+          !group.official ||
+          group.type != GroupType.classGroup) {
+        continue;
+      }
+      _currentClassByUid.putIfAbsent(uid, () => group);
+    }
+
+    // WISA students, indexed by wisaId so [classPlacementFor] can recover the
+    // concrete record (class group / sub-group) from a [LinkedAccount], which
+    // only carries the `wisaId` linking key. Also collect the class names that
+    // currently hold a student — legacy `WisaClassGroup.ContainsStudents`
+    // (`student.ClassGroup == Name`).
+    for (final student in wisa.students) {
+      final wisaId = _norm(student.wisaId.value);
+      if (wisaId != null) {
+        _wisaStudentByWisaId.putIfAbsent(wisaId, () => student);
+      }
+      final classGroup = _norm(student.classGroup);
+      if (classGroup != null) _classGroupsWithStudents.add(classGroup);
+    }
+
+    // Class names that use sub-groups: legacy `ClassGroupManager.UseSubGroups`
+    // — a class whose rows carry more than one distinct admin code. Also index
+    // WISA classes by fullName so [groupPlacementFor] can recover the source
+    // class (bare name / year) from a [LinkedGroup] keyed by fullName.
+    final adminCodesByName = <String, Set<String>>{};
+    for (final group in wisa.classGroups) {
+      final name = _norm(group.name);
+      if (name != null) {
+        adminCodesByName
+            .putIfAbsent(name, () => <String>{})
+            .add(group.adminCode);
+      }
+      final fullName = _norm(group.fullName);
+      if (fullName != null) _wisaByFullName.putIfAbsent(fullName, () => group);
+    }
+    for (final entry in adminCodesByName.entries) {
+      if (entry.value.length > 1) _subGroupClassNames.add(entry.key);
+    }
+  }
+
+  /// The class-tree config driving [GroupPlacement.parent] resolution.
+  final SmartschoolClassTree classTree;
+
+  final Map<String, Group> _groupsByName = {};
+  final Map<String, Group> _groupsByCode = {};
+  final Map<String, Group> _currentClassByUid = {};
+  final Map<String, wapi.WisaStudent> _wisaStudentByWisaId = {};
+  final Set<String> _subGroupClassNames = {};
+  final Map<String, wapi.WisaClassGroup> _wisaByFullName = {};
+  final Set<String> _classGroupsWithStudents = {};
+
+  /// Builds the [ClassPlacement] for one student (the dispatcher only calls
+  /// this for `account.wisa != null` records; a WISA-less lifecycle account
+  /// never needs a placement).
+  ///
+  /// - [ClassPlacement.className] is the WISA `classGroup`, plus the
+  ///   `classSubGroup` when the class uses sub-groups (legacy
+  ///   `Student.ClassName`).
+  /// - [ClassPlacement.currentClass] is the student's current official
+  ///   Smartschool class, sourced from the memberships, or `null` when the
+  ///   student has no Smartschool account or no official class membership.
+  /// - [ClassPlacement.resolveClass] resolves a class name against the whole
+  ///   Smartschool tree (legacy `GroupManager.Root.Find`).
+  ClassPlacement classPlacementFor(LinkedAccount account) {
+    final wisaId = _norm(account.wisa?.wisaId.value);
+    final student = wisaId == null ? null : _wisaStudentByWisaId[wisaId];
+    final classGroup = student?.classGroup ?? '';
+    final subGroup = student?.classSubGroup ?? '';
+    final useSubGroups = _subGroupClassNames.contains(_norm(classGroup));
+    final className = useSubGroups ? '$classGroup $subGroup' : classGroup;
+
+    final uid = _norm(account.smartschool?.uid);
+    final currentClass = uid == null ? null : _currentClassByUid[uid];
+
+    return ClassPlacement(
+      className: className,
+      currentClass: currentClass,
+      resolveClass: (name) => _groupsByName[_norm(name)],
+    );
+  }
+
+  /// Builds the [GroupPlacement] for one WISA-only class (the dispatcher only
+  /// calls this for `wisa != null && smartschool == null` groups).
+  ///
+  /// - [GroupPlacement.containsStudents] is whether the WISA class currently
+  ///   holds students (legacy `WisaClassGroup.ContainsStudents`), which selects
+  ///   `AddToSmartschool` (populated) over `CreateInSmartschool` (empty).
+  /// - [GroupPlacement.parent] is the resolved Smartschool parent group
+  ///   (legacy `GetLogicalParent` → `Root.FindByCode`), or `null` when the
+  ///   class year is out of range or the parent node is absent from the tree.
+  GroupPlacement groupPlacementFor(LinkedGroup group) {
+    // [LinkedGroup.wisa] is keyed by fullName; recover the source WISA class to
+    // read its bare name and year.
+    final wisaClass = _wisaByFullName[_norm(group.wisa?.name)];
+    final containsStudents = wisaClass != null &&
+        _classGroupsWithStudents.contains(_norm(wisaClass.name));
+    final parentCode = classTree.parentCodeForYear(wisaClass?.year ?? -1);
+    final parent = parentCode == null ? null : _groupsByCode[parentCode];
+
+    return GroupPlacement(
+      containsStudents: containsStudents,
+      parent: parent,
+    );
+  }
+}
+
+/// Trims and lower-cases [value] for case-insensitive, whitespace-tolerant
+/// matching (INV-12), returning `null` for a null or blank input so an empty
+/// key never indexes or matches anything. Mirrors the linker's `_norm`.
+String? _norm(String? value) {
+  if (value == null) return null;
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed.toLowerCase();
+}

--- a/packages/account_state/test/linked_state_test.dart
+++ b/packages/account_state/test/linked_state_test.dart
@@ -1,0 +1,473 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+final DateTime _d = DateTime.utc(2026);
+
+const core.Address _addr = core.Address(
+  street: '',
+  houseNumber: '',
+  postalCode: '',
+  city: '',
+  country: '',
+);
+
+wapi.WisaStudent _wStudent({
+  required String wisaId,
+  String classGroup = '',
+  String classSubGroup = '',
+}) =>
+    wapi.WisaStudent(
+      wisaId: core.WisaId(wisaId),
+      classGroup: classGroup,
+      classSubGroup: classSubGroup,
+      name: 'Doe',
+      firstName: 'Jane',
+      preferredName: '',
+      birthDate: _d,
+      stemId: '',
+      gender: core.Gender.female,
+      nationalId: '',
+      birthPlace: '',
+      nationality: '',
+      address: _addr,
+      classChange: _d,
+      schoolId: 1,
+    );
+
+ss.SmartschoolAccount _ssAccount({
+  required String uid,
+  required String accountId,
+  required String mail,
+}) =>
+    ss.SmartschoolAccount(
+      uid: uid,
+      accountId: accountId,
+      mail: mail,
+      registerId: '',
+      stemId: 0,
+      role: core.PersonRole.student,
+      givenName: 'Jane',
+      surname: 'Doe',
+      extraNames: '',
+      initials: '',
+      preferredName: '',
+      gender: core.Gender.female,
+      birthDate: null,
+      birthPlace: '',
+      birthCountry: '',
+      address: _addr,
+      mobilePhone: '',
+      homePhone: '',
+      fax: '',
+      untisId: '',
+      status: 'actief',
+    );
+
+az.AzureUser _azUser({
+  required String id,
+  required String upn,
+  String? employeeId,
+  String companyName = 'GBS',
+}) =>
+    az.AzureUser(
+      id: id,
+      upn: upn,
+      employeeId: employeeId,
+      companyName: companyName,
+    );
+
+core.Group _ssGroup(
+  String name, {
+  String? code,
+  bool official = true,
+  core.GroupType type = core.GroupType.classGroup,
+}) =>
+    core.Group(
+      id: core.GroupId(code ?? name),
+      name: name,
+      description: '',
+      type: type,
+      official: official,
+      origin: core.Origin.smartschool,
+    );
+
+ss.SmartschoolMembership _member(String uid, String groupCode) =>
+    ss.SmartschoolMembership(uid: uid, groupId: core.GroupId(groupCode));
+
+wapi.WisaClassGroup _wClass(
+  String name, {
+  String groupName = '00',
+  String adminCode = '',
+  String schoolCode = '123',
+}) =>
+    wapi.WisaClassGroup(
+      name: name,
+      groupName: groupName,
+      description: '',
+      adminCode: adminCode,
+      schoolCode: schoolCode,
+      schoolId: 1,
+    );
+
+wapi.WisaSnapshot _wSnap({
+  List<wapi.WisaStudent> students = const [],
+  List<wapi.WisaClassGroup> classGroups = const [],
+}) =>
+    wapi.WisaSnapshot(
+      fetchedAt: _d,
+      students: students,
+      staff: const [],
+      classGroups: classGroups,
+      schools: const [],
+    );
+
+ss.SmartschoolSnapshot _sSnap({
+  List<core.Group> groups = const [],
+  List<ss.SmartschoolAccount> accounts = const [],
+  List<ss.SmartschoolMembership> memberships = const [],
+}) =>
+    ss.SmartschoolSnapshot(
+      fetchedAt: _d,
+      groups: groups,
+      accounts: accounts,
+      memberships: memberships,
+    );
+
+az.AzureSnapshot _aSnap({List<az.AzureUser> users = const []}) =>
+    az.AzureSnapshot(fetchedAt: _d, users: users, groups: const []);
+
+core.LinkedAccount _linkedStudent({
+  required String wisaId,
+  String classGroup = '',
+  String? ssUid,
+}) =>
+    core.LinkedAccount(
+      id: const core.LinkedAccountId('p0'),
+      role: core.PersonRole.student,
+      wisa: _wStudent(wisaId: wisaId, classGroup: classGroup),
+      smartschool: ssUid == null
+          ? null
+          : _ssAccount(uid: ssUid, accountId: wisaId, mail: '$ssUid@x'),
+      confidence: core.LinkConfidence.medium,
+    );
+
+core.LinkedGroup _linkedWisaGroup(String fullName) => core.LinkedGroup(
+      wisa: core.Group(
+        id: core.GroupId(fullName),
+        name: fullName,
+        description: '',
+        type: core.GroupType.classGroup,
+        official: true,
+        origin: core.Origin.wisa,
+      ),
+      confidence: core.LinkConfidence.medium,
+    );
+
+/// Deterministic in-memory [PersonIdResolver] (mirrors the linker's fixture).
+class _SeqResolver implements core.PersonIdResolver {
+  final Map<String, String> _seen = {};
+
+  @override
+  core.PersonId resolve(String naturalKey) =>
+      core.PersonId(_seen.putIfAbsent(naturalKey, () => 'p${_seen.length}'));
+}
+
+final _studentConfig =
+    StudentActionConfig(schoolPrefix: 'GBS', azureDomain: 'school.example');
+final _staffConfig =
+    StaffActionConfig(schoolPrefix: 'GBS', azureDomain: 'school.example');
+
+SystemState<S> _sys<S extends core.Snapshot>(core.Origin o, S? initial) =>
+    SystemState<S>(
+      system: o,
+      syncer: (_) async => initial as S,
+      initial: initial,
+    );
+
+void main() {
+  group('PlacementResolver.classPlacementFor', () {
+    test('appends the sub-group to the class name when the class uses them',
+        () {
+      final resolver = PlacementResolver(
+        wisa: _wSnap(
+          students: [
+            _wStudent(wisaId: '1', classGroup: '1A', classSubGroup: 'A'),
+          ],
+          classGroups: [
+            _wClass('1A', groupName: 'A', adminCode: 'a1'),
+            _wClass('1A', groupName: 'B', adminCode: 'a2'),
+          ],
+        ),
+        smartschool: _sSnap(),
+      );
+
+      final placement = resolver.classPlacementFor(_linkedStudent(wisaId: '1'));
+
+      expect(placement.className, '1A A');
+    });
+
+    test('uses the bare class name when the class has a single admin code', () {
+      final resolver = PlacementResolver(
+        wisa: _wSnap(
+          students: [
+            _wStudent(wisaId: '1', classGroup: '3C', classSubGroup: 'x'),
+          ],
+          classGroups: [_wClass('3C', adminCode: 'c1')],
+        ),
+        smartschool: _sSnap(),
+      );
+
+      final placement = resolver.classPlacementFor(_linkedStudent(wisaId: '1'));
+
+      expect(placement.className, '3C');
+    });
+
+    test('currentClass is the student\'s official-class membership', () {
+      final resolver = PlacementResolver(
+        wisa: _wSnap(students: [_wStudent(wisaId: '1', classGroup: '3C')]),
+        smartschool: _sSnap(
+          groups: [
+            _ssGroup('2B', code: '2B_ss'),
+            _ssGroup('Leerlingen',
+                code: 'org', official: false, type: core.GroupType.group),
+          ],
+          memberships: [_member('jane', 'org'), _member('jane', '2B_ss')],
+        ),
+      );
+
+      final placement = resolver.classPlacementFor(
+        _linkedStudent(wisaId: '1', classGroup: '3C', ssUid: 'jane'),
+      );
+
+      expect(placement.currentClass?.name, '2B');
+      expect(placement.currentClassName, '2B');
+      expect(placement.className, '3C');
+    });
+
+    test('resolveClass finds any group by name across the whole tree', () {
+      final resolver = PlacementResolver(
+        wisa: _wSnap(),
+        smartschool: _sSnap(
+          groups: [
+            _ssGroup('Leerlingen',
+                code: 'root', official: false, type: core.GroupType.group),
+            _ssGroup('1A', code: '1A_ss'),
+          ],
+        ),
+      );
+
+      final placement = resolver.classPlacementFor(_linkedStudent(wisaId: 'x'));
+
+      expect(placement.resolveClass('1A')?.id.value, '1A_ss');
+      expect(placement.resolveClass('Leerlingen')?.id.value, 'root');
+      expect(placement.resolveClass('nope'), isNull);
+    });
+  });
+
+  group('PlacementResolver.groupPlacementFor', () {
+    test('populated WISA class → containsStudents + resolved grade parent', () {
+      final resolver = PlacementResolver(
+        wisa: _wSnap(
+          students: [_wStudent(wisaId: '1', classGroup: '1A')],
+          classGroups: [_wClass('1A', adminCode: 'a1')],
+        ),
+        smartschool: _sSnap(
+          groups: [
+            _ssGroup('Eerste graad',
+                code: 'G1', official: false, type: core.GroupType.group),
+          ],
+        ),
+        classTree: const SmartschoolClassTree(grades: ['G1', 'G2', 'G3']),
+      );
+
+      final placement = resolver.groupPlacementFor(_linkedWisaGroup('1A'));
+
+      expect(placement.containsStudents, isTrue);
+      expect(placement.parent?.id.value, 'G1');
+    });
+
+    test('empty WISA class → containsStudents false (parent still resolves)',
+        () {
+      final resolver = PlacementResolver(
+        wisa: _wSnap(
+          students: [_wStudent(wisaId: '1', classGroup: '1A')],
+          classGroups: [_wClass('2B', adminCode: 'b1')],
+        ),
+        smartschool: _sSnap(
+          groups: [
+            _ssGroup('Eerste graad',
+                code: 'G1', official: false, type: core.GroupType.group),
+          ],
+        ),
+        classTree: const SmartschoolClassTree(grades: ['G1', 'G2', 'G3']),
+      );
+
+      final placement = resolver.groupPlacementFor(_linkedWisaGroup('2B'));
+
+      expect(placement.containsStudents, isFalse);
+      expect(placement.parent?.id.value, 'G1', reason: 'year 2 → first grade');
+    });
+
+    test('per-year scheme resolves the year code', () {
+      final resolver = PlacementResolver(
+        wisa: _wSnap(classGroups: [_wClass('4D', adminCode: 'd1')]),
+        smartschool: _sSnap(
+          groups: [
+            _ssGroup('Vierde jaar',
+                code: 'Y4', official: false, type: core.GroupType.group),
+          ],
+        ),
+        classTree: const SmartschoolClassTree(
+          years: ['Y1', 'Y2', 'Y3', 'Y4', 'Y5', 'Y6', 'Y7'],
+        ),
+      );
+
+      final placement = resolver.groupPlacementFor(_linkedWisaGroup('4D'));
+
+      expect(placement.parent?.id.value, 'Y4');
+    });
+
+    test('parent is null when the class year is out of range', () {
+      final resolver = PlacementResolver(
+        wisa: _wSnap(classGroups: [_wClass('KA', adminCode: 'k1')]),
+        smartschool: _sSnap(),
+        classTree: const SmartschoolClassTree(path: 'P'),
+      );
+
+      expect(resolver.groupPlacementFor(_linkedWisaGroup('KA')).parent, isNull);
+    });
+
+    test('parent is null when the resolved code is absent from the tree', () {
+      final resolver = PlacementResolver(
+        wisa: _wSnap(classGroups: [_wClass('1A', adminCode: 'a1')]),
+        smartschool: _sSnap(),
+        classTree: const SmartschoolClassTree(grades: ['G1', 'G2', 'G3']),
+      );
+
+      expect(resolver.groupPlacementFor(_linkedWisaGroup('1A')).parent, isNull);
+    });
+  });
+
+  group('LinkedState wires placementFor into the dispatchers', () {
+    test('group create actions surface only with the placement callback', () {
+      final wisa = _wSnap(
+        students: [_wStudent(wisaId: '1', classGroup: '1A')],
+        classGroups: [
+          _wClass('1A', adminCode: 'a1'),
+          _wClass('2B', adminCode: 'b1'),
+        ],
+      );
+      final smartschool = _sSnap(
+        groups: [
+          _ssGroup('Eerste graad',
+              code: 'G1', official: false, type: core.GroupType.group),
+        ],
+      );
+
+      final state = LinkedState.recompute(
+        wisa: wisa,
+        smartschool: smartschool,
+        azure: _aSnap(),
+        resolver: _SeqResolver(),
+        studentConfig: _studentConfig,
+        staffConfig: _staffConfig,
+        classTree: const SmartschoolClassTree(grades: ['G1', 'G2', 'G3']),
+      );
+
+      // 1A holds a student → AddToSmartschool; 2B is empty → CreateInSmartschool.
+      expect(state.groupActions.whereType<AddToSmartschool>(), hasLength(1));
+      expect(state.groupActions.whereType<CreateInSmartschool>(), hasLength(1));
+
+      // Without the placement callback the dispatch cannot answer "does the
+      // WISA class have students?" so neither create action is considered.
+      final unwired = groupActions(state.snapshot);
+      expect(unwired.whereType<AddToSmartschool>(), isEmpty);
+      expect(unwired.whereType<CreateInSmartschool>(), isEmpty);
+    });
+
+    test(
+        'MoveToSmartschoolClassGroup surfaces only with the placement callback',
+        () {
+      final wisa = _wSnap(students: [_wStudent(wisaId: '1', classGroup: '3C')]);
+      final smartschool = _sSnap(
+        groups: [_ssGroup('2B', code: '2B_ss')],
+        accounts: [
+          _ssAccount(uid: 'jane', accountId: '1', mail: 'jane@school.example'),
+        ],
+        memberships: [_member('jane', '2B_ss')],
+      );
+      final azure = _aSnap(
+        users: [
+          _azUser(id: 'az1', upn: 'jane@school.example', employeeId: '1'),
+        ],
+      );
+
+      final state = LinkedState.recompute(
+        wisa: wisa,
+        smartschool: smartschool,
+        azure: azure,
+        resolver: _SeqResolver(),
+        studentConfig: _studentConfig,
+        staffConfig: _staffConfig,
+      );
+
+      // The student is complete but WISA says 3C while Smartschool has them in
+      // 2B → a class move is due, and it needs the membership placement.
+      expect(
+        state.studentActions.whereType<MoveToSmartschoolClassGroup>(),
+        hasLength(1),
+      );
+
+      final unwired = studentActions(state.snapshot, _studentConfig);
+      expect(
+        unwired.whereType<MoveToSmartschoolClassGroup>(),
+        isEmpty,
+      );
+    });
+  });
+
+  group('LinkedState.fromApplication', () {
+    test('links from the three current snapshots', () {
+      final app = ApplicationState(
+        wisa: _sys(
+          core.Origin.wisa,
+          _wSnap(students: [_wStudent(wisaId: '1', classGroup: '1A')]),
+        ),
+        smartschool: _sys(core.Origin.smartschool, _sSnap()),
+        azure: _sys(core.Origin.azure, _aSnap()),
+      );
+
+      final state = LinkedState.fromApplication(
+        app,
+        resolver: _SeqResolver(),
+        studentConfig: _studentConfig,
+        staffConfig: _staffConfig,
+      );
+
+      expect(state.snapshot.accounts, hasLength(1));
+    });
+
+    test('throws when a system has not synced yet', () {
+      final app = ApplicationState(
+        wisa: _sys(core.Origin.wisa, _wSnap()),
+        smartschool: _sys(core.Origin.smartschool, _sSnap()),
+        azure: _sys<az.AzureSnapshot>(core.Origin.azure, null),
+      );
+
+      expect(
+        () => LinkedState.fromApplication(
+          app,
+          resolver: _SeqResolver(),
+          studentConfig: _studentConfig,
+          staffConfig: _staffConfig,
+        ),
+        throwsStateError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Introduces the State layer's **derived** linked view that ties `sync → link → dispatch` together, and builds the `ClassPlacement` / `GroupPlacement` inputs the membership/tree-dependent actions need. Part of the State/persistence/frontend epic; unblocked by the sync/snapshot-ownership work (#70, merged).

## Linked issue

Closes #71

## Changes

- **`PlacementResolver`** (`lib/src/link/placement.dart`) — walks the WISA + Smartschool snapshots once and exposes two tear-off-friendly callbacks:
  - `classPlacementFor` — current official class from the Smartschool memberships, class name with sub-group handling (legacy `Student.ClassName` / `UseSubGroups`), and a whole-tree name resolver.
  - `groupPlacementFor` — WISA `ContainsStudents`, plus the logical-parent lookup (`GetLogicalParent → FindByCode`) driven by the injected `SmartschoolClassTree` (legacy `StudentYear` / `StudentGrade` / `StudentPath`).
- **`SmartschoolClassTree`** — injectable class-tree config for parent resolution; Smartschool live-config, deferred out of `AppSettings` like the connection credentials.
- **`LinkedState`** (`lib/src/link/linked_state.dart`) — re-runs the pure `link()` over the current snapshots and the student/staff/group dispatchers, wiring the `placementFor` callbacks so `MoveToSmartschoolClassGroup`, the placement step in `AddStudentToSmartschool`, and group `AddToSmartschool` / `CreateInSmartschool` are considered. **Derived, never persisted** (legacy `LinkedState.SaveContent` threw) — no persistence seam; `recompute(...)` (pure) and `fromApplication(app, ...)` (throws until all three systems have synced).
- Barrel exports + library doc updated.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed packages/account_state` clean
- [x] `dart analyze packages/account_state` clean (No issues found)
- [x] unit tests pass — `dart test packages/account_state`: **56 tests (13 new)**, covering placement class/parent resolution from fixtures and the dispatch-with-vs-without-`placementFor` assertions (create actions + `MoveToSmartschoolClassGroup` surface only when the placement callback is wired)
- [ ] integration/e2e — **not warranted**: `account_state` is a pure-Dart library with no UI or user-visible flow to drive end-to-end; the change is data-layer logic fully covered by unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
