### PR TITLE
Add DB-backed transactional PersonIdResolver (#85)

### DIFF
--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -104,6 +104,20 @@ Sliced into per-adapter issues: **#82** foundation, **#83** settings, **#84**
 secrets, **#85** PersonId resolver, **#86** password queue, plus **#89** the
 concrete ODBC/FFI `SqlConnectionFactory` deferred out of #83.
 
+**#85 — resolve-ahead PersonId seam.** The one place a seam swap *does* ripple
+above it: the pure `link()` calls `PersonIdResolver.resolve` synchronously, but
+a DB read is async, so the Azure SQL resolver cannot mint lazily on a miss the
+way `FilePersonIdResolver` does. Instead it mints **ahead** of the pass — a new
+`PreparablePersonIdResolver.prepare(keys)` runs the transactional mint-or-fetch
+(insert-if-absent under the natural-key primary key, then read back the winner,
+so concurrent operators converge on one id) before any `LinkedAccount` is built,
+and `resolve` becomes a total in-memory lookup. `account_linker.naturalKeysFor`
+enumerates the exact key set from the same record-building passes `link` uses,
+and the State layer drives it through the async `LinkedState.recomputeAsync` /
+`fromApplicationAsync` (so `StateApplier.link` now returns a `Future`). A
+file/in-memory resolver is not preparable and keeps minting lazily, so the sync
+`recompute` path is unchanged.
+
 **Provisioned infrastructure** (subscription *Yvan's Azure*, region
 `belgiumcentral`, resource group `accountmanager-rg`):
 

--- a/packages/account_core/lib/src/person_id_resolver.dart
+++ b/packages/account_core/lib/src/person_id_resolver.dart
@@ -17,3 +17,30 @@ abstract interface class PersonIdResolver {
   /// key — later in this process or in a future run — returns the same id.
   PersonId resolve(String naturalKey);
 }
+
+/// A [PersonIdResolver] whose in-memory id map is populated by an asynchronous
+/// [prepare] step *before* the pure pass, so [resolve] stays synchronous and
+/// total.
+///
+/// The file- and memory-backed resolvers mint lazily inside [resolve] and need
+/// no preparation. A resolver backed by a network store (the centralized Azure
+/// SQL identity map, issue #85) cannot do I/O inside the synchronous [resolve],
+/// so it is given the full set of keys up front: [prepare] runs the
+/// transactional mint-or-fetch for every key, and [resolve] then serves purely
+/// from memory. A caller that may hold either kind checks
+/// `resolver is PreparablePersonIdResolver` and awaits [prepare] before it links
+/// — a plain [PersonIdResolver] simply skips that step.
+///
+/// Moving minting ahead of the pass (rather than lazily inside it) is what lets
+/// the DB resolver converge concurrent operators on **one id per key**: the
+/// unique-constraint mint-or-fetch runs once, atomically, before any
+/// [LinkedAccount] is built, so no id can diverge and then need reconciling.
+abstract interface class PreparablePersonIdResolver
+    implements PersonIdResolver {
+  /// Mints-or-fetches the stable [PersonId] for every key in [naturalKeys] and
+  /// caches it, so a subsequent [resolve] of any of those keys is a pure
+  /// in-memory hit. New keys are minted and persisted; keys another operator
+  /// already minted are fetched, so all operators converge. Idempotent: calling
+  /// it again (e.g. before the next pass) only resolves keys not yet cached.
+  Future<void> prepare(Iterable<String> naturalKeys);
+}

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -53,6 +53,112 @@ LinkedSnapshot link(
   PersonIdResolver resolver, {
   required String schoolPrefix,
 }) {
+  // Build the student and staff records first, in that order, so the two
+  // populations' duplicate-mail warnings accumulate student-then-staff exactly
+  // as before. Group linking carries no identity, so it stays separate.
+  final warnings = <LinkWarning>[];
+  final studentRecords = _buildStudentRecords(
+    wisaSnapshot,
+    smartschoolSnapshot,
+    azureSnapshot,
+    schoolPrefix: schoolPrefix,
+    warnings: warnings,
+  );
+  final staffRecords = _buildStaffRecords(
+    wisaSnapshot,
+    smartschoolSnapshot,
+    azureSnapshot,
+    schoolPrefix: schoolPrefix,
+    warnings: warnings,
+  );
+
+  // Resolve a stable identity and confidence for each record — students first,
+  // then staff, so [resolver.resolve] is called in the same order as before
+  // (a sequential/minting resolver assigns ids in that order).
+  final accounts = <LinkedAccount>[
+    for (final rec in studentRecords)
+      LinkedAccount(
+        id: LinkedAccountId(resolver.resolve(_naturalKey(rec)).value),
+        role: PersonRole.student,
+        wisa: rec.wisa,
+        smartschool: rec.smartschool,
+        azure: rec.azure,
+        confidence: _confidence(rec),
+      ),
+  ];
+  final staff = <LinkedStaff>[
+    for (final rec in staffRecords)
+      LinkedStaff(
+        id: LinkedAccountId(resolver.resolve(_naturalStaffKey(rec)).value),
+        role: rec.smartschool?.role ?? PersonRole.teacher,
+        wisa: rec.wisa,
+        smartschool: rec.smartschool,
+        azure: rec.azure,
+        confidence: _staffConfidence(rec),
+      ),
+  ];
+
+  final groups = _linkGroups(wisaSnapshot, smartschoolSnapshot, azureSnapshot);
+
+  return LinkedSnapshot.fromRecords(
+    accounts: accounts,
+    staff: staff,
+    groups: groups,
+    warnings: warnings,
+  );
+}
+
+/// The set of natural keys [link] will hand to the [PersonIdResolver] for the
+/// same three snapshots — every student and staff key, deduplicated — derived
+/// by running the identical record-building passes but minting nothing.
+///
+/// A network-backed resolver cannot do I/O inside the synchronous
+/// `PersonIdResolver.resolve`, so it uses this to mint-or-fetch every id in one
+/// transaction *before* the pure [link] pass (see
+/// `PreparablePersonIdResolver`). Sharing the record-building with [link] keeps
+/// the key set and the resolve calls from ever drifting: any key returned here
+/// is exactly one [link] will resolve, and vice versa. Group records carry no
+/// [PersonId] (a group is keyed by name), so groups contribute nothing.
+Set<String> naturalKeysFor(
+  wapi.WisaSnapshot wisaSnapshot,
+  ss.SmartschoolSnapshot smartschoolSnapshot,
+  az.AzureSnapshot azureSnapshot, {
+  required String schoolPrefix,
+}) {
+  // The duplicate-mail warnings are a byproduct of building; discarded here.
+  final warnings = <LinkWarning>[];
+  final studentRecords = _buildStudentRecords(
+    wisaSnapshot,
+    smartschoolSnapshot,
+    azureSnapshot,
+    schoolPrefix: schoolPrefix,
+    warnings: warnings,
+  );
+  final staffRecords = _buildStaffRecords(
+    wisaSnapshot,
+    smartschoolSnapshot,
+    azureSnapshot,
+    schoolPrefix: schoolPrefix,
+    warnings: warnings,
+  );
+  return <String>{
+    for (final rec in studentRecords) _naturalKey(rec),
+    for (final rec in staffRecords) _naturalStaffKey(rec),
+  };
+}
+
+/// Builds one student [_Record] per linked person from the three snapshots,
+/// running the student bridges (spec `docs/domain-model.md` §6.2) but leaving
+/// identity resolution to the caller. Records are returned in creation order so
+/// the output is a deterministic function of the input order (INV-20).
+/// Duplicate-mail warnings (INV-23) are appended to [warnings].
+List<_Record> _buildStudentRecords(
+  wapi.WisaSnapshot wisaSnapshot,
+  ss.SmartschoolSnapshot smartschoolSnapshot,
+  az.AzureSnapshot azureSnapshot, {
+  required String schoolPrefix,
+  required List<LinkWarning> warnings,
+}) {
   // Records in creation order; the output preserves this order so the result
   // is a deterministic function of the input lists' order (INV-20).
   final records = <_Record>[];
@@ -60,7 +166,6 @@ LinkedSnapshot link(
   final byMail = <String, List<_Record>>{};
   // Normalized wisaId/accountId -> the first record indexed under it.
   final byWisaId = <String, _Record>{};
-  final warnings = <LinkWarning>[];
 
   // 1. Seed one record per Smartschool student account, in snapshot order.
   //    Staff (teacher/director role) are linked separately below, so they are
@@ -136,47 +241,18 @@ LinkedSnapshot link(
     // else: a user belonging to another school — not our concern, dropped.
   }
 
-  // 4. Resolve a stable identity and confidence for each record.
-  final accounts = <LinkedAccount>[
-    for (final rec in records)
-      LinkedAccount(
-        id: LinkedAccountId(resolver.resolve(_naturalKey(rec)).value),
-        role: PersonRole.student,
-        wisa: rec.wisa,
-        smartschool: rec.smartschool,
-        azure: rec.azure,
-        confidence: _confidence(rec),
-      ),
-  ];
-
-  final staff = _linkStaff(
-    wisaSnapshot,
-    smartschoolSnapshot,
-    azureSnapshot,
-    resolver,
-    schoolPrefix: schoolPrefix,
-    warnings: warnings,
-  );
-
-  final groups = _linkGroups(wisaSnapshot, smartschoolSnapshot, azureSnapshot);
-
-  return LinkedSnapshot.fromRecords(
-    accounts: accounts,
-    staff: staff,
-    groups: groups,
-    warnings: warnings,
-  );
+  return records;
 }
 
-/// Links the staff population, mirroring the student passes above but using
-/// the staff-specific bridges (see the `link` doc-comment): WISA staff match
-/// Smartschool by `code` (≡ `accountId`) and Azure by `wisaId` (≡
-/// `employeeId`). Appends any duplicate-mail warnings to [warnings].
-List<LinkedStaff> _linkStaff(
+/// Builds one staff [_StaffRecord] per linked staff member, mirroring
+/// [_buildStudentRecords] but using the staff-specific bridges (see the [link]
+/// doc-comment): WISA staff match Smartschool by `code` (≡ `accountId`) and
+/// Azure by `wisaId` (≡ `employeeId`). Appends any duplicate-mail warnings to
+/// [warnings].
+List<_StaffRecord> _buildStaffRecords(
   wapi.WisaSnapshot wisaSnapshot,
   ss.SmartschoolSnapshot smartschoolSnapshot,
-  az.AzureSnapshot azureSnapshot,
-  PersonIdResolver resolver, {
+  az.AzureSnapshot azureSnapshot, {
   required String schoolPrefix,
   required List<LinkWarning> warnings,
 }) {
@@ -266,18 +342,7 @@ List<LinkedStaff> _linkStaff(
     // else: a user belonging to another school/population — dropped.
   }
 
-  // 4. Resolve a stable identity, role, and confidence for each record.
-  return <LinkedStaff>[
-    for (final rec in records)
-      LinkedStaff(
-        id: LinkedAccountId(resolver.resolve(_naturalStaffKey(rec)).value),
-        role: rec.smartschool?.role ?? PersonRole.teacher,
-        wisa: rec.wisa,
-        smartschool: rec.smartschool,
-        azure: rec.azure,
-        confidence: _staffConfidence(rec),
-      ),
-  ];
+  return records;
 }
 
 /// Links the class-group population, ported from legacy

--- a/packages/account_linker/test/natural_keys_test.dart
+++ b/packages/account_linker/test/natural_keys_test.dart
@@ -1,0 +1,97 @@
+import 'package:account_core/account_core.dart';
+import 'package:account_linker/account_linker.dart';
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+/// A [PersonIdResolver] that records every key `link` asks it to resolve, so a
+/// test can compare that set against what [naturalKeysFor] enumerates.
+class _RecordingResolver implements PersonIdResolver {
+  final List<String> resolved = [];
+  final SeqResolver _delegate = SeqResolver();
+
+  @override
+  PersonId resolve(String naturalKey) {
+    resolved.add(naturalKey);
+    return _delegate.resolve(naturalKey);
+  }
+}
+
+void main() {
+  // A scenario spanning every record shape that carries a PersonId: a fully
+  // linked student, an Azure-only orphan student (INV-22), a fully linked staff
+  // member, and an Azure-only orphan staff member. Groups deliberately included
+  // to prove they contribute no keys.
+  final wisa = wisaSnap(
+    [wisaStudent('1')],
+    staff: [wisaStaff('DOE', wisaId: '100')],
+    classGroups: [wisaClassGroup('1A')],
+  );
+  final smartschool = ssSnap(
+    [ssAccount(uid: 'jane', accountId: '1', mail: 'jane@school.example')],
+    groups: [ssGroup('1A')],
+  );
+  final smartschoolStaff = ssStaffAccount(
+    uid: 'doe',
+    accountId: 'DOE',
+    mail: 'doe@school.example',
+  );
+  final withStaff = ssSnap(
+    [
+      ssAccount(uid: 'jane', accountId: '1', mail: 'jane@school.example'),
+      smartschoolStaff,
+    ],
+    groups: [ssGroup('1A')],
+  );
+  final azure = azSnap([
+    azureUser(id: 'az1', upn: 'jane@school.example', employeeId: '1'),
+    azureUser(id: 'az2', upn: 'ghost@school.example', companyName: 'SMA'),
+    azureUser(
+        id: 'az3',
+        upn: 'doe@school.example',
+        employeeId: '100',
+        department: 'SMA-team'),
+    azureUser(id: 'az4', upn: 'exstaff@school.example', department: 'SMA-team'),
+  ]);
+
+  group('naturalKeysFor', () {
+    test('returns exactly the keys link() resolves (the seam contract)', () {
+      final recorder = _RecordingResolver();
+      link(wisa, withStaff, azure, recorder, schoolPrefix: 'SMA');
+
+      final enumerated =
+          naturalKeysFor(wisa, withStaff, azure, schoolPrefix: 'SMA');
+
+      // Every key link asked for, deduplicated, is exactly what the enumerator
+      // returns — so a DB-backed resolver primed from naturalKeysFor can never
+      // hit an unprepared key inside the pure pass, and never mints a key link
+      // won't use.
+      expect(enumerated, equals(recorder.resolved.toSet()));
+    });
+
+    test('covers students, orphans, and staff under the right namespaces', () {
+      final keys = naturalKeysFor(wisa, withStaff, azure, schoolPrefix: 'SMA');
+      expect(
+        keys,
+        containsAll(<String>[
+          'wisa:1', // fully linked student
+          'upn:ghost@school.example', // Azure-only orphan student (INV-22)
+          'staff:wisa:100', // fully linked staff member
+          'staff:upn:exstaff@school.example', // Azure-only orphan staff
+        ]),
+      );
+    });
+
+    test('is a pure function of the snapshots — no group keys, stable', () {
+      // Groups carry no PersonId; the enumerated set is unchanged whether or not
+      // the resolver would be called, and repeated calls agree.
+      final first =
+          naturalKeysFor(wisa, smartschool, azure, schoolPrefix: 'SMA');
+      final second =
+          naturalKeysFor(wisa, smartschool, azure, schoolPrefix: 'SMA');
+      expect(first, equals(second));
+      expect(first.any((k) => k.contains('1a')), isFalse,
+          reason: 'a class-group name must never leak into the id key set');
+    });
+  });
+}

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -46,7 +46,8 @@ library;
 // Identity seam: reuse account_core's interface; account_store ships the
 // file-backed default. Re-exported so consumers get the whole persistence
 // surface from one import.
-export 'package:account_core/account_core.dart' show PersonId, PersonIdResolver;
+export 'package:account_core/account_core.dart'
+    show PersonId, PersonIdResolver, PreparablePersonIdResolver;
 export 'package:account_store/account_store.dart' show FilePersonIdResolver;
 
 export 'src/apply/state_applier.dart';
@@ -69,7 +70,9 @@ export 'src/settings/work_date.dart';
 export 'src/sql/aad_token_provider.dart';
 export 'src/sql/azure_sql_config.dart';
 export 'src/sql/azure_sql_live_config.dart';
+export 'src/sql/azure_sql_person_id_resolver.dart';
 export 'src/sql/azure_sql_settings_store.dart';
+export 'src/sql/person_id_schema.dart';
 export 'src/sql/settings_schema.dart';
 export 'src/sql/sql_connection.dart';
 export 'src/sync/application_state.dart';

--- a/packages/account_state/lib/src/apply/state_applier.dart
+++ b/packages/account_state/lib/src/apply/state_applier.dart
@@ -94,8 +94,12 @@ class StateApplier {
   /// The current derived linked view over [app]'s snapshots, built with the
   /// uniqueness-aware configs. Rebuild the UI's action lists from this after
   /// every sync or apply. Throws [StateError] if a system has not synced yet
-  /// (see [LinkedState.fromApplication]).
-  LinkedState link() => LinkedState.fromApplication(
+  /// (see [LinkedState.fromApplicationAsync]).
+  ///
+  /// Asynchronous because [resolver] may be a [PreparablePersonIdResolver] (the
+  /// DB-backed identity map), which is primed before the pure `link()` runs; a
+  /// file/in-memory resolver skips that step and this resolves immediately.
+  Future<LinkedState> link() => LinkedState.fromApplicationAsync(
         app,
         resolver: resolver,
         studentConfig: _studentConfig,
@@ -194,7 +198,7 @@ class StateApplier {
         );
     }
 
-    return ApplyResult(result, link());
+    return ApplyResult(result, await link());
   }
 }
 

--- a/packages/account_state/lib/src/link/linked_state.dart
+++ b/packages/account_state/lib/src/link/linked_state.dart
@@ -97,6 +97,45 @@ class LinkedState {
     );
   }
 
+  /// The async counterpart of [LinkedState.recompute] for a
+  /// [PreparablePersonIdResolver] (the DB-backed [AzureSqlPersonIdResolver]).
+  ///
+  /// A network-backed resolver cannot mint inside the synchronous pure `link()`,
+  /// so its id map is populated up front: this computes the exact key set with
+  /// `naturalKeysFor` (over the same snapshots and `schoolPrefix` the linker
+  /// uses) and awaits `resolver.prepare(keys)` before delegating to the
+  /// synchronous [recompute]. A plain [PersonIdResolver] (file/in-memory) is not
+  /// preparable and mints lazily, so it skips the prepare step and this behaves
+  /// exactly like [recompute].
+  static Future<LinkedState> recomputeAsync({
+    required wapi.WisaSnapshot wisa,
+    required ss.SmartschoolSnapshot smartschool,
+    required az.AzureSnapshot azure,
+    required PersonIdResolver resolver,
+    required actions.StudentActionConfig studentConfig,
+    required actions.StaffActionConfig staffConfig,
+    SmartschoolClassTree classTree = const SmartschoolClassTree(),
+  }) async {
+    if (resolver is PreparablePersonIdResolver) {
+      final keys = naturalKeysFor(
+        wisa,
+        smartschool,
+        azure,
+        schoolPrefix: studentConfig.schoolPrefix,
+      );
+      await resolver.prepare(keys);
+    }
+    return LinkedState.recompute(
+      wisa: wisa,
+      smartschool: smartschool,
+      azure: azure,
+      resolver: resolver,
+      studentConfig: studentConfig,
+      staffConfig: staffConfig,
+      classTree: classTree,
+    );
+  }
+
   /// Recomputes the linked view from an [ApplicationState]'s current snapshots.
   ///
   /// Throws a [StateError] when any system has not synced yet (its snapshot is
@@ -109,6 +148,47 @@ class LinkedState {
     required actions.StaffActionConfig staffConfig,
     SmartschoolClassTree classTree = const SmartschoolClassTree(),
   }) {
+    final (wisa, smartschool, azure) = _syncedSnapshots(app);
+    return LinkedState.recompute(
+      wisa: wisa,
+      smartschool: smartschool,
+      azure: azure,
+      resolver: resolver,
+      studentConfig: studentConfig,
+      staffConfig: staffConfig,
+      classTree: classTree,
+    );
+  }
+
+  /// The async counterpart of [LinkedState.fromApplication] for a
+  /// [PreparablePersonIdResolver]: same "every system must have synced" guard,
+  /// then delegates to [recomputeAsync] so a DB-backed resolver is prepared
+  /// before linking. Use this (not [fromApplication]) whenever the resolver may
+  /// be network-backed.
+  static Future<LinkedState> fromApplicationAsync(
+    ApplicationState app, {
+    required PersonIdResolver resolver,
+    required actions.StudentActionConfig studentConfig,
+    required actions.StaffActionConfig staffConfig,
+    SmartschoolClassTree classTree = const SmartschoolClassTree(),
+  }) async {
+    final (wisa, smartschool, azure) = _syncedSnapshots(app);
+    return recomputeAsync(
+      wisa: wisa,
+      smartschool: smartschool,
+      azure: azure,
+      resolver: resolver,
+      studentConfig: studentConfig,
+      staffConfig: staffConfig,
+      classTree: classTree,
+    );
+  }
+
+  /// Returns [app]'s three current snapshots, or throws a [StateError] when any
+  /// system has not synced yet — linking needs all three views, mirroring how
+  /// the legacy dashboard only re-linked after the syncs had run.
+  static (wapi.WisaSnapshot, ss.SmartschoolSnapshot, az.AzureSnapshot)
+      _syncedSnapshots(ApplicationState app) {
     final wisa = app.wisa.snapshot;
     final smartschool = app.smartschool.snapshot;
     final azure = app.azure.snapshot;
@@ -119,14 +199,6 @@ class LinkedState {
         'azure: ${azure != null}).',
       );
     }
-    return LinkedState.recompute(
-      wisa: wisa,
-      smartschool: smartschool,
-      azure: azure,
-      resolver: resolver,
-      studentConfig: studentConfig,
-      staffConfig: staffConfig,
-      classTree: classTree,
-    );
+    return (wisa, smartschool, azure);
   }
 }

