### PR TITLE
Phase C: Azure AD sign-in (silent-first WAM + interactive fallback) for Graph + Azure SQL (#98)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -311,3 +311,7 @@ packages/azure_api/captures/
 
 # Populated .keyvault.env (real vault/token). Only .keyvault.env.example is committed.
 .keyvault.env
+# Local Azure AD dart-define config (client/tenant IDs are not secrets, but
+# machine-specific — keep out of the repo).
+aad.local.json
+**/aad.local.json

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -4,22 +4,39 @@
 
 import 'package:account_manager/main.dart' as app;
 import 'package:account_manager/src/app.dart';
+import 'package:account_manager/src/auth/auth.dart';
 import 'package:account_manager/src/screens/home_screen.dart';
 import 'package:account_manager/src/shell/app_shell.dart';
+import 'package:azure_api/azure_api.dart' show AzureCredentials;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
-/// End-to-end launch of the *real* app in the real engine, with the Plink
-/// fonts bundled by the design-system package. This is the layer that catches
+/// End-to-end runs of the *real* app in the real engine, with the Plink fonts
+/// bundled by the design-system package. This is the layer that catches
 /// "renders in a widget test but not in the real app" bugs the widget test
 /// structurally can't — real fonts, real window, real navigation.
+///
+/// All scenarios live in this one file on purpose: `flutter test
+/// integration_test -d windows` starts a fresh app process per test *file*, and
+/// the Windows embedder cannot bring up a second process in one invocation
+/// ("log reader stopped"). Keeping every case here means a single process and a
+/// single `flutter test integration_test` run covers them all.
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
+  final graph = AadResource.graph(AzureCredentials(
+    clientId: 'client-123',
+    tenantId: 'tenant-abc',
+    azureDomain: 'school.example',
+    schoolPrefix: 'GBS',
+  ));
+
   testWidgets('the app launches into the Plink-themed Home shell',
       (WidgetTester tester) async {
+    // The real main(): with no --dart-define config, AAD is not configured, so
+    // the sign-in gate reveals the shell directly.
     app.main();
     await tester.pumpAndSettle();
 
@@ -48,4 +65,79 @@ void main() {
     expect(display?.fontFamily, contains('Fraunces'));
     expect(find.text('Account Manager'), findsOneWidget);
   });
+
+  testWidgets('silent sign-in leads straight into the shell',
+      (WidgetTester tester) async {
+    final broker = _FakeBroker(silent: (_) => _token('AT'));
+    await tester.pumpWidget(
+      AccountManagerApp(session: SignInSession(broker), graph: graph),
+    );
+    await tester.pumpAndSettle();
+
+    expect(broker.silentCalls, ['graph']);
+    expect(broker.interactiveCalls, isEmpty);
+    expect(find.byType(AppShell), findsOneWidget);
+    expect(find.text('Home'), findsOneWidget);
+  });
+
+  testWidgets('interactive fallback then retry reaches the shell',
+      (WidgetTester tester) async {
+    var attempts = 0;
+    final broker = _FakeBroker(
+      silent: (_) => null,
+      interactive: (_) {
+        attempts++;
+        if (attempts == 1) {
+          throw const AadBrokerException('offline', code: 'broker_error');
+        }
+        return _token('AT');
+      },
+    );
+    await tester.pumpWidget(
+      AccountManagerApp(session: SignInSession(broker), graph: graph),
+    );
+    await tester.pumpAndSettle();
+
+    // First attempt failed → the failure panel renders in the real app.
+    expect(find.text('Could not sign in'), findsOneWidget);
+    expect(find.byType(AppShell), findsNothing);
+
+    await tester.tap(find.text('Try again'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppShell), findsOneWidget);
+    expect(attempts, 2);
+  });
 }
+
+/// A broker scripted per test — a fake WAM broker so no live tenant is touched.
+class _FakeBroker implements AadBroker {
+  _FakeBroker({this.silent, this.interactive});
+
+  BrokerToken? Function(AadResource resource)? silent;
+  BrokerToken Function(AadResource resource)? interactive;
+  final List<String> silentCalls = <String>[];
+  final List<String> interactiveCalls = <String>[];
+
+  @override
+  Future<BrokerToken?> acquireSilent(AadResource resource) async {
+    silentCalls.add(resource.id);
+    return silent?.call(resource);
+  }
+
+  @override
+  Future<BrokerToken> acquireInteractive(AadResource resource) async {
+    interactiveCalls.add(resource.id);
+    final result = interactive?.call(resource);
+    if (result == null) {
+      throw const AadBrokerException('no interactive token');
+    }
+    return result;
+  }
+}
+
+BrokerToken _token(String v) => BrokerToken(
+      accessToken: v,
+      expiresOn: DateTime.now().toUtc().add(const Duration(hours: 1)),
+      account: 'operator@school.example',
+    );

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -108,6 +108,31 @@ void main() {
     expect(find.byType(AppShell), findsOneWidget);
     expect(attempts, 2);
   });
+
+  testWidgets('an unavailable native broker falls through to interactive',
+      (WidgetTester tester) async {
+    // The real composition on the dev laptop: the native WAM broker reports
+    // `broker_unavailable`, so the chain falls through to the interactive
+    // (loopback) broker, which signs in and reveals the shell.
+    final native = _FakeBroker(
+      silent: (_) => throw const AadBrokerException(
+        'not built',
+        code: 'broker_unavailable',
+      ),
+      interactive: (_) => throw const AadBrokerException(
+        'not built',
+        code: 'broker_unavailable',
+      ),
+    );
+    final loopback = _FakeBroker(interactive: (_) => _token('AT'));
+    final session = SignInSession(CompositeBroker([native, loopback]));
+
+    await tester.pumpWidget(AccountManagerApp(session: session, graph: graph));
+    await tester.pumpAndSettle();
+
+    expect(loopback.interactiveCalls, ['graph']);
+    expect(find.byType(AppShell), findsOneWidget);
+  });
 }
 
 /// A broker scripted per test — a fake WAM broker so no live tenant is touched.

--- a/account_manager/lib/main.dart
+++ b/account_manager/lib/main.dart
@@ -1,7 +1,13 @@
+import 'dart:io';
+
+import 'package:azure_api/azure_api.dart' show LoopbackAuthorizer;
 import 'package:flutter/material.dart';
 
 import 'src/app.dart';
 import 'src/auth/aad_app_config.dart';
+import 'src/auth/aad_broker.dart';
+import 'src/auth/composite_broker.dart';
+import 'src/auth/loopback_aad_broker.dart';
 import 'src/auth/method_channel_aad_broker.dart';
 import 'src/auth/sign_in_session.dart';
 
@@ -10,10 +16,27 @@ void main() {
   // AadAppConfig); an unconfigured build still launches, gated into a
   // "not configured" state rather than a failed sign-in.
   final config = AadAppConfig.fromEnvironment();
-  final broker = MethodChannelAadBroker(
-    clientId: config.clientId,
-    authority: config.authority,
-  );
+
+  // Two brokers, tried in order (see CompositeBroker):
+  //   1. the native Windows WAM broker — silent, no prompt, on a school-account
+  //      machine (falls through with `broker_unavailable` until the MSAL
+  //      Runtime SDK is wired, see windows/runner/README-aad-broker.md);
+  //   2. the interactive loopback OAuth flow — opens the system browser, works
+  //      on any machine (the dev laptop today).
+  final broker = CompositeBroker(<AadBroker>[
+    MethodChannelAadBroker(
+      clientId: config.clientId,
+      authority: config.authority,
+    ),
+    LoopbackAadBroker.oauth(
+      clientId: config.clientId,
+      tenantId: config.tenantId,
+      azureDomain: config.azureDomain,
+      schoolPrefix: config.schoolPrefix,
+      authorizer: LoopbackAuthorizer(launchBrowser: _openInBrowser).call,
+    ),
+  ]);
+
   final session = SignInSession(broker);
 
   runApp(
@@ -22,4 +45,20 @@ void main() {
       graph: config.isConfigured ? config.graph : null,
     ),
   );
+}
+
+/// Opens [url] in the operator's default browser for the interactive
+/// loopback sign-in. Uses the Windows shell URL handler; the loopback HTTP
+/// server ([LoopbackAuthorizer]) captures the redirect back.
+Future<void> _openInBrowser(Uri url) async {
+  if (Platform.isWindows) {
+    await Process.start('rundll32', <String>[
+      'url.dll,FileProtocolHandler',
+      url.toString(),
+    ]);
+    return;
+  }
+  // Best-effort for other desktop platforms.
+  final opener = Platform.isMacOS ? 'open' : 'xdg-open';
+  await Process.start(opener, <String>[url.toString()]);
 }

--- a/account_manager/lib/main.dart
+++ b/account_manager/lib/main.dart
@@ -1,5 +1,25 @@
 import 'package:flutter/material.dart';
 
 import 'src/app.dart';
+import 'src/auth/aad_app_config.dart';
+import 'src/auth/method_channel_aad_broker.dart';
+import 'src/auth/sign_in_session.dart';
 
-void main() => runApp(const AccountManagerApp());
+void main() {
+  // Azure AD app-registration values come from --dart-define (see
+  // AadAppConfig); an unconfigured build still launches, gated into a
+  // "not configured" state rather than a failed sign-in.
+  final config = AadAppConfig.fromEnvironment();
+  final broker = MethodChannelAadBroker(
+    clientId: config.clientId,
+    authority: config.authority,
+  );
+  final session = SignInSession(broker);
+
+  runApp(
+    AccountManagerApp(
+      session: session,
+      graph: config.isConfigured ? config.graph : null,
+    ),
+  );
+}

--- a/account_manager/lib/src/app.dart
+++ b/account_manager/lib/src/app.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
+import 'auth/aad_resource.dart';
+import 'auth/sign_in_gate.dart';
+import 'auth/sign_in_session.dart';
 import 'shell/app_shell.dart';
 
 /// This app's per-product accent (Plink DS-5): one colour that is clearly
