### PR TITLE
Add concrete ODBC/FFI SqlConnectionFactory for Azure SQL (#89)

### DIFF
--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -142,12 +142,16 @@ reintroduces the hosting the epic deliberately avoids. The DB + AAD-only +
 token-auth round-trip was **proven end to end** during the spike (connect →
 create table → insert → read back `roundtrip-ok` → drop, `SUSER_SNAME()` =
 the operator UPN). The `account_state` connection/auth seam (`SqlConnection` /
-`SqlConnectionFactory` / `AadTokenProvider`) is in place now; the concrete
-Dart-side ODBC/FFI factory and its live DB round-trip are **deferred to #89**
-(carved out of #83 because the FFI-over-`msodbcsql18` binding is Windows-only
-and can't be unit-tested headlessly). Adapters are written and fully tested
-against the seam with a scripted fake; their opt-in live round-trip tests stay
-skipped until #89 wires the driver.
+`SqlConnectionFactory` / `AadTokenProvider`) is in place, and **#89 landed the
+concrete `OdbcSqlConnectionFactory`**: `dart:ffi` over `odbc32.dll` →
+`msodbcsql18`, authenticated by packing the AAD token into
+`SQL_COPT_SS_ACCESS_TOKEN`, with `query` / `execute` / `transaction` / `close`
+over the seam. The driver-free decisions (connection string, token packing,
+column-type mapping) are factored out and unit-tested offline; the FFI caller
+itself is Windows-only and can't be unit-tested headlessly, so it is exercised
+by the three adapters' opt-in, write-capable live round-trips (settings,
+PersonId resolver, password queue) — now wired to the real driver and run
+manually per the live-testing policy, skipped by default when no token is set.
 
 **Key Vault secrets (#84).** `KeyVaultSecretProvider` backs the `SecretProvider`
 seam against `accountmanager-kv`, replacing `InMemorySecretProvider` so the WISA

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -73,6 +73,7 @@ export 'src/sql/azure_sql_live_config.dart';
 export 'src/sql/azure_sql_password_queue_store.dart';
 export 'src/sql/azure_sql_person_id_resolver.dart';
 export 'src/sql/azure_sql_settings_store.dart';
+export 'src/sql/odbc/odbc_sql_connection.dart' show OdbcSqlConnectionFactory;
 export 'src/sql/password_queue_schema.dart';
 export 'src/sql/person_id_schema.dart';
 export 'src/sql/settings_schema.dart';

--- a/packages/account_state/lib/src/sql/odbc/odbc_bindings.dart
+++ b/packages/account_state/lib/src/sql/odbc/odbc_bindings.dart
@@ -1,0 +1,242 @@
+/// The raw `dart:ffi` binding over the ODBC Driver Manager (`odbc32.dll`) used
+/// by the concrete [SqlConnection] driver (issue #89).
+///
+/// This is the Windows-only, un-unit-testable half: a thin set of `SQL*`
+/// function lookups plus [OdbcException]. It resolves the ODBC entry points from
+/// `odbc32.dll`, which in turn dispatches to `msodbcsql18` named in the
+/// connection string. Everything above it (marshalling, the [SqlConnection]
+/// contract) is driver-free and covered offline.
+library;
+
+import 'dart:ffi';
+
+/// Thrown when an ODBC call returns `SQL_ERROR` / `SQL_INVALID_HANDLE`. Carries
+/// the driver's own diagnostic text (SQLSTATE + message) so a live failure —
+/// an expired token, a firewall block, a bad statement — is legible.
+class OdbcException implements Exception {
+  OdbcException(this.operation, this.diagnostics);
+
+  /// The ODBC call that failed, e.g. `SQLDriverConnect`.
+  final String operation;
+
+  /// The concatenated diagnostic records read via `SQLGetDiagRec`.
+  final String diagnostics;
+
+  @override
+  String toString() => 'OdbcException($operation): $diagnostics';
+}
+
+// SQLHANDLE and friends are opaque pointers; SQLLEN/SQLULEN are pointer-sized on
+// 64-bit Windows, so IntPtr/UintPtr keep the binding architecture-correct.
+
+typedef _SQLAllocHandleNative = Int16 Function(
+    Int16 handleType, Pointer<Void> input, Pointer<Pointer<Void>> output);
+typedef SqlAllocHandle = int Function(
+    int handleType, Pointer<Void> input, Pointer<Pointer<Void>> output);
+
+typedef _SQLSetEnvAttrNative = Int16 Function(
+    Pointer<Void> env, Int32 attr, Pointer<Void> value, Int32 stringLength);
+typedef SqlSetEnvAttr = int Function(
+    Pointer<Void> env, int attr, Pointer<Void> value, int stringLength);
+
+typedef _SQLSetConnectAttrWNative = Int16 Function(
+    Pointer<Void> dbc, Int32 attr, Pointer<Void> value, Int32 stringLength);
+typedef SqlSetConnectAttrW = int Function(
+    Pointer<Void> dbc, int attr, Pointer<Void> value, int stringLength);
+
+typedef _SQLDriverConnectWNative = Int16 Function(
+    Pointer<Void> dbc,
+    Pointer<Void> windowHandle,
+    Pointer<Uint16> inConnStr,
+    Int16 inLen,
+    Pointer<Uint16> outConnStr,
+    Int16 outMax,
+    Pointer<Int16> outLen,
+    Uint16 completion);
+typedef SqlDriverConnectW = int Function(
+    Pointer<Void> dbc,
+    Pointer<Void> windowHandle,
+    Pointer<Uint16> inConnStr,
+    int inLen,
+    Pointer<Uint16> outConnStr,
+    int outMax,
+    Pointer<Int16> outLen,
+    int completion);
+
+typedef _SQLPrepareWNative = Int16 Function(
+    Pointer<Void> stmt, Pointer<Uint16> text, Int32 textLen);
+typedef SqlPrepareW = int Function(
+    Pointer<Void> stmt, Pointer<Uint16> text, int textLen);
+
+typedef _SQLBindParameterNative = Int16 Function(
+    Pointer<Void> stmt,
+    Uint16 paramNum,
+    Int16 ioType,
+    Int16 valueType,
+    Int16 paramType,
+    UintPtr columnSize,
+    Int16 decimalDigits,
+    Pointer<Void> value,
+    IntPtr bufferLength,
+    Pointer<IntPtr> strLenOrInd);
+typedef SqlBindParameter = int Function(
+    Pointer<Void> stmt,
+    int paramNum,
+    int ioType,
+    int valueType,
+    int paramType,
+    int columnSize,
+    int decimalDigits,
+    Pointer<Void> value,
+    int bufferLength,
+    Pointer<IntPtr> strLenOrInd);
+
+typedef _SQLExecuteNative = Int16 Function(Pointer<Void> stmt);
+typedef SqlExecute = int Function(Pointer<Void> stmt);
+
+typedef _SQLNumResultColsNative = Int16 Function(
+    Pointer<Void> stmt, Pointer<Int16> count);
+typedef SqlNumResultCols = int Function(
+    Pointer<Void> stmt, Pointer<Int16> count);
+
+typedef _SQLDescribeColWNative = Int16 Function(
+    Pointer<Void> stmt,
+    Uint16 col,
+    Pointer<Uint16> colName,
+    Int16 nameMax,
+    Pointer<Int16> nameLen,
+    Pointer<Int16> dataType,
+    Pointer<UintPtr> colSize,
+    Pointer<Int16> decimalDigits,
+    Pointer<Int16> nullable);
+typedef SqlDescribeColW = int Function(
+    Pointer<Void> stmt,
+    int col,
+    Pointer<Uint16> colName,
+    int nameMax,
+    Pointer<Int16> nameLen,
+    Pointer<Int16> dataType,
+    Pointer<UintPtr> colSize,
+    Pointer<Int16> decimalDigits,
+    Pointer<Int16> nullable);
+
+typedef _SQLFetchNative = Int16 Function(Pointer<Void> stmt);
+typedef SqlFetch = int Function(Pointer<Void> stmt);
+
+typedef _SQLGetDataNative = Int16 Function(
+    Pointer<Void> stmt,
+    Uint16 col,
+    Int16 targetType,
+    Pointer<Void> target,
+    IntPtr bufferLength,
+    Pointer<IntPtr> strLenOrInd);
+typedef SqlGetData = int Function(Pointer<Void> stmt, int col, int targetType,
+    Pointer<Void> target, int bufferLength, Pointer<IntPtr> strLenOrInd);
+
+typedef _SQLRowCountNative = Int16 Function(
+    Pointer<Void> stmt, Pointer<IntPtr> rowCount);
+typedef SqlRowCount = int Function(
+    Pointer<Void> stmt, Pointer<IntPtr> rowCount);
+
+typedef _SQLEndTranNative = Int16 Function(
+    Int16 handleType, Pointer<Void> handle, Int16 completionType);
+typedef SqlEndTran = int Function(
+    int handleType, Pointer<Void> handle, int completionType);
+
+typedef _SQLGetDiagRecWNative = Int16 Function(
+    Int16 handleType,
+    Pointer<Void> handle,
+    Int16 recNumber,
+    Pointer<Uint16> state,
+    Pointer<Int32> nativeError,
+    Pointer<Uint16> message,
+    Int16 messageMax,
+    Pointer<Int16> messageLen);
+typedef SqlGetDiagRecW = int Function(
+    int handleType,
+    Pointer<Void> handle,
+    int recNumber,
+    Pointer<Uint16> state,
+    Pointer<Int32> nativeError,
+    Pointer<Uint16> message,
+    int messageMax,
+    Pointer<Int16> messageLen);
+
+typedef _SQLFreeHandleNative = Int16 Function(
+    Int16 handleType, Pointer<Void> handle);
+typedef SqlFreeHandle = int Function(int handleType, Pointer<Void> handle);
+
+typedef _SQLDisconnectNative = Int16 Function(Pointer<Void> dbc);
+typedef SqlDisconnect = int Function(Pointer<Void> dbc);
+
+/// The bound `SQL*` entry points, looked up once from `odbc32.dll`.
+///
+/// A value type holding the resolved function pointers so the connection code
+/// reads as ordinary Dart calls. Constructed by [OdbcBindings.open], which is
+/// the single place the native library is loaded.
+class OdbcBindings {
+  OdbcBindings._(this._lib)
+      : allocHandle =
+            _lib.lookupFunction<_SQLAllocHandleNative, SqlAllocHandle>(
+                'SQLAllocHandle'),
+        setEnvAttr = _lib.lookupFunction<_SQLSetEnvAttrNative, SqlSetEnvAttr>(
+            'SQLSetEnvAttr'),
+        setConnectAttr =
+            _lib.lookupFunction<_SQLSetConnectAttrWNative, SqlSetConnectAttrW>(
+                'SQLSetConnectAttrW'),
+        driverConnect =
+            _lib.lookupFunction<_SQLDriverConnectWNative, SqlDriverConnectW>(
+                'SQLDriverConnectW'),
+        prepare =
+            _lib.lookupFunction<_SQLPrepareWNative, SqlPrepareW>('SQLPrepareW'),
+        bindParameter =
+            _lib.lookupFunction<_SQLBindParameterNative, SqlBindParameter>(
+                'SQLBindParameter'),
+        execute =
+            _lib.lookupFunction<_SQLExecuteNative, SqlExecute>('SQLExecute'),
+        numResultCols =
+            _lib.lookupFunction<_SQLNumResultColsNative, SqlNumResultCols>(
+                'SQLNumResultCols'),
+        describeCol =
+            _lib.lookupFunction<_SQLDescribeColWNative, SqlDescribeColW>(
+                'SQLDescribeColW'),
+        fetch = _lib.lookupFunction<_SQLFetchNative, SqlFetch>('SQLFetch'),
+        getData =
+            _lib.lookupFunction<_SQLGetDataNative, SqlGetData>('SQLGetData'),
+        rowCount =
+            _lib.lookupFunction<_SQLRowCountNative, SqlRowCount>('SQLRowCount'),
+        endTran =
+            _lib.lookupFunction<_SQLEndTranNative, SqlEndTran>('SQLEndTran'),
+        getDiagRec = _lib.lookupFunction<_SQLGetDiagRecWNative, SqlGetDiagRecW>(
+            'SQLGetDiagRecW'),
+        freeHandle = _lib.lookupFunction<_SQLFreeHandleNative, SqlFreeHandle>(
+            'SQLFreeHandle'),
+        disconnect = _lib.lookupFunction<_SQLDisconnectNative, SqlDisconnect>(
+            'SQLDisconnect');
+
+  /// Loads the ODBC Driver Manager and binds its entry points. On Windows this
+  /// is `odbc32.dll`, always present alongside the `msodbcsql18` driver the
+  /// connection string names.
+  factory OdbcBindings.open() =>
+      OdbcBindings._(DynamicLibrary.open('odbc32.dll'));
+
+  // ignore: unused_field
+  final DynamicLibrary _lib;
+
+  final SqlAllocHandle allocHandle;
+  final SqlSetEnvAttr setEnvAttr;
+  final SqlSetConnectAttrW setConnectAttr;
+  final SqlDriverConnectW driverConnect;
+  final SqlPrepareW prepare;
+  final SqlBindParameter bindParameter;
+  final SqlExecute execute;
+  final SqlNumResultCols numResultCols;
+  final SqlDescribeColW describeCol;
+  final SqlFetch fetch;
+  final SqlGetData getData;
+  final SqlRowCount rowCount;
+  final SqlEndTran endTran;
+  final SqlGetDiagRecW getDiagRec;
+  final SqlFreeHandle freeHandle;
+  final SqlDisconnect disconnect;
+}

--- a/packages/account_state/lib/src/sql/odbc/odbc_constants.dart
+++ b/packages/account_state/lib/src/sql/odbc/odbc_constants.dart
@@ -1,0 +1,109 @@
+/// ODBC API constants used by the concrete [SqlConnection] driver (issue #89).
+///
+/// These are the numeric codes from the ODBC headers (`sql.h`, `sqlext.h`,
+/// `msodbcsql.h`) the FFI binding passes to `odbc32.dll`. They are plain `int`s
+/// with no `dart:ffi` dependency so the marshalling logic that consumes them
+/// (`odbc_marshalling.dart`) stays unit-testable off a live driver.
+library;
+
+// --- Return codes (SQLRETURN) ------------------------------------------------
+
+/// The call succeeded with no diagnostic.
+const int sqlSuccess = 0;
+
+/// The call succeeded but posted an informational diagnostic (e.g. a truncated
+/// `SQLGetData` chunk). Treated as success by the driver's error check.
+const int sqlSuccessWithInfo = 1;
+
+/// A `SQLFetch` / `SQLGetData` returned no (more) data — the fetch loop's stop
+/// signal, not an error.
+const int sqlNoData = 100;
+
+/// The call failed; the diagnostic record carries the reason.
+const int sqlError = -1;
+
+/// The handle passed to the call was invalid.
+const int sqlInvalidHandle = -2;
+
+// --- Handle types ------------------------------------------------------------
+
+const int sqlHandleEnv = 1;
+const int sqlHandleDbc = 2;
+const int sqlHandleStmt = 3;
+
+// --- Environment / connection attributes -------------------------------------
+
+/// `SQL_ATTR_ODBC_VERSION` — must be set to [sqlOvOdbc3] on the environment
+/// before allocating a connection.
+const int sqlAttrOdbcVersion = 200;
+const int sqlOvOdbc3 = 3;
+
+/// `SQL_ATTR_AUTOCOMMIT` — toggled off for the span of a [SqlConnection.transaction].
+const int sqlAttrAutocommit = 102;
+const int sqlAutocommitOff = 0;
+const int sqlAutocommitOn = 1;
+
+/// `SQL_COPT_SS_ACCESS_TOKEN` — the SQL-Server-specific connection attribute
+/// that carries the AAD bearer token (packed by
+/// [packAccessToken]); this is how the AAD-only database is authenticated with
+/// no stored credential.
+const int sqlCoptSsAccessToken = 1256;
+
+/// `SQL_IS_POINTER` — the `StringLength` sentinel for an attribute whose value
+/// is a pointer (the access-token struct).
+const int sqlIsPointer = -4;
+
+/// `SQL_IS_INTEGER` — the `StringLength` sentinel for an attribute whose value
+/// is a fixed-size integer passed in the pointer slot.
+const int sqlIsInteger = -6;
+
+// --- Transaction completion --------------------------------------------------
+
+const int sqlCommit = 0;
+const int sqlRollback = 1;
+
+// --- DriverConnect completion ------------------------------------------------
+
+/// `SQL_DRIVER_NOPROMPT` — never pop a driver dialog; a headless connect.
+const int sqlDriverNoprompt = 0;
+
+// --- Length / indicator sentinels --------------------------------------------
+
+/// `SQL_NTS` — "null-terminated string": lets the driver measure a wide string
+/// itself rather than being handed a length.
+const int sqlNts = -3;
+
+/// `SQL_NULL_DATA` — a column read back as SQL `NULL`, or a bound parameter to
+/// send as `NULL`.
+const int sqlNullData = -1;
+
+/// `SQL_NO_TOTAL` — `SQLGetData` could not report the total remaining length of
+/// a streamed value up front.
+const int sqlNoTotal = -4;
+
+// --- Parameter direction -----------------------------------------------------
+
+const int sqlParamInput = 1;
+
+// --- C data types (SQL_C_*) --------------------------------------------------
+
+/// `SQL_C_WCHAR` — UTF-16 buffer; used for every text value and for values
+/// (dates) sent/received as their string form.
+const int sqlCWchar = -8;
+
+/// `SQL_C_SBIGINT` — signed 64-bit integer.
+const int sqlCSbigint = -25;
+
+/// `SQL_C_BIT` — a single 0/1 byte.
+const int sqlCBit = -7;
+
+// --- SQL data types (SQL_*) --------------------------------------------------
+
+const int sqlBit = -7;
+const int sqlTinyint = -6;
+const int sqlSmallint = 5;
+const int sqlInteger = 4;
+const int sqlBigint = -5;
+
+/// `SQL_WVARCHAR` — the parameter type strings (and stringified dates) bind as.
+const int sqlWvarchar = -9;

--- a/packages/account_state/lib/src/sql/odbc/odbc_marshalling.dart
+++ b/packages/account_state/lib/src/sql/odbc/odbc_marshalling.dart
@@ -1,0 +1,91 @@
+/// Pure, driver-free marshalling helpers for the ODBC/FFI [SqlConnection]
+/// (issue #89).
+///
+/// The FFI binding in `odbc_sql_connection.dart` is Windows-only and can only
+/// be exercised against a live `msodbcsql18` + Azure SQL database, so the
+/// decisions that don't *need* the driver — how the connection string is built,
+/// how the AAD token is packed into the `SQL_COPT_SS_ACCESS_TOKEN` struct, and
+/// which Dart shape a given SQL column type maps to — live here as plain
+/// functions with offline unit tests. The FFI layer is then a thin caller.
+library;
+
+import 'dart:typed_data';
+
+import 'odbc_constants.dart';
+
+/// The default ODBC driver name. The Microsoft **ODBC Driver 18 for SQL
+/// Server** redistributable (`msodbcsql18`) is bundled with the Windows
+/// installer, per the connectivity decision in `docs/port-plan.md`.
+const String defaultOdbcDriver = 'ODBC Driver 18 for SQL Server';
+
+/// Builds the ODBC connection string for [server]/[database].
+///
+/// It carries **no credential**: the database is AAD-only, so authentication is
+/// the AAD bearer token set separately through `SQL_COPT_SS_ACCESS_TOKEN`
+/// ([packAccessToken]). `Encrypt=yes` is mandatory for Azure SQL and, with
+/// Driver 18's default of not trusting arbitrary certificates, the server
+/// certificate is validated against the public CA chain. Only the target and
+/// transport appear here, so the string is safe to log.
+String buildOdbcConnectionString({
+  required String server,
+  required String database,
+  String driver = defaultOdbcDriver,
+}) =>
+    'Driver={$driver};'
+    'Server=tcp:$server,1433;'
+    'Database=$database;'
+    'Encrypt=yes;';
+
+/// Packs [accessToken] into the byte layout the `SQL_COPT_SS_ACCESS_TOKEN`
+/// connection attribute expects.
+///
+/// The driver reads an `ACCESSTOKEN { DWORD dataSize; BYTE data[]; }` struct: a
+/// little-endian `uint32` byte count followed by the token encoded as
+/// **UTF-16LE**. AAD access tokens are base64url JWTs (ASCII), so each character
+/// becomes a byte followed by `0x00`. Returned as a [Uint8List] the FFI layer
+/// copies verbatim into native memory before `SQLSetConnectAttr`.
+Uint8List packAccessToken(String accessToken) {
+  final units = accessToken.codeUnits;
+  final out = Uint8List(4 + units.length * 2);
+  final view = ByteData.view(out.buffer);
+  view.setUint32(0, units.length * 2, Endian.little);
+  for (var i = 0; i < units.length; i++) {
+    view.setUint16(4 + i * 2, units[i], Endian.little);
+  }
+  return out;
+}
+
+/// How a result column is retrieved from the driver and surfaced as a Dart
+/// value in a [SqlRow].
+enum OdbcColumnCategory {
+  /// `SQL_C_SBIGINT` → Dart `int`. For `INT`/`BIGINT`/`SMALLINT`/`TINYINT`.
+  integer,
+
+  /// `SQL_C_BIT` → Dart `bool`. For `BIT`.
+  boolean,
+
+  /// `SQL_C_WCHAR` → Dart `String` (or `null`). For everything else —
+  /// `NVARCHAR`, `NVARCHAR(MAX)`, and `DATETIME2` (read back as its ISO-8601
+  /// string, which the adapters' `_date` parses). Keeping dates as text avoids
+  /// binding the `SQL_TIMESTAMP_STRUCT` and matches what the adapters already
+  /// tolerate.
+  text,
+}
+
+/// Maps an ODBC SQL type code (as reported by `SQLDescribeCol`) to the retrieval
+/// [OdbcColumnCategory]. Only the types the Phase B schema actually uses get a
+/// dedicated numeric mapping; everything else — text and dates — is read as a
+/// string, which the four adapters accept.
+OdbcColumnCategory categoryForSqlType(int sqlType) {
+  switch (sqlType) {
+    case sqlBit:
+      return OdbcColumnCategory.boolean;
+    case sqlTinyint:
+    case sqlSmallint:
+    case sqlInteger:
+    case sqlBigint:
+      return OdbcColumnCategory.integer;
+    default:
+      return OdbcColumnCategory.text;
+  }
+}

--- a/packages/account_state/lib/src/sql/odbc/odbc_sql_connection.dart
+++ b/packages/account_state/lib/src/sql/odbc/odbc_sql_connection.dart
@@ -1,0 +1,502 @@
+/// The concrete, production [SqlConnectionFactory] / [SqlConnection] for the
+/// centralized Azure SQL database (issue #89).
+///
+/// This is the "real consumer" driver the four Phase B adapters plug into: FFI
+/// over the Microsoft **ODBC Driver 18 for SQL Server** (`msodbcsql18`),
+/// authenticated with the AAD bearer token from [AadTokenProvider] via
+/// `SQL_COPT_SS_ACCESS_TOKEN` — no stored database credential — per the
+/// connectivity decision in `docs/port-plan.md`.
+///
+/// It is **Windows-only** and cannot be unit-tested headlessly: it needs the
+/// driver, a live AAD-authenticated Azure SQL database, and a fresh token. The
+/// driver-free decisions (connection string, token packing, column-type
+/// mapping) are factored into `odbc_marshalling.dart` and covered by offline
+/// tests; this file is the thin FFI caller and is exercised only by the opt-in
+/// live round-trip tests under `test/integration/`.
+///
+/// ODBC's `SQL*` calls are synchronous and blocking. The Phase B workloads —
+/// loading config, priming the identity map, draining the password queue — are
+/// small and infrequent, so the work runs inline and each method simply returns
+/// a resolved [Future] to satisfy the async seam; no isolate offload is
+/// warranted at this volume.
+library;
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+import '../aad_token_provider.dart';
+import '../azure_sql_config.dart';
+import '../sql_connection.dart';
+import 'odbc_bindings.dart';
+import 'odbc_constants.dart';
+import 'odbc_marshalling.dart';
+
+/// Opens real [SqlConnection]s to Azure SQL over ODBC Driver 18.
+///
+/// Production wires this where the adapters are constructed; tests keep using
+/// the scripted fake. The native library (`odbc32.dll`) is loaded once, lazily,
+/// on the first [open] and shared by every connection it hands out.
+class OdbcSqlConnectionFactory implements SqlConnectionFactory {
+  OdbcSqlConnectionFactory();
+
+  OdbcBindings? _bindings;
+
+  OdbcBindings get _lib => _bindings ??= OdbcBindings.open();
+
+  @override
+  Future<SqlConnection> open(
+    AzureSqlConfig config,
+    AadTokenProvider tokens,
+  ) async {
+    // Read a fresh token per open so a connection never outlives its bearer.
+    final token = await tokens.databaseAccessToken();
+    final b = _lib;
+
+    final env = _allocHandle(b, sqlHandleEnv, nullptr);
+    _check(
+      b,
+      b.setEnvAttr(env, sqlAttrOdbcVersion,
+          Pointer<Void>.fromAddress(sqlOvOdbc3), sqlIsInteger),
+      'SQLSetEnvAttr(ODBC_VERSION)',
+      sqlHandleEnv,
+      env,
+    );
+
+    final dbc = _allocHandle(b, sqlHandleDbc, env);
+
+    // Pack the AAD token into the SQL_COPT_SS_ACCESS_TOKEN struct and hand the
+    // driver a pointer to it. The bytes must stay live until the connection is
+    // established, so this buffer is freed only after SQLDriverConnect returns.
+    final tokenBytes = packAccessToken(token);
+    final tokenPtr = malloc<Uint8>(tokenBytes.length);
+    tokenPtr.asTypedList(tokenBytes.length).setAll(0, tokenBytes);
+    try {
+      _check(
+        b,
+        b.setConnectAttr(
+            dbc, sqlCoptSsAccessToken, tokenPtr.cast(), sqlIsPointer),
+        'SQLSetConnectAttr(ACCESS_TOKEN)',
+        sqlHandleDbc,
+        dbc,
+      );
+
+      final connStr = buildOdbcConnectionString(
+        server: config.server,
+        database: config.database,
+      );
+      final connW = connStr.toNativeUtf16();
+      try {
+        _check(
+          b,
+          b.driverConnect(dbc, nullptr, connW.cast(), sqlNts, nullptr, 0,
+              nullptr, sqlDriverNoprompt),
+          'SQLDriverConnect',
+          sqlHandleDbc,
+          dbc,
+        );
+      } finally {
+        malloc.free(connW);
+      }
+    } catch (_) {
+      // Connect failed: don't leak the handles we already allocated.
+      b.freeHandle(sqlHandleDbc, dbc);
+      b.freeHandle(sqlHandleEnv, env);
+      rethrow;
+    } finally {
+      malloc.free(tokenPtr);
+    }
+
+    return _OdbcSqlConnection(b, env, dbc);
+  }
+}
+
+/// A live ODBC connection wrapping the environment + connection handles.
+class _OdbcSqlConnection implements SqlConnection {
+  _OdbcSqlConnection(this._b, this._env, this._dbc);
+
+  final OdbcBindings _b;
+  final Pointer<Void> _env;
+  final Pointer<Void> _dbc;
+
+  bool _closed = false;
+  bool _inTransaction = false;
+
+  @override
+  Future<List<SqlRow>> query(String sql,
+      [List<Object?> params = const []]) async {
+    _ensureOpen();
+    final stmt = _allocHandle(_b, sqlHandleStmt, _dbc);
+    final allocations = <Pointer<NativeType>>[];
+    try {
+      _prepare(stmt, sql);
+      _bindParams(stmt, params, allocations);
+      _check(_b, _b.execute(stmt), 'SQLExecute', sqlHandleStmt, stmt);
+      return _readRows(stmt);
+    } finally {
+      for (final p in allocations) {
+        malloc.free(p);
+      }
+      _b.freeHandle(sqlHandleStmt, stmt);
+    }
+  }
+
+  @override
+  Future<int> execute(String sql, [List<Object?> params = const []]) async {
+    _ensureOpen();
+    final stmt = _allocHandle(_b, sqlHandleStmt, _dbc);
+    final allocations = <Pointer<NativeType>>[];
+    try {
+      _prepare(stmt, sql);
+      _bindParams(stmt, params, allocations);
+      _check(_b, _b.execute(stmt), 'SQLExecute', sqlHandleStmt, stmt);
+
+      final rowsPtr = malloc<IntPtr>();
+      try {
+        _check(
+            _b, _b.rowCount(stmt, rowsPtr), 'SQLRowCount', sqlHandleStmt, stmt);
+        final affected = rowsPtr.value;
+        // A DDL / no-count statement reports -1; normalize to 0 affected rows.
+        return affected < 0 ? 0 : affected;
+      } finally {
+        malloc.free(rowsPtr);
+      }
+    } finally {
+      for (final p in allocations) {
+        malloc.free(p);
+      }
+      _b.freeHandle(sqlHandleStmt, stmt);
+    }
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function(SqlConnection tx) action) async {
+    _ensureOpen();
+    // The adapters never nest; a nested call joins the outer transaction so the
+    // whole unit still commits or rolls back once.
+    if (_inTransaction) return action(this);
+
+    _setAutocommit(false);
+    _inTransaction = true;
+    try {
+      final result = await action(this);
+      _check(_b, _b.endTran(sqlHandleDbc, _dbc, sqlCommit),
+          'SQLEndTran(COMMIT)', sqlHandleDbc, _dbc);
+      return result;
+    } catch (_) {
+      // Best-effort rollback; surface the original failure, not a rollback one.
+      _b.endTran(sqlHandleDbc, _dbc, sqlRollback);
+      rethrow;
+    } finally {
+      _inTransaction = false;
+      _setAutocommit(true);
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    _b.disconnect(_dbc);
+    _b.freeHandle(sqlHandleDbc, _dbc);
+    _b.freeHandle(sqlHandleEnv, _env);
+  }
+
+  void _ensureOpen() {
+    if (_closed) {
+      throw StateError('operation on a closed OdbcSqlConnection');
+    }
+  }
+
+  void _setAutocommit(bool on) {
+    _check(
+      _b,
+      _b.setConnectAttr(
+        _dbc,
+        sqlAttrAutocommit,
+        Pointer<Void>.fromAddress(on ? sqlAutocommitOn : sqlAutocommitOff),
+        sqlIsInteger,
+      ),
+      'SQLSetConnectAttr(AUTOCOMMIT)',
+      sqlHandleDbc,
+      _dbc,
+    );
+  }
+
+  void _prepare(Pointer<Void> stmt, String sql) {
+    final text = sql.toNativeUtf16();
+    try {
+      // SQL_NTS: the driver measures the null-terminated statement and copies
+      // it during prepare, so the buffer is safe to free right after.
+      _check(_b, _b.prepare(stmt, text.cast(), sqlNts), 'SQLPrepare',
+          sqlHandleStmt, stmt);
+    } finally {
+      malloc.free(text);
+    }
+  }
+
+  /// Binds [params] positionally (`?`), collecting every native buffer into
+  /// [allocations] so they stay live through `SQLExecute` and are freed by the
+  /// caller afterward. Values are bound by the driver, never interpolated.
+  void _bindParams(
+    Pointer<Void> stmt,
+    List<Object?> params,
+    List<Pointer<NativeType>> allocations,
+  ) {
+    for (var i = 0; i < params.length; i++) {
+      final value = params[i];
+      final paramNum = i + 1;
+      final ind = malloc<IntPtr>();
+      allocations.add(ind);
+
+      if (value == null) {
+        ind.value = sqlNullData;
+        // A NULL carries no value, but keep a valid (unused) pointer for it.
+        final dummy = malloc<Uint16>();
+        dummy.value = 0;
+        allocations.add(dummy);
+        _bind(stmt, paramNum, sqlCWchar, sqlWvarchar, 1, dummy.cast(), 0, ind);
+      } else if (value is bool) {
+        final buf = malloc<Uint8>();
+        buf.value = value ? 1 : 0;
+        allocations.add(buf);
+        ind.value = 1;
+        _bind(stmt, paramNum, sqlCBit, sqlBit, 0, buf.cast(), 0, ind);
+      } else if (value is int) {
+        final buf = malloc<Int64>();
+        buf.value = value;
+        allocations.add(buf);
+        ind.value = 8;
+        _bind(stmt, paramNum, sqlCSbigint, sqlBigint, 0, buf.cast(), 0, ind);
+      } else {
+        // String, and DateTime as its ISO-8601 text (SQL Server converts the
+        // nvarchar to DATETIME2 on the way in; the adapters read it back as a
+        // string and parse it).
+        final text = value is DateTime ? value.toIso8601String() : '$value';
+        final buf = text.toNativeUtf16();
+        allocations.add(buf);
+        ind.value = sqlNts;
+        final columnSize = text.isEmpty ? 1 : text.length;
+        final byteLength = (text.length + 1) * 2;
+        _bind(stmt, paramNum, sqlCWchar, sqlWvarchar, columnSize, buf.cast(),
+            byteLength, ind);
+      }
+    }
+  }
+
+  void _bind(
+    Pointer<Void> stmt,
+    int paramNum,
+    int valueType,
+    int paramType,
+    int columnSize,
+    Pointer<Void> value,
+    int bufferLength,
+    Pointer<IntPtr> ind,
+  ) {
+    _check(
+      _b,
+      _b.bindParameter(stmt, paramNum, sqlParamInput, valueType, paramType,
+          columnSize, 0, value, bufferLength, ind),
+      'SQLBindParameter($paramNum)',
+      sqlHandleStmt,
+      stmt,
+    );
+  }
+
+  List<SqlRow> _readRows(Pointer<Void> stmt) {
+    final countPtr = malloc<Int16>();
+    final int columnCount;
+    try {
+      _check(_b, _b.numResultCols(stmt, countPtr), 'SQLNumResultCols',
+          sqlHandleStmt, stmt);
+      columnCount = countPtr.value;
+    } finally {
+      malloc.free(countPtr);
+    }
+    if (columnCount == 0) return const [];
+
+    final columns = [
+      for (var c = 1; c <= columnCount; c++) _describeColumn(stmt, c),
+    ];
+
+    final rows = <SqlRow>[];
+    while (true) {
+      final ret = _b.fetch(stmt);
+      if (ret == sqlNoData) break;
+      _check(_b, ret, 'SQLFetch', sqlHandleStmt, stmt);
+      final row = <String, Object?>{};
+      for (var c = 1; c <= columnCount; c++) {
+        row[columns[c - 1].name] = _getValue(stmt, c, columns[c - 1].category);
+      }
+      rows.add(row);
+    }
+    return rows;
+  }
+
+  _Column _describeColumn(Pointer<Void> stmt, int col) {
+    const nameCap = 256;
+    final nameBuf = malloc<Uint16>(nameCap);
+    final nameLen = malloc<Int16>();
+    final dataType = malloc<Int16>();
+    final colSize = malloc<UintPtr>();
+    final decimals = malloc<Int16>();
+    final nullable = malloc<Int16>();
+    try {
+      _check(
+        _b,
+        _b.describeCol(stmt, col, nameBuf, nameCap, nameLen, dataType, colSize,
+            decimals, nullable),
+        'SQLDescribeCol($col)',
+        sqlHandleStmt,
+        stmt,
+      );
+      final name = String.fromCharCodes(nameBuf.asTypedList(nameLen.value));
+      return _Column(name, categoryForSqlType(dataType.value));
+    } finally {
+      malloc.free(nameBuf);
+      malloc.free(nameLen);
+      malloc.free(dataType);
+      malloc.free(colSize);
+      malloc.free(decimals);
+      malloc.free(nullable);
+    }
+  }
+
+  Object? _getValue(Pointer<Void> stmt, int col, OdbcColumnCategory category) {
+    final ind = malloc<IntPtr>();
+    try {
+      switch (category) {
+        case OdbcColumnCategory.integer:
+          final buf = malloc<Int64>();
+          try {
+            final ret = _b.getData(stmt, col, sqlCSbigint, buf.cast(), 8, ind);
+            if (ret == sqlNoData) return null;
+            _check(_b, ret, 'SQLGetData($col)', sqlHandleStmt, stmt);
+            return ind.value == sqlNullData ? null : buf.value;
+          } finally {
+            malloc.free(buf);
+          }
+        case OdbcColumnCategory.boolean:
+          final buf = malloc<Uint8>();
+          try {
+            final ret = _b.getData(stmt, col, sqlCBit, buf.cast(), 1, ind);
+            if (ret == sqlNoData) return null;
+            _check(_b, ret, 'SQLGetData($col)', sqlHandleStmt, stmt);
+            return ind.value == sqlNullData ? null : buf.value != 0;
+          } finally {
+            malloc.free(buf);
+          }
+        case OdbcColumnCategory.text:
+          return _getString(stmt, col, ind);
+      }
+    } finally {
+      malloc.free(ind);
+    }
+  }
+
+  /// Reads a text column, looping over `SQLGetData` chunks so an oversized
+  /// value (e.g. an import-rule `NVARCHAR(MAX)` payload) is reassembled whole.
+  String? _getString(Pointer<Void> stmt, int col, Pointer<IntPtr> ind) {
+    const capChars = 2048; // 4 KiB per chunk
+    const capBytes = capChars * 2;
+    final buf = malloc<Uint16>(capChars);
+    final out = StringBuffer();
+    try {
+      while (true) {
+        final ret = _b.getData(stmt, col, sqlCWchar, buf.cast(), capBytes, ind);
+        if (ret == sqlNoData) break;
+        _check(_b, ret, 'SQLGetData($col)', sqlHandleStmt, stmt);
+        if (ind.value == sqlNullData) return null;
+        if (ret == sqlSuccessWithInfo) {
+          // Truncated: the buffer is full bar the null terminator; take the
+          // full run of chars and go round again for the rest.
+          out.write(String.fromCharCodes(buf.asTypedList(capChars - 1)));
+          continue;
+        }
+        // Final chunk: the indicator is the remaining byte count.
+        final remainingBytes = ind.value;
+        final chars = remainingBytes == sqlNoTotal
+            ? _scanForNull(buf, capChars)
+            : remainingBytes ~/ 2;
+        out.write(String.fromCharCodes(buf.asTypedList(chars)));
+        break;
+      }
+      return out.toString();
+    } finally {
+      malloc.free(buf);
+    }
+  }
+
+  int _scanForNull(Pointer<Uint16> buf, int cap) {
+    final units = buf.asTypedList(cap);
+    final zero = units.indexOf(0);
+    return zero < 0 ? cap : zero;
+  }
+}
+
+/// A described result column: its name and how its value is marshalled.
+class _Column {
+  _Column(this.name, this.category);
+  final String name;
+  final OdbcColumnCategory category;
+}
+
+/// Allocates an ODBC handle of [type] under [input] and returns it.
+Pointer<Void> _allocHandle(OdbcBindings b, int type, Pointer<Void> input) {
+  final out = malloc<Pointer<Void>>();
+  try {
+    final ret = b.allocHandle(type, input, out);
+    if (ret != sqlSuccess && ret != sqlSuccessWithInfo) {
+      // The output handle is unset on failure, so there is nothing to read
+      // diagnostics from; report the raw code.
+      throw OdbcException('SQLAllocHandle($type)', 'return code $ret');
+    }
+    return out.value;
+  } finally {
+    malloc.free(out);
+  }
+}
+
+/// Throws an [OdbcException] with the driver's diagnostics when [ret] signals a
+/// failure. `SQL_SUCCESS_WITH_INFO` is treated as success (info-only).
+void _check(
+  OdbcBindings b,
+  int ret,
+  String operation,
+  int handleType,
+  Pointer<Void> handle,
+) {
+  if (ret == sqlSuccess || ret == sqlSuccessWithInfo) return;
+  throw OdbcException(operation, _diagnostics(b, handleType, handle));
+}
+
+/// Concatenates the diagnostic records (`SQLSTATE: message`) the driver posted
+/// for the last failing call on [handle].
+String _diagnostics(OdbcBindings b, int handleType, Pointer<Void> handle) {
+  const stateCap = 6; // 5 chars + null
+  const msgCap = 1024;
+  final state = malloc<Uint16>(stateCap);
+  final nativeError = malloc<Int32>();
+  final message = malloc<Uint16>(msgCap);
+  final msgLen = malloc<Int16>();
+  final records = <String>[];
+  try {
+    var record = 1;
+    while (true) {
+      final ret = b.getDiagRec(handleType, handle, record, state, nativeError,
+          message, msgCap, msgLen);
+      if (ret != sqlSuccess && ret != sqlSuccessWithInfo) break;
+      final sqlState = String.fromCharCodes(state.asTypedList(5));
+      final text = String.fromCharCodes(message.asTypedList(msgLen.value));
+      records.add('[$sqlState] $text');
+      record++;
+    }
+  } finally {
+    malloc.free(state);
+    malloc.free(nativeError);
+    malloc.free(message);
+    malloc.free(msgLen);
+  }
+  return records.isEmpty ? '(no diagnostic record)' : records.join('; ');
+}

--- a/packages/account_state/pubspec.yaml
+++ b/packages/account_state/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   azure_api:
   account_linker:
   account_actions:
+  ffi: ^2.1.0
   uuid: ^4.5.0
 
 dev_dependencies:

--- a/packages/account_state/test/integration/azure_sql_password_queue_store_live_test.dart
+++ b/packages/account_state/test/integration/azure_sql_password_queue_store_live_test.dart
@@ -15,11 +15,11 @@ import 'package:test/test.dart';
 /// — never part of the read-only CI live set — and needs a fresh AAD token (see
 /// `AzureSqlLiveConfig`).
 ///
-/// It cannot run yet: the concrete ODBC/FFI [SqlConnectionFactory] is deferred
-/// to #89 (Windows-only, needs `msodbcsql18` + a live DB, not unit-testable
-/// headlessly). The body below is the ready-made round-trip that slice will
-/// enable by wiring [_liveFactory] to the real driver and dropping the `skip`.
-/// Until then the adapter is fully covered by the seam-fake unit tests in
+/// Enabled by #89, which wired [_liveFactory] to the concrete ODBC/FFI driver.
+/// It is Windows-only (needs `msodbcsql18` + a live AAD-authenticated DB + a
+/// fresh token), so it stays offline-by-default: the group runs only when
+/// `AZURE_SQL_ACCESS_TOKEN` (+ server/database) is set, and is skipped
+/// otherwise. The adapter also stays covered by the seam-fake unit tests in
 /// `test/sql/azure_sql_password_queue_store_test.dart`.
 void main() {
   final config = AzureSqlLiveConfig.fromEnvironment();
@@ -35,9 +35,9 @@ void main() {
         );
         final tokens = StaticAadTokenProvider(config.accessToken);
 
-        // #89 will provision the schema through the factory before this runs;
-        // documented here as the precondition rather than executed blind.
-        //   for (final ddl in passwordQueueSchemaStatements) { ... }
+        // Provision the schema through the real driver before the round-trip;
+        // the DDL is idempotent, so a re-run is a no-op.
+        await _provision(sqlConfig, tokens, passwordQueueSchemaStatements);
 
         final generator = AzureSqlPasswordQueueStore(
           factory: _liveFactory(),
@@ -81,16 +81,30 @@ void main() {
         expect(await printer.load(), isEmpty);
       });
     },
-    // Two gates: offline by default (no token), and blocked on the real driver.
-    skip: 'Requires the concrete ODBC/FFI SqlConnectionFactory (#89); '
-        'the adapter is covered by the seam-fake unit tests. '
-        'Set AZURE_SQL_ACCESS_TOKEN and wire _liveFactory to run.',
+    // Offline by default: skipped unless a live token (+ server/database) is set.
+    skip: config == null
+        ? 'Set AZURE_SQL_ACCESS_TOKEN (+ AZURE_SQL_SERVER/DATABASE) to run.'
+        : false,
   );
 }
 