--- a/packages/account_state/lib/src/sql/azure_sql_person_id_resolver.dart
+++ b/packages/account_state/lib/src/sql/azure_sql_person_id_resolver.dart
@@ -1,0 +1,138 @@
+import 'package:account_core/account_core.dart';
+import 'package:uuid/uuid.dart';
+
+import 'aad_token_provider.dart';
+import 'azure_sql_config.dart';
+import 'person_id_schema.dart';
+import 'sql_connection.dart';
+
+/// A [PersonIdResolver] backed by the centralized Azure SQL identity map.
+///
+/// The Phase B replacement for `FilePersonIdResolver` (issue #85): the same
+/// `NaturalKey → PersonId` mapping, but shared by the whole team instead of
+/// living in each operator's `%APPDATA%` JSON. Centralizing it fixes the latent
+/// correctness bug the epic is built around (#76) — a per-machine map mints a
+/// *different* [PersonId] for the same human on each operator.
+///
+/// **Why two phases.** The linker calls `resolve` synchronously inside its pure
+/// pass, but a database read is asynchronous, so this resolver cannot mint
+/// lazily on a miss the way the file resolver does. Instead it is
+/// [prepare]d up front: [prepare] loads the whole map and mints-or-fetches every
+/// still-unknown key in one transaction, then [resolve] is a pure, synchronous,
+/// *total* lookup into the primed cache (an unknown key means the caller forgot
+/// to prepare it — a programming error, not a normal miss). The State layer
+/// computes the exact key set with `account_linker`'s `naturalKeysFor` and
+/// awaits [prepare] before it links (see `PreparablePersonIdResolver`).
+///
+/// **Convergence.** For a brand-new key two operators may both mint a fresh
+/// UUID. The insert is guarded by the natural-key primary key
+/// ([personIdentityTableName]): each operator inserts its id *only if the key is
+/// still absent* (a serializable key-range lock orders the two), then reads the
+/// row back. Whoever committed first owns the id; the other inserts nothing and
+/// adopts the winner — so both [resolve] the same [PersonId], with no
+/// after-the-fact reconciliation.
+///
+/// Like the other Phase B adapters, each [prepare] opens a fresh connection
+/// through the injected [SqlConnectionFactory] (which reads a new per-operator
+/// token) and closes it when done. The concrete ODBC/FFI factory is deferred to
+/// #89; unit tests drive a scripted fake and the opt-in live round-trip
+/// (skipped by default) exercises the real driver once it lands.
+class AzureSqlPersonIdResolver implements PreparablePersonIdResolver {
+  AzureSqlPersonIdResolver({
+    required SqlConnectionFactory factory,
+    required AzureSqlConfig config,
+    required AadTokenProvider tokens,
+    String Function()? mintId,
+  })  : _factory = factory,
+        _config = config,
+        _tokens = tokens,
+        _mintId = mintId ?? _defaultMint;
+
+  final SqlConnectionFactory _factory;
+  final AzureSqlConfig _config;
+  final AadTokenProvider _tokens;
+  final String Function() _mintId;
+
+  /// The primed identity map: natural key → resolved id. Seeded from the table
+  /// and grown with freshly minted (or adopted) ids by [prepare].
+  final Map<String, PersonId> _cache = {};
+
+  static String _defaultMint() => const Uuid().v4();
+
+  @override
+  Future<void> prepare(Iterable<String> naturalKeys) async {
+    // Idempotent: keys already resolved this session need no work.
+    final wanted = naturalKeys.toSet()..removeWhere(_cache.containsKey);
+    if (wanted.isEmpty) return;
+
+    final connection = await _factory.open(_config, _tokens);
+    try {
+      // Load the whole identity map — one small row per person, mirroring the
+      // file resolver reading its whole file — so every already-minted id is
+      // served without a round-trip per key.
+      for (final row in await connection.query(_selectAllSql)) {
+        _cache[_string(row['NaturalKey'])] = PersonId(_string(row['PersonId']));
+      }
+
+      final missing = [
+        for (final key in wanted)
+          if (!_cache.containsKey(key)) key
+      ];
+      if (missing.isEmpty) return;
+
+      // Mint-or-fetch the genuinely new keys atomically (see the class doc): the
+      // guarded insert plus its read-back is the "converge on one id" step, so
+      // it runs inside a single transaction as the seam intends (#85).
+      await connection.transaction((tx) async {
+        for (final key in missing) {
+          await tx.execute(_insertIfAbsentSql, [key, _mintId(), key]);
+          final winner = await tx.query(_selectOneSql, [key]);
+          if (winner.isEmpty) {
+            // Unreachable: the key either pre-existed or we just inserted it.
+            throw StateError('PersonIdentity row vanished for key: $key');
+          }
+          _cache[key] = PersonId(_string(winner.first['PersonId']));
+        }
+      });
+    } finally {
+      await connection.close();
+    }
+  }
+
+  @override
+  PersonId resolve(String naturalKey) {
+    final id = _cache[naturalKey];
+    if (id == null) {
+      throw StateError(
+        'AzureSqlPersonIdResolver.resolve("$naturalKey") before prepare(): the '
+        'DB-backed resolver mints ahead of the pass, so every natural key link() '
+        'will resolve must be passed to prepare() first (via naturalKeysFor).',
+      );
+    }
+    return id;
+  }
+}
+
+/// Loads the whole identity map. Small — one row per person — so reading it
+/// whole to seed the cache is simpler and safe rather than a bottleneck.
+const String _selectAllSql =
+    'SELECT NaturalKey, PersonId FROM $personIdentityTableName';
+
+/// Reads back the row that owns [NaturalKey] after a guarded insert — either the
+/// id this operator just minted or the one a concurrent operator committed first.
+const String _selectOneSql =
+    'SELECT PersonId FROM $personIdentityTableName WHERE NaturalKey = ?';
+
+/// Inserts a freshly minted id **only if the key is still absent**. The
+/// `UPDLOCK, HOLDLOCK` takes a serializable key-range lock so two operators
+/// minting the same new key are ordered: the loser's `NOT EXISTS` sees the
+/// winner's row and inserts nothing. Params: `[naturalKey, personId, naturalKey]`.
+const String _insertIfAbsentSql = 'INSERT INTO $personIdentityTableName '
+    '(NaturalKey, PersonId) SELECT ?, ? WHERE NOT EXISTS ('
+    'SELECT 1 FROM $personIdentityTableName WITH (UPDLOCK, HOLDLOCK) '
+    'WHERE NaturalKey = ?)';
+
+/// Reads a driver value as a non-null string. The identity columns are declared
+/// `NOT NULL`, so a null here would be a schema violation; coercing keeps the
+/// mapping total and driver-agnostic.
+String _string(Object? value) => (value as String?) ?? '';

