### PR TITLE
Reuse a warm identity-map cache across prepare() (#93)

### DIFF
--- a/packages/account_state/lib/src/sql/azure_sql_person_id_resolver.dart
+++ b/packages/account_state/lib/src/sql/azure_sql_person_id_resolver.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:account_core/account_core.dart';
 import 'package:uuid/uuid.dart';
 
@@ -17,12 +19,23 @@ import 'sql_connection.dart';
 /// **Why two phases.** The linker calls `resolve` synchronously inside its pure
 /// pass, but a database read is asynchronous, so this resolver cannot mint
 /// lazily on a miss the way the file resolver does. Instead it is
-/// [prepare]d up front: [prepare] loads the whole map and mints-or-fetches every
-/// still-unknown key in one transaction, then [resolve] is a pure, synchronous,
-/// *total* lookup into the primed cache (an unknown key means the caller forgot
-/// to prepare it — a programming error, not a normal miss). The State layer
-/// computes the exact key set with `account_linker`'s `naturalKeysFor` and
-/// awaits [prepare] before it links (see `PreparablePersonIdResolver`).
+/// [prepare]d up front: [prepare] fetches the still-unknown keys and
+/// mints-or-fetches every one still absent in one transaction, then [resolve] is
+/// a pure, synchronous, *total* lookup into the primed cache (an unknown key
+/// means the caller forgot to prepare it — a programming error, not a normal
+/// miss). The State layer computes the exact key set with `account_linker`'s
+/// `naturalKeysFor` and awaits [prepare] before it links (see
+/// `PreparablePersonIdResolver`).
+///
+/// **Warm cache (#93).** The [_cache] survives across [prepare] calls within a
+/// session, and [prepare] never reloads the whole table: it fetches only the
+/// keys it does not already hold, batched under the SQL Server parameter limit
+/// (`WHERE NaturalKey IN (...)`). Since one link pass runs [prepare] once —
+/// including after every apply-triggered incremental relink — a full-table
+/// `SELECT *` per call reloaded the same rows many times over for no gain. The
+/// convergence guarantee below is what makes the narrow fetch safe: dropping the
+/// proactive full reload cannot miss an id another operator minted, because the
+/// mint-or-fetch path already adopts it on write.
 ///
 /// **Convergence.** For a brand-new key two operators may both mint a fresh
 /// UUID. The insert is guarded by the natural-key primary key
@@ -57,21 +70,36 @@ class AzureSqlPersonIdResolver implements PreparablePersonIdResolver {
   /// and grown with freshly minted (or adopted) ids by [prepare].
   final Map<String, PersonId> _cache = {};
 
+  /// The maximum number of natural keys bound into one `WHERE NaturalKey IN
+  /// (...)` lookup.
+  /// SQL Server caps a single statement at ~2100 parameters, so a larger key set
+  /// is split into this-sized chunks. Kept well under the ceiling for headroom.
+  static const int maxKeysPerLookup = 2000;
+
   static String _defaultMint() => const Uuid().v4();
 
   @override
   Future<void> prepare(Iterable<String> naturalKeys) async {
-    // Idempotent: keys already resolved this session need no work.
+    // Idempotent: keys already resolved this session need no work. The cache is
+    // warm across calls, so a re-prepare only ever fetches genuinely new keys.
     final wanted = naturalKeys.toSet()..removeWhere(_cache.containsKey);
     if (wanted.isEmpty) return;
 
     final connection = await _factory.open(_config, _tokens);
     try {
-      // Load the whole identity map — one small row per person, mirroring the
-      // file resolver reading its whole file — so every already-minted id is
-      // served without a round-trip per key.
-      for (final row in await connection.query(_selectAllSql)) {
-        _cache[_string(row['NaturalKey'])] = PersonId(_string(row['PersonId']));
+      // Fetch only the keys we do not already hold — never the whole table.
+      // Batched under [maxKeysPerLookup] so a large key set stays under the SQL
+      // Server parameter limit; each already-minted id is served without a
+      // round-trip per key.
+      final lookup = wanted.toList();
+      for (var i = 0; i < lookup.length; i += maxKeysPerLookup) {
+        final chunk =
+            lookup.sublist(i, math.min(i + maxKeysPerLookup, lookup.length));
+        for (final row
+            in await connection.query(_selectInSql(chunk.length), chunk)) {
+          _cache[_string(row['NaturalKey'])] =
+              PersonId(_string(row['PersonId']));
+        }
       }
 
       final missing = [
@@ -113,10 +141,14 @@ class AzureSqlPersonIdResolver implements PreparablePersonIdResolver {
   }
 }
 
-/// Loads the whole identity map. Small — one row per person — so reading it
-/// whole to seed the cache is simpler and safe rather than a bottleneck.
-const String _selectAllSql =
-    'SELECT NaturalKey, PersonId FROM $personIdentityTableName';
+/// Reads the rows for a batch of [count] natural keys — the warm-cache fetch
+/// that replaced the full-table load (#93). The placeholders are generated (not
+/// interpolated data): the keys themselves are bound positionally as parameters,
+/// so a key can never be read as SQL. Callers chunk [count] under the SQL Server
+/// parameter limit (see `AzureSqlPersonIdResolver.maxKeysPerLookup`).
+String _selectInSql(int count) =>
+    'SELECT NaturalKey, PersonId FROM $personIdentityTableName '
+    'WHERE NaturalKey IN (${List.filled(count, '?').join(', ')})';
 
 /// Reads back the row that owns [NaturalKey] after a guarded insert — either the
 /// id this operator just minted or the one a concurrent operator committed first.

--- a/packages/account_state/test/sql/azure_sql_person_id_resolver_test.dart
+++ b/packages/account_state/test/sql/azure_sql_person_id_resolver_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 /// opened against it — the way one Azure SQL database is shared by every
 /// operator. It models `INSERT ... WHERE NOT EXISTS` (guarded insert) so the
 /// unique-key arbitration the resolver relies on is exercised for real, and can
-/// optionally hide its rows from the full-map load to simulate the window where
+/// optionally hide its rows from the keyed lookup to simulate the window where
 /// one operator has committed a row the other hasn't seen yet.
 class _FakePersonIdDb implements SqlConnection {
   _FakePersonIdDb({this.hideOnLoad = false});
@@ -13,9 +13,14 @@ class _FakePersonIdDb implements SqlConnection {
   /// The persisted map — the singular source of truth all connections share.
   final Map<String, String> table = {};
 
-  /// When true, the full-map load reports an empty table even though [table]
-  /// may hold rows: the "stale load" a concurrent minter races against.
+  /// When true, the keyed lookup reports no rows even though [table] may hold
+  /// them: the "stale load" a concurrent minter races against.
   final bool hideOnLoad;
+
+  /// The parameter list of each `WHERE NaturalKey IN (...)` lookup, in order —
+  /// so a test can assert the warm cache only fetches uncached keys and that a
+  /// large key set is chunked under the parameter limit.
+  final List<List<Object?>> lookups = [];
 
   final List<String> statements = [];
   final List<List<Object?>> params = [];
@@ -27,12 +32,15 @@ class _FakePersonIdDb implements SqlConnection {
   Future<List<SqlRow>> query(String sql, [List<Object?> p = const []]) async {
     statements.add(sql);
     params.add(p);
-    // Full-map load: SELECT NaturalKey, PersonId FROM ...
+    // Keyed lookup: SELECT NaturalKey, PersonId FROM ... WHERE NaturalKey IN (?, ...)
     if (sql.contains('SELECT NaturalKey, PersonId')) {
+      lookups.add(p);
       if (hideOnLoad) return [];
+      final keys = p.cast<String>();
       return [
-        for (final e in table.entries)
-          {'NaturalKey': e.key, 'PersonId': e.value},
+        for (final key in keys)
+          if (table.containsKey(key))
+            {'NaturalKey': key, 'PersonId': table[key]!},
       ];
     }
     // Read-back of one row: SELECT PersonId FROM ... WHERE NaturalKey = ?
@@ -170,6 +178,52 @@ void main() {
       await resolver.prepare(['wisa:1', 'wisa:2']);
       expect(resolver.resolve('wisa:1'), const PersonId('existing'));
       expect(resolver.resolve('wisa:2'), const PersonId('minted-0'));
+    });
+  });
+
+  group('warm cache across prepare() calls (#93)', () {
+    test('a re-prepare fetches only the keys not already cached', () async {
+      final db = _FakePersonIdDb();
+      final resolver = resolverOver(db);
+
+      await resolver.prepare(['wisa:1']);
+      // A second pass over a superset must fetch only the new key — the warm
+      // cache already holds wisa:1, so it is never looked up again.
+      await resolver.prepare(['wisa:1', 'wisa:2']);
+
+      expect(db.lookups, [
+        ['wisa:1'],
+        ['wisa:2'],
+      ]);
+    });
+
+    test('never reloads the whole table: an uncached key is not fetched',
+        () async {
+      // Another operator minted wisa:other; we never ask for it, so the narrow
+      // lookup must not pull it into our cache (the old SELECT * would have).
+      final db = _FakePersonIdDb()..table['wisa:other'] = 'someone-else';
+      final resolver = resolverOver(db);
+
+      await resolver.prepare(['wisa:1']);
+
+      expect(db.lookups, [
+        ['wisa:1'],
+      ]);
+      expect(() => resolver.resolve('wisa:other'), throwsStateError);
+    });
+
+    test('a large key set is chunked under the parameter limit', () async {
+      final db = _FakePersonIdDb();
+      final resolver = resolverOver(db);
+      const limit = AzureSqlPersonIdResolver.maxKeysPerLookup;
+      final keys = [for (var i = 0; i < limit + 500; i++) 'wisa:$i'];
+
+      await resolver.prepare(keys);
+
+      // Split into bounded lookups, none exceeding the limit, covering every key.
+      expect(db.lookups.length, 2);
+      expect(db.lookups.every((p) => p.length <= limit), isTrue);
+      expect(db.lookups.expand((p) => p).toSet(), keys.toSet());
     });
   });
 


### PR DESCRIPTION
## Summary

`AzureSqlPersonIdResolver.prepare()` reloaded the **whole** `dbo.PersonIdentity` table (`SELECT NaturalKey, PersonId FROM ...`) on every call. Because one link pass runs `prepare()` once — including after each apply-triggered incremental relink (`StateApplier.link()` → `LinkedState.fromApplicationAsync` → `prepare()`) — a session that applies many actions reloaded the full map many times over.

This keeps the warm `_cache` across `prepare()` calls and fetches **only the keys not already held**, via a batched `WHERE NaturalKey IN (...)` chunked under the SQL Server ~2100-parameter limit (`maxKeysPerLookup = 2000`). Purely an efficiency change — no behavior change above the seam.

## Linked issue

Closes #93

## Changes

- `azure_sql_person_id_resolver.dart`: `prepare()` fetches only uncached keys via a chunked `WHERE NaturalKey IN (...)` instead of `SELECT *` per call. Replaced the `_selectAllSql` const with a `_selectInSql(count)` builder — placeholders are generated, the keys themselves stay bound as positional parameters. Added `maxKeysPerLookup` and updated the class doc (new **Warm cache (#93)** section).
- `azure_sql_person_id_resolver_test.dart`: the seam-fake now models the keyed `IN` lookup (returns only requested+present rows) and records each lookup's params. Three new tests: a re-prepare fetches only the uncached keys; an uncached key another operator minted is never pulled in (proves the full reload is gone); a key set larger than the limit splits into bounded lookups covering every key.

## Convergence preserved

The narrow fetch is safe because the guarded insert + read-back already adopts an id a concurrent operator minted between our load and our insert — the full reload was only ever a *proactive* optimization, never required for correctness. The existing convergence tests (including the `hideOnLoad` stale-load race) still pass unchanged.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed` clean
- [x] `dart analyze packages/account_state` clean (No issues found)
- [x] unit tests pass — full `account_state` suite: **173 pass, 6 live skipped** (`dart test`)
- [x] no integration/e2e test: this is a **pure data-layer efficiency change with no user-visible surface**, fully covered by the unit tests above

🤖 Generated with [Claude Code](https://claude.com/claude-code)