### PR TITLE
Phase B0: Azure infra foundation + Dart↔SQL connectivity seam (#82)

### DIFF
--- a/.azuresql.env.example
+++ b/.azuresql.env.example
@@ -1,0 +1,21 @@
+# Live Azure SQL config for the opt-in, read-only auth-foundation check
+# (packages/account_state/test/integration/azure_sql_live_test.dart, issue #82).
+#
+# Copy this file to `.azuresql.env` (gitignored) and fill in the server and
+# database. Leave AZURE_SQL_ACCESS_TOKEN blank: it is a bearer token for the
+# SQL resource and expires in ~1 hour, so mint a fresh one per run rather than
+# storing it, e.g.:
+#
+#     $env:AZURE_SQL_ACCESS_TOKEN = az account get-access-token `
+#       --resource https://database.windows.net/ --query accessToken -o tsv
+#
+# The check reads the token, asserts it is scoped to the SQL resource and not
+# expired, and does NOT write to the database (repo live-testing policy).
+#
+# AZURE_SQL_SERVER   the fully-qualified server host.
+# AZURE_SQL_DATABASE the database (catalog) name.
+# AZURE_SQL_ACCESS_TOKEN a bearer token for https://database.windows.net/.
+
+AZURE_SQL_SERVER=accountmanager-sql-arcadia.database.windows.net
+AZURE_SQL_DATABASE=accountmanager
+AZURE_SQL_ACCESS_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -305,3 +305,6 @@ packages/azure_api/captures/
 
 # Populated .azure.env (real token/ids). Only .azure.env.example is committed.
 .azure.env
+
+# Populated .azuresql.env (real server/db). Only .azuresql.env.example is committed.
+.azuresql.env

--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -93,12 +93,42 @@ Two seams keep the model clean:
   an argument instead of reading `DateTime.now()` internally, so the model has
   no hidden clock and round-trips deterministically.
 
-### Phase B — centralized Azure SQL persistence *(not started, epic #74)*
+### Phase B — centralized Azure SQL persistence *(epic #74, in progress)*
 
 Swap the file-backed defaults (`FilePersonIdResolver`, `FileSettingsStore`,
 `FilePasswordQueueStore`) and the `InMemorySecretProvider` for centralized
 adapters — Azure SQL for the shared state, Key Vault for the secrets — so the
 tool can move to team maintenance. Nothing above the seams changes.
+
+Sliced into per-adapter issues: **#82** foundation (this slice), **#83**
+settings, **#84** secrets, **#85** PersonId resolver, **#86** password queue.
+
+**Provisioned infrastructure** (subscription *Yvan's Azure*, region
+`belgiumcentral`, resource group `accountmanager-rg`):
+
+| Resource | Name | Notes |
+|---|---|---|
+| SQL server | `accountmanager-sql-arcadia.database.windows.net` | AAD-only auth; no SQL login. AAD admin: the operator identity. |
+| SQL database | `accountmanager` | Serverless `GP_S_Gen5`, min 0.5 vCore, auto-pause 60 min, local backup — near-zero idle cost. |
+| Key Vault | `accountmanager-kv` (`https://accountmanager-kv.vault.azure.net/`) | RBAC-authorized; operator holds *Key Vault Secrets Officer*. |
+
+Firewall allows Azure services plus the operator's client IP. AAD-only means
+every connection carries a per-operator bearer token minted for
+`https://database.windows.net/` — no shared database secret exists.
+
+**Connectivity decision (spike, #82): ODBC Driver 18 via FFI.** Dart has no
+production-grade pure-Dart Azure SQL / TDS driver; the community Flutter plugins
+(`mssql_connection`, `sql_conn`) are method-channel/mobile-oriented, not pure
+Dart. Since the frontend is a **Windows desktop** app (Phase C), the adapters
+will use FFI over the Microsoft **ODBC Driver 18 for SQL Server** (`msodbcsql18`,
+a standard redistributable bundled with the installer), authenticated with the
+AAD token. A REST front (Data API builder / Function) was rejected because it
+reintroduces the hosting the epic deliberately avoids. The DB + AAD-only +
+token-auth round-trip was **proven end to end** during the spike (connect →
+create table → insert → read back `roundtrip-ok` → drop, `SUSER_SNAME()` =
+the operator UPN); the Dart-side ODBC factory and its DB round-trip test land
+with the first adapter slice (#83). The `account_state` connection/auth seam
+(`SqlConnection` / `SqlConnectionFactory` / `AadTokenProvider`) is in place now.
 
 ### Phase C — Flutter Windows desktop app *(not started, epic #75)*
 

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -9,6 +9,10 @@
 /// - `PersonIdResolver` (re-exported from `account_core`) — the identity seam,
 ///   with `account_store`'s [FilePersonIdResolver] as the default
 ///   implementation.
+/// - [SqlConnection] / [SqlConnectionFactory] + [AadTokenProvider] — the
+///   connection/auth seam the Phase B Azure SQL adapters plug into (#74). The
+///   database is AAD-only, so a connection is authenticated with a per-operator
+///   bearer token; the concrete ODBC/FFI factory lands with the first adapter.
 ///
 /// Every seam has an in-memory default so the layer is testable headlessly
 /// with zero network and zero infra. The persist-vs-derive split — what is
@@ -57,5 +61,9 @@ export 'src/settings/import_rule_codec.dart';
 export 'src/settings/secret_provider.dart';
 export 'src/settings/settings_store.dart';
 export 'src/settings/work_date.dart';
+export 'src/sql/aad_token_provider.dart';
+export 'src/sql/azure_sql_config.dart';
+export 'src/sql/azure_sql_live_config.dart';
+export 'src/sql/sql_connection.dart';
 export 'src/sync/application_state.dart';
 export 'src/sync/system_state.dart';

--- a/packages/account_state/lib/src/sql/aad_token_provider.dart
+++ b/packages/account_state/lib/src/sql/aad_token_provider.dart
@@ -1,0 +1,36 @@
+/// The authentication seam for the centralized Azure SQL database.
+///
+/// The Phase B database is provisioned **AAD-only** — there is no SQL login and
+/// no stored database password (issue #82, PROJECT_OVERVIEW §6.2's plaintext
+/// credentials are exactly what the port removes). Each operator connects with
+/// their own Azure AD identity, so a connection needs a short-lived bearer
+/// token minted for the SQL resource (`https://database.windows.net/`).
+///
+/// This interface hides *how* that token is obtained the same way
+/// [AzureConnector]'s `AuthProvider` does for Graph: production wires an
+/// interactive / `az` / MSAL-backed implementation (deferred to the adapter
+/// slices), while tests and headless runs inject a [StaticAadTokenProvider].
+/// Nothing above the seam knows which.
+abstract interface class AadTokenProvider {
+  /// Returns a valid bearer token for the Azure SQL resource
+  /// (`https://database.windows.net/`). Implementations may cache and refresh;
+  /// callers should treat each returned value as short-lived and re-read before
+  /// opening a new connection rather than holding one indefinitely.
+  Future<String> databaseAccessToken();
+}
+
+/// An [AadTokenProvider] that returns a pre-acquired token verbatim.
+///
+/// The default for headless tests and the opt-in live check: the token is
+/// minted outside the process (e.g. `az account get-access-token --resource
+/// https://database.windows.net/`) and handed in, so the package never shells
+/// out or drives an interactive sign-in. Mirrors `azure_api`'s
+/// `StaticAuthProvider`.
+class StaticAadTokenProvider implements AadTokenProvider {
+  const StaticAadTokenProvider(this._token);
+
+  final String _token;
+
+  @override
+  Future<String> databaseAccessToken() async => _token;
+}

--- a/packages/account_state/lib/src/sql/azure_sql_config.dart
+++ b/packages/account_state/lib/src/sql/azure_sql_config.dart
@@ -1,0 +1,45 @@
+/// The connection target for the centralized Azure SQL database.
+///
+/// Phase B moves the shared state off per-operator files (`FileSettingsStore`,
+/// `FilePersonIdResolver`, `FilePasswordQueueStore`) into one Azure SQL
+/// database (epic #74). This value type names *where* that database lives —
+/// the server host and catalog — and nothing more. It is deliberately free of
+/// credentials: authentication is a separate seam ([AadTokenProvider]), so the
+/// target can round-trip through settings or a log line without leaking a
+/// secret (the same discipline `SecretRef` applies to the config blob).
+///
+/// The concrete server/catalog names for this deployment are recorded in
+/// `docs/port-plan.md`, not hard-coded here, so the library stays independent
+/// of any one environment.
+class AzureSqlConfig {
+  const AzureSqlConfig({required this.server, required this.database});
+
+  /// The fully-qualified server host, e.g.
+  /// `accountmanager-sql-arcadia.database.windows.net`.
+  final String server;
+
+  /// The database (catalog) name on [server], e.g. `accountmanager`.
+  final String database;
+
+  /// Serializes to a JSON-encodable map. Carries no secret, so it is safe to
+  /// persist next to the rest of [AppSettings].
+  Map<String, dynamic> toJson() => {'server': server, 'database': database};
+
+  /// Reconstructs an [AzureSqlConfig] from a map produced by [toJson].
+  factory AzureSqlConfig.fromJson(Map<String, dynamic> json) => AzureSqlConfig(
+        server: json['server'] as String,
+        database: json['database'] as String,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is AzureSqlConfig &&
+      other.server == server &&
+      other.database == database;
+
+  @override
+  int get hashCode => Object.hash(server, database);
+
+  @override
+  String toString() => 'AzureSqlConfig($server/$database)';
+}

--- a/packages/account_state/lib/src/sql/azure_sql_live_config.dart
+++ b/packages/account_state/lib/src/sql/azure_sql_live_config.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+/// Configuration for the opt-in, **read-only** Azure SQL live check
+/// (`test/integration/azure_sql_live_test.dart`).
+///
+/// The check verifies the *authentication foundation* from Dart: that an
+/// operator can mint a bearer token scoped to the SQL resource
+/// (`https://database.windows.net/`) against the real tenant. It does not write
+/// to the database — honouring the repo live-testing policy — and does not need
+/// a driver, so it runs before the ODBC adapter exists. The full DB round-trip
+/// was proven by the connectivity spike (see `docs/port-plan.md`) and is
+/// re-exercised in Dart once the adapter lands (#83).
+///
+/// Offline unit tests never read this. See `.azuresql.env.example` at the
+/// repository root for the variable names.
+class AzureSqlLiveConfig {
+  const AzureSqlLiveConfig({
+    required this.server,
+    required this.database,
+    required this.accessToken,
+  });
+
+  /// The fully-qualified server host under test.
+  final String server;
+
+  /// The database (catalog) name under test.
+  final String database;
+
+  /// A pre-acquired bearer token for `https://database.windows.net/`. Expires
+  /// in ~1 hour, so it is minted fresh per run rather than stored (e.g.
+  /// `az account get-access-token --resource https://database.windows.net/`).
+  final String accessToken;
+
+  /// Names of the environment variables, in canonical order.
+  static const List<String> envVarNames = [
+    'AZURE_SQL_SERVER',
+    'AZURE_SQL_DATABASE',
+    'AZURE_SQL_ACCESS_TOKEN',
+  ];
+
+  /// Reads config from environment variables (defaulting to
+  /// `Platform.environment`). Returns `null` when `AZURE_SQL_ACCESS_TOKEN` is
+  /// empty or missing — the integration test uses this as its skip signal, so
+  /// `dart test` stays offline by default.
+  ///
+  /// Throws [ArgumentError] when `AZURE_SQL_ACCESS_TOKEN` is set but one of the
+  /// other required variables is missing.
+  static AzureSqlLiveConfig? fromEnvironment([Map<String, String>? env]) {
+    final source = env ?? Platform.environment;
+    final accessToken = (source['AZURE_SQL_ACCESS_TOKEN'] ?? '').trim();
+    if (accessToken.isEmpty) return null;
+
+    String required(String name) {
+      final value = (source[name] ?? '').trim();
+      if (value.isEmpty) {
+        throw ArgumentError(
+          'AZURE_SQL_ACCESS_TOKEN is set but $name is missing or empty.',
+        );
+      }
+      return value;
+    }
+
+    return AzureSqlLiveConfig(
+      server: required('AZURE_SQL_SERVER'),
+      database: required('AZURE_SQL_DATABASE'),
+      accessToken: accessToken,
+    );
+  }
+}

--- a/packages/account_state/lib/src/sql/sql_connection.dart
+++ b/packages/account_state/lib/src/sql/sql_connection.dart
@@ -1,0 +1,54 @@
+import 'azure_sql_config.dart';
+import 'aad_token_provider.dart';
+
+/// One row of a query result: column name to value.
+typedef SqlRow = Map<String, Object?>;
+
+/// An open, authenticated connection to the centralized Azure SQL database.
+///
+/// The seam the four Phase B adapters plug into (issue #74): the Azure-backed
+/// `SettingsStore`, `SecretProvider` companion, `PersonIdResolver`, and
+/// `PasswordQueueStore` all read and write through this surface instead of
+/// touching a driver directly, exactly as they hide disk behind their existing
+/// file-backed defaults. Keeping the surface this small means the adapters are
+/// unit-testable against a hand-written fake and only one class binds the real
+/// driver.
+///
+/// [transaction] is not a convenience: the DB-backed PersonId resolver (#85)
+/// mints one id per natural key under a unique constraint, and needs the
+/// insert-or-fetch to run atomically so two operators converge on the same id.
+///
+/// The concrete implementation is FFI over the Microsoft ODBC Driver 18 for SQL
+/// Server (`msodbcsql18`), authenticated with the [AadTokenProvider] token —
+/// see the connectivity decision in `docs/port-plan.md`. It is built in the
+/// first adapter slice (#83) so it lands with a real consumer; there is no
+/// pure-Dart TDS driver to use instead.
+abstract interface class SqlConnection {
+  /// Runs [sql] and returns the result rows. Parameters are passed positionally
+  /// as [params] and bound by the driver (never string-interpolated), so a
+  /// value can never be read as SQL.
+  Future<List<SqlRow>> query(String sql, [List<Object?> params]);
+
+  /// Runs [sql] as a statement and returns the number of affected rows.
+  Future<int> execute(String sql, [List<Object?> params]);
+
+  /// Runs [action] inside a single database transaction, passing a connection
+  /// scoped to it. Commits when [action] completes, rolls back if it throws.
+  Future<T> transaction<T>(Future<T> Function(SqlConnection tx) action);
+
+  /// Releases the underlying connection. A no-op if already closed.
+  Future<void> close();
+}
+
+/// Opens [SqlConnection]s to a configured Azure SQL database.
+///
+/// Injected wherever the adapters are constructed, the same way `azure_api`
+/// takes an `AuthProvider`: production wires the ODBC/FFI factory, tests wire a
+/// fake that returns a scripted [SqlConnection]. [open] reads a fresh token
+/// from [tokens] each call, so a connection never outlives its bearer token.
+abstract interface class SqlConnectionFactory {
+  /// Opens a connection to [config], authenticating with a token read from
+  /// [tokens]. The caller owns the returned connection and must [
+  /// SqlConnection.close] it (directly or via the orchestration layer).
+  Future<SqlConnection> open(AzureSqlConfig config, AadTokenProvider tokens);
+}

--- a/packages/account_state/test/integration/azure_sql_live_test.dart
+++ b/packages/account_state/test/integration/azure_sql_live_test.dart
@@ -1,0 +1,78 @@
+@Timeout(Duration(minutes: 1))
+library;
+
+import 'dart:convert';
+
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+
+/// Opt-in, **read-only** live check of the Azure SQL authentication foundation
+/// (issue #82).
+///
+/// The Phase B database is AAD-only, so before any adapter can read or write it
+/// an operator must be able to mint a bearer token scoped to the SQL resource
+/// (`https://database.windows.net/`) against the real tenant. This test proves
+/// exactly that half of the foundation from Dart: it drives the [
+/// AadTokenProvider] seam over the supplied token and asserts the token is live
+/// and correctly scoped. It performs **no** database write, honouring the repo
+/// live-testing policy.
+///
+/// The full connect + write + read-back round-trip was proven by the
+/// connectivity spike (`docs/port-plan.md`) and is re-exercised in Dart once
+/// the ODBC/FFI adapter lands (#83), which is the first slice with a real DB
+/// consumer.
+///
+/// Runs only when `AZURE_SQL_ACCESS_TOKEN` (+ server/database) is present;
+/// otherwise it is skipped, so `dart test` stays offline by default.
+void main() {
+  final config = AzureSqlLiveConfig.fromEnvironment();
+
+  group(
+    'Azure SQL live (auth foundation, read-only)',
+    () {
+      test('the AAD token is scoped to the SQL resource and not expired',
+          () async {
+        final AadTokenProvider tokens =
+            StaticAadTokenProvider(config!.accessToken);
+        final token = await tokens.databaseAccessToken();
+
+        final claims = _decodeJwtClaims(token);
+
+        // Audience must be the Azure SQL resource, not Graph or another API.
+        final audience = claims['aud'];
+        expect(
+          audience is String && audience.contains('database.windows.net'),
+          isTrue,
+          reason: 'token audience should be the SQL resource, got: $audience',
+        );
+
+        // Token must still be valid — a future `exp` (seconds since epoch).
+        final exp = claims['exp'];
+        expect(exp, isA<int>());
+        final expiry = DateTime.fromMillisecondsSinceEpoch((exp as int) * 1000,
+            isUtc: true);
+        expect(
+          expiry.isAfter(DateTime.now().toUtc()),
+          isTrue,
+          reason: 'token already expired at $expiry',
+        );
+      });
+    },
+    skip: config == null
+        ? 'Set AZURE_SQL_ACCESS_TOKEN (+ AZURE_SQL_SERVER/DATABASE) to run.'
+        : false,
+  );
+}
+
+/// Decodes the claims (payload) segment of a JWT without verifying its
+/// signature — enough to assert audience and expiry on a token we just minted.
+Map<String, dynamic> _decodeJwtClaims(String jwt) {
+  final parts = jwt.split('.');
+  if (parts.length != 3) {
+    throw FormatException(
+        'not a JWT: expected 3 segments, got ${parts.length}');
+  }
+  final normalized = base64Url.normalize(parts[1]);
+  final payload = utf8.decode(base64Url.decode(normalized));
+  return jsonDecode(payload) as Map<String, dynamic>;
+}

--- a/packages/account_state/test/sql/azure_sql_live_config_test.dart
+++ b/packages/account_state/test/sql/azure_sql_live_config_test.dart
@@ -1,0 +1,50 @@
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AzureSqlLiveConfig.fromEnvironment', () {
+    test('returns null with no environment', () {
+      expect(AzureSqlLiveConfig.fromEnvironment(const {}), isNull);
+    });
+
+    test('returns null when the access token is blank', () {
+      expect(
+        AzureSqlLiveConfig.fromEnvironment(
+            const {'AZURE_SQL_ACCESS_TOKEN': '  '}),
+        isNull,
+      );
+    });
+
+    test('reads all fields when fully configured', () {
+      final config = AzureSqlLiveConfig.fromEnvironment(const {
+        'AZURE_SQL_SERVER': 'srv.database.windows.net',
+        'AZURE_SQL_DATABASE': 'accountmanager',
+        'AZURE_SQL_ACCESS_TOKEN': 'tok',
+      });
+
+      expect(config, isNotNull);
+      expect(config!.server, 'srv.database.windows.net');
+      expect(config.database, 'accountmanager');
+      expect(config.accessToken, 'tok');
+    });
+
+    test('throws when the token is set but another field is missing', () {
+      expect(
+        () => AzureSqlLiveConfig.fromEnvironment(const {
+          'AZURE_SQL_ACCESS_TOKEN': 'tok',
+          'AZURE_SQL_SERVER': 'srv.database.windows.net',
+          // AZURE_SQL_DATABASE missing
+        }),
+        throwsArgumentError,
+      );
+    });
+
+    test('exposes its variable names in canonical order', () {
+      expect(AzureSqlLiveConfig.envVarNames, [
+        'AZURE_SQL_SERVER',
+        'AZURE_SQL_DATABASE',
+        'AZURE_SQL_ACCESS_TOKEN',
+      ]);
+    });
+  });
+}

--- a/packages/account_state/test/sql/sql_seam_test.dart
+++ b/packages/account_state/test/sql/sql_seam_test.dart
@@ -1,0 +1,147 @@
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+
+/// A scripted [SqlConnection] for headless adapter tests: it records every
+/// statement it is handed and replays canned rows, so an adapter can be driven
+/// with no database. The real ODBC/FFI connection lands with the first adapter
+/// slice (#83); until then this proves the seam's contract composes.
+class _RecordingConnection implements SqlConnection {
+  _RecordingConnection([this._rows = const []]);
+
+  final List<SqlRow> _rows;
+  final List<String> statements = [];
+  bool closed = false;
+
+  @override
+  Future<List<SqlRow>> query(String sql,
+      [List<Object?> params = const []]) async {
+    statements.add(sql);
+    return _rows;
+  }
+
+  @override
+  Future<int> execute(String sql, [List<Object?> params = const []]) async {
+    statements.add(sql);
+    return 1;
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function(SqlConnection tx) action) =>
+      action(this);
+
+  @override
+  Future<void> close() async => closed = true;
+}
+
+class _FakeFactory implements SqlConnectionFactory {
+  _FakeFactory(this._connection);
+  final _RecordingConnection _connection;
+
+  AzureSqlConfig? openedWith;
+  String? tokenUsed;
+
+  @override
+  Future<SqlConnection> open(
+    AzureSqlConfig config,
+    AadTokenProvider tokens,
+  ) async {
+    openedWith = config;
+    tokenUsed = await tokens.databaseAccessToken();
+    return _connection;
+  }
+}
+
+void main() {
+  group('AzureSqlConfig', () {
+    const config = AzureSqlConfig(
+      server: 'accountmanager-sql-arcadia.database.windows.net',
+      database: 'accountmanager',
+    );
+
+    test('round-trips through JSON', () {
+      final restored = AzureSqlConfig.fromJson(config.toJson());
+      expect(restored, equals(config));
+    });
+
+    test('value equality distinguishes server and database', () {
+      expect(
+        config,
+        isNot(equals(const AzureSqlConfig(
+          server: 'other.database.windows.net',
+          database: 'accountmanager',
+        ))),
+      );
+      expect(
+        config,
+        isNot(equals(const AzureSqlConfig(
+          server: 'accountmanager-sql-arcadia.database.windows.net',
+          database: 'other',
+        ))),
+      );
+    });
+
+    test('toString names the target without a credential', () {
+      expect(config.toString(), contains('accountmanager'));
+    });
+  });
+
+  group('StaticAadTokenProvider', () {
+    test('returns the injected token verbatim', () async {
+      const provider = StaticAadTokenProvider('bearer-xyz');
+      expect(await provider.databaseAccessToken(), 'bearer-xyz');
+    });
+  });
+
+  group('SqlConnection seam', () {
+    test('factory opens with the config and a freshly read token', () async {
+      final connection = _RecordingConnection();
+      final factory = _FakeFactory(connection);
+      const config = AzureSqlConfig(server: 'srv', database: 'db');
+
+      final opened = await factory.open(
+        config,
+        const StaticAadTokenProvider('tok-1'),
+      );
+
+      expect(identical(opened, connection), isTrue);
+      expect(factory.openedWith, equals(config));
+      expect(factory.tokenUsed, 'tok-1');
+    });
+
+    test('query and execute forward their statements', () async {
+      final connection = _RecordingConnection([
+        {'note': 'roundtrip-ok'},
+      ]);
+
+      final rows = await connection.query('SELECT note FROM probe');
+      final affected =
+          await connection.execute('INSERT INTO probe VALUES (?)', ['x']);
+
+      expect(rows.single['note'], 'roundtrip-ok');
+      expect(affected, 1);
+      expect(connection.statements, [
+        'SELECT note FROM probe',
+        'INSERT INTO probe VALUES (?)',
+      ]);
+    });
+
+    test('transaction passes a connection scoped to it', () async {
+      final connection = _RecordingConnection();
+
+      final result = await connection.transaction((tx) async {
+        await tx.execute('INSERT INTO ids VALUES (?)', ['wisa:123']);
+        return 'committed';
+      });
+
+      expect(result, 'committed');
+      expect(connection.statements, ['INSERT INTO ids VALUES (?)']);
+    });
+
+    test('close is idempotent-safe and marks the connection closed', () async {
+      final connection = _RecordingConnection();
+      await connection.close();
+      await connection.close();
+      expect(connection.closed, isTrue);
+    });
+  });
+}

--- a/tool/live-tests.ps1
+++ b/tool/live-tests.ps1
@@ -17,17 +17,24 @@
   Each connector's test self-skips when its trigger var is absent, so a
   missing .env file just skips that connector rather than failing.
 
+  Azure SQL works the same way as Azure: the bearer token is minted fresh for
+  the SQL resource (https://database.windows.net/) rather than stored, and the
+  server/database names come from .azuresql.env. That check is read-only -- it
+  verifies the operator can mint a SQL-scoped token, and does not write to the
+  database.
+
 .PARAMETER Only
-  Restrict the run to one connector: wisa, smartschool, or azure.
+  Restrict the run to one connector: wisa, smartschool, azure, or azuresql.
   Default: all.
 
 .EXAMPLE
   ./tool/live-tests.ps1
   ./tool/live-tests.ps1 -Only azure
+  ./tool/live-tests.ps1 -Only azuresql
 #>
 [CmdletBinding()]
 param(
-  [ValidateSet('all', 'wisa', 'smartschool', 'azure')]
+  [ValidateSet('all', 'wisa', 'smartschool', 'azure', 'azuresql')]
   [string]$Only = 'all'
 )
 
@@ -71,6 +78,17 @@ try {
     }
     $env:AZURE_ACCESS_TOKEN = $tok
     $dirs += 'packages/azure_api/test/integration/'
+  }
+
+  if ($Only -in @('all', 'azuresql')) {
+    Import-EnvFile (Join-Path $repoRoot '.azuresql.env')
+    Write-Host "  minting fresh read-only Azure SQL token via az..."
+    $sqlTok = az account get-access-token --resource https://database.windows.net/ --query accessToken -o tsv
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($sqlTok)) {
+      throw "az account get-access-token failed. Run 'az login' first (with an account that is an AAD admin on the SQL server)."
+    }
+    $env:AZURE_SQL_ACCESS_TOKEN = $sqlTok
+    $dirs += 'packages/account_state/test/integration/'
   }
 
   $dirList = $dirs -join ' '