-/// The production [SqlConnectionFactory] the live round-trip needs. Deferred to
-/// #89 — throws until the real ODBC/FFI driver is wired, which is why the group
-/// above is skipped.
-SqlConnectionFactory _liveFactory() => throw UnimplementedError(
-      'Concrete ODBC/FFI SqlConnectionFactory is deferred to #89.',
-    );
+/// The production [SqlConnectionFactory] the live round-trip runs against: the
+/// concrete ODBC/FFI driver wired in #89.
+SqlConnectionFactory _liveFactory() => OdbcSqlConnectionFactory();
+
+/// Runs the schema [ddl] through the real driver so the round-trip has its
+/// tables. Opens a fresh connection (a new token per open) and closes it.
+Future<void> _provision(
+  AzureSqlConfig config,
+  AadTokenProvider tokens,
+  List<String> ddl,
+) async {
+  final connection = await _liveFactory().open(config, tokens);
+  try {
+    for (final statement in ddl) {
+      await connection.execute(statement);
+    }
+  } finally {
+    await connection.close();
+  }
+}

--- a/packages/account_state/test/integration/azure_sql_person_id_resolver_live_test.dart
+++ b/packages/account_state/test/integration/azure_sql_person_id_resolver_live_test.dart
@@ -14,11 +14,11 @@ import 'package:test/test.dart';
 /// repo live-testing policy — never part of the read-only CI live set — and
 /// needs a fresh AAD token (see `AzureSqlLiveConfig`).
 ///