--- a/packages/account_state/lib/src/sql/person_id_schema.dart
+++ b/packages/account_state/lib/src/sql/person_id_schema.dart
@@ -1,0 +1,43 @@
+/// The Azure SQL schema backing [AzureSqlPersonIdResolver].
+///
+/// Phase B moves the shared PersonId identity map off each operator's
+/// per-machine `FilePersonIdResolver` JSON into one centralized Azure SQL table
+/// (epic #74, slice #85). This is the correctness fix at the heart of the epic
+/// (#76): a per-machine map mints a *different* [PersonId] for the same human on
+/// each operator, so the map must centralize.
+///
+/// The table is the whole design: a single `NaturalKey → PersonId` mapping with
+/// the natural key as the **primary key**. That primary key is the unique
+/// constraint the resolver relies on — when two operators both mint an id for a
+/// brand-new key, the second `INSERT` finds the key present (the first
+/// operator's row) and takes that id instead of its own, so both converge on one
+/// [PersonId]. No id is a secret, so nothing here goes through Key Vault.
+///
+/// The statement is idempotent (`IF OBJECT_ID(...) IS NULL`), so provisioning
+/// can re-run it safely. It is exposed as data rather than executed here because
+/// the concrete ODBC/FFI driver that would run it is deferred to #89; the opt-in
+/// live round-trip test provisions the schema through the seam.
+library;
+
+/// The identity-map table: one row per person, keyed by the linker's natural
+/// key. [naturalKeyMaxLength] bounds the key so it fits a clustered primary-key
+/// index (SQL Server caps a key column at 900 bytes; `NVARCHAR(450)` is the
+/// widest that always fits).
+const String personIdentityTableName = 'dbo.PersonIdentity';
+
+/// The maximum natural-key length the [personIdentityTableName] primary key
+/// admits. Natural keys are short, namespaced strings (`wisa:123`,
+/// `staff:code:abc`, `mail:<address>`); 450 leaves ample headroom while staying
+/// within the 900-byte index-key limit.
+const int naturalKeyMaxLength = 450;
+
+/// The ordered DDL that provisions the identity-map schema. Idempotent: the
+/// statement is a no-op when the table already exists, so a deploy can re-run it.
+const List<String> personIdentitySchemaStatements = [
+  '''
+IF OBJECT_ID(N'dbo.PersonIdentity', N'U') IS NULL
+CREATE TABLE dbo.PersonIdentity (
+  NaturalKey NVARCHAR(450) NOT NULL PRIMARY KEY,
+  PersonId NVARCHAR(64) NOT NULL
+);''',
+];