### PR DESCRIPTION
## Summary

Foundation slice of the Phase B epic (#74). Stands up the shared Azure infrastructure, settles the one architectural fork that blocks every adapter — **how Dart talks to Azure SQL** (no first-party TDS driver exists) — with evidence, and adds the connection/auth seam the four adapter slices plug into. Nothing above the existing seams changes.

The epic was sliced into per-adapter issues first: #82 (this) + #83 settings, #84 secrets, #85 PersonId, #86 password queue.

## Linked issue
Closes #82

## Provisioned infrastructure
Subscription *Yvan's Azure*, region `belgiumcentral`, new resource group `accountmanager-rg`:

| Resource | Name | Notes |
|---|---|---|
| SQL server | `accountmanager-sql-arcadia.database.windows.net` | **AAD-only** auth; no SQL login. AAD admin = operator identity. |
| SQL database | `accountmanager` | Serverless `GP_S_Gen5`, min 0.5 vCore, auto-pause 60 min, local backup — near-zero idle cost. |
| Key Vault | `accountmanager-kv` | RBAC-authorized; operator holds *Key Vault Secrets Officer*. |

Every connection carries a per-operator bearer token minted for `https://database.windows.net/` — no shared database secret exists.

## Connectivity decision (spike)
**ODBC Driver 18 for SQL Server (`msodbcsql18`) via FFI.** Dart has no production-grade pure-Dart TDS driver; the community Flutter plugins are method-channel/mobile-oriented. Since the frontend is a Windows desktop app (Phase C), the adapters will use FFI over the standard ODBC redistributable, authenticated with the AAD token. A REST front (Data API builder / Function) was rejected because it reintroduces the hosting the epic deliberately avoids.

The DB + AAD-only + token-auth round-trip was **proven end to end** during the spike (connect → create table → insert → read back → drop; `SUSER_SNAME()` = operator UPN). The Dart ODBC factory + its DB round-trip test land with the first adapter (#83), the first slice with a real DB consumer.

## Changes
- New `account_state` connection/auth seam under `lib/src/sql/`: `SqlConnection`, `SqlConnectionFactory`, `AadTokenProvider` (+ `StaticAadTokenProvider`), `AzureSqlConfig`, `AzureSqlLiveConfig` — barrel-exported.
- Opt-in, read-only live check of the AAD auth foundation from Dart (`test/integration/azure_sql_live_test.dart`).
- `.azuresql.env.example`, `.gitignore` entry, and a new `azuresql` mode in `tool/live-tests.ps1` (mints a fresh SQL-scoped token, mirroring the Azure path).
- `docs/port-plan.md`: infra table + connectivity decision recorded.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` — clean
- [x] `dart analyze packages/account_state` — No issues found
- [x] `dart test packages/account_state` — 89 pass, 1 skip (live test self-skips offline)
- [x] Live auth-foundation test passes against the real tenant (token scoped to `database.windows.net`, unexpired); **read-only** per the live-testing policy
- [x] DB write round-trip proven via the connectivity spike (documented); the Dart ODBC-backed DB round-trip test is scoped to #83

**Why no full Dart DB round-trip test here:** the ODBC/FFI factory needs `msodbcsql18` in the toolchain and belongs with the first real consumer (#83). This slice is the infra + decision + seam + auth proof; the DB half is proven by the spike probe.