-/// It cannot run yet: the concrete ODBC/FFI [SqlConnectionFactory] is deferred
-/// to #89 (Windows-only, needs `msodbcsql18` + a live DB, not unit-testable
-/// headlessly). The body below is the ready-made round-trip that slice will
-/// enable by wiring [_liveFactory] to the real driver and dropping the `skip`.
-/// Until then the resolver is fully covered by the seam-fake unit tests in
+/// Enabled by #89, which wired [_liveFactory] to the concrete ODBC/FFI driver.
+/// It is Windows-only (needs `msodbcsql18` + a live AAD-authenticated DB + a
+/// fresh token), so it stays offline-by-default: the group runs only when
+/// `AZURE_SQL_ACCESS_TOKEN` (+ server/database) is set, and is skipped
+/// otherwise. The resolver also stays covered by the seam-fake unit tests in
 /// `test/sql/azure_sql_person_id_resolver_test.dart`.
 void main() {
   final config = AzureSqlLiveConfig.fromEnvironment();
@@ -33,9 +33,9 @@ void main() {
         );
         final tokens = StaticAadTokenProvider(config.accessToken);
 
-        // #89 will provision the schema through the factory before this runs;
-        // documented here as the precondition rather than executed blind.
-        //   for (final ddl in personIdentitySchemaStatements) { ... }
+        // Provision the schema through the real driver before the round-trip;
+        // the DDL is idempotent, so a re-run is a no-op.
+        await _provision(sqlConfig, tokens, personIdentitySchemaStatements);
 
         final key = 'wisa:live-${config.accessToken.hashCode}';
 
@@ -58,16 +58,30 @@ void main() {
             reason: 'the shared map yields one id per natural key');
       });
     },
