### PR TITLE
Phase B1: Azure SQL SettingsStore adapter (#83)

### DIFF
--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -100,8 +100,9 @@ Swap the file-backed defaults (`FilePersonIdResolver`, `FileSettingsStore`,
 adapters — Azure SQL for the shared state, Key Vault for the secrets — so the
 tool can move to team maintenance. Nothing above the seams changes.
 
-Sliced into per-adapter issues: **#82** foundation (this slice), **#83**
-settings, **#84** secrets, **#85** PersonId resolver, **#86** password queue.
+Sliced into per-adapter issues: **#82** foundation, **#83** settings, **#84**
+secrets, **#85** PersonId resolver, **#86** password queue, plus **#89** the
+concrete ODBC/FFI `SqlConnectionFactory` deferred out of #83.
 
 **Provisioned infrastructure** (subscription *Yvan's Azure*, region
 `belgiumcentral`, resource group `accountmanager-rg`):
@@ -126,9 +127,13 @@ AAD token. A REST front (Data API builder / Function) was rejected because it
 reintroduces the hosting the epic deliberately avoids. The DB + AAD-only +
 token-auth round-trip was **proven end to end** during the spike (connect →
 create table → insert → read back `roundtrip-ok` → drop, `SUSER_SNAME()` =
-the operator UPN); the Dart-side ODBC factory and its DB round-trip test land
-with the first adapter slice (#83). The `account_state` connection/auth seam
-(`SqlConnection` / `SqlConnectionFactory` / `AadTokenProvider`) is in place now.
+the operator UPN). The `account_state` connection/auth seam (`SqlConnection` /
+`SqlConnectionFactory` / `AadTokenProvider`) is in place now; the concrete
+Dart-side ODBC/FFI factory and its live DB round-trip are **deferred to #89**
+(carved out of #83 because the FFI-over-`msodbcsql18` binding is Windows-only
+and can't be unit-tested headlessly). Adapters are written and fully tested
+against the seam with a scripted fake; their opt-in live round-trip tests stay
+skipped until #89 wires the driver.
 
 ### Phase C — Flutter Windows desktop app *(not started, epic #75)*
 

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -64,6 +64,8 @@ export 'src/settings/work_date.dart';
 export 'src/sql/aad_token_provider.dart';
 export 'src/sql/azure_sql_config.dart';
 export 'src/sql/azure_sql_live_config.dart';
+export 'src/sql/azure_sql_settings_store.dart';
+export 'src/sql/settings_schema.dart';
 export 'src/sql/sql_connection.dart';
 export 'src/sync/application_state.dart';
 export 'src/sync/system_state.dart';

--- a/packages/account_state/lib/src/sql/azure_sql_settings_store.dart
+++ b/packages/account_state/lib/src/sql/azure_sql_settings_store.dart
@@ -1,0 +1,288 @@
+import 'dart:convert';
+
+import 'package:smartschool_api/smartschool_api.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+import '../settings/app_settings.dart';
+import '../settings/connection.dart';
+import '../settings/import_rule_codec.dart';
+import '../settings/secret_provider.dart';
+import '../settings/settings_store.dart';
+import '../settings/work_date.dart';
+import 'aad_token_provider.dart';
+import 'azure_sql_config.dart';
+import 'settings_schema.dart';
+import 'sql_connection.dart';
+
+/// A [SettingsStore] backed by the centralized Azure SQL database.
+///
+/// The Phase B replacement for [FileSettingsStore] (issue #83): the same
+/// [AppSettings] model, persisted once for the whole team instead of in each
+/// operator's `config.json`. Nothing above the seam changes — the orchestration
+/// layer still loads once at startup and saves on operator edits — but the
+/// bytes now live in the shared [settingsTableName] / [importRulesTableName]
+/// tables (see `settings_schema.dart`).
+///
+/// The config maps **fully relationally**: every scalar is a typed column and
+/// the two import-rule sets are child rows whose `Payload` is the codec's
+/// tagged JSON, round-tripped through [encodeWisaRule] / [decodeWisaRule] et al.
+/// unchanged. No secret is written — a profile contributes only its
+/// [SecretRef] name, resolved out of band through the Key Vault [SecretProvider]
+/// (#84).
+///
+/// Because the database is AAD-only with short-lived per-operator tokens, each
+/// [load] / [save] opens a fresh connection through the injected
+/// [SqlConnectionFactory] (which reads a new token per open) and closes it when
+/// done; the config is read and written infrequently enough that connection
+/// reuse would buy nothing but a stale-token risk. A [save] runs inside a single
+/// transaction so a partially written config can never be read back.
+///
+/// The concrete ODBC/FFI [SqlConnectionFactory] this plugs into is deferred to
+/// #89; unit tests drive a scripted fake and the opt-in live round-trip test
+/// (skipped by default) exercises the real driver once it lands.
+class AzureSqlSettingsStore implements SettingsStore {
+  AzureSqlSettingsStore({
+    required SqlConnectionFactory factory,
+    required AzureSqlConfig config,
+    required AadTokenProvider tokens,
+  })  : _factory = factory,
+        _config = config,
+        _tokens = tokens;
+
+  final SqlConnectionFactory _factory;
+  final AzureSqlConfig _config;
+  final AadTokenProvider _tokens;
+
+  @override
+  Future<AppSettings> load() async {
+    final connection = await _factory.open(_config, _tokens);
+    try {
+      final rows = await connection.query(_selectSettingsSql);
+      // No row yet is first-run, not an error: mirror the file/in-memory stores
+      // and hand back a default config so the caller has no special case.
+      if (rows.isEmpty) return const AppSettings();
+      final ruleRows = await connection.query(_selectRulesSql);
+      return _settingsFromRows(rows.first, ruleRows);
+    } finally {
+      await connection.close();
+    }
+  }
+
+  @override
+  Future<void> save(AppSettings settings) async {
+    final connection = await _factory.open(_config, _tokens);
+    try {
+      await connection.transaction((tx) async {
+        // Whole-config replace: the settings row is a singleton and the rule
+        // sets are small, so clearing and re-inserting is simpler than a
+        // per-field diff and keeps `save` faithful to "replaces the previous
+        // value". Rules go first so the FK-free child table is never orphaned
+        // mid-transaction.
+        await tx.execute('DELETE FROM $importRulesTableName');
+        await tx.execute('DELETE FROM $settingsTableName');
+        await tx.execute(_insertSettingsSql, _settingsParams(settings));
+        await _insertRules(
+          tx,
+          'wisa',
+          settings.wisaRules.map((r) => jsonEncode(encodeWisaRule(r))),
+        );
+        await _insertRules(
+          tx,
+          'smartschool',
+          settings.smartschoolRules
+              .map((r) => jsonEncode(encodeSmartschoolRule(r))),
+        );
+      });
+    } finally {
+      await connection.close();
+    }
+  }
+
+  Future<void> _insertRules(
+    SqlConnection tx,
+    String system,
+    Iterable<String> payloads,
+  ) async {
+    var ordinal = 0;
+    for (final payload in payloads) {
+      await tx.execute(_insertRuleSql, [system, ordinal, payload]);
+      ordinal++;
+    }
+  }
+
+  AppSettings _settingsFromRows(SqlRow row, List<SqlRow> ruleRows) {
+    final wisaRules = <WisaImportRule>[];
+    final smartschoolRules = <SmartschoolImportRule>[];
+    for (final r in ruleRows) {
+      final system = _string(r['SystemKey']);
+      final payload = jsonDecode(_string(r['Payload'])) as Map<String, dynamic>;
+      switch (system) {
+        case 'wisa':
+          wisaRules.add(decodeWisaRule(payload));
+        case 'smartschool':
+          smartschoolRules.add(decodeSmartschoolRule(payload));
+        default:
+          throw FormatException('Unknown import-rule system: $system');
+      }
+    }
+
+    return AppSettings(
+      schoolPrefix: _string(row['SchoolPrefix']),
+      debugMode: _bool(row['DebugMode']),
+      wisa: WisaConnection(
+        server: _string(row['WisaServer']),
+        port: _string(row['WisaPort']),
+        database: _string(row['WisaDatabase']),
+        username: _string(row['WisaUsername']),
+        passwordRef: SecretRef(_string(row['WisaPasswordRef'])),
+        workDate: WorkDateSetting(
+          isNow: _bool(row['WisaWorkDateIsNow']),
+          date: _date(row['WisaWorkDate']),
+        ),
+        virtualWorkDate: WorkDateSetting(
+          isNow: _bool(row['WisaVirtualWorkDateIsNow']),
+          date: _date(row['WisaVirtualWorkDate']),
+        ),
+      ),
+      smartschool: SmartschoolConnection(
+        uri: _string(row['SmartschoolUri']),
+        passphraseRef: SecretRef(_string(row['SmartschoolPassphraseRef'])),
+        testUser: _string(row['SmartschoolTestUser']),
+        studentGroup: _string(row['SmartschoolStudentGroup']),
+        staffGroup: _string(row['SmartschoolStaffGroup']),
+        useGrades: _bool(row['SmartschoolUseGrades']),
+        useYears: _bool(row['SmartschoolUseYears']),
+        grades: [
+          _string(row['SmartschoolGrade1']),
+          _string(row['SmartschoolGrade2']),
+          _string(row['SmartschoolGrade3']),
+        ],
+        years: [
+          for (var i = 1; i <= SmartschoolConnection.yearCount; i++)
+            _string(row['SmartschoolYear$i']),
+        ],
+      ),
+      azure: AzureConnection(
+        clientId: _string(row['AzureClientId']),
+        tenantId: _string(row['AzureTenantId']),
+        domain: _string(row['AzureDomain']),
+      ),
+      wisaRules: wisaRules,
+      smartschoolRules: smartschoolRules,
+    );
+  }
+
+  List<Object?> _settingsParams(AppSettings s) => [
+        1, // Id — the singleton key
+        s.schoolPrefix,
+        s.debugMode,
+        s.wisa.server,
+        s.wisa.port,
+        s.wisa.database,
+        s.wisa.username,
+        s.wisa.passwordRef.name,
+        s.wisa.workDate.isNow,
+        s.wisa.workDate.date,
+        s.wisa.virtualWorkDate.isNow,
+        s.wisa.virtualWorkDate.date,
+        s.smartschool.uri,
+        s.smartschool.passphraseRef.name,
+        s.smartschool.testUser,
+        s.smartschool.studentGroup,
+        s.smartschool.staffGroup,
+        s.smartschool.useGrades,
+        s.smartschool.useYears,
+        s.smartschool.grades[0],
+        s.smartschool.grades[1],
+        s.smartschool.grades[2],
+        s.smartschool.years[0],
+        s.smartschool.years[1],
+        s.smartschool.years[2],
+        s.smartschool.years[3],
+        s.smartschool.years[4],
+        s.smartschool.years[5],
+        s.smartschool.years[6],
+        s.azure.clientId,
+        s.azure.tenantId,
+        s.azure.domain,
+      ];
+}
+
+/// The settings-row columns, in the order [AzureSqlSettingsStore._settingsParams]
+/// binds them. Shared by the INSERT and SELECT so the two can never drift.
+const List<String> _settingsColumns = [
+  'Id',
+  'SchoolPrefix',
+  'DebugMode',
+  'WisaServer',
+  'WisaPort',
+  'WisaDatabase',
+  'WisaUsername',
+  'WisaPasswordRef',
+  'WisaWorkDateIsNow',
+  'WisaWorkDate',
+  'WisaVirtualWorkDateIsNow',
+  'WisaVirtualWorkDate',
+  'SmartschoolUri',
+  'SmartschoolPassphraseRef',
+  'SmartschoolTestUser',
+  'SmartschoolStudentGroup',
+  'SmartschoolStaffGroup',
+  'SmartschoolUseGrades',
+  'SmartschoolUseYears',
+  'SmartschoolGrade1',
+  'SmartschoolGrade2',
+  'SmartschoolGrade3',
+  'SmartschoolYear1',
+  'SmartschoolYear2',
+  'SmartschoolYear3',
+  'SmartschoolYear4',
+  'SmartschoolYear5',
+  'SmartschoolYear6',
+  'SmartschoolYear7',
+  'AzureClientId',
+  'AzureTenantId',
+  'AzureDomain',
+];
+
+final String _insertSettingsSql = 'INSERT INTO $settingsTableName '
+    '(${_settingsColumns.join(', ')}) '
+    'VALUES (${List.filled(_settingsColumns.length, '?').join(', ')})';
+
+final String _selectSettingsSql =
+    'SELECT ${_settingsColumns.join(', ')} FROM $settingsTableName WHERE Id = 1';
+
+const String _selectRulesSql =
+    'SELECT SystemKey, Ordinal, Payload FROM dbo.ImportRules '
+    'ORDER BY SystemKey, Ordinal';
+
+const String _insertRuleSql =
+    'INSERT INTO dbo.ImportRules (SystemKey, Ordinal, Payload) '
+    'VALUES (?, ?, ?)';
+
+/// Reads a driver value as a non-null string, treating SQL `NULL` as empty so a
+/// blank column and an absent one look the same to the model (matching the
+/// file store, where a missing key falls back to `''`).
+String _string(Object? value) => (value as String?) ?? '';
+
+/// Reads a `BIT` column as a bool. Drivers may surface it as a real `bool` or as
+/// `0`/`1`; both are accepted so the adapter is not coupled to one driver's
+/// marshalling.
+bool _bool(Object? value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  throw FormatException('expected a BIT value, got: $value');
+}
+
+/// Reads a nullable `DATETIME2` column. Accepts a native `DateTime` or an
+/// ISO-8601 string (again, to stay driver-agnostic); `NULL` stays `null` so a
+/// pinned-but-unset work date round-trips faithfully.
+DateTime? _date(Object? value) {
+  if (value == null) return null;
+  if (value is DateTime) return value;
+  if (value is String) {
+    final trimmed = value.trim();
+    return trimmed.isEmpty ? null : DateTime.parse(trimmed);
+  }
+  throw FormatException('expected a DATETIME2 value, got: $value');
+}

--- a/packages/account_state/lib/src/sql/settings_schema.dart
+++ b/packages/account_state/lib/src/sql/settings_schema.dart
@@ -1,0 +1,85 @@
+/// The Azure SQL schema backing [AzureSqlSettingsStore].
+///
+/// Phase B moves the shared config off per-operator `config.json`
+/// ([FileSettingsStore]) into one centralized Azure SQL database (epic #74) so
+/// the tool can move to team maintenance. This is the *settings* slice (#83):
+/// the [AppSettings] model laid out **fully relationally** — one typed column
+/// per scalar field (including the WISA work-date pair and each Smartschool
+/// grade/year label), plus a child table for the per-connector import-rule
+/// sets. Nothing sensitive is stored: the WISA password and Smartschool
+/// passphrase live behind a `SecretRef` and are resolved through the Key Vault
+/// adapter (#84), so only the (non-secret) ref names reach these tables.
+///
+/// The statements are idempotent (`IF OBJECT_ID(...) IS NULL`), so provisioning
+/// can re-run them safely. They are exposed as data rather than executed here
+/// because the concrete ODBC/FFI driver that would run them is deferred to #89;
+/// the opt-in live round-trip test provisions the schema through the seam.
+library;
+
+/// Singleton settings row. A `CHECK (Id = 1)` constraint enforces exactly one
+/// row: the config is loaded and saved whole, never queried per-operator.
+const String settingsTableName = 'dbo.AppSettings';
+
+/// Child table holding one row per import rule, ordered within its connector by
+/// [ordinal]. Each rule's [payload] is the tagged JSON produced by
+/// `encodeWisaRule` / `encodeSmartschoolRule` — the codec round-trips unchanged,
+/// so the sealed rule hierarchy stays free of any persistence concern.
+const String importRulesTableName = 'dbo.ImportRules';
+
+/// The ordered DDL that provisions the settings schema. Idempotent: each
+/// statement is a no-op when its table already exists, so a deploy can re-run
+/// the whole list.
+const List<String> settingsSchemaStatements = [
+  '''
+IF OBJECT_ID(N'dbo.AppSettings', N'U') IS NULL
+CREATE TABLE dbo.AppSettings (
+  Id INT NOT NULL PRIMARY KEY CHECK (Id = 1),
+  SchoolPrefix NVARCHAR(64) NOT NULL,
+  DebugMode BIT NOT NULL,
+  WisaServer NVARCHAR(256) NOT NULL,
+  WisaPort NVARCHAR(16) NOT NULL,
+  WisaDatabase NVARCHAR(256) NOT NULL,
+  WisaUsername NVARCHAR(256) NOT NULL,
+  WisaPasswordRef NVARCHAR(256) NOT NULL,
+  WisaWorkDateIsNow BIT NOT NULL,
+  WisaWorkDate DATETIME2 NULL,
+  WisaVirtualWorkDateIsNow BIT NOT NULL,
+  WisaVirtualWorkDate DATETIME2 NULL,
+  SmartschoolUri NVARCHAR(512) NOT NULL,
+  SmartschoolPassphraseRef NVARCHAR(256) NOT NULL,
+  SmartschoolTestUser NVARCHAR(256) NOT NULL,
+  SmartschoolStudentGroup NVARCHAR(256) NOT NULL,
+  SmartschoolStaffGroup NVARCHAR(256) NOT NULL,
+  SmartschoolUseGrades BIT NOT NULL,
+  SmartschoolUseYears BIT NOT NULL,
+  SmartschoolGrade1 NVARCHAR(128) NOT NULL,
+  SmartschoolGrade2 NVARCHAR(128) NOT NULL,
+  SmartschoolGrade3 NVARCHAR(128) NOT NULL,
+  SmartschoolYear1 NVARCHAR(128) NOT NULL,
+  SmartschoolYear2 NVARCHAR(128) NOT NULL,
+  SmartschoolYear3 NVARCHAR(128) NOT NULL,
+  SmartschoolYear4 NVARCHAR(128) NOT NULL,
+  SmartschoolYear5 NVARCHAR(128) NOT NULL,
+  SmartschoolYear6 NVARCHAR(128) NOT NULL,
+  SmartschoolYear7 NVARCHAR(128) NOT NULL,
+  AzureClientId NVARCHAR(256) NOT NULL,
+  AzureTenantId NVARCHAR(256) NOT NULL,
+  AzureDomain NVARCHAR(256) NOT NULL
+);''',
+  '''
+IF OBJECT_ID(N'dbo.ImportRules', N'U') IS NULL
+CREATE TABLE dbo.ImportRules (
+  Id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+  SystemKey NVARCHAR(16) NOT NULL CHECK (SystemKey IN (N'wisa', N'smartschool')),
+  Ordinal INT NOT NULL,
+  Payload NVARCHAR(MAX) NOT NULL
+);''',
+  '''
+IF NOT EXISTS (
+  SELECT 1 FROM sys.indexes
+  WHERE name = N'IX_ImportRules_SystemKey_Ordinal'
+    AND object_id = OBJECT_ID(N'dbo.ImportRules', N'U')
+)
+CREATE INDEX IX_ImportRules_SystemKey_Ordinal
+  ON dbo.ImportRules (SystemKey, Ordinal);''',
+];

--- a/packages/account_state/test/integration/azure_sql_settings_store_live_test.dart
+++ b/packages/account_state/test/integration/azure_sql_settings_store_live_test.dart
@@ -1,0 +1,77 @@
+@Timeout(Duration(minutes: 1))
+library;
+
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+/// Opt-in, **write-capable** live round-trip of [AzureSqlSettingsStore] against
+/// the real Azure SQL database (issue #83).
+///
+/// This is the DB half of the foundation the connectivity spike proved
+/// (`docs/port-plan.md`): provision the settings schema, save an [AppSettings],
+/// read it back, and assert it survived the relational mapping. Because it
+/// writes, it is **manual/opt-in** per the repo live-testing policy — never part
+/// of the read-only CI live set — and needs a fresh AAD token (see
+/// `AzureSqlLiveConfig`).
+///
+/// It cannot run yet: the concrete ODBC/FFI [SqlConnectionFactory] is deferred
+/// to #89 (it is Windows-only, needs `msodbcsql18` + a live DB, and can't be
+/// unit-tested headlessly). The body below is the ready-made round-trip that
+/// slice will enable by wiring [_liveFactory] to the real driver and dropping
+/// the group `skip`. Until then the adapter is fully covered by the seam-fake
+/// unit tests in `test/sql/azure_sql_settings_store_test.dart`.
+void main() {
+  final config = AzureSqlLiveConfig.fromEnvironment();
+
+  group(
+    'AzureSqlSettingsStore live round-trip',
+    () {
+      test('save then load round-trips through real Azure SQL', () async {
+        final store = AzureSqlSettingsStore(
+          factory: _liveFactory(),
+          config: AzureSqlConfig(
+            server: config!.server,
+            database: config.database,
+          ),
+          tokens: StaticAadTokenProvider(config.accessToken),
+        );
+
+        // #89 will provision the schema through the factory before this runs;
+        // documented here as the precondition rather than executed blind.
+        //   for (final ddl in settingsSchemaStatements) { ... }
+
+        final probe = AppSettings(
+          schoolPrefix: 'LIVE',
+          debugMode: true,
+          wisa: WisaConnection(
+            server: 'db.example',
+            workDate:
+                WorkDateSetting(isNow: false, date: DateTime(2026, 6, 30)),
+          ),
+          wisaRules: const [DontImportClass('1A')],
+        );
+
+        await store.save(probe);
+        final loaded = await store.load();
+
+        expect(loaded.schoolPrefix, 'LIVE');
+        expect(loaded.debugMode, isTrue);
+        expect(loaded.wisa.server, 'db.example');
+        expect(loaded.wisa.workDate.date, DateTime(2026, 6, 30));
+        expect(loaded.wisaRules, hasLength(1));
+      });
+    },
+    // Two gates: offline by default (no token), and blocked on the real driver.
+    skip: 'Requires the concrete ODBC/FFI SqlConnectionFactory (#89); '
+        'the adapter is covered by the seam-fake unit tests. '
+        'Set AZURE_SQL_ACCESS_TOKEN and wire _liveFactory to run.',
+  );
+}
+
+/// The production [SqlConnectionFactory] the live round-trip needs. Deferred to
+/// #89 — throws until the real ODBC/FFI driver is wired, which is why the group
+/// above is skipped.
+SqlConnectionFactory _liveFactory() => throw UnimplementedError(
+      'Concrete ODBC/FFI SqlConnectionFactory is deferred to #89.',
+    );

--- a/packages/account_state/test/sql/azure_sql_settings_store_test.dart
+++ b/packages/account_state/test/sql/azure_sql_settings_store_test.dart
@@ -1,0 +1,308 @@
+import 'dart:convert';
+
+import 'package:account_state/account_state.dart';
+import 'package:smartschool_api/smartschool_api.dart';
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+/// A semantic in-memory fake of the [SqlConnection] seam: it models the two
+/// settings tables as a singleton row plus a rule list, so the adapter can be
+/// driven through a real save/load round-trip with no database. Unlike the
+/// scripted `_RecordingConnection` in `sql_seam_test.dart`, this one actually
+/// stores what `save` writes and returns it to `load`, keeping the mapping code
+/// honest. It stays independent of column order by zipping each INSERT's
+/// explicit column list with its positional parameters.
+class _FakeSqlDatabase implements SqlConnection {
+  Map<String, Object?>? _settingsRow;
+  final List<Map<String, Object?>> _rules = [];
+
+  final List<String> statements = [];
+  final List<List<Object?>> params = [];
+  int transactions = 0;
+  int closes = 0;
+
+  @override
+  Future<List<SqlRow>> query(String sql, [List<Object?> p = const []]) async {
+    statements.add(sql);
+    params.add(p);
+    if (sql.contains('FROM $settingsTableName')) {
+      return _settingsRow == null ? [] : [Map.of(_settingsRow!)];
+    }
+    if (sql.contains('FROM $importRulesTableName')) {
+      final rows = [for (final r in _rules) Map<String, Object?>.of(r)];
+      rows.sort((a, b) {
+        final bySystem =
+            (a['SystemKey'] as String).compareTo(b['SystemKey'] as String);
+        return bySystem != 0
+            ? bySystem
+            : (a['Ordinal'] as int).compareTo(b['Ordinal'] as int);
+      });
+      return rows;
+    }
+    throw StateError('unexpected query: $sql');
+  }
+
+  @override
+  Future<int> execute(String sql, [List<Object?> p = const []]) async {
+    statements.add(sql);
+    params.add(p);
+    if (sql.contains('DELETE FROM $settingsTableName')) {
+      final had = _settingsRow != null;
+      _settingsRow = null;
+      return had ? 1 : 0;
+    }
+    if (sql.contains('DELETE FROM $importRulesTableName')) {
+      final n = _rules.length;
+      _rules.clear();
+      return n;
+    }
+    if (sql.contains('INSERT INTO $settingsTableName')) {
+      _settingsRow = _zip(sql, p);
+      return 1;
+    }
+    if (sql.contains('INSERT INTO $importRulesTableName')) {
+      _rules.add(_zip(sql, p));
+      return 1;
+    }
+    throw StateError('unexpected execute: $sql');
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function(SqlConnection tx) action) async {
+    transactions++;
+    // Faithful rollback: snapshot and restore if the action throws, so a failed
+    // save can never leave a half-written config to be read back.
+    final settingsSnapshot =
+        _settingsRow == null ? null : Map.of(_settingsRow!);
+    final rulesSnapshot = [for (final r in _rules) Map<String, Object?>.of(r)];
+    try {
+      return await action(this);
+    } catch (_) {
+      _settingsRow = settingsSnapshot;
+      _rules
+        ..clear()
+        ..addAll(rulesSnapshot);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> close() async => closes++;
+
+  /// Builds a column→value row by zipping an INSERT's explicit column list with
+  /// its positional parameters, so the fake never hard-codes column order.
+  Map<String, Object?> _zip(String insertSql, List<Object?> p) {
+    final match = RegExp(r'\(([^)]*)\)\s*VALUES', caseSensitive: false)
+        .firstMatch(insertSql);
+    if (match == null) {
+      throw StateError('cannot parse columns from: $insertSql');
+    }
+    final columns = match.group(1)!.split(',').map((c) => c.trim()).toList();
+    if (columns.length != p.length) {
+      throw StateError(
+          'column/param mismatch: ${columns.length} cols, ${p.length} params');
+    }
+    return {for (var i = 0; i < columns.length; i++) columns[i]: p[i]};
+  }
+}
+
+/// Records how it was opened so tests can assert a fresh token is read per open
+/// and the injected config is passed through.
+class _FakeFactory implements SqlConnectionFactory {
+  _FakeFactory(this._db);
+  final _FakeSqlDatabase _db;
+
+  int opens = 0;
+  AzureSqlConfig? lastConfig;
+  final List<String> tokensRead = [];
+
+  @override
+  Future<SqlConnection> open(
+      AzureSqlConfig config, AadTokenProvider tokens) async {
+    opens++;
+    lastConfig = config;
+    tokensRead.add(await tokens.databaseAccessToken());
+    return _db;
+  }
+}
+
+/// A representative config exercising the flags, all three profiles (including
+/// the work-date pair and the grade/year vocabulary), and every rule variant.
+AppSettings _sample() => AppSettings(
+      schoolPrefix: 'SMA',
+      debugMode: true,
+      wisa: WisaConnection(
+        server: 'db.example',
+        port: '1521',
+        database: 'WISA',
+        username: 'svc',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2026, 6, 30)),
+        virtualWorkDate:
+            WorkDateSetting(isNow: false, date: DateTime(2027, 9, 1)),
+      ),
+      smartschool: SmartschoolConnection(
+        uri: 'https://school.smartschool.be',
+        testUser: 'test.user',
+        studentGroup: 'Leerlingen',
+        staffGroup: 'Personeel',
+        useGrades: true,
+        useYears: true,
+        grades: const ['graad 1', 'graad 2', 'graad 3'],
+        years: const ['1', '2', '3', '4', '5', '6', '7'],
+      ),
+      azure: const AzureConnection(
+        clientId: 'client-123',
+        tenantId: 'tenant-456',
+        domain: 'sma.onmicrosoft.com',
+      ),
+      wisaRules: const [
+        DontImportClass('1A'),
+        DontImportUserFromWisa('U42'),
+        ReplaceInstitute(original: '001', replacement: '002'),
+        MarkAsVirtual('VIRT'),
+      ],
+      smartschoolRules: const [
+        DiscardSmartschoolGroup('Archief'),
+        NoSmartschoolSubgroups('Klassen'),
+      ],
+    );
+
+void _expectSame(AppSettings a, AppSettings b) {
+  expect(a.schoolPrefix, b.schoolPrefix);
+  expect(a.debugMode, b.debugMode);
+  expect(a.wisa, b.wisa);
+  expect(a.smartschool, b.smartschool);
+  expect(a.azure, b.azure);
+  expect(a.wisaRules.map(encodeWisaRule), b.wisaRules.map(encodeWisaRule));
+  expect(a.smartschoolRules.map(encodeSmartschoolRule),
+      b.smartschoolRules.map(encodeSmartschoolRule));
+}
+
+void main() {
+  late _FakeSqlDatabase db;
+  late _FakeFactory factory;
+  late AzureSqlSettingsStore store;
+
+  const config = AzureSqlConfig(
+    server: 'accountmanager-sql-arcadia.database.windows.net',
+    database: 'accountmanager',
+  );
+
+  setUp(() {
+    db = _FakeSqlDatabase();
+    factory = _FakeFactory(db);
+    store = AzureSqlSettingsStore(
+      factory: factory,
+      config: config,
+      tokens: const StaticAadTokenProvider('bearer-xyz'),
+    );
+  });
+
+  group('AzureSqlSettingsStore (SettingsStore contract)', () {
+    test('load returns defaults when nothing has been saved', () async {
+      final settings = await store.load();
+      expect(settings.schoolPrefix, isEmpty);
+      expect(settings.debugMode, isFalse);
+      expect(settings.wisa, const WisaConnection());
+      expect(settings.smartschool, SmartschoolConnection());
+      expect(settings.azure, const AzureConnection());
+      expect(settings.wisaRules, isEmpty);
+      expect(settings.smartschoolRules, isEmpty);
+    });
+
+    test('save then load round-trips every field and rule variant', () async {
+      await store.save(_sample());
+      _expectSame(await store.load(), _sample());
+    });
+
+    test('save replaces the previously stored value (singleton row)', () async {
+      await store.save(const AppSettings(schoolPrefix: 'first'));
+      await store.save(const AppSettings(schoolPrefix: 'second'));
+      expect((await store.load()).schoolPrefix, 'second');
+      // The singleton is genuinely replaced, not appended to.
+      expect(db.transactions, 2);
+    });
+
+    test('a live-now / unpinned work date round-trips as a NULL date',
+        () async {
+      // The default WISA profile tracks "now" with no pinned date; the DATETIME2
+      // column must round-trip that null rather than materialize a date.
+      await store.save(const AppSettings());
+      final loaded = await store.load();
+      expect(loaded.wisa.workDate.isNow, isTrue);
+      expect(loaded.wisa.workDate.date, isNull);
+      expect(loaded.wisa.virtualWorkDate.date, isNull);
+    });
+  });
+
+  group('import rules', () {
+    test('persist as their ImportRuleCodec tagged JSON, in order', () async {
+      await store.save(_sample());
+      final wisaPayloads = [
+        for (final r in db._rules)
+          if (r['SystemKey'] == 'wisa')
+            (r['Ordinal'] as int, r['Payload'] as String)
+      ]..sort((a, b) => a.$1.compareTo(b.$1));
+
+      expect(
+        wisaPayloads.map((e) => e.$2),
+        _sample().wisaRules.map((r) => jsonEncode(encodeWisaRule(r))),
+      );
+    });
+
+    test('a corrupt SystemKey surfaces as a FormatException on load', () async {
+      await store.save(const AppSettings(schoolPrefix: 'x'));
+      db._rules.add({'SystemKey': 'bogus', 'Ordinal': 0, 'Payload': '{}'});
+      expect(store.load(), throwsA(isA<FormatException>()));
+    });
+  });
+
+  group('connection handling', () {
+    test('save opens with the config, reads a fresh token, and closes',
+        () async {
+      await store.save(_sample());
+      expect(factory.opens, 1);
+      expect(factory.lastConfig, config);
+      expect(factory.tokensRead, ['bearer-xyz']);
+      expect(db.closes, 1);
+    });
+
+    test('load opens and closes its own connection', () async {
+      await store.load();
+      expect(factory.opens, 1);
+      expect(db.closes, 1);
+    });
+
+    test('save runs its writes inside a single transaction', () async {
+      await store.save(_sample());
+      expect(db.transactions, 1);
+    });
+
+    test('values are bound as parameters, never interpolated into the SQL',
+        () async {
+      await store.save(_sample());
+      final insert = db.statements
+          .firstWhere((s) => s.contains('INSERT INTO $settingsTableName'));
+      // The secret-free but still-sensitive-shaped values live in params, not
+      // in the statement text — so a value can never be read as SQL.
+      expect(insert, contains('?'));
+      expect(insert, isNot(contains('SMA')));
+      expect(insert, isNot(contains('sma.onmicrosoft.com')));
+    });
+  });
+
+  group('settingsSchemaStatements', () {
+    test('provisions both tables idempotently', () {
+      final ddl = settingsSchemaStatements.join('\n');
+      expect(ddl, contains('CREATE TABLE dbo.AppSettings'));
+      expect(ddl, contains('CREATE TABLE dbo.ImportRules'));
+      // Idempotent guards so a re-deploy is a no-op.
+      expect(
+        RegExp(r'IF OBJECT_ID').allMatches(ddl).length,
+        greaterThanOrEqualTo(2),
+      );
+      // The singleton is enforced at the schema level.
+      expect(ddl, contains('CHECK (Id = 1)'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Backs the `SettingsStore` seam with Azure SQL for centralized, team-shared config, replacing `FileSettingsStore`. Nothing above the seam changes. Part of #74; builds on the #82 connection/auth seam.

The config maps **fully relationally**: a singleton `dbo.AppSettings` row with one typed column per scalar (including the WISA work-date pair and each Smartschool grade/year label), plus a `dbo.ImportRules` child table whose `Payload` holds each rule's `ImportRuleCodec` tagged JSON unchanged. No secret is persisted — profiles contribute only their `SecretRef` name.

The adapter opens a fresh connection per `load`/`save` (short-lived AAD token), and writes inside a single transaction so a half-written config can never be read back.

## Linked issue
Closes #83

## Changes
- `settings_schema.dart` — idempotent DDL (`IF OBJECT_ID`) for both tables; `CHECK (Id = 1)` enforces the singleton.
- `azure_sql_settings_store.dart` — `AzureSqlSettingsStore implements SettingsStore` over the `SqlConnection` seam; driver-agnostic value readers for `BIT`/`DATETIME2`/`NVARCHAR`.
- `azure_sql_settings_store_test.dart` — semantic in-memory SQL fake for a true save/load round-trip.
- `azure_sql_settings_store_live_test.dart` — opt-in live DB round-trip, **skipped** pending the deferred driver.
- Barrel exports + `docs/port-plan.md` updated.

## Deferred (out of scope, filed as #89)
The concrete **ODBC/FFI `SqlConnectionFactory`** is carved out to #89: the FFI-over-`msodbcsql18` binding is Windows-only, needs a live AAD-authenticated DB, and can't be unit-tested headlessly. The adapter is written and fully tested against the seam with a scripted fake; its live round-trip test is in place but skipped until #89 wires the driver.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `dart analyze` clean (whole workspace)
- [x] Unit/widget tests pass — `dart test` in `account_state`: **100 pass, 2 skipped** (the two opt-in live tests). New coverage: full field + every-rule-variant round-trip, singleton replace, null work-date, codec-payload order, transaction usage, connection lifecycle (open with config + fresh token, close), bound-parameter (no interpolation), and schema-DDL shape.
- [x] Integration/e2e: **not a Flutter/user-visible change** — this is data-layer logic fully covered by the seam-fake unit tests. The live DB round-trip (the relevant e2e) is written but blocked on the #89 ODBC/FFI driver, so it is opt-in and skipped by default per the live-testing policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)