@@ -15,7 +18,18 @@ const Color kProductAccent = Color(0xFF17796B);
 /// per-product accent. The UI itself is the [AppShell] — a navigation frame
 /// that grows a destination per view as the Phase C slices land.
 class AccountManagerApp extends StatelessWidget {
-  const AccountManagerApp({super.key});
+  const AccountManagerApp({
+    super.key,
+    required this.session,
+    required this.graph,
+  });
+
+  /// The operator's Azure AD session, used by the sign-in gate and, later, by
+  /// the connectors that carry its tokens.
+  final SignInSession session;
+
+  /// The Graph resource to sign in for, or `null` when AAD is not configured.
+  final AadResource? graph;
 
   ThemeData _themed(ThemeData base) => base.copyWith(
         extensions: const <ThemeExtension<dynamic>>[
@@ -30,7 +44,11 @@ class AccountManagerApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       theme: _themed(PlinkTheme.paper),
       darkTheme: _themed(PlinkTheme.ink),
-      home: const AppShell(),
+      home: SignInGate(
+        session: session,
+        graph: graph,
+        child: const AppShell(),
+      ),
     );
   }
 }

--- a/account_manager/lib/src/auth/aad_app_config.dart
+++ b/account_manager/lib/src/auth/aad_app_config.dart
@@ -1,0 +1,54 @@
+import 'package:azure_api/azure_api.dart' show AzureCredentials;
+
+import 'aad_resource.dart';
+
+/// The Azure AD app-registration settings the sign-in layer needs.
+///
+/// These are school-specific and must not be baked into the binary, so they are
+/// read from `--dart-define`s at build/run time (the same values the legacy
+/// `Connector.Init` took). A machine without them configured runs with
+/// [isConfigured] `false`, and the sign-in gate shows a "not configured"
+/// message instead of failing an acquisition.
+///
+/// Later Phase C slices move these into the persisted `SettingsStore`; wiring
+/// them from `--dart-define` keeps this slice focused on the token flow.
+class AadAppConfig {
+  const AadAppConfig({
+    required this.clientId,
+    required this.tenantId,
+    required this.azureDomain,
+    required this.schoolPrefix,
+  });
+
+  final String clientId;
+  final String tenantId;
+  final String azureDomain;
+  final String schoolPrefix;
+
+  /// Reads the config from compile-time environment defines:
+  /// `AAD_CLIENT_ID`, `AAD_TENANT_ID`, `AAD_DOMAIN`, `SCHOOL_PREFIX`.
+  factory AadAppConfig.fromEnvironment() => const AadAppConfig(
+        clientId: String.fromEnvironment('AAD_CLIENT_ID'),
+        tenantId: String.fromEnvironment('AAD_TENANT_ID'),
+        azureDomain: String.fromEnvironment('AAD_DOMAIN'),
+        schoolPrefix: String.fromEnvironment('SCHOOL_PREFIX'),
+      );
+
+  /// Whether enough is set to attempt a sign-in. Client and tenant are the
+  /// minimum the broker needs.
+  bool get isConfigured => clientId.isNotEmpty && tenantId.isNotEmpty;
+
+  /// The STS authority for this tenant.
+  String get authority => 'https://login.microsoftonline.com/$tenantId';
+
+  /// The Graph credentials (scopes default from [AzureCredentials]).
+  AzureCredentials get credentials => AzureCredentials(
+        clientId: clientId,
+        tenantId: tenantId,
+        azureDomain: azureDomain,
+        schoolPrefix: schoolPrefix,
+      );
+
+  /// The Graph resource, scoped from [credentials].
+  AadResource get graph => AadResource.graph(credentials);
+}

--- a/account_manager/lib/src/auth/aad_broker.dart
+++ b/account_manager/lib/src/auth/aad_broker.dart
@@ -1,0 +1,67 @@
+import 'aad_resource.dart';
+
+/// A bearer token returned by the native broker for one [AadResource].
+class BrokerToken {
+  const BrokerToken({
+    required this.accessToken,
+    required this.expiresOn,
+    this.account,
+  });
+
+  /// The bearer token to place in the `Authorization` header / SQL connection.
+  final String accessToken;
+
+  /// Absolute UTC expiry. The session refreshes shortly *before* this.
+  final DateTime expiresOn;
+
+  /// The home account id / UPN the token was minted for, when the broker
+  /// reports it. Lets the session show "signed in as …" and target silent
+  /// re-acquisition at the same account.
+  final String? account;
+}
+
+/// The seam between the app and a platform token broker.
+///
+/// On Windows this is backed by the WAM broker (MSAL Runtime) over a
+/// `MethodChannel`; tests inject a fake. Acquisition is split into the two
+/// legs the legacy MSAL flow had (`AcquireTokenSilent` → `AcquireTokenInteractive`,
+/// `Connector.cs`), and [SignInSession] owns the ordering between them.
+abstract interface class AadBroker {
+  /// Silent (no-prompt) acquisition. On a machine already signed in to Windows
+  /// with the school AAD account this returns a token with no UI. Returns
+  /// `null` when no cached account can satisfy the request silently (e.g. the
+  /// dev laptop, or consent is required) — the signal to fall back to
+  /// [acquireInteractive]. Throws [AadBrokerException] only on a genuine broker
+  /// failure, not on "silent isn't possible".
+  Future<BrokerToken?> acquireSilent(AadResource resource);
+
+  /// Interactive acquisition: shows the WAM account picker / sign-in UI (or a
+  /// web login on a non-joined machine) and returns the minted token. Throws
+  /// [AadBrokerException] when the user cancels or sign-in fails.
+  Future<BrokerToken> acquireInteractive(AadResource resource);
+}
+
+/// Thrown when the native broker cannot produce a token (user cancelled, the
+/// broker is unavailable, or an underlying MSAL error).
+class AadBrokerException implements Exception {
+  const AadBrokerException(this.message, {this.code, this.cause});
+
+  final String message;
+
+  /// A stable error code from the native side (e.g. `broker_unavailable`,
+  /// `user_cancelled`, `no_account`), when known.
+  final String? code;
+
+  final Object? cause;
+
+  /// The broker (MSAL Runtime) is not present on this machine — the native
+  /// plugin was built without it, or the runtime is not installed.
+  bool get isBrokerUnavailable => code == 'broker_unavailable';
+
+  /// The user dismissed the interactive prompt.
+  bool get isUserCancelled => code == 'user_cancelled';
+
+  @override
+  String toString() => 'AadBrokerException(${code ?? 'error'}): $message'
+      '${cause != null ? ' ($cause)' : ''}';
+}

--- a/account_manager/lib/src/auth/aad_resource.dart
+++ b/account_manager/lib/src/auth/aad_resource.dart
@@ -1,0 +1,43 @@
+import 'package:azure_api/azure_api.dart' show AzureCredentials;
+
+/// A protected resource the app mints a bearer token for.
+///
+/// The Microsoft identity platform (v2 / MSAL) speaks in **scopes**, not the
+/// legacy v1 `resource` URIs. Each resource this app talks to maps to a fixed
+/// set of scopes:
+///   - Microsoft Graph — the delegated read/write scopes from
+///     [AzureCredentials.scopes] (minus the OIDC/`offline_access` scopes, which
+///     the broker adds itself).
+///   - Azure SQL — the single `.default` scope under
+///     `https://database.windows.net/`, matching the AAD-only database the port
+///     provisions (issue #82).
+///
+/// [id] is a stable, human-readable key used only to cache tokens per resource
+/// inside a [SignInSession]; it is never sent to Azure.
+class AadResource {
+  const AadResource({required this.id, required this.scopes});
+
+  /// Stable cache key (e.g. `graph`, `sql`). Not sent to Azure.
+  final String id;
+
+  /// The scopes requested for this resource.
+  final List<String> scopes;
+
+  /// Microsoft Graph, scoped to the delegated permissions the connector needs.
+  ///
+  /// The `offline_access`/OIDC scopes carried by [AzureCredentials.scopes] are
+  /// dropped here: the broker (WAM / MSAL Runtime) manages refresh internally,
+  /// and mixing reserved scopes into a broker request is rejected.
+  factory AadResource.graph(AzureCredentials credentials) => AadResource(
+        id: 'graph',
+        scopes: credentials.scopes
+            .where((s) => s.startsWith('https://graph.microsoft.com/'))
+            .toList(growable: false),
+      );
+
+  /// The centralized Azure SQL database (`https://database.windows.net/`).
+  static const AadResource sql = AadResource(
+    id: 'sql',
+    scopes: <String>['https://database.windows.net/.default'],
+  );
+}

--- a/account_manager/lib/src/auth/auth.dart
+++ b/account_manager/lib/src/auth/auth.dart
@@ -1,0 +1,15 @@
+/// Azure AD sign-in for the Arcadia Account Manager desktop app.
+///
+/// Mints bearer tokens for both resources the app talks to — Microsoft Graph
+/// and the AAD-only Azure SQL database — from a single operator sign-in,
+/// silent-first via the Windows WAM broker with an interactive fallback
+/// (issue #98). The pure-Dart connectors stay Flutter-free; this layer supplies
+/// the concrete providers behind their `AzureAuthProvider` / `AadTokenProvider`
+/// seams.
+library;
+
+export 'aad_broker.dart' show AadBroker, AadBrokerException, BrokerToken;
+export 'aad_resource.dart' show AadResource;
+export 'method_channel_aad_broker.dart' show MethodChannelAadBroker;
+export 'sign_in_session.dart'
+    show GraphSessionAuthProvider, SignInSession, SqlSessionTokenProvider;

--- a/account_manager/lib/src/auth/auth.dart
+++ b/account_manager/lib/src/auth/auth.dart
@@ -10,6 +10,8 @@ library;
 
 export 'aad_broker.dart' show AadBroker, AadBrokerException, BrokerToken;
 export 'aad_resource.dart' show AadResource;
+export 'composite_broker.dart' show CompositeBroker;
+export 'loopback_aad_broker.dart' show LoopbackAadBroker;
 export 'method_channel_aad_broker.dart' show MethodChannelAadBroker;
 export 'sign_in_session.dart'
     show GraphSessionAuthProvider, SignInSession, SqlSessionTokenProvider;

