### PR TITLE
Add State-layer apply + incremental refresh (#72)

### DIFF
--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -29,6 +29,13 @@
 ///   wired through a [PlacementResolver] built from the injected
 ///   [SmartschoolClassTree] (#55 / #65).
 ///
+/// Driving the action engine and keeping the snapshots consistent afterwards:
+///
+/// - [StateApplier] — runs an action's dry-run-capable `apply()`, then on a
+///   real write patches the owning snapshot from the mutated record and
+///   re-runs `link()` with no re-sync, or (for a `DontImportFromWisa` rule)
+///   accumulates it in [WisaImportRules] and re-syncs WISA (#72).
+///
 /// Pure Dart plus `dart:io`. No Flutter.
 library;
 
@@ -38,6 +45,8 @@ library;
 export 'package:account_core/account_core.dart' show PersonId, PersonIdResolver;
 export 'package:account_store/account_store.dart' show FilePersonIdResolver;
 
+export 'src/apply/state_applier.dart';
+export 'src/apply/wisa_import_rules.dart';
 export 'src/link/linked_state.dart';
 export 'src/link/placement.dart';
 export 'src/passwords/password_entry.dart';

--- a/packages/account_state/lib/src/apply/state_applier.dart
+++ b/packages/account_state/lib/src/apply/state_applier.dart
@@ -1,0 +1,356 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart' as core;
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+
+import '../link/linked_state.dart';
+import '../link/placement.dart';
+import '../sync/application_state.dart';
+import 'wisa_import_rules.dart';
+
+/// The outcome of driving one action's `apply()` through the State layer.
+///
+/// Carries the action's own [ActionResult] plus, **only when a real write
+/// happened**, the recomputed [linked] view — the State layer patched the
+/// in-memory snapshot from the mutated record and re-ran the pure `link()`, so
+/// [linked] already reflects the change with no network re-sync (#72). On a
+/// dry run or a failed apply the snapshot is untouched, so [linked] is `null`
+/// and the caller keeps its previous [LinkedState].
+class ApplyResult {
+  const ApplyResult(this.result, this.linked);
+
+  /// The action's own result — outcome, changes, mutated record.
+  final ActionResult result;
+
+  /// The linked view recomputed after the incremental refresh, or `null` when
+  /// nothing was written (dry run / failure).
+  final LinkedState? linked;
+
+  /// Whether the snapshot was patched and [linked] recomputed.
+  bool get refreshed => linked != null;
+}
+
+/// Drives the action engine from the State layer and keeps the in-memory
+/// snapshots consistent afterwards (spec `docs/domain-model.md` §6.4; #72).
+///
+/// Sits on top of [ApplicationState] (which owns the three connector snapshots)
+/// and the pure `link()`. For each apply it:
+///
+/// 1. runs the action's `apply(connectors, options)` — a dry run performs no
+///    writes and just returns the projected [ActionResult] (PAIN-3);
+/// 2. on a successful real write, **patches the owning snapshot** from the
+///    result's mutated record ([ActionResult.smartschool] / [ActionResult.azure]
+///    / [ActionResult.group], or a removal) and re-runs `link()` — no re-sync;
+/// 3. for a `DontImportFromWisa` action (which writes nothing and returns a
+///    [ActionResult.wisaRule]), accumulates the rule in [wisaRules] and
+///    **re-syncs WISA** so the ignored record drops from the next snapshot —
+///    the one path that does hit the network again.
+///
+/// **Smartschool uid uniqueness (#72).** Because State holds the account set,
+/// this applier wraps the injected [StudentActionConfig] / [StaffActionConfig]
+/// with a `smartschoolUid` builder that disambiguates a freshly created login
+/// against the uids already in the current Smartschool snapshot (`uid`, then
+/// `uid1`, `uid2`, … — the legacy `AccountManager.CreateUID` counter). Read the
+/// current derived view (and the actions to apply) via [link], so both linking
+/// and applying use those uniqueness-aware configs.
+class StateApplier {
+  StateApplier({
+    required this.app,
+    required this.connectors,
+    required this.resolver,
+    required this.wisaRules,
+    required StudentActionConfig studentConfig,
+    required StaffActionConfig staffConfig,
+    this.classTree = const SmartschoolClassTree(),
+  })  : _studentConfig = _uniqueStudentConfig(studentConfig, _uidsFrom(app)),
+        _staffConfig = _uniqueStaffConfig(staffConfig, _uidsFrom(app));
+
+  /// The snapshots this applier reads and patches.
+  final ApplicationState app;
+
+  /// The write-capable connectors the actions call.
+  final Connectors connectors;
+
+  /// The identity seam the linker mints/persists person ids through.
+  final core.PersonIdResolver resolver;
+
+  /// The shared WISA import-rule set the `DontImportFromWisa` path grows before
+  /// re-syncing WISA. Must be the same instance the WISA [Syncer] reads (see
+  /// [WisaImportRules]).
+  final WisaImportRules wisaRules;
+
+  /// Smartschool class-tree live-config the placement resolver needs.
+  final SmartschoolClassTree classTree;
+
+  final StudentActionConfig _studentConfig;
+  final StaffActionConfig _staffConfig;
+
+  /// The uid-uniqueness-aware student config used for both linking and applying.
+  StudentActionConfig get studentConfig => _studentConfig;
+
+  /// The uid-uniqueness-aware staff config used for both linking and applying.
+  StaffActionConfig get staffConfig => _staffConfig;
+
+  /// The current derived linked view over [app]'s snapshots, built with the
+  /// uniqueness-aware configs. Rebuild the UI's action lists from this after
+  /// every sync or apply. Throws [StateError] if a system has not synced yet
+  /// (see [LinkedState.fromApplication]).
+  LinkedState link() => LinkedState.fromApplication(
+        app,
+        resolver: resolver,
+        studentConfig: _studentConfig,
+        staffConfig: _staffConfig,
+        classTree: classTree,
+      );
+
+  /// Applies a [StudentAction] and refreshes the snapshot on a real write.
+  Future<ApplyResult> applyStudent(
+    StudentAction action, {
+    ApplyOptions options = const ApplyOptions(),
+  }) async {
+    final result = await action.apply(connectors, options);
+    return _refresh(
+      result,
+      removedSmartschoolUid: action.target.smartschool?.uid,
+      removedAzureId: action.target.azure?.id,
+    );
+  }
+
+  /// Applies a [StaffAction] and refreshes the snapshot on a real write.
+  Future<ApplyResult> applyStaff(
+    StaffAction action, {
+    ApplyOptions options = const ApplyOptions(),
+  }) async {
+    final result = await action.apply(connectors, options);
+    return _refresh(
+      result,
+      removedSmartschoolUid: action.target.smartschool?.uid,
+      removedAzureId: action.target.azure?.id,
+    );
+  }
+
+  /// Applies a [GroupAction] and refreshes the snapshot on a real write.
+  Future<ApplyResult> applyGroup(
+    GroupAction action, {
+    ApplyOptions options = const ApplyOptions(),
+  }) async {
+    final result = await action.apply(connectors, options);
+    return _refresh(
+      result,
+      removedGroupId: action.target.smartschool?.id,
+    );
+  }
+
+  /// Patches the owning snapshot from [result] and re-links, unless nothing was
+  /// written. The `removed*` keys identify the record to drop for a delete
+  /// action — a delete's [ActionResult] carries no record, so the key comes
+  /// from the action's bound target (read by the typed `apply*` entry points).
+  Future<ApplyResult> _refresh(
+    ActionResult result, {
+    String? removedSmartschoolUid,
+    String? removedAzureId,
+    core.GroupId? removedGroupId,
+  }) async {
+    // Dry run or failure: the snapshot is untouched, so there is nothing to
+    // re-link — the caller keeps its previous view.
+    if (!result.wrote) return ApplyResult(result, null);
+
+    switch (result.system) {
+      case core.Origin.wisa:
+        // WISA is read-only: the action produced an import rule instead of a
+        // write. Accumulate it and re-sync WISA so the ignored record drops
+        // from the next snapshot. This is the only path that hits the network.
+        final rule = result.wisaRule;
+        if (rule != null) {
+          wisaRules.add(rule);
+          await app.sync(core.Origin.wisa);
+        }
+      case core.Origin.smartschool:
+        final current = app.smartschool.snapshot!;
+        if (result.removed) {
+          app.smartschool.patch(
+            _dropFromSmartschool(
+              current,
+              uid: removedSmartschoolUid,
+              groupId: removedGroupId,
+            ),
+          );
+        } else if (result.group != null) {
+          app.smartschool.patch(_putGroup(current, result.group!));
+        } else if (result.smartschool != null) {
+          app.smartschool.patch(_putAccount(current, result.smartschool!));
+        }
+      case core.Origin.azure:
+        final current = app.azure.snapshot!;
+        if (result.removed) {
+          app.azure.patch(_dropAzureUser(current, removedAzureId));
+        } else if (result.azure != null) {
+          app.azure.patch(_putAzureUser(current, result.azure!));
+        }
+      case core.Origin.all:
+      case core.Origin.other:
+        throw StateError(
+          'an applied action targeted the non-writable ${result.system}',
+        );
+    }
+
+    return ApplyResult(result, link());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot splicing. Each helper rebuilds an immutable snapshot with a single
+// record replaced/removed, reusing the current snapshot's `fetchedAt` so the
+// patch reads as the same fetch (a local edit, not a fresh network read).
+// ---------------------------------------------------------------------------
+
+ss.SmartschoolSnapshot _putAccount(
+  ss.SmartschoolSnapshot current,
+  core.SmartschoolAccount account,
+) {
+  final record = account as ss.SmartschoolAccount;
+  final accounts = [
+    for (final a in current.accounts)
+      if (a.uid != record.uid) a,
+    record,
+  ];
+  return ss.SmartschoolSnapshot(
+    fetchedAt: current.fetchedAt,
+    groups: current.groups,
+    accounts: accounts,
+    memberships: current.memberships,
+  );
+}
+
+ss.SmartschoolSnapshot _putGroup(
+  ss.SmartschoolSnapshot current,
+  core.Group group,
+) {
+  final groups = [
+    for (final g in current.groups)
+      if (g.id != group.id) g,
+    group,
+  ];
+  return ss.SmartschoolSnapshot(
+    fetchedAt: current.fetchedAt,
+    groups: groups,
+    accounts: current.accounts,
+    memberships: current.memberships,
+  );
+}
+
+ss.SmartschoolSnapshot _dropFromSmartschool(
+  ss.SmartschoolSnapshot current, {
+  String? uid,
+  core.GroupId? groupId,
+}) {
+  return ss.SmartschoolSnapshot(
+    fetchedAt: current.fetchedAt,
+    // Drop the group by id (no group-delete action ships yet, so this is a
+    // defensive branch), else drop the account and its now-dangling
+    // memberships by uid.
+    groups: groupId == null
+        ? current.groups
+        : [
+            for (final g in current.groups)
+              if (g.id != groupId) g,
+          ],
+    accounts: uid == null
+        ? current.accounts
+        : [
+            for (final a in current.accounts)
+              if (a.uid != uid) a,
+          ],
+    memberships: uid == null
+        ? current.memberships
+        : [
+            for (final m in current.memberships)
+              if (m.uid != uid) m,
+          ],
+  );
+}
+
+az.AzureSnapshot _putAzureUser(az.AzureSnapshot current, core.AzureUser user) {
+  final record = user as az.AzureUser;
+  final users = [
+    for (final u in current.users)
+      if (u.id != record.id) u,
+    record,
+  ];
+  return az.AzureSnapshot(
+    fetchedAt: current.fetchedAt,
+    deltaToken: current.deltaToken,
+    users: users,
+    groups: current.groups,
+  );
+}
+
+az.AzureSnapshot _dropAzureUser(az.AzureSnapshot current, String? id) {
+  return az.AzureSnapshot(
+    fetchedAt: current.fetchedAt,
+    deltaToken: current.deltaToken,
+    users: id == null
+        ? current.users
+        : [
+            for (final u in current.users)
+              if (u.id != id) u,
+          ],
+    groups: current.groups,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Uid-uniqueness-aware config wrapping (#72). State holds the account set, so
+// it disambiguates a created login against the current Smartschool uids.
+// ---------------------------------------------------------------------------
+
+/// A live view of the uids currently taken in [app]'s Smartschool snapshot,
+/// lower-cased. Read at uid-generation time so each apply sees the accounts the
+/// previous applies spliced in.
+Set<String> Function() _uidsFrom(ApplicationState app) => () => {
+      for (final a in app.smartschool.snapshot?.accounts ??
+          const <ss.SmartschoolAccount>[])
+        a.uid.toLowerCase(),
+    };
+
+StudentActionConfig _uniqueStudentConfig(
+  StudentActionConfig base,
+  Set<String> Function() taken,
+) =>
+    StudentActionConfig(
+      schoolPrefix: base.schoolPrefix,
+      azureDomain: base.azureDomain,
+      studentDomain: base.studentDomain,
+      newAccountPassword: base.newAccountPassword,
+      smartschoolUid: _uniqueUid(base.smartschoolUid, taken),
+    );
+
+StaffActionConfig _uniqueStaffConfig(
+  StaffActionConfig base,
+  Set<String> Function() taken,
+) =>
+    StaffActionConfig(
+      schoolPrefix: base.schoolPrefix,
+      azureDomain: base.azureDomain,
+      newAccountPassword: base.newAccountPassword,
+      smartschoolUid: _uniqueUid(base.smartschoolUid, taken),
+    );
+
+/// Wraps [base] so a generated uid that collides with a currently-taken one is
+/// suffixed with the lowest free counter — `uid`, then `uid1`, `uid2`, …,
+/// matching legacy `AccountManager.CreateUID`.
+String Function(String, String) _uniqueUid(
+  String Function(String, String) base,
+  Set<String> Function() taken,
+) {
+  return (givenName, surname) {
+    final baseUid = base(givenName, surname);
+    final takenLower = taken();
+    if (!takenLower.contains(baseUid.toLowerCase())) return baseUid;
+    var counter = 1;
+    while (takenLower.contains('$baseUid$counter'.toLowerCase())) {
+      counter++;
+    }
+    return '$baseUid$counter';
+  };
+}

--- a/packages/account_state/lib/src/apply/wisa_import_rules.dart
+++ b/packages/account_state/lib/src/apply/wisa_import_rules.dart
@@ -1,0 +1,67 @@
+import 'package:wisa_api/wisa_api.dart';
+
+/// A mutable, de-duplicating set of [WisaImportRule]s shared between the WISA
+/// [Syncer] and the [StateApplier].
+///
+/// WISA is read-only, so the `DontImportFromWisa` actions (student/staff
+/// [DontImportUserFromWisa], group [DontImportClass]) cannot write anything;
+/// instead they hand back a rule for the State layer to accumulate here and
+/// re-sync WISA, which drops the ignored record from the next snapshot
+/// (spec `docs/domain-model.md` §3.11; #72).
+///
+/// ## Wiring contract
+///
+/// This holder is the seam that lets [StateApplier] re-sync WISA with the
+/// accumulated rules **without** re-wiring the [SystemState]. Build it once,
+/// wire the WISA syncer to read [rules] live, then hand the same instance to
+/// the applier:
+///
+/// ```dart
+/// final importRules = WisaImportRules(initial: settings.wisaRules);
+/// final wisa = SystemState<WisaSnapshot>(
+///   system: Origin.wisa,
+///   syncer: (_) => connector.sync(
+///     schools: schools,
+///     workDate: workDate,
+///     rules: importRules.rules, // read live, so a later add() takes effect
+///   ),
+/// );
+/// // ... build ApplicationState, then:
+/// final applier = StateApplier(app: app, wisaRules: importRules, ...);
+/// ```
+///
+/// Because the syncer reads [rules] at call time, `applier` only has to
+/// [add] the new rule and trigger `app.sync(Origin.wisa)`.
+class WisaImportRules {
+  WisaImportRules({Iterable<WisaImportRule> initial = const []}) {
+    for (final rule in initial) {
+      add(rule);
+    }
+  }
+
+  final List<WisaImportRule> _rules = [];
+  final Set<String> _keys = {};
+
+  /// The accumulated rules, in insertion order. Pass this to the WISA
+  /// connector's `sync(rules: ...)` — read live so an [add] between syncs is
+  /// picked up by the next re-sync.
+  List<WisaImportRule> get rules => List.unmodifiable(_rules);
+
+  /// Adds [rule] unless a structurally-equal rule is already present. Returns
+  /// `true` if the set changed. De-duplication keeps a repeated
+  /// `DontImportFromWisa` apply (or a rule already loaded from settings) from
+  /// growing the set unbounded — applying the same rule twice is a no-op for
+  /// the snapshot either way.
+  bool add(WisaImportRule rule) {
+    if (!_keys.add(_keyOf(rule))) return false;
+    _rules.add(rule);
+    return true;
+  }
+
+  static String _keyOf(WisaImportRule rule) => switch (rule) {
+        DontImportClass(:final className) => 'class:$className',
+        DontImportUserFromWisa(:final userCode) => 'user:$userCode',
+        ReplaceInstitute(:final original) => 'institute:$original',
+        MarkAsVirtual(:final schoolCode) => 'virtual:$schoolCode',
+      };
+}

--- a/packages/account_state/lib/src/sync/system_state.dart
+++ b/packages/account_state/lib/src/sync/system_state.dart
@@ -90,6 +90,26 @@ class SystemState<S extends core.Snapshot> {
     }
   }
 
+  /// Installs [snapshot] as the current [snapshot] **without running a sync** —
+  /// the incremental-refresh primitive (#72).
+  ///
+  /// The State layer uses this to splice an action's mutated connector record
+  /// into the in-memory snapshot after a successful `apply`, so a re-`link()`
+  /// sees the change with no network re-sync (the incremental-refresh
+  /// constraint from #40). [lastSync] is deliberately left untouched: a local
+  /// patch is not a fresh fetch, so the dashboard freshness badge must not
+  /// reset. Callers build [snapshot] by copying the current one with the single
+  /// record replaced/removed and reusing its `fetchedAt`.
+  ///
+  /// Rejected while a [sync] is in flight — patching the shared snapshot slot
+  /// under an in-flight sync would race the fresh result in.
+  void patch(S snapshot) {
+    if (_syncing) {
+      throw StateError('Cannot patch $system while a sync is in progress');
+    }
+    _snapshot = snapshot;
+  }
+
   /// Probes the connector with [tester] and records the outcome in
   /// [connection] ([core.ConnectionState.ok] / [core.ConnectionState.failed]).
   /// A tester that throws counts as a failed probe. The result is transient

--- a/packages/account_state/test/state_applier_test.dart
+++ b/packages/account_state/test/state_applier_test.dart
@@ -1,0 +1,452 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+final DateTime _d = DateTime.utc(2026);
+
+const core.Address _addr = core.Address(
+  street: '',
+  houseNumber: '',
+  postalCode: '',
+  city: '',
+  country: '',
+);
+
+// ---------------------------------------------------------------------------
+// Recording fake transports: let a real action's apply() run offline while we
+// assert exactly what it wrote (a dry run must record nothing).
+// ---------------------------------------------------------------------------
+
+class _RecordingSoap implements ss.SmartschoolSoapTransport {
+  final List<String> soapActions = [];
+
+  @override
+  Future<String> send({
+    required Uri endpoint,
+    required String soapAction,
+    required String envelope,
+  }) async {
+    soapActions.add(soapAction);
+    // Every recorded write succeeds (return code 0).
+    return '<?xml version="1.0" encoding="utf-8"?>'
+        '<soap:Envelope '
+        'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        '<soap:Body><response><return>0</return></response>'
+        '</soap:Body></soap:Envelope>';
+  }
+}
+
+class _RecordingGraph implements az.GraphTransport {
+  final List<az.GraphRequest> requests = [];
+
+  @override
+  Future<az.GraphResponse> send(az.GraphRequest request) async {
+    requests.add(request);
+    return const az.GraphResponse(statusCode: 204);
+  }
+}
+
+ss.SmartschoolConnector _ssConn(_RecordingSoap t) =>
+    ss.SmartschoolConnector.fromParts(
+      site: 'demo',
+      accessCode: 'secret',
+      transport: t,
+    );
+
+az.AzureConnector _azConn(_RecordingGraph t) => az.AzureConnector(
+      credentials: az.AzureCredentials(
+        clientId: 'c',
+        tenantId: 't',
+        azureDomain: 'school.example',
+        schoolPrefix: 'SSM',
+      ),
+      authProvider: const az.StaticAuthProvider('token'),
+      transport: t,
+    );
+
+// ---------------------------------------------------------------------------
+// Record + snapshot builders.
+// ---------------------------------------------------------------------------
+
+wapi.WisaStudent _wStudent({
+  String wisaId = 'W1',
+  String firstName = 'Jan',
+  String name = 'Peeters',
+  String classGroup = '3A',
+}) =>
+    wapi.WisaStudent(
+      wisaId: core.WisaId(wisaId),
+      classGroup: classGroup,
+      classSubGroup: '00',
+      name: name,
+      firstName: firstName,
+      preferredName: '',
+      birthDate: _d,
+      stemId: '',
+      gender: core.Gender.male,
+      nationalId: '',
+      birthPlace: '',
+      nationality: '',
+      address: _addr,
+      classChange: _d,
+      schoolId: 1,
+    );
+
+wapi.WisaStaff _wStaff({String code = 'SMIT', String wisaId = '42'}) =>
+    wapi.WisaStaff(
+      code: core.WisaStaffCode(code),
+      wisaId: core.WisaId(wisaId),
+      firstName: 'Anna',
+      lastName: 'Smit',
+    );
+
+ss.SmartschoolAccount _ssAccount({
+  String uid = 'jan.peeters',
+  String accountId = 'W1',
+  String mail = 'jan.peeters@student.school.example',
+  core.PersonRole role = core.PersonRole.student,
+}) =>
+    ss.SmartschoolAccount(
+      uid: uid,
+      accountId: accountId,
+      mail: mail,
+      registerId: '',
+      stemId: 0,
+      role: role,
+      givenName: 'Jan',
+      surname: 'Peeters',
+      extraNames: '',
+      initials: '',
+      preferredName: '',
+      gender: core.Gender.male,
+      birthDate: null,
+      birthPlace: '',
+      birthCountry: '',
+      address: _addr,
+      mobilePhone: '',
+      homePhone: '',
+      fax: '',
+      untisId: '',
+      status: 'actief',
+    );
+
+az.AzureUser _azUser({
+  String id = 'az-1',
+  String upn = 'jan.peeters@student.school.example',
+  String employeeId = 'W1',
+}) =>
+    az.AzureUser(
+      id: id,
+      upn: upn,
+      employeeId: employeeId,
+      displayName: 'Jan Peeters',
+      givenName: 'Jan',
+      surname: 'Peeters',
+      companyName: 'SSM',
+      department: '3A',
+    );
+
+wapi.WisaSnapshot _wSnap({
+  List<wapi.WisaStudent> students = const [],
+  List<wapi.WisaStaff> staff = const [],
+}) =>
+    wapi.WisaSnapshot(
+      fetchedAt: _d,
+      students: students,
+      staff: staff,
+      classGroups: const [],
+      schools: const [],
+    );
+
+ss.SmartschoolSnapshot _sSnap(
+        {List<ss.SmartschoolAccount> accounts = const []}) =>
+    ss.SmartschoolSnapshot(
+      fetchedAt: _d,
+      groups: const [],
+      accounts: accounts,
+      memberships: const [],
+    );
+
+az.AzureSnapshot _aSnap({List<az.AzureUser> users = const []}) =>
+    az.AzureSnapshot(fetchedAt: _d, users: users, groups: const []);
+
+core.LinkedAccount _linkedStudent({
+  wapi.WisaStudent? wisa,
+  ss.SmartschoolAccount? smartschool,
+  az.AzureUser? azure,
+  String id = 'p0',
+}) =>
+    core.LinkedAccount(
+      id: core.LinkedAccountId(id),
+      role: core.PersonRole.student,
+      wisa: wisa,
+      smartschool: smartschool,
+      azure: azure,
+      confidence: core.LinkConfidence.high,
+    );
+
+core.LinkedStaff _linkedStaff({
+  wapi.WisaStaff? wisa,
+  ss.SmartschoolAccount? smartschool,
+  az.AzureUser? azure,
+  String id = 's0',
+}) =>
+    core.LinkedStaff(
+      id: core.LinkedAccountId(id),
+      role: core.PersonRole.teacher,
+      wisa: wisa,
+      smartschool: smartschool,
+      azure: azure,
+      confidence: core.LinkConfidence.high,
+    );
+
+/// Deterministic in-memory [core.PersonIdResolver] (mirrors the linker fixture).
+class _SeqResolver implements core.PersonIdResolver {
+  final Map<String, String> _seen = {};
+
+  @override
+  core.PersonId resolve(String naturalKey) =>
+      core.PersonId(_seen.putIfAbsent(naturalKey, () => 'p${_seen.length}'));
+}
+
+StudentActionConfig _studentConfig() => StudentActionConfig(
+      schoolPrefix: 'SSM',
+      azureDomain: 'school.example',
+      newAccountPassword: () => 'FakeP4ss!',
+    );
+
+StaffActionConfig _staffConfig() => StaffActionConfig(
+      schoolPrefix: 'SSM',
+      azureDomain: 'school.example',
+      newAccountPassword: () => 'FakeP4ss!',
+    );
+
+/// One assembled State layer: [ApplicationState] seeded with the three
+/// snapshots, a [StateApplier] wired to recording connectors, and the sync-call
+/// counters so a test can prove the incremental path did **not** re-sync.
+class _Harness {
+  _Harness({
+    wapi.WisaSnapshot? wisa,
+    List<wapi.WisaStaff> wisaBaseStaff = const [],
+    List<wapi.WisaStudent> wisaBaseStudents = const [],
+    ss.SmartschoolSnapshot? smartschool,
+    az.AzureSnapshot? azure,
+  }) {
+    final ssSnap = smartschool ?? _sSnap();
+    final azSnap = azure ?? _aSnap();
+    rules = WisaImportRules();
+
+    final wisaState = SystemState<wapi.WisaSnapshot>(
+      system: core.Origin.wisa,
+      initial: wisa ?? _wSnap(),
+      // A re-sync re-reads the base rows filtered by the current rule set —
+      // exactly what the real WISA connector does at snapshot construction.
+      syncer: (_) async {
+        counts[0]++;
+        // Students carry no drop rule; staff are filtered by the accumulated
+        // DontImportUserFromWisa rules, as the real connector does.
+        return _wSnap(
+          students: wisaBaseStudents,
+          staff: wapi.applyRulesToStaff(wisaBaseStaff, rules.rules),
+        );
+      },
+    );
+    final ssState = SystemState<ss.SmartschoolSnapshot>(
+      system: core.Origin.smartschool,
+      initial: ssSnap,
+      syncer: (_) async {
+        counts[1]++;
+        return ssSnap;
+      },
+    );
+    final azState = SystemState<az.AzureSnapshot>(
+      system: core.Origin.azure,
+      initial: azSnap,
+      syncer: (_) async {
+        counts[2]++;
+        return azSnap;
+      },
+    );
+
+    app =
+        ApplicationState(wisa: wisaState, smartschool: ssState, azure: azState);
+    applier = StateApplier(
+      app: app,
+      connectors: Connectors(smartschool: _ssConn(soap), azure: _azConn(graph)),
+      resolver: _SeqResolver(),
+      wisaRules: rules,
+      studentConfig: _studentConfig(),
+      staffConfig: _staffConfig(),
+    );
+  }
+
+  final soap = _RecordingSoap();
+  final graph = _RecordingGraph();
+  late final WisaImportRules rules;
+  late final ApplicationState app;
+  late final StateApplier applier;
+
+  /// [wisa, smartschool, azure] sync-call counters.
+  final List<int> counts = [0, 0, 0];
+}
+
+void main() {
+  group('dry run (PAIN-3)', () {
+    test('performs zero writes, returns the projected record, patches nothing',
+        () async {
+      final account = _linkedStudent(
+        wisa: _wStudent(wisaId: 'W1'),
+        smartschool: _ssAccount(accountId: 'OLD'),
+        azure: _azUser(),
+      );
+      final harness = _Harness(
+          smartschool: _sSnap(
+              accounts: [account.smartschool! as ss.SmartschoolAccount]));
+      final action = ModifyAccountId(account, harness.applier.studentConfig);
+
+      final applied =
+          await harness.applier.applyStudent(action, options: ApplyOptions.dry);
+
+      expect(harness.soap.soapActions, isEmpty,
+          reason: 'no write on a dry run');
+      expect(applied.result.outcome, ActionOutcome.dryRun);
+      expect(applied.result.smartschool?.accountId, 'W1',
+          reason: 'projected record carries the change');
+      expect(applied.refreshed, isFalse, reason: 'no state change to re-link');
+      expect(harness.app.smartschool.snapshot!.accounts.single.accountId, 'OLD',
+          reason: 'the in-memory snapshot is untouched');
+      expect(harness.counts, [0, 0, 0]);
+    });
+  });
+
+  group('incremental refresh on a real Smartschool write', () {
+    test('patches the owning snapshot and re-links with no second sync',
+        () async {
+      final account = _linkedStudent(
+        wisa: _wStudent(wisaId: 'W1'),
+        smartschool: _ssAccount(uid: 'jan.peeters', accountId: 'OLD'),
+        azure: _azUser(),
+      );
+      final harness = _Harness(
+        smartschool:
+            _sSnap(accounts: [account.smartschool! as ss.SmartschoolAccount]),
+      );
+      final action = ModifyAccountId(account, harness.applier.studentConfig);
+
+      final applied = await harness.applier.applyStudent(action);
+
+      expect(applied.result.wrote, isTrue);
+      expect(harness.soap.soapActions, isNotEmpty,
+          reason: 'the write happened');
+      // The snapshot now carries the mutated record, spliced in by uid.
+      final patched = harness.app.smartschool.snapshot!.accounts
+          .singleWhere((a) => a.uid == 'jan.peeters');
+      expect(patched.accountId, 'W1');
+      expect(applied.refreshed, isTrue, reason: 're-linked from the patch');
+      expect(harness.counts, [0, 0, 0],
+          reason: 'incremental refresh must not hit the network');
+      expect(harness.app.smartschool.lastSync, _d,
+          reason: 'a patch is not a fresh fetch, so lastSync is unchanged');
+    });
+
+    test('a delete drops the record (and its memberships) from the snapshot',
+        () async {
+      final account = _linkedStudent(
+        smartschool: _ssAccount(uid: 'ghost', accountId: 'G1'),
+      );
+      final harness = _Harness(
+        smartschool:
+            _sSnap(accounts: [account.smartschool! as ss.SmartschoolAccount]),
+      );
+      final action =
+          DeleteStudentFromSmartschool(account, harness.applier.studentConfig);
+
+      final applied = await harness.applier.applyStudent(action);
+
+      expect(applied.result.removed, isTrue);
+      expect(harness.app.smartschool.snapshot!.accounts, isEmpty,
+          reason: 'the removed account is spliced out by uid');
+      expect(applied.refreshed, isTrue);
+      expect(harness.counts, [0, 0, 0]);
+    });
+  });
+
+  group('DontImportFromWisa re-sync path', () {
+    test('accumulates the rule and re-syncs WISA to drop the record', () async {
+      final staff = _linkedStaff(wisa: _wStaff(code: 'SMIT'));
+      final harness = _Harness(
+        wisa: _wSnap(staff: [_wStaff(code: 'SMIT'), _wStaff(code: 'KEEP')]),
+        wisaBaseStaff: [_wStaff(code: 'SMIT'), _wStaff(code: 'KEEP')],
+      );
+      final action =
+          DontImportStaffFromWisa(staff, harness.applier.staffConfig);
+
+      // Precondition: SMIT is present before the rule is applied.
+      expect(
+        harness.app.wisa.snapshot!.staff.map((s) => s.code.value),
+        containsAll(['SMIT', 'KEEP']),
+      );
+
+      final applied = await harness.applier.applyStaff(action);
+
+      expect(applied.result.wrote, isTrue);
+      expect(harness.soap.soapActions, isEmpty,
+          reason: 'WISA is read-only — the action writes nothing itself');
+      expect(
+          harness.rules.rules
+              .whereType<wapi.DontImportUserFromWisa>()
+              .single
+              .userCode,
+          'SMIT');
+      expect(harness.counts[0], 1, reason: 'WISA was re-synced exactly once');
+      expect(harness.counts[1], 0);
+      expect(harness.counts[2], 0);
+      // The re-sync applied the rule: SMIT is gone, KEEP remains.
+      expect(
+        harness.app.wisa.snapshot!.staff.map((s) => s.code.value),
+        ['KEEP'],
+      );
+      expect(applied.refreshed, isTrue);
+    });
+  });
+
+  group('Smartschool uid uniqueness for created accounts (#72)', () {
+    test(
+        'suffixes a colliding login and stays unique across sequential creates',
+        () async {
+      // The snapshot already holds "jan.peeters"; two new Jan Peeters students
+      // are created back-to-back.
+      final harness = _Harness(
+        smartschool: _sSnap(accounts: [_ssAccount(uid: 'jan.peeters')]),
+      );
+
+      core.LinkedAccount fresh(String id, String wisaId) => _linkedStudent(
+            id: id,
+            wisa: _wStudent(wisaId: wisaId),
+            azure: _azUser(id: 'az-$id', upn: '$id@student.school.example'),
+          );
+
+      final first = await harness.applier.applyStudent(
+        AddStudentToSmartschool(
+            fresh('p1', 'W101'), harness.applier.studentConfig),
+      );
+      final second = await harness.applier.applyStudent(
+        AddStudentToSmartschool(
+            fresh('p2', 'W102'), harness.applier.studentConfig),
+      );
+
+      expect(first.result.smartschool?.uid, 'jan.peeters1',
+          reason: 'base login taken → first free counter');
+      expect(second.result.smartschool?.uid, 'jan.peeters2',
+          reason: 'reads the snapshot the first create was spliced into');
+      expect(
+        harness.app.smartschool.snapshot!.accounts.map((a) => a.uid),
+        containsAll(['jan.peeters', 'jan.peeters1', 'jan.peeters2']),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds the State-layer driver for the action engine (Phase A, #72). It runs an action's dry-run-capable `apply()` and, on a real write, keeps the in-memory snapshots consistent by **patching the mutated record and re-running the pure `link()` — no network re-sync**. The one exception is `DontImportFromWisa`, which (WISA being read-only) accumulates an import rule and re-syncs WISA so the ignored record drops from the next snapshot.

## Linked issue
Closes #72

## Changes
- **`SystemState.patch(snapshot)`** — the incremental-refresh primitive: installs a snapshot without a sync, leaving `lastSync` untouched (a local patch is not a fresh fetch); rejected while a sync is in flight.
- **`StateApplier`** (new) — `applyStudent` / `applyStaff` / `applyGroup`:
  - dry run → projected `ActionResult`, zero writes, snapshot untouched, no re-link;
  - real write → patch the owning snapshot from `ActionResult.smartschool` / `.azure` / `.group` (or a removal, keyed off the action's bound target since a delete carries no record) and re-run `link()`;
  - `DontImportFromWisa` (student/staff `DontImportUserFromWisa`, group `DontImportClass`) → accumulate the `WisaImportRule` and re-sync WISA — the only path that hits the network.
- **`WisaImportRules`** (new) — the shared, de-duplicating rule set the WISA `Syncer` reads live and the applier grows.
- **Smartschool uid uniqueness** — the applier wraps the injected `StudentActionConfig` / `StaffActionConfig` with a `smartschoolUid` builder that disambiguates a created login against the current Smartschool account set (`uid`, `uid1`, `uid2`, … — the legacy `AccountManager.CreateUID` counter).

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` clean (164 files)
- [x] `dart analyze` (workspace) clean — No issues found
- [x] unit tests pass — full workspace green (8 packages); `account_state` 61 tests, incl. 5 new: dry-run zero-writes + projected record, real-apply patch + re-link with **no second sync**, delete splices the record (and memberships) out, WISA rule accumulation + re-sync drop, sequential-create uid uniqueness (`jan.peeters` → `jan.peeters1` → `jan.peeters2`).
- [ ] integration/e2e — **not applicable**: this is a pure-Dart State-orchestration layer with no UI/runtime surface (the Flutter app is still empty), fully covered by unit tests. It will be exercised end-to-end once the Views layer lands.

## Notes
- No group *delete* action exists yet (group actions only create/modify or emit rules), so the group-removal branch is defensive and not driven by a real action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