--- a/packages/account_state/pubspec.yaml
+++ b/packages/account_state/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   azure_api:
   account_linker:
   account_actions:
+  uuid: ^4.5.0
 
 dev_dependencies:
   lints: ^5.1.0

--- a/packages/account_state/test/integration/azure_sql_person_id_resolver_live_test.dart
+++ b/packages/account_state/test/integration/azure_sql_person_id_resolver_live_test.dart
@@ -1,0 +1,73 @@
+@Timeout(Duration(minutes: 1))
+library;
+
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+
+/// Opt-in, **write-capable** live round-trip of [AzureSqlPersonIdResolver]
+/// against the real Azure SQL identity map (issue #85).
+///
+/// Provisions the identity table, primes two keys, and asserts a second
+/// resolver over the same database adopts the ids the first minted — the
+/// centralized-map convergence the epic exists for (#76), proven end-to-end
+/// through the real driver. Because it writes, it is **manual/opt-in** per the
+/// repo live-testing policy — never part of the read-only CI live set — and
+/// needs a fresh AAD token (see `AzureSqlLiveConfig`).
+///
+/// It cannot run yet: the concrete ODBC/FFI [SqlConnectionFactory] is deferred
+/// to #89 (Windows-only, needs `msodbcsql18` + a live DB, not unit-testable
+/// headlessly). The body below is the ready-made round-trip that slice will
+/// enable by wiring [_liveFactory] to the real driver and dropping the `skip`.
+/// Until then the resolver is fully covered by the seam-fake unit tests in
+/// `test/sql/azure_sql_person_id_resolver_test.dart`.
+void main() {
+  final config = AzureSqlLiveConfig.fromEnvironment();
+
+  group(
+    'AzureSqlPersonIdResolver live convergence',
+    () {
+      test('two resolvers over one DB converge on a single PersonId', () async {
+        final sqlConfig = AzureSqlConfig(
+          server: config!.server,
+          database: config.database,
+        );
+        final tokens = StaticAadTokenProvider(config.accessToken);
+
+        // #89 will provision the schema through the factory before this runs;
+        // documented here as the precondition rather than executed blind.
+        //   for (final ddl in personIdentitySchemaStatements) { ... }
+
+        final key = 'wisa:live-${config.accessToken.hashCode}';
+
+        final first = AzureSqlPersonIdResolver(
+          factory: _liveFactory(),
+          config: sqlConfig,
+          tokens: tokens,
+        );
+        await first.prepare([key]);
+        final minted = first.resolve(key);
+
+        final second = AzureSqlPersonIdResolver(
+          factory: _liveFactory(),
+          config: sqlConfig,
+          tokens: tokens,
+        );
+        await second.prepare([key]);
+
+        expect(second.resolve(key), equals(minted),
+            reason: 'the shared map yields one id per natural key');
+      });
+    },
+    // Two gates: offline by default (no token), and blocked on the real driver.
+    skip: 'Requires the concrete ODBC/FFI SqlConnectionFactory (#89); '
+        'the resolver is covered by the seam-fake unit tests. '
+        'Set AZURE_SQL_ACCESS_TOKEN and wire _liveFactory to run.',
+  );
+}
+
+/// The production [SqlConnectionFactory] the live round-trip needs. Deferred to
+/// #89 — throws until the real ODBC/FFI driver is wired, which is why the group
+/// above is skipped.
+SqlConnectionFactory _liveFactory() => throw UnimplementedError(
+      'Concrete ODBC/FFI SqlConnectionFactory is deferred to #89.',
+    );