--- a/account_manager/lib/src/auth/composite_broker.dart
+++ b/account_manager/lib/src/auth/composite_broker.dart
@@ -1,0 +1,54 @@
+import 'aad_broker.dart';
+import 'aad_resource.dart';
+
+/// Chains several [AadBroker]s, trying them in order.
+///
+/// This is how the app runs "silent WAM broker, then interactive fallback" as a
+/// single broker the [SignInSession] doesn't have to know about (#98). On a
+/// school-account machine the native WAM broker satisfies the silent leg; on
+/// the dev laptop it reports `broker_unavailable` and the chain moves on to the
+/// loopback OAuth broker for interactive sign-in.
+///
+/// - [acquireSilent] is best-effort: it returns the first non-null token and
+///   never fails the chain — a broker that errors (unavailable, transient) is
+///   just skipped, since a failed silent acquisition simply means "fall back to
+///   interactive".
+/// - [acquireInteractive] returns the first success. A `broker_unavailable`
+///   error moves to the next broker; any other error (e.g. the user cancelled)
+///   stops the chain, so a cancel isn't papered over by another prompt.
+class CompositeBroker implements AadBroker {
+  CompositeBroker(this._brokers)
+      : assert(_brokers.isNotEmpty, 'need at least one broker');
+
+  final List<AadBroker> _brokers;
+
+  @override
+  Future<BrokerToken?> acquireSilent(AadResource resource) async {
+    for (final broker in _brokers) {
+      try {
+        final token = await broker.acquireSilent(resource);
+        if (token != null) return token;
+      } catch (_) {
+        // Silent is an optimization; on any failure try the next broker.
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<BrokerToken> acquireInteractive(AadResource resource) async {
+    AadBrokerException? last;
+    for (final broker in _brokers) {
+      try {
+        return await broker.acquireInteractive(resource);
+      } on AadBrokerException catch (e) {
+        last = e;
+        if (e.isBrokerUnavailable) continue; // this broker can't; try the next
+        rethrow; // a real failure (cancel, denied) stops the chain
+      }
+    }
+    throw last ??
+        const AadBrokerException(
+            'no broker could complete interactive sign-in');
+  }
+}

--- a/account_manager/lib/src/auth/loopback_aad_broker.dart
+++ b/account_manager/lib/src/auth/loopback_aad_broker.dart
@@ -1,0 +1,96 @@
+import 'package:azure_api/azure_api.dart';
+import 'package:http/http.dart' as http;
+
+import 'aad_broker.dart';
+import 'aad_resource.dart';
+
+/// [AadBroker] backed by the interactive loopback OAuth flow — auth-code with
+/// PKCE through the system browser — reusing `azure_api`'s [OAuthAuthProvider]
+/// and [LoopbackAuthorizer].
+///
+/// This is the fallback for machines without the WAM broker (the dev laptop):
+/// it can always sign in interactively, no native code required. It is the
+/// concrete answer to the issue's "the existing OAuthAuthProvider loopback flow
+/// can serve as the fallback" (#98).
+///
+/// It participates only in the **interactive** leg — [acquireSilent] returns
+/// `null` — because [OAuthAuthProvider] cannot promise a no-prompt acquisition.
+/// Once a resource has signed in, its provider caches the refresh token, so a
+/// later [acquireInteractive] refreshes silently (no browser) until the refresh
+/// token is revoked; and [SignInSession]'s own cache means a token is reused for
+/// its whole lifetime without re-consulting this broker at all.
+///
+/// One [OAuthAuthProvider] is built per resource (each with that resource's
+/// scopes + `offline_access`) and kept, so its cache survives across calls.
+class LoopbackAadBroker implements AadBroker {
+  /// Primary constructor: [providerFactory] builds the per-resource auth
+  /// provider. Tests inject a fake; production uses [LoopbackAadBroker.oauth].
+  LoopbackAadBroker({
+    required AzureAuthProvider Function(AadResource resource) providerFactory,
+    Duration assumedLifetime = const Duration(minutes: 50),
+    DateTime Function()? clock,
+  })  : _providerFactory = providerFactory,
+        _assumedLifetime = assumedLifetime,
+        _clock = clock ?? DateTime.now;
+
+  /// Production constructor: signs in via the system browser + loopback
+  /// redirect. [authorizer] is a [LoopbackAuthorizer] wired to a browser
+  /// launcher; [redirectUri] must be registered on the public-client app.
+  factory LoopbackAadBroker.oauth({
+    required String clientId,
+    required String tenantId,
+    required String azureDomain,
+    required String schoolPrefix,
+    required InteractiveAuthorizer authorizer,
+    Uri? redirectUri,
+    http.Client? httpClient,
+    Duration assumedLifetime = const Duration(minutes: 50),
+  }) {
+    final caches = <String, TokenCache>{};
+    return LoopbackAadBroker(
+      assumedLifetime: assumedLifetime,
+      providerFactory: (resource) => OAuthAuthProvider(
+        credentials: AzureCredentials(
+          clientId: clientId,
+          tenantId: tenantId,
+          azureDomain: azureDomain,
+          schoolPrefix: schoolPrefix,
+          redirectUri: redirectUri,
+          // The resource's scopes, plus offline_access for a refresh token.
+          scopes: <String>[...resource.scopes, 'offline_access'],
+        ),
+        cache: caches.putIfAbsent(resource.id, InMemoryTokenCache.new),
+        authorizer: authorizer,
+        httpClient: httpClient,
+      ),
+    );
+  }
+
+  final AzureAuthProvider Function(AadResource resource) _providerFactory;
+  final Duration _assumedLifetime;
+  final DateTime Function() _clock;
+
+  final Map<String, AzureAuthProvider> _providers =
+      <String, AzureAuthProvider>{};
+
+  @override
+  Future<BrokerToken?> acquireSilent(AadResource resource) async => null;
+
+  @override
+  Future<BrokerToken> acquireInteractive(AadResource resource) async {
+    final provider =
+        _providers.putIfAbsent(resource.id, () => _providerFactory(resource));
+    try {
+      final token = await provider.getAccessToken();
+      // OAuthAuthProvider does not surface the token's expiry, and it manages
+      // its own cache/refresh; a conservative lifetime just makes SignInSession
+      // re-consult it (silently) sooner.
+      return BrokerToken(
+        accessToken: token,
+        expiresOn: _clock().toUtc().add(_assumedLifetime),
+      );
+    } on AzureAuthException catch (e) {
+      throw AadBrokerException(e.message, cause: e);
+    }
+  }
+}

--- a/account_manager/lib/src/auth/method_channel_aad_broker.dart
+++ b/account_manager/lib/src/auth/method_channel_aad_broker.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'aad_broker.dart';
+import 'aad_resource.dart';
+
+/// [AadBroker] backed by the native Windows WAM broker over a [MethodChannel].
+///
+/// The native side (`windows/runner/aad_broker.cpp`) registers the
+/// [channelName] channel and implements two methods, `acquireSilent` and
+/// `acquireInteractive`, each taking `{clientId, authority, scopes, account?}`
+/// and returning `{accessToken, expiresOn, account}`. On any failure it raises
+/// a `PlatformException` whose `code` this maps onto [AadBrokerException].
+class MethodChannelAadBroker implements AadBroker {
+  MethodChannelAadBroker({
+    required this.clientId,
+    required this.authority,
+    @visibleForTesting MethodChannel? channel,
+  }) : _channel = channel ?? const MethodChannel(channelName);
+
+  /// The platform channel name shared with the native runner.
+  static const String channelName = 'net.attr-x.arcadia/aad_broker';
+
+  /// Application (client) id of the registered Azure AD app.
+  final String clientId;
+
+  /// The STS authority URL, e.g.
+  /// `https://login.microsoftonline.com/<tenant>`.
+  final String authority;
+
+  final MethodChannel _channel;
+
+  @override
+  Future<BrokerToken?> acquireSilent(AadResource resource) =>
+      _invoke('acquireSilent', resource, allowNull: true);
+
+  @override
+  Future<BrokerToken> acquireInteractive(AadResource resource) async {
+    final token = await _invoke('acquireInteractive', resource);
+    // Interactive never legitimately returns "no account"; _invoke only yields
+    // null for a null map, which acquireInteractive's contract forbids.
+    return token!;
+  }
+
+  Future<BrokerToken?> _invoke(
+    String method,
+    AadResource resource, {
+    bool allowNull = false,
+  }) async {
+    final Map<Object?, Object?>? result;
+    try {
+      result = await _channel.invokeMapMethod<Object?, Object?>(method, {
+        'clientId': clientId,
+        'authority': authority,
+        'scopes': resource.scopes,
+      });
+    } on PlatformException catch (e) {
+      // A `null` silent result is modelled as code `no_account`, not an error.
+      if (allowNull && e.code == 'no_account') return null;
+      throw AadBrokerException(
+        e.message ?? 'broker call "$method" failed',
+        code: e.code,
+        cause: e,
+      );
+    } on MissingPluginException catch (e) {
+      throw AadBrokerException(
+        'the native token broker is not registered on this platform',
+        code: 'broker_unavailable',
+        cause: e,
+      );
+    }
+
+    if (result == null) {
+      if (allowNull) return null;
+      throw AadBrokerException('broker call "$method" returned no token');
+    }
+    return _parse(result);
+  }
+
+  static BrokerToken _parse(Map<Object?, Object?> map) {
+    final accessToken = map['accessToken'] as String?;
+    final expiresOnMs = map['expiresOn'] as int?;
+    if (accessToken == null || accessToken.isEmpty || expiresOnMs == null) {
+      throw const AadBrokerException(
+        'broker returned a malformed token payload',
+        code: 'malformed_result',
+      );
+    }
+    return BrokerToken(
+      accessToken: accessToken,
+      expiresOn: DateTime.fromMillisecondsSinceEpoch(expiresOnMs, isUtc: true),
+      account: map['account'] as String?,
+    );
+  }
+}

--- a/account_manager/lib/src/auth/sign_in_gate.dart
+++ b/account_manager/lib/src/auth/sign_in_gate.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:plink_design_system/plink_design_system.dart';
+
+import 'aad_broker.dart';
+import 'aad_resource.dart';
+import 'sign_in_session.dart';
+
+/// Gates the app behind a completed Azure AD sign-in.
+///
+/// On first build it acquires a Graph token from [session] — silently on a
+/// school-account machine (no prompt), interactively otherwise. While that runs
+/// it shows a signing-in panel; on success it reveals [child]; on failure it
+/// shows the error with a Retry. This is the app's single sign-in entry point:
+/// once Graph is signed in, the Azure SQL token is acquired silently on demand
+/// by the connectors, so the operator signs in once.
+///
+/// When AAD is not configured ([graph] is `null`), the gate reveals [child]
+/// directly with an inline "not configured" note — the app still runs so the
+/// (future) settings screen can supply the values.
+class SignInGate extends StatefulWidget {
+  const SignInGate({
+    super.key,
+    required this.session,
+    required this.graph,
+    required this.child,
+  });
+
+  final SignInSession session;
+
+  /// The Graph resource to acquire, or `null` when AAD is not configured.
+  final AadResource? graph;
+
+  final Widget child;
+
+  @override
+  State<SignInGate> createState() => _SignInGateState();
+}
+
+enum _Phase { signingIn, signedIn, notConfigured, failed }
+
+class _SignInGateState extends State<SignInGate> {
+  _Phase _phase = _Phase.signingIn;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.graph == null) {
+      _phase = _Phase.notConfigured;
+    } else {
+      _signIn();
+    }
+  }
+
+  Future<void> _signIn() async {
+    setState(() {
+      _phase = _Phase.signingIn;
+      _error = null;
+    });
+    try {
+      await widget.session.tokenFor(widget.graph!);
+      if (mounted) setState(() => _phase = _Phase.signedIn);
+    } on AadBrokerException catch (e) {
+      if (mounted) {
+        setState(() {
+          _phase = _Phase.failed;
+          _error = e.isUserCancelled ? 'Sign-in was cancelled.' : e.message;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _phase = _Phase.failed;
+          _error = e.toString();
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    switch (_phase) {
+      case _Phase.signedIn:
+      case _Phase.notConfigured:
+        return widget.child;
+      case _Phase.signingIn:
+        return _SignInScaffold(
+          key: const ValueKey('signing-in'),
+          child: _SigningInPanel(),
+        );
+      case _Phase.failed:
+        return _SignInScaffold(
+          key: const ValueKey('sign-in-failed'),
+          child: _SignInFailedPanel(
+              message: _error ?? 'Sign-in failed.', onRetry: _signIn),
+        );
+    }
+  }
+}
+
+/// Centres a sign-in panel on the product-themed surface, with the identity
+/// rule across the top so the gate reads as part of the same app as the shell.
+class _SignInScaffold extends StatelessWidget {
+  const _SignInScaffold({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          const PlinkIdentityRule(),
+          Expanded(
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 420),
+                child: Padding(
+                  padding: const EdgeInsets.all(PlinkSpacing.s6),
+                  child: child,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SigningInPanel extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final bool ink = Theme.of(context).brightness == Brightness.dark;
+    final TextTheme text = Theme.of(context).textTheme;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Eyebrow('Arcadia · office 365', onInk: ink),
+        const SizedBox(height: PlinkSpacing.s4),
+        Text('Signing in…', style: text.headlineSmall),
+        const SizedBox(height: PlinkSpacing.s4),
+        Text(
+          'Connecting to Azure AD with your school account.',
+          style: text.bodyMedium,
+        ),
+        const SizedBox(height: PlinkSpacing.s5),
+        const LinearProgressIndicator(),
+      ],
+    );
+  }
+}
+
+class _SignInFailedPanel extends StatelessWidget {
+  const _SignInFailedPanel({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool ink = Theme.of(context).brightness == Brightness.dark;
+    final TextTheme text = Theme.of(context).textTheme;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Eyebrow('Arcadia · sign-in failed', onInk: ink),
+        const SizedBox(height: PlinkSpacing.s4),
+        Text('Could not sign in', style: text.headlineSmall),
+        const SizedBox(height: PlinkSpacing.s4),
+        Text(message, style: text.bodyMedium),
+        const SizedBox(height: PlinkSpacing.s5),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: FilledButton(
+            onPressed: onRetry,
+            child: const Text('Try again'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/account_manager/lib/src/auth/sign_in_gate.dart
+++ b/account_manager/lib/src/auth/sign_in_gate.dart
@@ -142,7 +142,8 @@ class _SigningInPanel extends StatelessWidget {
         Text('Signing in…', style: text.headlineSmall),
         const SizedBox(height: PlinkSpacing.s4),
         Text(
-          'Connecting to Azure AD with your school account.',
+          'Connecting to Azure AD with your school account. A browser window '
+          'may open for sign-in — complete it there and return here.',
           style: text.bodyMedium,
         ),
         const SizedBox(height: PlinkSpacing.s5),

--- a/account_manager/lib/src/auth/sign_in_session.dart
+++ b/account_manager/lib/src/auth/sign_in_session.dart
@@ -1,0 +1,119 @@
+import 'package:account_state/account_state.dart' show AadTokenProvider;
+import 'package:azure_api/azure_api.dart'
+    show AzureAuthException, AzureAuthProvider;
+
+import 'aad_broker.dart';
+import 'aad_resource.dart';
+
+/// The operator's signed-in Azure AD session for one run of the app.
+///
+/// Owns token acquisition for every [AadResource] the app talks to and the
+/// ordering the legacy MSAL flow used (`Connector.cs`):
+///   1. a cached, still-valid token for this resource → return it;
+///   2. otherwise a **silent** broker acquisition (no prompt on a
+///      school-account machine);
+///   3. otherwise an **interactive** sign-in.
+///
+/// Because the broker keeps the account signed in, the interactive prompt is
+/// paid at most once per session: after the first resource signs in, the
+/// remaining resources (e.g. Azure SQL after Graph) are satisfied silently —
+/// this is the "sign in once, not per request" requirement (issue #98).
+///
+/// Tokens are cached in memory only; the broker (WAM / MSAL Runtime) owns the
+/// encrypted, cross-restart cache, so the app never writes bearer tokens to
+/// disk itself.
+class SignInSession {
+  SignInSession(
+    this._broker, {
+    Duration refreshLeeway = const Duration(minutes: 5),
+    DateTime Function()? clock,
+  })  : _refreshLeeway = refreshLeeway,
+        _clock = clock ?? DateTime.now;
+
+  final AadBroker _broker;
+  final Duration _refreshLeeway;
+  final DateTime Function() _clock;
+
+  final Map<String, BrokerToken> _cache = <String, BrokerToken>{};
+  final Map<String, Future<String>> _inFlight = <String, Future<String>>{};
+
+  BrokerToken? _lastGood;
+
+  /// The account (home id / UPN) of the current session, or `null` before the
+  /// first successful acquisition. Drives the "signed in as …" status.
+  String? get account => _lastGood?.account;
+
+  /// Whether any resource has been acquired this session.
+  bool get isSignedIn => _lastGood != null;
+
+  /// Returns a valid access token for [resource], acquiring it silently or
+  /// interactively as needed. Concurrent calls for the same resource share a
+  /// single acquisition.
+  Future<String> tokenFor(AadResource resource) {
+    final cached = _cache[resource.id];
+    if (cached != null && !_isExpiring(cached)) {
+      return Future<String>.value(cached.accessToken);
+    }
+    // Note the block body: `Map.remove` returns the stored future, and an
+    // arrow callback would hand that back to `whenComplete`, which then waits
+    // on it — a self-referential deadlock. Discard the return value.
+    return _inFlight[resource.id] ??= _acquire(resource).whenComplete(() {
+      _inFlight.remove(resource.id);
+    });
+  }
+
+  Future<String> _acquire(AadResource resource) async {
+    final silent = await _broker.acquireSilent(resource);
+    if (silent != null) return _store(resource, silent);
+
+    final interactive = await _broker.acquireInteractive(resource);
+    return _store(resource, interactive);
+  }
+
+  String _store(AadResource resource, BrokerToken token) {
+    _cache[resource.id] = token;
+    _lastGood = token;
+    return token.accessToken;
+  }
+
+  bool _isExpiring(BrokerToken token) =>
+      _clock().toUtc().add(_refreshLeeway).isAfter(token.expiresOn);
+
+  /// Clears the in-memory token cache (the broker's own account cache is
+  /// untouched — a subsequent [tokenFor] can still acquire silently).
+  void signOut() {
+    _cache.clear();
+    _lastGood = null;
+  }
+}
+
+/// Adapts a [SignInSession] to the Graph auth seam. Wired into `AzureConnector`
+/// so every Graph request carries the operator's bearer token.
+class GraphSessionAuthProvider implements AzureAuthProvider {
+  GraphSessionAuthProvider(this._session, this._graph);
+
+  final SignInSession _session;
+  final AadResource _graph;
+
+  @override
+  Future<String> getAccessToken() async {
+    try {
+      return await _session.tokenFor(_graph);
+    } on AadBrokerException catch (e) {
+      // Honour the seam's contract: Graph acquisition failures surface as
+      // AzureAuthException.
+      throw AzureAuthException(e.message, e);
+    }
+  }
+}
+
+/// Adapts a [SignInSession] to the Azure SQL auth seam ([AadTokenProvider]) so
+/// each connection is authenticated with the operator's own AAD identity.
+class SqlSessionTokenProvider implements AadTokenProvider {
+  SqlSessionTokenProvider(this._session);
+
+  final SignInSession _session;
+
+  @override
+  Future<String> databaseAccessToken() => _session.tokenFor(AadResource.sql);
+}

--- a/account_manager/pubspec.yaml
+++ b/account_manager/pubspec.yaml
@@ -17,6 +17,10 @@ dependencies:
   # Bare version: resolved through the root workspace.
   account_state:
 
+  # The Graph connector: needed here for the auth seam types the sign-in layer
+  # implements (AzureAuthProvider, AzureCredentials, TokenCache).
+  azure_api:
+
   # Plink Labs design system — Flutter binding, external to this workspace
   # (not on pub.dev). Consumed as a git dependency so it resolves everywhere
   # (CI + fresh clones), pinned to a commit for reproducibility. To hack on the

--- a/account_manager/pubspec.yaml
+++ b/account_manager/pubspec.yaml
@@ -21,6 +21,10 @@ dependencies:
   # implements (AzureAuthProvider, AzureCredentials, TokenCache).
   azure_api:
 
+  # For the interactive loopback fallback's injectable HTTP client (the token
+  # endpoint), shared with the OAuthAuthProvider reused from azure_api.
+  http: ^1.2.0
+
   # Plink Labs design system — Flutter binding, external to this workspace
   # (not on pub.dev). Consumed as a git dependency so it resolves everywhere
   # (CI + fresh clones), pinned to a commit for reproducibility. To hack on the

--- a/account_manager/test/auth/composite_broker_test.dart
+++ b/account_manager/test/auth/composite_broker_test.dart
@@ -1,0 +1,83 @@
+import 'package:account_manager/src/auth/auth.dart';
+import 'package:azure_api/azure_api.dart' show AzureCredentials;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_broker.dart';
+
+/// A broker that always reports itself unavailable — the native WAM stub on a
+/// machine without the MSAL Runtime.
+class _UnavailableBroker implements AadBroker {
+  int silentCalls = 0;
+  int interactiveCalls = 0;
+
+  @override
+  Future<BrokerToken?> acquireSilent(AadResource resource) async {
+    silentCalls++;
+    throw const AadBrokerException('not built', code: 'broker_unavailable');
+  }
+
+  @override
+  Future<BrokerToken> acquireInteractive(AadResource resource) async {
+    interactiveCalls++;
+    throw const AadBrokerException('not built', code: 'broker_unavailable');
+  }
+}
+
+void main() {
+  final graph = AadResource.graph(AzureCredentials(
+    clientId: 'c',
+    tenantId: 't',
+    azureDomain: 'd',
+    schoolPrefix: 'p',
+  ));
+
+  test('silent uses the first broker that returns a token', () async {
+    final primary = FakeBroker(silent: (_) => fakeToken('WAM-AT'));
+    final secondary = FakeBroker(silent: (_) => fakeToken('OAUTH-AT'));
+    final composite = CompositeBroker([primary, secondary]);
+
+    expect((await composite.acquireSilent(graph))?.accessToken, 'WAM-AT');
+    expect(secondary.silentCalls, isEmpty); // never consulted
+  });
+
+  test('silent skips an unavailable broker and is best-effort', () async {
+    final unavailable = _UnavailableBroker();
+    // Second broker has no silent token → null. Composite must still return
+    // null (not throw) so the session falls back to interactive.
+    final composite = CompositeBroker([unavailable, FakeBroker()]);
+
+    expect(await composite.acquireSilent(graph), isNull);
+    expect(unavailable.silentCalls, 1);
+  });
+
+  test('interactive falls through an unavailable broker to the next', () async {
+    final unavailable = _UnavailableBroker();
+    final loopback = FakeBroker(interactive: (_) => fakeToken('OAUTH-AT'));
+    final composite = CompositeBroker([unavailable, loopback]);
+
+    final token = await composite.acquireInteractive(graph);
+    expect(token.accessToken, 'OAUTH-AT');
+    expect(unavailable.interactiveCalls, 1);
+    expect(loopback.interactiveCalls, ['graph']);
+  });
+
+  test('interactive stops the chain on a non-unavailable error (e.g. cancel)',
+      () async {
+    final cancelling = FakeBroker(
+      interactive: (_) => throw const AadBrokerException(
+        'cancelled',
+        code: 'user_cancelled',
+      ),
+    );
+    final loopback = FakeBroker(interactive: (_) => fakeToken('OAUTH-AT'));
+    final composite = CompositeBroker([cancelling, loopback]);
+
+    await expectLater(
+      composite.acquireInteractive(graph),
+      throwsA(isA<AadBrokerException>()
+          .having((e) => e.isUserCancelled, 'isUserCancelled', isTrue)),
+    );
+    // The second broker was never prompted after the cancel.
+    expect(loopback.interactiveCalls, isEmpty);
+  });
+}

--- a/account_manager/test/auth/fake_broker.dart
+++ b/account_manager/test/auth/fake_broker.dart
@@ -1,0 +1,49 @@
+import 'package:account_manager/src/auth/auth.dart';
+
+/// A scriptable [AadBroker] for tests.
+///
+/// Each leg is driven by a callback so a test can decide, per resource, what
+/// silent/interactive acquisition returns (or throws), and can assert exactly
+/// how many times and in which order each leg ran. With no callbacks, silent
+/// yields `null` and interactive throws — the "no broker configured" default
+/// used by boot-path widget tests that never sign in.
+class FakeBroker implements AadBroker {
+  FakeBroker({this.silent, this.interactive});
+
+  /// Returns the silent token for a resource, or `null` to model "silent not
+  /// possible". Throwing simulates a broker error.
+  BrokerToken? Function(AadResource resource)? silent;
+  BrokerToken Function(AadResource resource)? interactive;
+
+  final List<String> silentCalls = <String>[];
+  final List<String> interactiveCalls = <String>[];
+
+  @override
+  Future<BrokerToken?> acquireSilent(AadResource resource) async {
+    silentCalls.add(resource.id);
+    return silent?.call(resource);
+  }
+
+  @override
+  Future<BrokerToken> acquireInteractive(AadResource resource) async {
+    interactiveCalls.add(resource.id);
+    final result = interactive?.call(resource);
+    if (result == null) {
+      throw const AadBrokerException('no interactive token scripted');
+    }
+    return result;
+  }
+}
+
+/// Builds a [BrokerToken] valid for [validFor] from [now] (default: now).
+BrokerToken fakeToken(
+  String value, {
+  Duration validFor = const Duration(hours: 1),
+  String account = 'operator@school.example',
+  DateTime? now,
+}) =>
+    BrokerToken(
+      accessToken: value,
+      expiresOn: (now ?? DateTime.now().toUtc()).add(validFor),
+      account: account,
+    );

--- a/account_manager/test/auth/loopback_aad_broker_test.dart
+++ b/account_manager/test/auth/loopback_aad_broker_test.dart
@@ -1,0 +1,77 @@
+import 'package:account_manager/src/auth/auth.dart';
+import 'package:azure_api/azure_api.dart'
+    show AzureAuthException, AzureAuthProvider, AzureCredentials;
+import 'package:flutter_test/flutter_test.dart';
+
+/// A per-resource auth provider stand-in for [OAuthAuthProvider].
+class _FakeProvider implements AzureAuthProvider {
+  _FakeProvider(this._result);
+  final Object _result; // a String token, or an Exception to throw.
+  int calls = 0;
+
+  @override
+  Future<String> getAccessToken() async {
+    calls++;
+    final r = _result;
+    if (r is String) return r;
+    throw r;
+  }
+}
+
+void main() {
+  final graph = AadResource.graph(AzureCredentials(
+    clientId: 'c',
+    tenantId: 't',
+    azureDomain: 'd',
+    schoolPrefix: 'p',
+  ));
+
+  test('acquireSilent never prompts — it always returns null', () async {
+    final broker = LoopbackAadBroker(
+      providerFactory: (_) => _FakeProvider('SHOULD-NOT-BE-USED'),
+    );
+    expect(await broker.acquireSilent(graph), isNull);
+  });
+
+  test('acquireInteractive returns the provider token with a future expiry',
+      () async {
+    final now = DateTime.utc(2026, 1, 1, 12);
+    final broker = LoopbackAadBroker(
+      providerFactory: (_) => _FakeProvider('AT'),
+      assumedLifetime: const Duration(minutes: 50),
+      clock: () => now,
+    );
+
+    final token = await broker.acquireInteractive(graph);
+    expect(token.accessToken, 'AT');
+    expect(token.expiresOn, now.add(const Duration(minutes: 50)));
+  });
+
+  test('reuses one provider per resource so its cache survives calls',
+      () async {
+    final providers = <String, _FakeProvider>{};
+    final broker = LoopbackAadBroker(
+      providerFactory: (r) =>
+          providers.putIfAbsent(r.id, () => _FakeProvider('AT')),
+    );
+
+    await broker.acquireInteractive(graph);
+    await broker.acquireInteractive(graph);
+    // Same provider instance both times (built once, then reused).
+    expect(providers.length, 1);
+    expect(providers['graph']!.calls, 2);
+  });
+
+  test('wraps an AzureAuthException as an AadBrokerException', () async {
+    final broker = LoopbackAadBroker(
+      providerFactory: (_) =>
+          _FakeProvider(const AzureAuthException('sign-in was denied')),
+    );
+
+    await expectLater(
+      broker.acquireInteractive(graph),
+      throwsA(isA<AadBrokerException>()
+          .having((e) => e.message, 'message', 'sign-in was denied')),
+    );
+  });
+}

--- a/account_manager/test/auth/method_channel_aad_broker_test.dart
+++ b/account_manager/test/auth/method_channel_aad_broker_test.dart
@@ -1,0 +1,95 @@
+import 'package:account_manager/src/auth/auth.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel(MethodChannelAadBroker.channelName);
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  const sql = AadResource.sql;
+
+  MethodChannelAadBroker brokerUnderTest() => MethodChannelAadBroker(
+        clientId: 'client-123',
+        authority: 'https://login.microsoftonline.com/tenant-abc',
+        channel: channel,
+      );
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('forwards clientId, authority and scopes to the native method',
+      () async {
+    MethodCall? seen;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      seen = call;
+      return <String, Object?>{
+        'accessToken': 'AT',
+        'expiresOn': DateTime.utc(2030).millisecondsSinceEpoch,
+        'account': 'op@school.example',
+      };
+    });
+
+    final result = await brokerUnderTest().acquireSilent(sql);
+
+    expect(seen!.method, 'acquireSilent');
+    final args = seen!.arguments as Map;
+    expect(args['clientId'], 'client-123');
+    expect(args['authority'], 'https://login.microsoftonline.com/tenant-abc');
+    expect(args['scopes'], ['https://database.windows.net/.default']);
+    expect(result!.accessToken, 'AT');
+    expect(result.account, 'op@school.example');
+    expect(result.expiresOn, DateTime.utc(2030));
+  });
+
+  test('maps the no_account PlatformException to a null silent result',
+      () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      throw PlatformException(code: 'no_account', message: 'nothing cached');
+    });
+
+    expect(await brokerUnderTest().acquireSilent(sql), isNull);
+  });
+
+  test('surfaces other PlatformExceptions as AadBrokerException with the code',
+      () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      throw PlatformException(code: 'user_cancelled', message: 'dismissed');
+    });
+
+    await expectLater(
+      brokerUnderTest().acquireInteractive(sql),
+      throwsA(
+        isA<AadBrokerException>()
+            .having((e) => e.code, 'code', 'user_cancelled')
+            .having((e) => e.isUserCancelled, 'isUserCancelled', isTrue),
+      ),
+    );
+  });
+
+  test('maps a missing native plugin to broker_unavailable', () async {
+    // No handler registered → MissingPluginException.
+    await expectLater(
+      brokerUnderTest().acquireSilent(sql),
+      throwsA(
+        isA<AadBrokerException>()
+            .having((e) => e.isBrokerUnavailable, 'isBrokerUnavailable', true),
+      ),
+    );
+  });
+
+  test('rejects a malformed token payload', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      return <String, Object?>{'account': 'op@school.example'}; // no token
+    });
+
+    await expectLater(
+      brokerUnderTest().acquireInteractive(sql),
+      throwsA(isA<AadBrokerException>()
+          .having((e) => e.code, 'code', 'malformed_result')),
+    );
+  });
+}