-    // Two gates: offline by default (no token), and blocked on the real driver.
-    skip: 'Requires the concrete ODBC/FFI SqlConnectionFactory (#89); '
-        'the resolver is covered by the seam-fake unit tests. '
-        'Set AZURE_SQL_ACCESS_TOKEN and wire _liveFactory to run.',
+    // Offline by default: skipped unless a live token (+ server/database) is set.
+    skip: config == null
+        ? 'Set AZURE_SQL_ACCESS_TOKEN (+ AZURE_SQL_SERVER/DATABASE) to run.'
+        : false,
   );
 }
 
-/// The production [SqlConnectionFactory] the live round-trip needs. Deferred to
-/// #89 — throws until the real ODBC/FFI driver is wired, which is why the group
-/// above is skipped.
-SqlConnectionFactory _liveFactory() => throw UnimplementedError(
-      'Concrete ODBC/FFI SqlConnectionFactory is deferred to #89.',
-    );
+/// The production [SqlConnectionFactory] the live round-trip runs against: the
+/// concrete ODBC/FFI driver wired in #89.
+SqlConnectionFactory _liveFactory() => OdbcSqlConnectionFactory();
+
+/// Runs the schema [ddl] through the real driver so the round-trip has its
+/// tables. Opens a fresh connection (a new token per open) and closes it.
+Future<void> _provision(
+  AzureSqlConfig config,
+  AadTokenProvider tokens,
+  List<String> ddl,
+) async {
+  final connection = await _liveFactory().open(config, tokens);
+  try {
+    for (final statement in ddl) {
+      await connection.execute(statement);
+    }
+  } finally {
+    await connection.close();
+  }
+}