--- a/packages/account_state/test/linked_state_test.dart
+++ b/packages/account_state/test/linked_state_test.dart
@@ -177,6 +177,31 @@ class _SeqResolver implements core.PersonIdResolver {
       core.PersonId(_seen.putIfAbsent(naturalKey, () => 'p${_seen.length}'));
 }
 
+/// A [PreparablePersonIdResolver] stand-in (the shape of the DB-backed one):
+/// [resolve] is total and throws for any key not [prepare]d, so a test proves
+/// the async link path primes exactly the keys the pure pass will resolve.
+class _PreparableResolver implements core.PreparablePersonIdResolver {
+  final Map<String, String> _cache = {};
+  final List<Set<String>> prepareCalls = [];
+
+  @override
+  Future<void> prepare(Iterable<String> naturalKeys) async {
+    prepareCalls.add(naturalKeys.toSet());
+    for (final key in naturalKeys) {
+      _cache.putIfAbsent(key, () => 'db${_cache.length}');
+    }
+  }
+
+  @override
+  core.PersonId resolve(String naturalKey) {
+    final id = _cache[naturalKey];
+    if (id == null) {
+      throw StateError('resolve("$naturalKey") before prepare');
+    }
+    return core.PersonId(id);
+  }
+}
+
 final _studentConfig =
     StudentActionConfig(schoolPrefix: 'GBS', azureDomain: 'school.example');
 final _staffConfig =