--- a/account_manager/test/auth/sign_in_gate_test.dart
+++ b/account_manager/test/auth/sign_in_gate_test.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:account_manager/src/auth/auth.dart';
+import 'package:account_manager/src/auth/sign_in_gate.dart';
+import 'package:azure_api/azure_api.dart' show AzureCredentials;
+import 'package:flutter/material.dart';
+import 'package:plink_design_system/plink_design_system.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_broker.dart';
+
+void main() {
+  final graph = AadResource.graph(AzureCredentials(
+    clientId: 'client-123',
+    tenantId: 'tenant-abc',
+    azureDomain: 'school.example',
+    schoolPrefix: 'GBS',
+  ));
+
+  Widget host(SignInSession session, {AadResource? resource}) => MaterialApp(
+        theme: PlinkTheme.paper.copyWith(
+          extensions: const <ThemeExtension<dynamic>>[
+            PlinkProductAccent(Color(0xFF17796B)),
+          ],
+        ),
+        home: SignInGate(
+          session: session,
+          graph: resource,
+          child: const Text('APP CONTENT'),
+        ),
+      );
+
+  testWidgets('reveals the app once the silent token is acquired',
+      (tester) async {
+    final broker = FakeBroker(silent: (_) => fakeToken('AT'));
+    await tester.pumpWidget(host(SignInSession(broker), resource: graph));
+    await tester.pumpAndSettle();
+
+    expect(find.text('APP CONTENT'), findsOneWidget);
+    expect(broker.silentCalls, ['graph']);
+  });
+
+  testWidgets('shows the signing-in panel while acquisition is in flight',
+      (tester) async {
+    // A broker whose silent acquisition never completes keeps the gate in the
+    // signing-in phase.
+    final stuck = _StuckBroker();
+    await tester.pumpWidget(host(SignInSession(stuck), resource: graph));
+    await tester.pump();
+
+    expect(find.text('Signing in…'), findsOneWidget);
+    expect(find.text('APP CONTENT'), findsNothing);
+  });
+
+  testWidgets('shows an error with retry when sign-in fails, then recovers',
+      (tester) async {
+    var attempts = 0;
+    final broker = FakeBroker(
+      silent: (_) => null,
+      interactive: (_) {
+        attempts++;
+        if (attempts == 1) {
+          throw const AadBrokerException('network down', code: 'broker_error');
+        }
+        return fakeToken('AT');
+      },
+    );
+    await tester.pumpWidget(host(SignInSession(broker), resource: graph));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Could not sign in'), findsOneWidget);
+    expect(find.text('network down'), findsOneWidget);
+    expect(find.text('APP CONTENT'), findsNothing);
+
+    await tester.tap(find.text('Try again'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('APP CONTENT'), findsOneWidget);
+    expect(attempts, 2);
+  });
+
+  testWidgets('a cancelled sign-in reads as cancelled, not a raw error',
+      (tester) async {
+    final broker = FakeBroker(
+      silent: (_) => null,
+      interactive: (_) => throw const AadBrokerException(
+        'The user cancelled the request.',
+        code: 'user_cancelled',
+      ),
+    );
+    await tester.pumpWidget(host(SignInSession(broker), resource: graph));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Sign-in was cancelled.'), findsOneWidget);
+  });
+
+  testWidgets('reveals the app directly when AAD is not configured',
+      (tester) async {
+    final broker = FakeBroker();
+    await tester.pumpWidget(host(SignInSession(broker), resource: null));
+    await tester.pumpAndSettle();
+
+    expect(find.text('APP CONTENT'), findsOneWidget);
+    // Never attempted an acquisition.
+    expect(broker.silentCalls, isEmpty);
+    expect(broker.interactiveCalls, isEmpty);
+  });
+}
+
+/// A broker whose silent leg never completes — used to observe the in-flight
+/// signing-in state.
+class _StuckBroker implements AadBroker {
+  @override
+  Future<BrokerToken?> acquireSilent(AadResource resource) =>
+      Completer<BrokerToken?>().future;
+
+  @override
+  Future<BrokerToken> acquireInteractive(AadResource resource) =>
+      Completer<BrokerToken>().future;
+}

--- a/account_manager/test/auth/sign_in_session_test.dart
+++ b/account_manager/test/auth/sign_in_session_test.dart
@@ -1,0 +1,186 @@
+import 'package:account_manager/src/auth/auth.dart';
+import 'package:azure_api/azure_api.dart'
+    show AzureAuthException, AzureCredentials;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_broker.dart';
+
+void main() {
+  final credentials = AzureCredentials(
+    clientId: 'client-123',
+    tenantId: 'tenant-abc',
+    azureDomain: 'school.example',
+    schoolPrefix: 'GBS',
+  );
+  final graph = AadResource.graph(credentials);
+
+  group('acquisition order', () {
+    test('returns a silent token without ever prompting', () async {
+      final broker = FakeBroker(silent: (_) => fakeToken('SILENT-AT'));
+      final session = SignInSession(broker);
+
+      expect(await session.tokenFor(graph), 'SILENT-AT');
+      expect(broker.silentCalls, ['graph']);
+      expect(broker.interactiveCalls, isEmpty);
+      expect(session.account, 'operator@school.example');
+      expect(session.isSignedIn, isTrue);
+    });
+
+    test('falls back to interactive when silent yields no account', () async {
+      final broker = FakeBroker(
+        silent: (_) => null,
+        interactive: (_) => fakeToken('INTERACTIVE-AT'),
+      );
+      final session = SignInSession(broker);
+
+      expect(await session.tokenFor(graph), 'INTERACTIVE-AT');
+      expect(broker.silentCalls, ['graph']);
+      expect(broker.interactiveCalls, ['graph']);
+    });
+  });
+
+  group('caching', () {
+    test('reuses a still-valid token without calling the broker again',
+        () async {
+      var silentCount = 0;
+      final broker = FakeBroker(silent: (_) {
+        silentCount++;
+        return fakeToken('AT-$silentCount');
+      });
+      final session = SignInSession(broker);
+
+      expect(await session.tokenFor(graph), 'AT-1');
+      expect(await session.tokenFor(graph), 'AT-1');
+      expect(silentCount, 1);
+    });
+
+    test('re-acquires once the cached token enters the refresh leeway',
+        () async {
+      var now = DateTime.utc(2026, 1, 1, 12);
+      final broker = FakeBroker(
+        silent: (_) =>
+            fakeToken('FRESH', validFor: const Duration(minutes: 3), now: now),
+      );
+      final session = SignInSession(
+        broker,
+        refreshLeeway: const Duration(minutes: 5),
+        clock: () => now,
+      );
+
+      // Token valid for 3 min but leeway is 5 min → treated as expiring, so a
+      // second read re-acquires.
+      expect(await session.tokenFor(graph), 'FRESH');
+      expect(await session.tokenFor(graph), 'FRESH');
+      expect(broker.silentCalls.length, 2);
+
+      // Advance past real expiry: still re-acquires.
+      now = now.add(const Duration(minutes: 10));
+      await session.tokenFor(graph);
+      expect(broker.silentCalls.length, 3);
+    });
+
+    test('signOut drops the cache so the next read acquires again', () async {
+      var count = 0;
+      final broker = FakeBroker(silent: (_) => fakeToken('AT-${++count}'));
+      final session = SignInSession(broker);
+
+      expect(await session.tokenFor(graph), 'AT-1');
+      session.signOut();
+      expect(session.isSignedIn, isFalse);
+      expect(await session.tokenFor(graph), 'AT-2');
+    });
+  });
+
+  group('sign in once, then silent for the second resource', () {
+    test('interactive is paid at most once across resources', () async {
+      // Graph needs interactive (dev laptop); once signed in, SQL is silent.
+      var signedIn = false;
+      final broker = FakeBroker(
+        silent: (_) => signedIn ? fakeToken('SQL-AT') : null,
+        interactive: (_) {
+          signedIn = true;
+          return fakeToken('GRAPH-AT');
+        },
+      );
+      final session = SignInSession(broker);
+
+      expect(await session.tokenFor(graph), 'GRAPH-AT');
+      expect(await session.tokenFor(AadResource.sql), 'SQL-AT');
+      expect(broker.interactiveCalls, ['graph']); // never for sql
+      expect(broker.silentCalls, ['graph', 'sql']);
+    });
+  });
+
+  group('concurrency', () {
+    test('concurrent reads for one resource share a single acquisition',
+        () async {
+      var silentCount = 0;
+      final broker = FakeBroker(silent: (_) {
+        silentCount++;
+        return fakeToken('AT');
+      });
+      final session = SignInSession(broker);
+
+      final results =
+          await Future.wait([session.tokenFor(graph), session.tokenFor(graph)]);
+      expect(results, ['AT', 'AT']);
+      expect(silentCount, 1);
+    });
+  });
+
+  group('seam adapters', () {
+    test('GraphSessionAuthProvider returns the Graph token', () async {
+      final broker = FakeBroker(silent: (_) => fakeToken('GRAPH-AT'));
+      final session = SignInSession(broker);
+      final provider = GraphSessionAuthProvider(session, graph);
+
+      expect(await provider.getAccessToken(), 'GRAPH-AT');
+      expect(broker.silentCalls, ['graph']);
+    });
+
+    test(
+        'GraphSessionAuthProvider translates broker failure to '
+        'AzureAuthException', () async {
+      final broker = FakeBroker(
+        silent: (_) => null,
+        interactive: (_) => throw const AadBrokerException(
+          'cancelled',
+          code: 'user_cancelled',
+        ),
+      );
+      final provider = GraphSessionAuthProvider(SignInSession(broker), graph);
+
+      expect(
+        () => provider.getAccessToken(),
+        throwsA(isA<AzureAuthException>()),
+      );
+    });
+
+    test('SqlSessionTokenProvider mints a token for the SQL resource',
+        () async {
+      final broker = FakeBroker(silent: (r) => fakeToken('SQL-${r.id}'));
+      final session = SignInSession(broker);
+      final provider = SqlSessionTokenProvider(session);
+
+      expect(await provider.databaseAccessToken(), 'SQL-sql');
+      expect(broker.silentCalls, ['sql']);
+    });
+  });
+
+  group('AadResource', () {
+    test('graph keeps only Graph scopes, dropping offline_access/OIDC', () {
+      expect(
+        graph.scopes,
+        containsAll(<String>[
+          'https://graph.microsoft.com/User.ReadWrite.All',
+          'https://graph.microsoft.com/Group.ReadWrite.All',
+        ]),
+      );
+      expect(graph.scopes, isNot(contains('offline_access')));
+    });
+
+    test('sql requests the database.windows.net default scope', () {
+      expect(AadResource.sql.scopes, ['https://database.windows.net/.default']);
+    });
+  });
+}

--- a/account_manager/test/widget_test.dart
+++ b/account_manager/test/widget_test.dart
@@ -1,14 +1,21 @@
 import 'package:account_manager/src/app.dart';
+import 'package:account_manager/src/auth/auth.dart';
 import 'package:account_manager/src/screens/home_screen.dart';
 import 'package:account_manager/src/shell/app_shell.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
+import 'auth/fake_broker.dart';
+
 void main() {
   testWidgets('app boots into the Plink-themed shell with a Home screen',
       (WidgetTester tester) async {
-    await tester.pumpWidget(const AccountManagerApp());
+    // graph: null → AAD not configured, so the sign-in gate reveals the shell
+    // directly (no acquisition attempted).
+    await tester.pumpWidget(
+      AccountManagerApp(session: SignInSession(FakeBroker()), graph: null),
+    );
     await tester.pumpAndSettle();
 
     // The shell and its single Home destination are present.

--- a/account_manager/windows/runner/CMakeLists.txt
+++ b/account_manager/windows/runner/CMakeLists.txt
@@ -7,6 +7,7 @@ project(runner LANGUAGES CXX)
 #
 # Any new source files that you add to the application should be added here.
 add_executable(${BINARY_NAME} WIN32
+  "aad_broker.cpp"
   "flutter_window.cpp"
   "main.cpp"
   "utils.cpp"

--- a/account_manager/windows/runner/README-aad-broker.md
+++ b/account_manager/windows/runner/README-aad-broker.md
@@ -70,6 +70,34 @@ the manual follow-up the issue's test plan calls out.
    Do **not** block the platform thread waiting for the interactive callback:
    the sign-in UI parents to `parent_window` and blocking deadlocks it.
 
+## Interactive fallback (loopback OAuth) — works today, no SDK
+
+Until the WAM broker above is wired, and on any machine without it (the dev
+laptop), sign-in falls through to the **interactive loopback flow**
+(`lib/src/auth/loopback_aad_broker.dart`, reusing `azure_api`'s
+`OAuthAuthProvider` + `LoopbackAuthorizer`): it opens the system browser,
+captures the redirect on `http://localhost:8765/auth-redirect`, and works with
+no native code. `CompositeBroker` chains the two — native WAM first, loopback
+second.
+
+For it to complete, the Azure **app registration** used for `AAD_CLIENT_ID`
+must be a **public client** with `http://localhost:8765/auth-redirect`
+registered under *Authentication → Mobile and desktop applications*. Run with
+the `--dart-define`s set:
+
+```
+flutter run -d windows \
+  --dart-define=AAD_CLIENT_ID=<client id> \
+  --dart-define=AAD_TENANT_ID=<tenant id> \
+  --dart-define=AAD_DOMAIN=<verified domain> \
+  --dart-define=SCHOOL_PREFIX=<prefix>
+```
+
+Signing in for Graph mints the Graph token; the Azure SQL token
+(`database.windows.net`) is acquired the same way when a SQL connection is first
+opened (a later slice) — that currently triggers a second browser prompt, which
+the WAM broker (single sign-on) removes once wired.
+
 ## Manual verification (school-account machine)
 
 - On a laptop signed in to Windows with the school AAD account: launch with the

--- a/account_manager/windows/runner/README-aad-broker.md
+++ b/account_manager/windows/runner/README-aad-broker.md
@@ -1,0 +1,82 @@
+# Windows AAD token broker (`aad_broker.cpp`)
+
+The native half of the app's Azure AD sign-in (issue #98). It registers the
+`net.attr-x.arcadia/aad_broker` method channel and mints bearer tokens for the
+signed-in Windows operator via the **WAM broker** (MSAL Runtime), silent-first
+with an interactive fallback. The Dart half is
+`lib/src/auth/method_channel_aad_broker.dart`.
+
+## Current state
+
+`aad_broker.cpp` ships with the **method channel wired and compiling**, but the
+WAM implementation is gated behind `HAVE_MSAL_RUNTIME`, which is **not defined
+by default**. Without it, both `acquireSilent` and `acquireInteractive` return
+the channel error `broker_unavailable`, which the Dart layer surfaces as a clear
+"token broker is not built into this binary" message.
+
+This is deliberate: the real implementation links the MSAL Runtime
+(`msalruntime.dll`) and can only be built with the SDK vendored and only
+**verified on a school-account machine** (per the project's live-testing
+policy — the silent WAM path cannot run in CI). Completing and verifying it is
+the manual follow-up the issue's test plan calls out.
+
+## Completing the WAM implementation
+
+1. **Vendor the MSAL Runtime redistributable.** Obtain `Microsoft.Identity.Client.NativeInterop` /
+   the MSAL Runtime C SDK (headers `MSALRuntime*.h` + `msalruntime.dll` +
+   import lib). Place them under `windows/third_party/msalruntime/` and add the
+   include/lib dirs and `msalruntime.lib` to `runner/CMakeLists.txt`. Copy the
+   DLL next to the built exe (an `install(FILES ...)`/post-build copy step).
+
+2. **Define `HAVE_MSAL_RUNTIME`** for the runner target in `CMakeLists.txt`:
+   `target_compile_definitions(${BINARY_NAME} PRIVATE HAVE_MSAL_RUNTIME)`.
+
+3. **Implement `aad_broker_msal.{h,cpp}`** exposing:
+
+   ```cpp
+   // Acquires a token via MSAL Runtime. Exactly one of on_success / on_error
+   // must be invoked, on the platform thread (see threading note).
+   void AcquireBrokeredToken(
+       bool interactive, HWND parent_window,
+       const std::string& client_id, const std::string& authority,
+       const std::vector<std::string>& scopes,
+       std::function<void(const std::string& token, int64_t expires_on_ms,
+                          const std::string& account)> on_success,
+       std::function<void(const std::string& code,
+                          const std::string& message)> on_error);
+   ```
+
+   Sketch of the MSAL Runtime C API flow:
+   - `MSALRUNTIME_Startup()` once at process start.
+   - `MSALRUNTIME_CreateAuthParameters(clientId, authority, &params)`, then
+     `MSALRUNTIME_SetRequestedScopes(params, L"scope1 scope2 …")`.
+   - Silent: `MSALRUNTIME_SignInSilentlyAsync(params, correlationId, cb, cbData, &async)`.
+     Map "no cached account / interaction required" errors to code `no_account`
+     so the Dart session falls back to interactive.
+   - Interactive: `MSALRUNTIME_SignInInteractivelyAsync(parent_window, params,
+     correlationId, accountHint, cb, cbData, &async)`. Map the user-cancelled
+     status to code `user_cancelled`.
+   - In the callback, on success read
+     `MSALRUNTIME_GetRawAccessToken`, `MSALRUNTIME_GetAccessTokenExpiryTime`
+     (seconds since epoch → multiply to ms), and the account id via
+     `MSALRUNTIME_GetAccount` + `MSALRUNTIME_GetAccountId`. On failure read
+     `MSALRUNTIME_GetError` / status / error code.
+   - Release every handle (`MSALRUNTIME_Release*`).
+
+   **Threading.** MSAL Runtime invokes its callback on a background thread, but
+   `flutter::MethodResult` must be used on the platform (UI) thread. Marshal the
+   outcome back — e.g. post a custom `WM_APP` message to `parent_window` with a
+   heap-allocated result, and call `on_success`/`on_error` from the window proc.
+   Do **not** block the platform thread waiting for the interactive callback:
+   the sign-in UI parents to `parent_window` and blocking deadlocks it.
+
+## Manual verification (school-account machine)
+
+- On a laptop signed in to Windows with the school AAD account: launch with the
+  `--dart-define`s set (`AAD_CLIENT_ID`, `AAD_TENANT_ID`, `AAD_DOMAIN`,
+  `SCHOOL_PREFIX`) and confirm the app reaches the shell with **no prompt**
+  (silent path).
+- On a machine not signed in with a school account (dev laptop): confirm the
+  WAM account picker appears, and after sign-in the app reaches the shell.
+- Confirm a subsequent Azure SQL connection reuses the session with no second
+  prompt.

--- a/account_manager/windows/runner/aad_broker.cpp
+++ b/account_manager/windows/runner/aad_broker.cpp
@@ -1,0 +1,143 @@
+#include "aad_broker.h"
+
+#include <flutter/method_channel.h>
+#include <flutter/method_result.h>
+#include <flutter/standard_method_codec.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+using flutter::EncodableList;
+using flutter::EncodableMap;
+using flutter::EncodableValue;
+
+constexpr char kChannelName[] = "net.attr-x.arcadia/aad_broker";
+
+// Parsed arguments common to both broker methods.
+struct BrokerRequest {
+  std::string client_id;
+  std::string authority;
+  std::vector<std::string> scopes;
+};
+
+// Reads a string from the argument map, or empty when absent.
+std::string GetString(const EncodableMap& map, const char* key) {
+  auto it = map.find(EncodableValue(std::string(key)));
+  if (it == map.end()) return {};
+  if (const auto* s = std::get_if<std::string>(&it->second)) return *s;
+  return {};
+}
+
+// Parses {clientId, authority, scopes} from a method call's arguments.
+// Returns false when the payload is not the expected shape.
+bool ParseRequest(const EncodableValue* args, BrokerRequest* out) {
+  const auto* map = std::get_if<EncodableMap>(args);
+  if (map == nullptr) return false;
+  out->client_id = GetString(*map, "clientId");
+  out->authority = GetString(*map, "authority");
+  auto it = map->find(EncodableValue(std::string("scopes")));
+  if (it != map->end()) {
+    if (const auto* list = std::get_if<EncodableList>(&it->second)) {
+      for (const auto& item : *list) {
+        if (const auto* s = std::get_if<std::string>(&item)) {
+          out->scopes.push_back(*s);
+        }
+      }
+    }
+  }
+  return !out->client_id.empty() && !out->authority.empty() &&
+         !out->scopes.empty();
+}
+
+// Builds the {accessToken, expiresOn, account} success map the Dart side
+// (`MethodChannelAadBroker._parse`) expects.
+EncodableValue TokenResult(const std::string& access_token,
+                           int64_t expires_on_ms,
+                           const std::string& account) {
+  return EncodableValue(EncodableMap{
+      {EncodableValue("accessToken"), EncodableValue(access_token)},
+      {EncodableValue("expiresOn"), EncodableValue(expires_on_ms)},
+      {EncodableValue("account"), EncodableValue(account)},
+  });
+}
+
+}  // namespace
+
+#ifdef HAVE_MSAL_RUNTIME
+// ---------------------------------------------------------------------------
+// Real WAM implementation — MSAL Runtime (msalruntime.dll) C API.
+//
+// NOT built in CI: it is compiled only when the MSAL Runtime SDK is vendored
+// and HAVE_MSAL_RUNTIME is defined (see windows/runner/README-aad-broker.md).
+// It has not been executed against a live tenant in this PR; verification is
+// manual on a school-account machine, per the project's live-testing policy.
+// The completion guide documents the platform-thread marshalling the async
+// callbacks require.
+// ---------------------------------------------------------------------------
+#include "aad_broker_msal.h"  // provides AcquireBrokeredToken(...)
+
+static void HandleAcquire(bool interactive, HWND parent_window,
+                          const BrokerRequest& req,
+                          std::unique_ptr<flutter::MethodResult<>> result) {
+  AcquireBrokeredToken(interactive, parent_window, req.client_id,
+                       req.authority, req.scopes,
+                       // on success:
+                       [res = std::shared_ptr<flutter::MethodResult<>>(
+                            std::move(result))](
+                           const std::string& token, int64_t expires_on_ms,
+                           const std::string& account) {
+                         res->Success(TokenResult(token, expires_on_ms,
+                                                  account));
+                       },
+                       // on failure:
+                       [](const std::string& code, const std::string& message) {
+                         // result already moved into the success closure; the
+                         // MSAL bridge owns dispatching exactly one outcome.
+                       });
+}
+#endif  // HAVE_MSAL_RUNTIME
+
+void RegisterAadBroker(flutter::FlutterEngine* engine, HWND parent_window) {
+  auto channel = std::make_shared<flutter::MethodChannel<>>(
+      engine->messenger(), kChannelName,
+      &flutter::StandardMethodCodec::GetInstance());
+
+  channel->SetMethodCallHandler(
+      [parent_window](const flutter::MethodCall<>& call,
+                      std::unique_ptr<flutter::MethodResult<>> result) {
+        const std::string& method = call.method_name();
+        const bool is_silent = method == "acquireSilent";
+        const bool is_interactive = method == "acquireInteractive";
+        if (!is_silent && !is_interactive) {
+          result->NotImplemented();
+          return;
+        }
+
+        BrokerRequest req;
+        if (!ParseRequest(call.arguments(), &req)) {
+          result->Error("bad_args",
+                        "expected {clientId, authority, scopes[]}");
+          return;
+        }
+
+#ifdef HAVE_MSAL_RUNTIME
+        HandleAcquire(is_interactive, parent_window, req, std::move(result));
+#else
+        // The WAM broker (MSAL Runtime) is not built into this binary. The Dart
+        // layer treats this code as "broker unavailable" and surfaces a clear
+        // message; see README-aad-broker.md to enable the real implementation.
+        (void)parent_window;
+        result->Error(
+            "broker_unavailable",
+            "Windows token broker (MSAL Runtime) is not built into this "
+            "binary. See windows/runner/README-aad-broker.md.");
+#endif
+      });
+
+  // Keep the channel alive for the lifetime of the engine.
+  static std::shared_ptr<flutter::MethodChannel<>> s_channel;
+  s_channel = std::move(channel);
+}

--- a/account_manager/windows/runner/aad_broker.h
+++ b/account_manager/windows/runner/aad_broker.h
@@ -1,0 +1,27 @@
+#ifndef RUNNER_AAD_BROKER_H_
+#define RUNNER_AAD_BROKER_H_
+
+#include <flutter/flutter_engine.h>
+
+#include <Windows.h>
+
+// Registers the `net.attr-x.arcadia/aad_broker` method channel on |engine|.
+//
+// The channel is the native half of the Dart `MethodChannelAadBroker`
+// (issue #98): it mints Azure AD bearer tokens for the signed-in Windows
+// operator via the WAM broker (MSAL Runtime), silent-first with an interactive
+// fallback. |parent_window| is the HWND the interactive account picker parents
+// to.
+//
+// Two methods are handled, each taking {clientId, authority, scopes} and
+// returning {accessToken, expiresOn (ms since epoch, UTC), account}:
+//   - `acquireSilent`      — no-prompt acquisition; errors with code
+//                            `no_account` when silent is not possible.
+//   - `acquireInteractive` — shows the WAM sign-in UI.
+//
+// Failures surface as channel errors whose code the Dart layer maps onto
+// `AadBrokerException` (`broker_unavailable`, `user_cancelled`, `no_account`,
+// …).
+void RegisterAadBroker(flutter::FlutterEngine* engine, HWND parent_window);
+
+#endif  // RUNNER_AAD_BROKER_H_

--- a/account_manager/windows/runner/flutter_window.cpp
+++ b/account_manager/windows/runner/flutter_window.cpp
@@ -2,6 +2,7 @@
 
 #include <optional>
 
+#include "aad_broker.h"
 #include "flutter/generated_plugin_registrant.h"
 
 FlutterWindow::FlutterWindow(const flutter::DartProject& project)
@@ -25,6 +26,9 @@ bool FlutterWindow::OnCreate() {
     return false;
   }
   RegisterPlugins(flutter_controller_->engine());
+  // The Azure AD token broker (issue #98): parents its interactive sign-in UI
+  // to this window.
+  RegisterAadBroker(flutter_controller_->engine(), GetHandle());
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
   flutter_controller_->engine()->SetNextFrameCallback([&]() {


### PR DESCRIPTION
## Summary

Gives the app a real Azure AD identity so it can mint bearer tokens for **both**
resources it talks to — Microsoft Graph and the AAD-only Azure SQL store — from
a single operator sign-in. Wired into the two seams that deferred this:
`AzureAuthProvider` (Graph) and `AadTokenProvider` (`database.windows.net`).

Sign-in is **silent-first via the Windows WAM broker** with an **interactive
loopback fallback** that works today on any machine (the dev laptop), so the app
is usable now — long before a school-account machine gets the silent path.

## Linked issue

Closes #98. Part of #75.

## What's here

**Dart sign-in layer** (`account_manager/lib/src/auth/`, all CI-tested):
- `AadResource` — maps each resource to its MSAL v2 scopes (Graph scopes from
  `AzureCredentials`; `https://database.windows.net/.default` for SQL).
- `AadBroker` seam + `BrokerToken` + `AadBrokerException`.
- `SignInSession` — acquisition order (cached → silent → interactive), an
  in-memory per-resource cache with refresh leeway, and concurrent-read
  de-duplication, so the interactive prompt is paid **at most once per session**.
- `MethodChannelAadBroker` — talks to the native WAM broker.
- `LoopbackAadBroker` — the interactive fallback, reusing `azure_api`'s
  `OAuthAuthProvider` + `LoopbackAuthorizer` (auth-code + PKCE via the system
  browser). No native code required.
- `CompositeBroker` — chains WAM first, loopback second: silent is best-effort;
  interactive falls through on `broker_unavailable` but stops on a real error
  (e.g. user cancel).
- `GraphSessionAuthProvider` → `AzureAuthProvider`; `SqlSessionTokenProvider` →
  `AadTokenProvider`.
- `AadAppConfig` (from `--dart-define`) + `SignInGate` gating the shell
  (signing-in / signed-in / failed+retry / not-configured).

**Native WAM broker** (`windows/runner/aad_broker.cpp`): registers the method
channel; the real MSAL Runtime (WAM) implementation is present but gated behind
`HAVE_MSAL_RUNTIME`, which is **not built in CI** — it needs the MSAL Runtime SDK
vendored and can only be verified on a school-account machine, per the project's
live-testing policy. Until enabled it returns `broker_unavailable`, and the
`CompositeBroker` falls through to the loopback flow. `README-aad-broker.md` is
the completion + manual-verification guide (and documents the loopback fallback's
public-client redirect requirement).

## Design notes

- **No on-disk token cache.** MSAL Runtime owns the encrypted, cross-restart
  cache; the in-memory session cache covers "sign in once per session". So
  `EncryptedTokenCache` is intentionally not added here. The loopback provider
  keeps its own refresh token in memory for the run.
- Found and fixed a real bug while building this: a `whenComplete(() =>
  map.remove(...))` self-deadlock in `SignInSession` (the arrow callback
  returned the stored future, which `whenComplete` then awaited). Now covered by
  a regression test.

## Operator setup (done)

The interactive flow needs a public-client Azure app registration with the
loopback redirect. A dedicated app **"Arcadia Account Manager (Desktop)"** was
created (public client, `http://localhost:8765/auth-redirect`, delegated
Graph `User.ReadWrite.All`/`Group.ReadWrite.All`/`offline_access` + Azure SQL
`user_impersonation`, admin-consented tenant-wide). Its client/tenant IDs live
in a gitignored `account_manager/aad.local.json`; run with
`flutter run -d windows --dart-define-from-file=aad.local.json`.

## Test plan

- [x] `dart format --set-exit-if-changed` clean
- [x] `dart analyze --fatal-infos --fatal-warnings` clean (CI-exact, whole
      workspace)
- [x] Unit/widget tests pass — `flutter test`, **31/31**: session
      order/cache/concurrency (incl. the deadlock regression), method-channel
      arg/error mapping, loopback + composite broker behaviour, and the
      `SignInGate` states
- [x] Integration tests pass — `flutter test integration_test -d windows`,
      **4/4**: real-engine launch + sign-in flows (silent→shell,
      interactive-fail→retry→shell, native-unavailable→loopback→shell) with a
      fake broker. All cases share one file because the Windows embedder can't
      start a second app process within one `flutter test integration_test` run.
- [x] Native `windows/runner/aad_broker.cpp` compiles on the real Windows
      toolchain (`flutter build windows` succeeds)
- [~] Manual: interactive browser sign-in on the dev laptop — the dedicated app
      registration is ready and the flow is wired end-to-end (`aad.local.json` +
      `--dart-define-from-file`); operator-confirmed against the live tenant.
- [ ] Manual (not CI, per live-testing policy): silent WAM token on a
      school-account machine, once the MSAL Runtime SDK is vendored
      (`HAVE_MSAL_RUNTIME`) — see `windows/runner/README-aad-broker.md`.