--- a/packages/account_state/test/integration/azure_sql_settings_store_live_test.dart
+++ b/packages/account_state/test/integration/azure_sql_settings_store_live_test.dart
@@ -15,12 +15,12 @@ import 'package:wisa_api/wisa_api.dart';
 /// of the read-only CI live set — and needs a fresh AAD token (see
 /// `AzureSqlLiveConfig`).
 ///
-/// It cannot run yet: the concrete ODBC/FFI [SqlConnectionFactory] is deferred
-/// to #89 (it is Windows-only, needs `msodbcsql18` + a live DB, and can't be
-/// unit-tested headlessly). The body below is the ready-made round-trip that
-/// slice will enable by wiring [_liveFactory] to the real driver and dropping
-/// the group `skip`. Until then the adapter is fully covered by the seam-fake
-/// unit tests in `test/sql/azure_sql_settings_store_test.dart`.
+/// Enabled by #89, which wired [_liveFactory] to the concrete ODBC/FFI driver.
+/// It is Windows-only (needs `msodbcsql18` + a live AAD-authenticated DB + a
+/// fresh token), so it stays offline-by-default: the group runs only when
+/// `AZURE_SQL_ACCESS_TOKEN` (+ server/database) is set, and is skipped
+/// otherwise. The adapter also stays covered by the seam-fake unit tests in
+/// `test/sql/azure_sql_settings_store_test.dart`.
 void main() {
   final config = AzureSqlLiveConfig.fromEnvironment();
 
@@ -28,18 +28,20 @@ void main() {
     'AzureSqlSettingsStore live round-trip',
     () {
       test('save then load round-trips through real Azure SQL', () async {
+        final sqlConfig = AzureSqlConfig(
+          server: config!.server,
+          database: config.database,
+        );
+        final tokens = StaticAadTokenProvider(config.accessToken);
         final store = AzureSqlSettingsStore(
           factory: _liveFactory(),
-          config: AzureSqlConfig(
-            server: config!.server,
-            database: config.database,
-          ),
-          tokens: StaticAadTokenProvider(config.accessToken),
+          config: sqlConfig,
+          tokens: tokens,
         );
 
-        // #89 will provision the schema through the factory before this runs;
-        // documented here as the precondition rather than executed blind.
-        //   for (final ddl in settingsSchemaStatements) { ... }
+        // Provision the schema through the real driver before the round-trip;
+        // the DDL is idempotent, so a re-run is a no-op.
+        await _provision(sqlConfig, tokens, settingsSchemaStatements);
 
         final probe = AppSettings(
           schoolPrefix: 'LIVE',
@@ -62,16 +64,30 @@ void main() {
         expect(loaded.wisaRules, hasLength(1));
       });
     },
-    // Two gates: offline by default (no token), and blocked on the real driver.
-    skip: 'Requires the concrete ODBC/FFI SqlConnectionFactory (#89); '
-        'the adapter is covered by the seam-fake unit tests. '
-        'Set AZURE_SQL_ACCESS_TOKEN and wire _liveFactory to run.',
+    // Offline by default: skipped unless a live token (+ server/database) is set.
+    skip: config == null
+        ? 'Set AZURE_SQL_ACCESS_TOKEN (+ AZURE_SQL_SERVER/DATABASE) to run.'
+        : false,
   );
 }
 
-/// The production [SqlConnectionFactory] the live round-trip needs. Deferred to
-/// #89 — throws until the real ODBC/FFI driver is wired, which is why the group
-/// above is skipped.
-SqlConnectionFactory _liveFactory() => throw UnimplementedError(
-      'Concrete ODBC/FFI SqlConnectionFactory is deferred to #89.',
-    );
+/// The production [SqlConnectionFactory] the live round-trip runs against: the
+/// concrete ODBC/FFI driver wired in #89.
+SqlConnectionFactory _liveFactory() => OdbcSqlConnectionFactory();
+
+/// Runs the schema [ddl] through the real driver so the round-trip has its
+/// tables. Opens a fresh connection (a new token per open) and closes it.
+Future<void> _provision(
+  AzureSqlConfig config,
+  AadTokenProvider tokens,
+  List<String> ddl,
+) async {
+  final connection = await _liveFactory().open(config, tokens);
+  try {
+    for (final statement in ddl) {
+      await connection.execute(statement);
+    }
+  } finally {
+    await connection.close();
+  }
+}

--- a/packages/account_state/test/sql/odbc_marshalling_test.dart
+++ b/packages/account_state/test/sql/odbc_marshalling_test.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:account_state/src/sql/odbc/odbc_constants.dart';
+import 'package:account_state/src/sql/odbc/odbc_marshalling.dart';
+import 'package:test/test.dart';
+
+/// Offline coverage for the driver-free half of the ODBC connection (issue #89).
+///
+/// The FFI binding itself is Windows-only and only exercised by the opt-in live
+/// round-trips, but its *decisions* — the connection string, the access-token
+/// packing, and the column-type mapping — are plain functions and are asserted
+/// here without a driver.
+void main() {
+  group('buildOdbcConnectionString', () {
+    test('names Driver 18, the tcp server and database, and forces encryption',
+        () {
+      final connStr = buildOdbcConnectionString(
+        server: 'accountmanager-sql-arcadia.database.windows.net',
+        database: 'accountmanager',
+      );
+
+      expect(connStr, contains('Driver={ODBC Driver 18 for SQL Server}'));
+      expect(
+        connStr,
+        contains(
+            'Server=tcp:accountmanager-sql-arcadia.database.windows.net,1433'),
+      );
+      expect(connStr, contains('Database=accountmanager'));
+      expect(connStr, contains('Encrypt=yes'));
+    });
+
+    test('carries no credential — safe to log', () {
+      final connStr = buildOdbcConnectionString(server: 'srv', database: 'db');
+      expect(connStr.toLowerCase(), isNot(contains('pwd')));
+      expect(connStr.toLowerCase(), isNot(contains('uid')));
+      expect(connStr.toLowerCase(), isNot(contains('password')));
+    });
+  });
+
+  group('packAccessToken', () {
+    test('lays out [uint32 byteLength][UTF-16LE token]', () {
+      final packed = packAccessToken('AbC1');
+      // 4-byte length prefix + 2 bytes per ASCII char.
+      expect(packed, hasLength(4 + 4 * 2));
+
+      final view = ByteData.view(packed.buffer);
+      expect(view.getUint32(0, Endian.little), 8);
+
+      // Each ASCII code unit is a low byte followed by 0x00 (UTF-16LE).
+      expect(packed.sublist(4), [0x41, 0, 0x62, 0, 0x43, 0, 0x31, 0]);
+    });
+
+    test('length prefix counts bytes, not characters', () {
+      final token = 'x' * 100;
+      final packed = packAccessToken(token);
+      final view = ByteData.view(packed.buffer);
+      expect(view.getUint32(0, Endian.little), 200);
+      expect(packed, hasLength(4 + 200));
+    });
+
+    test('handles a realistic base64url JWT shape', () {
+      // A JWT is dot-separated base64url — all ASCII, so it round-trips through
+      // the low byte of each UTF-16LE unit.
+      final jwt =
+          '${base64Url.encode(utf8.encode('{"alg":"none"}'))}.payload.sig';
+      final packed = packAccessToken(jwt);
+
+      final data = packed.sublist(4);
+      final recovered = <int>[];
+      for (var i = 0; i < data.length; i += 2) {
+        expect(data[i + 1], 0, reason: 'high byte of an ASCII unit is zero');
+        recovered.add(data[i]);
+      }
+      expect(String.fromCharCodes(recovered), jwt);
+    });
+
+    test('empty token packs to a bare zero-length prefix', () {
+      final packed = packAccessToken('');
+      expect(packed, [0, 0, 0, 0]);
+    });
+  });
+
+  group('categoryForSqlType', () {
+    test('BIT reads back as a bool', () {
+      expect(categoryForSqlType(sqlBit), OdbcColumnCategory.boolean);
+    });
+
+    test('the integer family reads back as int', () {
+      for (final type in [sqlTinyint, sqlSmallint, sqlInteger, sqlBigint]) {
+        expect(categoryForSqlType(type), OdbcColumnCategory.integer,
+            reason: 'SQL type $type should map to integer');
+      }
+    });
+
+    test('NVARCHAR / DATETIME2 and anything unrecognized read back as text',
+        () {
+      // -9 = SQL_WVARCHAR, 93 = SQL_TYPE_TIMESTAMP (DATETIME2), plus an
+      // arbitrary unmapped code.
+      for (final type in [-9, 93, 12, 9999]) {
+        expect(categoryForSqlType(type), OdbcColumnCategory.text,
+            reason: 'SQL type $type should fall through to text');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the concrete **ODBC Driver 18 via FFI** `SqlConnectionFactory` / `SqlConnection` — the "real consumer" driver deferred out of #83 — that the four Phase B Azure SQL adapters plug into. The seam was already in place and all adapters unit-tested against a scripted fake; this PR delivers the one production class that binds a real driver.

`dart:ffi` over `odbc32.dll` → `msodbcsql18`, authenticated by packing the AAD bearer token into `SQL_COPT_SS_ACCESS_TOKEN` (no stored DB credential), per the connectivity decision in `docs/port-plan.md`.

## Linked issue

Closes #89 (part of epic #74).

## Changes

- **New ODBC/FFI driver** under `packages/account_state/lib/src/sql/odbc/`:
  - `odbc_constants.dart` — FFI-free ODBC numeric codes.
  - `odbc_marshalling.dart` — the driver-free decisions: connection-string assembly, `SQL_COPT_SS_ACCESS_TOKEN` token packing (`[uint32 len][UTF-16LE token]`), and SQL-type → Dart-value mapping.
  - `odbc_bindings.dart` — `dart:ffi` typedefs, `odbc32.dll` symbol lookups, and `OdbcException` (carries the driver's `SQLGetDiagRec` diagnostics).
  - `odbc_sql_connection.dart` — `OdbcSqlConnectionFactory.open()` + a connection implementing `query` / `execute` / `transaction` / `close`, with parameters bound positionally by the driver (never string-interpolated).
- Exported `OdbcSqlConnectionFactory` from the `account_state` barrel; added `ffi: ^2.1.0`.
- Wired the three adapters' opt-in live round-trips (settings, PersonId resolver, password queue) to the real driver, with idempotent schema provisioning before each round-trip. They now gate only on `AZURE_SQL_ACCESS_TOKEN` (skipped offline by default).
- Updated `docs/port-plan.md` to record that #89 landed.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed` — clean
- [x] `dart analyze` (whole workspace) — No issues found
- [x] Offline suite: **170 pass, 6 skipped** (`dart test packages/account_state`). The 6 skipped are the live round-trips (skipped without a token). New `odbc_marshalling_test.dart` adds 9 offline tests covering the connection string, token packing, and type mapping.
- [ ] **Live round-trip (manual/opt-in, not run here):** the three write-capable round-trips against real Azure SQL are the end-to-end coverage, but per the repo live-testing policy they are manual-only, and are genuinely infeasible headlessly — they require `msodbcsql18` + a live AAD-authenticated Azure SQL database + a fresh bearer token (an un-fakeable third-party system). The FFI caller itself therefore has no offline coverage by design; the driver-free logic it depends on is unit-tested.

> Note for review: the FFI constants (notably `SQL_COPT_SS_ACCESS_TOKEN` + `SQL_IS_POINTER`) follow Microsoft's documented C++ sample, but this code path has **not** yet been executed against a real driver. The first live run (`AZURE_SQL_ACCESS_TOKEN=... dart test packages/account_state/test/integration`) is its real validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)