@@ -468,6 +493,85 @@ void main() {
         ),
         throwsStateError,
       );
+    });
+  });
+
+  group('LinkedState async path primes a PreparablePersonIdResolver', () {
+    test('recomputeAsync prepares the natural keys before linking', () async {
+      final resolver = _PreparableResolver();
+      final wisa = _wSnap(students: [_wStudent(wisaId: '1', classGroup: '1A')]);
+
+      // A DB-backed resolver throws on an unprepared key, so this only succeeds
+      // if recomputeAsync primed the key set before running the pure link().
+      final state = await LinkedState.recomputeAsync(
+        wisa: wisa,
+        smartschool: _sSnap(),
+        azure: _aSnap(),
+        resolver: resolver,
+        studentConfig: _studentConfig,
+        staffConfig: _staffConfig,
+      );
+
+      expect(state.snapshot.accounts, hasLength(1));
+      expect(resolver.prepareCalls, hasLength(1));
+      expect(resolver.prepareCalls.single, contains('wisa:1'));
+      expect(state.snapshot.accounts.single.id.value, startsWith('db'));
+    });
+
+    test('fromApplicationAsync primes from an ApplicationState', () async {
+      final resolver = _PreparableResolver();
+      final app = ApplicationState(
+        wisa: _sys(
+          core.Origin.wisa,
+          _wSnap(students: [_wStudent(wisaId: '1', classGroup: '1A')]),
+        ),
+        smartschool: _sys(core.Origin.smartschool, _sSnap()),
+        azure: _sys(core.Origin.azure, _aSnap()),
+      );
+
+      final state = await LinkedState.fromApplicationAsync(
+        app,
+        resolver: resolver,
+        studentConfig: _studentConfig,
+        staffConfig: _staffConfig,
+      );
+
+      expect(state.snapshot.accounts, hasLength(1));
+      expect(resolver.prepareCalls.single, contains('wisa:1'));
+    });
+
+    test('fromApplicationAsync still guards on an unsynced system', () {
+      final app = ApplicationState(
+        wisa: _sys(core.Origin.wisa, _wSnap()),
+        smartschool: _sys(core.Origin.smartschool, _sSnap()),
+        azure: _sys<az.AzureSnapshot>(core.Origin.azure, null),
+      );
+
+      expect(
+        LinkedState.fromApplicationAsync(
+          app,
+          resolver: _PreparableResolver(),
+          studentConfig: _studentConfig,
+          staffConfig: _staffConfig,
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('a non-preparable resolver skips prepare and links unchanged',
+        () async {
+      // recomputeAsync must stay a drop-in for a file/in-memory resolver: no
+      // prepare capability, mints lazily inside resolve, same result.
+      final state = await LinkedState.recomputeAsync(
+        wisa: _wSnap(students: [_wStudent(wisaId: '1', classGroup: '1A')]),
+        smartschool: _sSnap(),
+        azure: _aSnap(),
+        resolver: _SeqResolver(),
+        studentConfig: _studentConfig,
+        staffConfig: _staffConfig,
+      );
+      expect(state.snapshot.accounts, hasLength(1));
+      expect(state.snapshot.accounts.single.id.value, startsWith('p'));
     });
   });
 }

--- a/packages/account_state/test/sql/azure_sql_person_id_resolver_test.dart
+++ b/packages/account_state/test/sql/azure_sql_person_id_resolver_test.dart
@@ -1,0 +1,255 @@
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+
+/// A semantic in-memory fake of the identity-map table shared by every resolver
+/// opened against it — the way one Azure SQL database is shared by every
+/// operator. It models `INSERT ... WHERE NOT EXISTS` (guarded insert) so the
+/// unique-key arbitration the resolver relies on is exercised for real, and can
+/// optionally hide its rows from the full-map load to simulate the window where
+/// one operator has committed a row the other hasn't seen yet.
+class _FakePersonIdDb implements SqlConnection {
+  _FakePersonIdDb({this.hideOnLoad = false});
+
+  /// The persisted map — the singular source of truth all connections share.
+  final Map<String, String> table = {};
+
+  /// When true, the full-map load reports an empty table even though [table]
+  /// may hold rows: the "stale load" a concurrent minter races against.
+  final bool hideOnLoad;
+
+  final List<String> statements = [];
+  final List<List<Object?>> params = [];
+  int opens = 0;
+  int closes = 0;
+  int transactions = 0;
+
+  @override
+  Future<List<SqlRow>> query(String sql, [List<Object?> p = const []]) async {
+    statements.add(sql);
+    params.add(p);
+    // Full-map load: SELECT NaturalKey, PersonId FROM ...
+    if (sql.contains('SELECT NaturalKey, PersonId')) {
+      if (hideOnLoad) return [];
+      return [
+        for (final e in table.entries)
+          {'NaturalKey': e.key, 'PersonId': e.value},
+      ];
+    }
+    // Read-back of one row: SELECT PersonId FROM ... WHERE NaturalKey = ?
+    if (sql.contains('SELECT PersonId FROM')) {
+      final key = p.single as String;
+      final id = table[key];
+      return id == null
+          ? []
+          : [
+              {'PersonId': id},
+            ];
+    }
+    throw StateError('unexpected query: $sql');
+  }
+
+  @override
+  Future<int> execute(String sql, [List<Object?> p = const []]) async {
+    statements.add(sql);
+    params.add(p);
+    // Guarded insert: params are [naturalKey, personId, naturalKey].
+    if (sql.contains('INSERT INTO') && sql.contains('WHERE NOT EXISTS')) {
+      final key = p[0] as String;
+      final id = p[1] as String;
+      if (table.containsKey(key)) return 0; // key present ⇒ insert nothing
+      table[key] = id;
+      return 1;
+    }
+    throw StateError('unexpected execute: $sql');
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function(SqlConnection tx) action) async {
+    transactions++;
+    final snapshot = Map<String, String>.of(table);
+    try {
+      return await action(this);
+    } catch (_) {
+      table
+        ..clear()
+        ..addAll(snapshot);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> close() async => closes++;
+}
+
+/// Opens the shared [_FakePersonIdDb], recording each open so a test can assert
+/// a fresh token is read per connection (the DB is AAD-only).
+class _FakeFactory implements SqlConnectionFactory {
+  _FakeFactory(this._db);
+  final _FakePersonIdDb _db;
+
+  AzureSqlConfig? lastConfig;
+  final List<String> tokensRead = [];
+
+  @override
+  Future<SqlConnection> open(
+      AzureSqlConfig config, AadTokenProvider tokens) async {
+    _db.opens++;
+    lastConfig = config;
+    tokensRead.add(await tokens.databaseAccessToken());
+    return _db;
+  }
+}
+
+/// A counter-based mint so a test can predict the ids and prove which operator
+/// won a race. [prefix] distinguishes two competing resolvers.
+String Function() _mint(String prefix) {
+  var n = 0;
+  return () => '$prefix-${n++}';
+}
+
+void main() {
+  const config = AzureSqlConfig(
+    server: 'accountmanager-sql-arcadia.database.windows.net',
+    database: 'accountmanager',
+  );
+
+  AzureSqlPersonIdResolver resolverOver(
+    _FakePersonIdDb db, {
+    String mintPrefix = 'id',
+    String token = 'bearer-xyz',
+  }) =>
+      AzureSqlPersonIdResolver(
+        factory: _FakeFactory(db),
+        config: config,
+        tokens: StaticAadTokenProvider(token),
+        mintId: _mint(mintPrefix),
+      );
+
+  group('AzureSqlPersonIdResolver (PersonIdResolver contract)', () {
+    test('resolve before prepare is a StateError, not a silent miss', () {
+      final resolver = resolverOver(_FakePersonIdDb());
+      expect(() => resolver.resolve('wisa:1'), throwsStateError);
+    });
+
+    test('prepare mints a stable id for each new key; resolve returns it',
+        () async {
+      final resolver = resolverOver(_FakePersonIdDb());
+      await resolver.prepare(['wisa:1', 'wisa:2']);
+
+      final a = resolver.resolve('wisa:1');
+      final b = resolver.resolve('wisa:2');
+      expect(a.value, isNotEmpty);
+      expect(a, isNot(equals(b)));
+      // Stable within the session.
+      expect(resolver.resolve('wisa:1'), equals(a));
+    });
+
+    test('prepare reuses an id already persisted by an earlier run', () async {
+      final db = _FakePersonIdDb()..table['wisa:1'] = 'persisted-uuid';
+      final resolver = resolverOver(db, mintPrefix: 'fresh');
+
+      await resolver.prepare(['wisa:1']);
+      expect(resolver.resolve('wisa:1'), const PersonId('persisted-uuid'));
+    });
+
+    test('prepare is idempotent: a re-prepare of cached keys opens nothing',
+        () async {
+      final db = _FakePersonIdDb();
+      final resolver = resolverOver(db);
+
+      await resolver.prepare(['wisa:1']);
+      final opensAfterFirst = db.opens;
+      await resolver.prepare(['wisa:1']); // all cached ⇒ no work
+      expect(db.opens, opensAfterFirst);
+    });
+
+    test('mints only the keys not already loaded from the map', () async {
+      final db = _FakePersonIdDb()..table['wisa:1'] = 'existing';
+      final resolver = resolverOver(db, mintPrefix: 'minted');
+
+      await resolver.prepare(['wisa:1', 'wisa:2']);
+      expect(resolver.resolve('wisa:1'), const PersonId('existing'));
+      expect(resolver.resolve('wisa:2'), const PersonId('minted-0'));
+    });
+  });
+
+  group('convergence under concurrency (#85)', () {
+    test('a second operator fetches the first operator\'s committed id',
+        () async {
+      final db = _FakePersonIdDb(); // shared central table
+      final a = resolverOver(db, mintPrefix: 'A');
+      final b = resolverOver(db, mintPrefix: 'B');
+
+      await a.prepare(['wisa:1']); // A mints A-0 and commits
+      await b.prepare(['wisa:1']); // B loads the map, sees A-0, adopts it
+
+      expect(a.resolve('wisa:1'), const PersonId('A-0'));
+      expect(b.resolve('wisa:1'), equals(a.resolve('wisa:1')));
+    });
+
+    test('a stale-load minter loses the unique-key race and adopts the winner',
+        () async {
+      // Both operators load an empty map (B's load misses A's freshly committed
+      // row — the real concurrency window). The guarded insert arbitrates: B's
+      // INSERT finds the key present and writes nothing, then reads back A's id.
+      final db = _FakePersonIdDb(hideOnLoad: true);
+      final a = resolverOver(db, mintPrefix: 'A');
+      final b = resolverOver(db, mintPrefix: 'B');
+
+      await a.prepare(['wisa:1']); // loads empty, inserts A-0
+      await b.prepare(['wisa:1']); // loads empty, insert no-ops, reads back A-0
+
+      expect(db.table['wisa:1'], 'A-0', reason: 'only the first mint persists');
+      expect(a.resolve('wisa:1'), const PersonId('A-0'));
+      expect(b.resolve('wisa:1'), const PersonId('A-0'),
+          reason: 'the loser adopts the winner rather than its own B-0');
+    });
+  });
+
+  group('connection + statement discipline', () {
+    test('prepare opens with the config, reads a fresh token, and closes',
+        () async {
+      final db = _FakePersonIdDb();
+      final factory = _FakeFactory(db);
+      final resolver = AzureSqlPersonIdResolver(
+        factory: factory,
+        config: config,
+        tokens: const StaticAadTokenProvider('bearer-xyz'),
+        mintId: _mint('id'),
+      );
+
+      await resolver.prepare(['wisa:1']);
+      expect(factory.lastConfig, config);
+      expect(factory.tokensRead, ['bearer-xyz']);
+      expect(db.closes, 1);
+    });
+
+    test('mints run inside a single transaction', () async {
+      final db = _FakePersonIdDb();
+      final resolver = resolverOver(db);
+      await resolver.prepare(['wisa:1', 'wisa:2']);
+      expect(db.transactions, 1);
+    });
+
+    test('keys and ids are bound as parameters, never interpolated', () async {
+      final db = _FakePersonIdDb();
+      final resolver = resolverOver(db);
+      await resolver.prepare(['wisa:1']);
+
+      final insert = db.statements
+          .firstWhere((s) => s.contains('INSERT INTO') && s.contains('?'));
+      expect(insert, isNot(contains('wisa:1')));
+    });
+  });
+
+  group('personIdentitySchemaStatements', () {
+    test('provisions the identity map idempotently with the key as PK', () {
+      final ddl = personIdentitySchemaStatements.join('\n');
+      expect(ddl, contains('CREATE TABLE dbo.PersonIdentity'));
+      expect(ddl, contains('IF OBJECT_ID'));
+      // The natural key is the primary key — that is the unique constraint the
+      // concurrent mint-or-fetch converges on.
+      expect(ddl, contains('NaturalKey NVARCHAR(450) NOT NULL PRIMARY KEY'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Replaces the per-machine `FilePersonIdResolver` with a centralized **Azure SQL identity map** so concurrent operators converge on **one `PersonId` per natural key** — the latent correctness bug called out in #76 (Phase B3, part of epic #74).

The linker calls `resolve()` **synchronously** inside its pure pass, but a DB read is async, so the adapter mints **ahead** of the pass rather than lazily on a miss. This keeps `resolve()` a total, pure lookup and makes convergence atomic — the unique-constraint mint-or-fetch runs once, before any `LinkedAccount` is built, so no id can diverge and later need reconciling.

## Linked issue

Closes #85

## Changes

- **account_core** — `PreparablePersonIdResolver` adds an async `prepare(keys)`; `resolve()` stays synchronous and becomes *total* (an unprepared key is a programming error, not a miss).
- **account_linker** — factored the student/staff record-building into a shared step and exported the pure `naturalKeysFor()`, which returns exactly the keys `link()` resolves (locked by a recording-resolver contract test, so the primed set can never drift from the pass). Behavior of `link()` is unchanged.
- **account_state**
  - `AzureSqlPersonIdResolver` — loads the whole map, then mints new keys in one transaction via `INSERT … WHERE NOT EXISTS` (`UPDLOCK, HOLDLOCK`) under the `NaturalKey` primary key and reads back the winner, so a losing operator adopts the committed id.
  - `dbo.PersonIdentity` schema (natural key = PK = the unique constraint), idempotent DDL.
  - Async link path: `LinkedState.recomputeAsync` / `fromApplicationAsync` prime a preparable resolver before the pure `link()`; `StateApplier.link()` now returns a `Future`. A file/in-memory resolver isn't preparable, skips prepare, and the sync `recompute` path is unchanged.
- **docs/port-plan.md** — recorded the one deviation above the seam (resolve-ahead + async link path).

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` clean (191 files, 0 changed)
- [x] `dart analyze packages` clean (No issues found)
- [x] unit/widget tests pass — full workspace green; **248** in the three touched packages. Covers mint/fetch/idempotency, **convergence** (fetch path + stale-load unique-key race), the `naturalKeysFor ≡ link` seam contract, and the async State wiring (`recomputeAsync`/`fromApplicationAsync`, preparable vs non-preparable).
- [x] integration/e2e — **not run**: the real end-to-end (live Azure SQL) needs the concrete ODBC/FFI `SqlConnectionFactory` deferred to #89, and this is data-layer logic fully covered by unit tests. Ships a ready-made, `skip`ped live convergence round-trip (same pattern as #83/#84), enabled once #89 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
