### PR TITLE
Reconcile screen: sync, linked overview, actions, dry-run/apply (#99)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -6,12 +6,15 @@ import 'package:account_manager/main.dart' as app;
 import 'package:account_manager/src/app.dart';
 import 'package:account_manager/src/auth/auth.dart';
 import 'package:account_manager/src/screens/home_screen.dart';
+import 'package:account_manager/src/screens/reconcile_screen.dart';
 import 'package:account_manager/src/shell/app_shell.dart';
 import 'package:azure_api/azure_api.dart' show AzureCredentials;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:plink_design_system/plink_design_system.dart';
+
+import '../test/reconcile/reconcile_fakes.dart';
 
 /// End-to-end runs of the *real* app in the real engine, with the Plink fonts
 /// bundled by the design-system package. This is the layer that catches
@@ -64,6 +67,74 @@ void main() {
     final TextStyle? display = Theme.of(context).textTheme.displaySmall;
     expect(display?.fontFamily, contains('Fraunces'));
     expect(find.text('Account Manager'), findsOneWidget);
+
+    // The shell carries the Reconcile destination; with no AAD config the
+    // screen renders its "not configured" panel instead of bootstrapping.
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    expect(find.byType(ReconcileScreen), findsOneWidget);
+    expect(find.text('Not configured'), findsOneWidget);
+  });
+
+  testWidgets(
+      'the reconcile flow runs end-to-end: sign-in → sync → overview → '
+      'actions → dry-run → apply → unchanged re-sync',
+      (WidgetTester tester) async {
+    // The real app composition — shell, navigation, theme — over the offline
+    // reconcile harness (scripted syncers + recording transports), driven the
+    // way the operator drives it.
+    final harness = ReconcileHarness();
+    final broker = _FakeBroker(silent: (_) => _token('AT'));
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(broker),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    expect(find.byType(AppShell), findsOneWidget);
+
+    // Open the reconcile screen; the stack bootstraps lazily.
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('reconcile-sync')), findsOneWidget);
+
+    // Sync: all three systems pull, the overview + pending actions render.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.wisaSyncs, 1);
+    expect(harness.ssSyncs, 1);
+    expect(harness.azSyncs, 1);
+    expect(find.text('Linked overview'), findsOneWidget);
+    expect(find.textContaining('Pending actions'), findsOneWidget);
+    expect(find.text('Wijzig de klas in Smartschool'), findsWidgets);
+
+    // Dry-run: the projected changes render and nothing is written.
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-dry-run')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-dry-run')));
+    await tester.pumpAndSettle();
+    expect(find.text('Dry-run result'), findsOneWidget);
+    expect(harness.soap.soapActions, isEmpty);
+
+    // Apply: confirm the dialog, the Smartschool write happens for real
+    // (against the recording transport).
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-apply')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-apply')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-apply-confirm')));
+    await tester.pumpAndSettle();
+    expect(find.text('Apply result'), findsOneWidget);
+    expect(harness.soap.soapActions, isNotEmpty);
+
+    // Re-sync with unchanged WISA: the smart diff reports "no changes
+    // needed" and leaves Smartschool / Azure unread.
+    harness.wisaResult =
+        wisaSnap(fetchedAt: kFixtureDate.add(const Duration(hours: 1)));
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('no account changes needed'), findsWidgets);
+    expect(harness.ssSyncs, 1);
+    expect(harness.azSyncs, 1);
   });
 
   testWidgets('silent sign-in leads straight into the shell',

--- a/account_manager/lib/main.dart
+++ b/account_manager/lib/main.dart
@@ -1,12 +1,19 @@
 import 'dart:io';
 
-import 'package:azure_api/azure_api.dart' show LoopbackAuthorizer;
+import 'package:azure_api/azure_api.dart'
+    show
+        EncryptedTokenCache,
+        InMemoryTokenCache,
+        LoopbackAuthorizer,
+        TokenCache;
 import 'package:flutter/material.dart';
 
 import 'src/app.dart';
 import 'src/auth/aad_app_config.dart';
 import 'src/auth/aad_broker.dart';
 import 'src/auth/composite_broker.dart';
+import 'src/auth/dpapi.dart';
+import 'src/auth/file_token_cache.dart';
 import 'src/auth/loopback_aad_broker.dart';
 import 'src/auth/method_channel_aad_broker.dart';
 import 'src/auth/sign_in_session.dart';
@@ -35,6 +42,10 @@ void main() {
       azureDomain: config.azureDomain,
       schoolPrefix: config.schoolPrefix,
       authorizer: LoopbackAuthorizer(launchBrowser: _openInBrowser).call,
+      // Persist the sign-in across restarts (#103): each resource's OAuth
+      // credentials are DPAPI-encrypted (user-scoped) on disk, so a returning
+      // operator gets a silent acquisition instead of a browser round-trip.
+      cacheFactory: _persistentTokenCache,
     ),
   ]);
 
@@ -51,6 +62,23 @@ void main() {
           ? () => bootstrapReconcile(session: session, aad: config)
           : null,
     ),
+  );
+}
+
+/// The persistent, encrypted token cache for one resource: ciphertext in
+/// `%APPDATA%\AccountManager\auth\<resource>.token`, DPAPI (user scope) as the
+/// cipher — never a plaintext refresh token on disk. Outside Windows (or with
+/// no APPDATA) sign-in still works, just per-run: in-memory only.
+TokenCache _persistentTokenCache(String resourceId) {
+  final appData = Platform.environment['APPDATA'];
+  if (!Platform.isWindows || appData == null || appData.isEmpty) {
+    return InMemoryTokenCache();
+  }
+  final path = '$appData\\AccountManager\\auth\\$resourceId.token';
+  return EncryptedTokenCache(
+    inner: FileTokenCache(path),
+    encrypt: Dpapi.protect,
+    decrypt: Dpapi.unprotect,
   );
 }
 

--- a/account_manager/lib/main.dart
+++ b/account_manager/lib/main.dart
@@ -10,6 +10,7 @@ import 'src/auth/composite_broker.dart';
 import 'src/auth/loopback_aad_broker.dart';
 import 'src/auth/method_channel_aad_broker.dart';
 import 'src/auth/sign_in_session.dart';
+import 'src/reconcile/reconcile_bootstrap.dart';
 
 void main() {
   // Azure AD app-registration values come from --dart-define (see
@@ -43,6 +44,12 @@ void main() {
     AccountManagerApp(
       session: session,
       graph: config.isConfigured ? config.graph : null,
+      // The reconcile stack (settings from Azure SQL, secrets from Key Vault,
+      // the three connectors) is assembled lazily, the first time the screen
+      // is opened — after the sign-in gate has a session to mint tokens from.
+      reconcileBootstrap: config.isConfigured
+          ? () => bootstrapReconcile(session: session, aad: config)
+          : null,
     ),
   );
 }

--- a/account_manager/lib/src/app.dart
+++ b/account_manager/lib/src/app.dart
@@ -4,6 +4,7 @@ import 'package:plink_design_system/plink_design_system.dart';
 import 'auth/aad_resource.dart';
 import 'auth/sign_in_gate.dart';
 import 'auth/sign_in_session.dart';
+import 'reconcile/reconcile_bootstrap.dart';
 import 'shell/app_shell.dart';
 
 /// This app's per-product accent (Plink DS-5): one colour that is clearly
@@ -22,6 +23,7 @@ class AccountManagerApp extends StatelessWidget {
     super.key,
     required this.session,
     required this.graph,
+    this.reconcileBootstrap,
   });
 
   /// The operator's Azure AD session, used by the sign-in gate and, later, by
@@ -30,6 +32,11 @@ class AccountManagerApp extends StatelessWidget {
 
   /// The Graph resource to sign in for, or `null` when AAD is not configured.
   final AadResource? graph;
+
+  /// Assembles the reconcile stack when its screen is first opened, or `null`
+  /// when AAD is not configured. Injectable so tests can bind the screen to
+  /// fakes; the real closure is built in `main()`.
+  final Future<ReconcileServices> Function()? reconcileBootstrap;
 
   ThemeData _themed(ThemeData base) => base.copyWith(
         extensions: const <ThemeExtension<dynamic>>[
@@ -47,7 +54,7 @@ class AccountManagerApp extends StatelessWidget {
       home: SignInGate(
         session: session,
         graph: graph,
-        child: const AppShell(),
+        child: AppShell(reconcileBootstrap: reconcileBootstrap),
       ),
     );
   }

--- a/account_manager/lib/src/auth/aad_resource.dart
+++ b/account_manager/lib/src/auth/aad_resource.dart
@@ -40,4 +40,11 @@ class AadResource {
     id: 'sql',
     scopes: <String>['https://database.windows.net/.default'],
   );
+
+  /// The centralized Key Vault data plane (`https://vault.azure.net/`), where
+  /// the WISA password and Smartschool passphrase live (issue #84).
+  static const AadResource vault = AadResource(
+    id: 'vault',
+    scopes: <String>['https://vault.azure.net/.default'],
+  );
 }

--- a/account_manager/lib/src/auth/auth.dart
+++ b/account_manager/lib/src/auth/auth.dart
@@ -11,6 +11,8 @@ library;
 export 'aad_broker.dart' show AadBroker, AadBrokerException, BrokerToken;
 export 'aad_resource.dart' show AadResource;
 export 'composite_broker.dart' show CompositeBroker;
+export 'dpapi.dart' show Dpapi;
+export 'file_token_cache.dart' show FileTokenCache;
 export 'loopback_aad_broker.dart' show LoopbackAadBroker;
 export 'method_channel_aad_broker.dart' show MethodChannelAadBroker;
 export 'sign_in_session.dart'

--- a/account_manager/lib/src/auth/dpapi.dart
+++ b/account_manager/lib/src/auth/dpapi.dart
@@ -1,0 +1,114 @@
+/// Windows DPAPI (`CryptProtectData` / `CryptUnprotectData`) over `dart:ffi`,
+/// used to encrypt the persisted OAuth token cache at rest (#103).
+///
+/// DPAPI ties the ciphertext to the signed-in Windows user, so the cached
+/// refresh token can only be read back by the operator who wrote it, on this
+/// machine — the same mechanism the legacy connector used
+/// (`TokenCacheHelper.cs`). No key management: Windows owns the key.
+library;
+
+import 'dart:convert';
+import 'dart:ffi';
+import 'dart:typed_data';
+
+import 'package:ffi/ffi.dart';
+
+/// `DATA_BLOB` from `dpapi.h`: a length + byte-pointer pair.
+final class _DataBlob extends Struct {
+  @Uint32()
+  external int cbData;
+  external Pointer<Uint8> pbData;
+}
+
+typedef _CryptDataNative = Int32 Function(
+  Pointer<_DataBlob> dataIn,
+  Pointer<Utf16> description,
+  Pointer<_DataBlob> entropy,
+  Pointer<Void> reserved,
+  Pointer<Void> promptStruct,
+  Uint32 flags,
+  Pointer<_DataBlob> dataOut,
+);
+typedef _CryptData = int Function(
+  Pointer<_DataBlob> dataIn,
+  Pointer<Utf16> description,
+  Pointer<_DataBlob> entropy,
+  Pointer<Void> reserved,
+  Pointer<Void> promptStruct,
+  int flags,
+  Pointer<_DataBlob> dataOut,
+);
+
+typedef _LocalFreeNative = Pointer<Void> Function(Pointer<Void> mem);
+
+/// Never show a DPAPI UI prompt; fail instead (`CRYPTPROTECT_UI_FORBIDDEN`).
+const int _uiForbidden = 0x1;
+
+final DynamicLibrary _crypt32 = DynamicLibrary.open('crypt32.dll');
+final DynamicLibrary _kernel32 = DynamicLibrary.open('kernel32.dll');
+
+final _CryptData _protectData =
+    _crypt32.lookupFunction<_CryptDataNative, _CryptData>('CryptProtectData');
+final _CryptData _unprotectData =
+    _crypt32.lookupFunction<_CryptDataNative, _CryptData>('CryptUnprotectData');
+final _LocalFreeNative _localFree =
+    _kernel32.lookupFunction<_LocalFreeNative, _LocalFreeNative>('LocalFree');
+
+/// User-scoped DPAPI as the [EncryptedTokenCache] cipher pair: [protect] maps
+/// plaintext to base64 ciphertext, [unprotect] back. [unprotect] throws
+/// [FormatException] when the payload cannot be decrypted (tampered, another
+/// user's, or another machine's) — the exact signal `OAuthAuthProvider` treats
+/// as a corrupt cache, discarding it and falling back to interactive sign-in.
+abstract final class Dpapi {
+  static String protect(String plaintext) =>
+      base64Encode(_transform(_protectData, utf8.encode(plaintext), 'protect'));
+
+  static String unprotect(String ciphertext) {
+    final Uint8List bytes;
+    try {
+      bytes = base64Decode(ciphertext);
+    } on FormatException {
+      throw const FormatException('token cache is not valid base64');
+    }
+    return utf8.decode(_transform(_unprotectData, bytes, 'unprotect'));
+  }
+
+  static Uint8List _transform(_CryptData fn, List<int> input, String op) {
+    final inData = malloc<_DataBlob>();
+    final outData = malloc<_DataBlob>();
+    final inBytes = malloc<Uint8>(input.length);
+    try {
+      inBytes.asTypedList(input.length).setAll(0, input);
+      inData.ref
+        ..cbData = input.length
+        ..pbData = inBytes;
+      outData.ref
+        ..cbData = 0
+        ..pbData = nullptr;
+
+      final ok = fn(
+        inData,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        _uiForbidden,
+        outData,
+      );
+      if (ok == 0) {
+        throw FormatException('DPAPI $op failed');
+      }
+      try {
+        return Uint8List.fromList(
+          outData.ref.pbData.asTypedList(outData.ref.cbData),
+        );
+      } finally {
+        _localFree(outData.ref.pbData.cast());
+      }
+    } finally {
+      malloc.free(inBytes);
+      malloc.free(inData);
+      malloc.free(outData);
+    }
+  }
+}

--- a/account_manager/lib/src/auth/file_token_cache.dart
+++ b/account_manager/lib/src/auth/file_token_cache.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:azure_api/azure_api.dart' show TokenCache;
+
+/// A [TokenCache] backed by one file, so the loopback sign-in survives app
+/// restarts (#103). Store only ciphertext here — wrap it in azure_api's
+/// `EncryptedTokenCache` with the DPAPI cipher; this class never sees (or
+/// writes) a plaintext refresh token.
+class FileTokenCache implements TokenCache {
+  FileTokenCache(String path) : _file = File(path);
+
+  final File _file;
+
+  @override
+  Future<String?> read() async {
+    try {
+      if (!await _file.exists()) return null;
+      final data = await _file.readAsString();
+      return data.isEmpty ? null : data;
+    } on FileSystemException {
+      // Unreadable cache = no cache; the caller falls back to interactive.
+      return null;
+    }
+  }
+
+  @override
+  Future<void> write(String data) async {
+    await _file.parent.create(recursive: true);
+    await _file.writeAsString(data, flush: true);
+  }
+
+  @override
+  Future<void> clear() async {
+    try {
+      if (await _file.exists()) await _file.delete();
+    } on FileSystemException {
+      // Best effort: a locked file just means a stale cache lingers.
+    }
+  }
+}

--- a/account_manager/lib/src/auth/loopback_aad_broker.dart
+++ b/account_manager/lib/src/auth/loopback_aad_broker.dart
@@ -18,10 +18,11 @@ import 'aad_resource.dart';
 /// AAD refresh token is issued per client (app), not per scope set, so once
 /// any resource has signed in interactively, [acquireSilent] redeems that
 /// refresh token for the next resource's scopes with no browser round-trip.
-/// Graph pays the one interactive prompt at startup; SQL and Key Vault are
-/// then acquired silently. Nothing persists across restarts — the caches are
-/// in-memory, so a fresh run pays one prompt again (#103 tracks the encrypted
-/// on-disk cache).
+/// With a persistent [cacheFactory] (the DPAPI-encrypted file cache, #103)
+/// the refresh token also survives restarts, so a returning operator signs in
+/// with no browser at all; the default in-memory caches pay one interactive
+/// prompt per run (Graph at startup — SQL and Key Vault always follow
+/// silently).
 ///
 /// One [OAuthAuthProvider] is built per resource (each with that resource's
 /// scopes + `offline_access`) and kept, so its cache survives across calls.
@@ -52,15 +53,25 @@ class LoopbackAadBroker implements AadBroker {
     http.Client? httpClient,
     Duration assumedLifetime = const Duration(minutes: 50),
     DateTime Function()? clock,
+    TokenCache Function(String resourceId)? cacheFactory,
   }) {
     final client = httpClient ?? http.Client();
     final now = clock ?? DateTime.now;
+    final makeCache = cacheFactory ?? ((_) => InMemoryTokenCache());
     final caches = <String, TokenCache>{};
     TokenCache cacheFor(String id) =>
-        caches.putIfAbsent(id, InMemoryTokenCache.new);
+        caches.putIfAbsent(id, () => makeCache(id));
 
+    // Materializes the cache on first use — with a persistent factory that
+    // is what reads the previous run's credentials back off disk.
     Future<oauth2.Credentials?> storedCredentials(String id) async {
-      final stored = await caches[id]?.read();
+      final String? stored;
+      try {
+        stored = await cacheFor(id).read();
+      } on FormatException {
+        // Undecryptable payload (tampered / another user's): no cache.
+        return null;
+      }
       if (stored == null || stored.isEmpty) return null;
       try {
         return oauth2.Credentials.fromJson(stored);

--- a/account_manager/lib/src/auth/loopback_aad_broker.dart
+++ b/account_manager/lib/src/auth/loopback_aad_broker.dart
@@ -1,5 +1,6 @@
 import 'package:azure_api/azure_api.dart';
 import 'package:http/http.dart' as http;
+import 'package:oauth2/oauth2.dart' as oauth2;
 
 import 'aad_broker.dart';
 import 'aad_resource.dart';
@@ -13,23 +14,28 @@ import 'aad_resource.dart';
 /// concrete answer to the issue's "the existing OAuthAuthProvider loopback flow
 /// can serve as the fallback" (#98).
 ///
-/// It participates only in the **interactive** leg — [acquireSilent] returns
-/// `null` — because [OAuthAuthProvider] cannot promise a no-prompt acquisition.
-/// Once a resource has signed in, its provider caches the refresh token, so a
-/// later [acquireInteractive] refreshes silently (no browser) until the refresh
-/// token is revoked; and [SignInSession]'s own cache means a token is reused for
-/// its whole lifetime without re-consulting this broker at all.
+/// The **silent** leg honours the "sign in once per session" requirement: an
+/// AAD refresh token is issued per client (app), not per scope set, so once
+/// any resource has signed in interactively, [acquireSilent] redeems that
+/// refresh token for the next resource's scopes with no browser round-trip.
+/// Graph pays the one interactive prompt at startup; SQL and Key Vault are
+/// then acquired silently. Nothing persists across restarts — the caches are
+/// in-memory, so a fresh run pays one prompt again (#103 tracks the encrypted
+/// on-disk cache).
 ///
 /// One [OAuthAuthProvider] is built per resource (each with that resource's
 /// scopes + `offline_access`) and kept, so its cache survives across calls.
 class LoopbackAadBroker implements AadBroker {
   /// Primary constructor: [providerFactory] builds the per-resource auth
-  /// provider. Tests inject a fake; production uses [LoopbackAadBroker.oauth].
+  /// provider and [silentAcquirer] (when given) implements the no-prompt leg.
+  /// Tests inject fakes; production uses [LoopbackAadBroker.oauth].
   LoopbackAadBroker({
     required AzureAuthProvider Function(AadResource resource) providerFactory,
+    Future<BrokerToken?> Function(AadResource resource)? silentAcquirer,
     Duration assumedLifetime = const Duration(minutes: 50),
     DateTime Function()? clock,
   })  : _providerFactory = providerFactory,
+        _silentAcquirer = silentAcquirer,
         _assumedLifetime = assumedLifetime,
         _clock = clock ?? DateTime.now;
 
@@ -45,10 +51,70 @@ class LoopbackAadBroker implements AadBroker {
     Uri? redirectUri,
     http.Client? httpClient,
     Duration assumedLifetime = const Duration(minutes: 50),
+    DateTime Function()? clock,
   }) {
+    final client = httpClient ?? http.Client();
+    final now = clock ?? DateTime.now;
     final caches = <String, TokenCache>{};
+    TokenCache cacheFor(String id) =>
+        caches.putIfAbsent(id, InMemoryTokenCache.new);
+
+    Future<oauth2.Credentials?> storedCredentials(String id) async {
+      final stored = await caches[id]?.read();
+      if (stored == null || stored.isEmpty) return null;
+      try {
+        return oauth2.Credentials.fromJson(stored);
+      } on FormatException {
+        return null;
+      }
+    }
+
+    BrokerToken asBrokerToken(oauth2.Credentials credentials) => BrokerToken(
+          accessToken: credentials.accessToken,
+          expiresOn: credentials.expiration?.toUtc() ??
+              now().toUtc().add(assumedLifetime),
+        );
+
+    Future<BrokerToken?> silent(AadResource resource) async {
+      // 1. This resource's own cached token, still valid.
+      final own = await storedCredentials(resource.id);
+      if (own != null && !own.isExpired) return asBrokerToken(own);
+
+      // 2. Redeem a held refresh token for this resource's scopes — own
+      //    first, then any other signed-in resource's. An AAD refresh token
+      //    is issued per client, not per scope set, so the Graph sign-in can
+      //    silently mint the SQL and Key Vault tokens.
+      final donors = <oauth2.Credentials>[
+        if (own != null && own.canRefresh) own,
+      ];
+      for (final id in caches.keys.toList()) {
+        if (id == resource.id) continue;
+        final other = await storedCredentials(id);
+        if (other != null && other.canRefresh) donors.add(other);
+      }
+
+      for (final donor in donors) {
+        try {
+          final refreshed = await donor.refresh(
+            identifier: clientId,
+            newScopes: <String>[...resource.scopes, 'offline_access'],
+            httpClient: client,
+          );
+          await cacheFor(resource.id).write(refreshed.toJson());
+          return asBrokerToken(refreshed);
+        } on Exception {
+          // Rejected/revoked refresh token or a malformed response — try the
+          // next donor; with none left the caller falls back to interactive.
+          continue;
+        }
+      }
+      return null;
+    }
+
     return LoopbackAadBroker(
       assumedLifetime: assumedLifetime,
+      clock: clock,
+      silentAcquirer: silent,
       providerFactory: (resource) => OAuthAuthProvider(
         credentials: AzureCredentials(
           clientId: clientId,
@@ -59,14 +125,15 @@ class LoopbackAadBroker implements AadBroker {
           // The resource's scopes, plus offline_access for a refresh token.
           scopes: <String>[...resource.scopes, 'offline_access'],
         ),
-        cache: caches.putIfAbsent(resource.id, InMemoryTokenCache.new),
+        cache: cacheFor(resource.id),
         authorizer: authorizer,
-        httpClient: httpClient,
+        httpClient: client,
       ),
     );
   }
 
   final AzureAuthProvider Function(AadResource resource) _providerFactory;
+  final Future<BrokerToken?> Function(AadResource resource)? _silentAcquirer;
   final Duration _assumedLifetime;
   final DateTime Function() _clock;
 
@@ -74,7 +141,8 @@ class LoopbackAadBroker implements AadBroker {
       <String, AzureAuthProvider>{};
 
   @override
-  Future<BrokerToken?> acquireSilent(AadResource resource) async => null;
+  Future<BrokerToken?> acquireSilent(AadResource resource) async =>
+      _silentAcquirer?.call(resource);
 
   @override
   Future<BrokerToken> acquireInteractive(AadResource resource) async {

--- a/account_manager/lib/src/auth/sign_in_session.dart
+++ b/account_manager/lib/src/auth/sign_in_session.dart
@@ -1,4 +1,5 @@
-import 'package:account_state/account_state.dart' show AadTokenProvider;
+import 'package:account_state/account_state.dart'
+    show AadTokenProvider, KeyVaultTokenProvider;
 import 'package:azure_api/azure_api.dart'
     show AzureAuthException, AzureAuthProvider;
 
@@ -116,4 +117,16 @@ class SqlSessionTokenProvider implements AadTokenProvider {
 
   @override
   Future<String> databaseAccessToken() => _session.tokenFor(AadResource.sql);
+}
+
+/// Adapts a [SignInSession] to the Key Vault auth seam ([KeyVaultTokenProvider])
+/// so the WISA password and Smartschool passphrase are read with the operator's
+/// own AAD identity (Key Vault Secrets Officer), no stored vault secret.
+class VaultSessionTokenProvider implements KeyVaultTokenProvider {
+  VaultSessionTokenProvider(this._session);
+
+  final SignInSession _session;
+
+  @override
+  Future<String> vaultAccessToken() => _session.tokenFor(AadResource.vault);
 }

--- a/account_manager/lib/src/reconcile/log_buffer.dart
+++ b/account_manager/lib/src/reconcile/log_buffer.dart
@@ -1,0 +1,65 @@
+import 'package:account_core/account_core.dart' show ILog, Origin;
+import 'package:flutter/foundation.dart';
+
+/// One entry in the inline log panel.
+class LogEntry {
+  const LogEntry({
+    required this.time,
+    required this.origin,
+    required this.message,
+    required this.isError,
+  });
+
+  final DateTime time;
+  final Origin origin;
+  final String message;
+  final bool isError;
+}
+
+/// The app's [ILog] sink: an in-memory, notifying buffer the inline log panel
+/// renders (#99). Wired into the connectors at bootstrap and used by the
+/// reconcile controller for its own progress messages, so every diagnostic in
+/// one run lands in the same panel.
+///
+/// Keeps at most [capacity] entries, dropping the oldest — the panel is a
+/// session diagnostic, not an archive (promote to its own view later only if
+/// it gets busy, per the issue).
+class LogBuffer extends ChangeNotifier implements ILog {
+  LogBuffer({this.capacity = 500, DateTime Function()? clock})
+      : _clock = clock ?? DateTime.now;
+
+  final int capacity;
+  final DateTime Function() _clock;
+  final List<LogEntry> _entries = <LogEntry>[];
+
+  /// The buffered entries, oldest first.
+  List<LogEntry> get entries => List.unmodifiable(_entries);
+
+  bool get hasErrors => _entries.any((e) => e.isError);
+
+  @override
+  void addMessage(Origin origin, String message) =>
+      _add(origin, message, isError: false);
+
+  @override
+  void addError(Origin origin, String message) =>
+      _add(origin, message, isError: true);
+
+  void clear() {
+    _entries.clear();
+    notifyListeners();
+  }
+
+  void _add(Origin origin, String message, {required bool isError}) {
+    _entries.add(LogEntry(
+      time: _clock(),
+      origin: origin,
+      message: message,
+      isError: isError,
+    ));
+    if (_entries.length > capacity) {
+      _entries.removeRange(0, _entries.length - capacity);
+    }
+    notifyListeners();
+  }
+}

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -1,0 +1,275 @@
+import 'package:account_actions/account_actions.dart' as actions;
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+import '../auth/aad_app_config.dart';
+import '../auth/sign_in_session.dart';
+import 'log_buffer.dart';
+import 'reconcile_controller.dart';
+
+/// Where the centralized stores live. These are deployment constants of the
+/// provisioned infrastructure (docs/port-plan.md, Phase B) — not secrets and
+/// not per-school config, so they default to the real resources and can be
+/// overridden per environment with `--dart-define`.
+class StoreEndpoints {
+  const StoreEndpoints({
+    required this.sqlServer,
+    required this.sqlDatabase,
+    required this.vaultUri,
+  });
+
+  factory StoreEndpoints.fromEnvironment() => const StoreEndpoints(
+        sqlServer: String.fromEnvironment(
+          'SQL_SERVER',
+          defaultValue: 'accountmanager-sql-arcadia.database.windows.net',
+        ),
+        sqlDatabase: String.fromEnvironment(
+          'SQL_DATABASE',
+          defaultValue: 'accountmanager',
+        ),
+        vaultUri: String.fromEnvironment(
+          'KEY_VAULT_URI',
+          defaultValue: 'https://accountmanager-kv.vault.azure.net/',
+        ),
+      );
+
+  final String sqlServer;
+  final String sqlDatabase;
+  final String vaultUri;
+}
+
+/// The assembled reconcile stack for one signed-in session: settings loaded
+/// from the Azure SQL [SettingsStore], secrets resolved from Key Vault, the
+/// three connectors wired into an [ApplicationState], and the
+/// [ReconcileController] the screen binds to.
+class ReconcileServices {
+  const ReconcileServices({
+    required this.settings,
+    required this.app,
+    required this.applier,
+    required this.controller,
+    required this.log,
+  });
+
+  final AppSettings settings;
+  final ApplicationState app;
+  final StateApplier applier;
+  final ReconcileController controller;
+  final LogBuffer log;
+}
+
+/// A configuration problem the operator can act on (missing secret, malformed
+/// profile). Rendered as the reconcile screen's error panel, distinct from a
+/// transient sync failure.
+class ReconcileConfigException implements Exception {
+  const ReconcileConfigException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// Builds the real reconcile stack (#99): loads [AppSettings] from the Azure
+/// SQL settings store using the operator's SQL token, resolves the WISA
+/// password and Smartschool passphrase from Key Vault, constructs the three
+/// connectors (Graph calls carry the session token from #98), and assembles
+/// `ApplicationState` → `StateApplier` → [ReconcileController].
+///
+/// The optional parameters are test seams; production callers pass only
+/// [session] and [aad].
+Future<ReconcileServices> bootstrapReconcile({
+  required SignInSession session,
+  required AadAppConfig aad,
+  StoreEndpoints? endpoints,
+  SettingsStore? settingsStore,
+  SecretProvider? secretProvider,
+  SqlConnectionFactory? sqlFactory,
+  LogBuffer? log,
+  DateTime Function()? clock,
+}) async {
+  final ends = endpoints ?? StoreEndpoints.fromEnvironment();
+  final logBuffer = log ?? LogBuffer();
+  final now = clock ?? DateTime.now;
+
+  final sqlTokens = SqlSessionTokenProvider(session);
+  final factory = sqlFactory ?? OdbcSqlConnectionFactory();
+  final sqlConfig = AzureSqlConfig(
+    server: ends.sqlServer,
+    database: ends.sqlDatabase,
+  );
+
+  final store = settingsStore ??
+      AzureSqlSettingsStore(
+        factory: factory,
+        config: sqlConfig,
+        tokens: sqlTokens,
+      );
+  final settings = await store.load();
+
+  final secrets = secretProvider ??
+      KeyVaultSecretProvider(
+        config: KeyVaultConfig(vaultUri: ends.vaultUri),
+        tokens: VaultSessionTokenProvider(session),
+      );
+
+  final wisaPassword = await secrets.read(settings.wisa.passwordRef);
+  if (wisaPassword == null) {
+    throw ReconcileConfigException(
+      'The WISA password (secret "${settings.wisa.passwordRef.name}") is not '
+      'set in the Key Vault.',
+    );
+  }
+  final passphrase = await secrets.read(settings.smartschool.passphraseRef);
+  if (passphrase == null) {
+    throw ReconcileConfigException(
+      'The Smartschool passphrase (secret '
+      '"${settings.smartschool.passphraseRef.name}") is not set in the '
+      'Key Vault.',
+    );
+  }
+
+  final wisaPort = int.tryParse(settings.wisa.port.trim());
+  if (settings.wisa.server.trim().isEmpty || wisaPort == null) {
+    throw ReconcileConfigException(
+      'The WISA connection profile is incomplete '
+      '(server: "${settings.wisa.server}", port: "${settings.wisa.port}").',
+    );
+  }
+  final site = smartschoolSiteFrom(settings.smartschool.uri);
+  if (site.isEmpty) {
+    throw ReconcileConfigException(
+      'The Smartschool connection profile has no site/URI configured.',
+    );
+  }
+
+  final wisaConnector = wapi.WisaConnector.fromParts(
+    server: settings.wisa.server.trim(),
+    port: wisaPort,
+    database: settings.wisa.database,
+    username: settings.wisa.username,
+    password: wisaPassword,
+    log: logBuffer,
+  );
+  final ssConnector = ss.SmartschoolConnector.fromParts(
+    site: site,
+    accessCode: passphrase,
+    log: logBuffer,
+  );
+
+  // Per-school values prefer the persisted settings and fall back to the
+  // dart-define sign-in config, so a not-yet-filled settings row still runs.
+  final schoolPrefix = _firstNonEmpty(settings.schoolPrefix, aad.schoolPrefix);
+  final azureDomain = _firstNonEmpty(settings.azure.domain, aad.azureDomain);
+  final azConnector = az.AzureConnector(
+    credentials: az.AzureCredentials(
+      clientId: aad.clientId,
+      tenantId: aad.tenantId,
+      azureDomain: azureDomain,
+      schoolPrefix: schoolPrefix,
+    ),
+    authProvider: GraphSessionAuthProvider(session, aad.graph),
+    log: logBuffer,
+  );
+
+  final wisaRules = WisaImportRules(initial: settings.wisaRules);
+
+  final app = ApplicationState(
+    wisa: SystemState<wapi.WisaSnapshot>(
+      system: core.Origin.wisa,
+      // Schools are re-read per sync so a WISA-side school change is picked
+      // up; MarkAsVirtual rules are applied to them before the row pulls, the
+      // other rules at snapshot construction. Rules are read live from the
+      // shared holder so a DontImportFromWisa apply affects the re-sync (#72).
+      syncer: (_) async {
+        final schools = wapi.WisaConnector.applySchoolRules(
+          await wisaConnector.loadSchools(),
+          wisaRules.rules,
+        );
+        final at = now();
+        return wisaConnector.sync(
+          schools: schools,
+          workDate: settings.wisa.workDate.resolve(at),
+          virtualWorkDate: settings.wisa.virtualWorkDate.resolve(at),
+          rules: wisaRules.rules,
+        );
+      },
+    ),
+    smartschool: SystemState<ss.SmartschoolSnapshot>(
+      system: core.Origin.smartschool,
+      syncer: (_) => ssConnector.sync(rules: settings.smartschoolRules),
+    ),
+    azure: SystemState<az.AzureSnapshot>(
+      system: core.Origin.azure,
+      syncer: azureSyncer(azConnector),
+    ),
+  );
+
+  final applier = StateApplier(
+    app: app,
+    connectors: actions.Connectors(
+      smartschool: ssConnector,
+      azure: azConnector,
+    ),
+    resolver: AzureSqlPersonIdResolver(
+      factory: factory,
+      config: sqlConfig,
+      tokens: sqlTokens,
+    ),
+    wisaRules: wisaRules,
+    studentConfig: actions.StudentActionConfig(
+      schoolPrefix: schoolPrefix,
+      azureDomain: azureDomain,
+    ),
+    staffConfig: actions.StaffActionConfig(
+      schoolPrefix: schoolPrefix,
+      azureDomain: azureDomain,
+    ),
+    classTree: classTreeFrom(settings.smartschool),
+  );
+
+  return ReconcileServices(
+    settings: settings,
+    app: app,
+    applier: applier,
+    controller: ReconcileController(
+      app: app,
+      applier: applier,
+      log: logBuffer,
+    ),
+    log: logBuffer,
+  );
+}
+
+/// The Smartschool class-tree live-config, derived from the persisted
+/// connection profile: the year or grade group codes (whichever the school
+/// uses) with the student-group root as the flat fallback path.
+SmartschoolClassTree classTreeFrom(SmartschoolConnection smartschool) =>
+    SmartschoolClassTree(
+      years: smartschool.useYears ? smartschool.years : const [],
+      grades: smartschool.useGrades ? smartschool.grades : const [],
+      path: smartschool.studentGroup,
+    );
+
+/// Extracts the tenant subdomain the SOAP connector needs from the persisted
+/// Smartschool URI, which operators have entered as a full URL
+/// (`https://school.smartschool.be/...`), a bare host, or just the site name.
+String smartschoolSiteFrom(String uri) {
+  final trimmed = uri.trim();
+  if (trimmed.isEmpty) return '';
+  final parsed =
+      Uri.tryParse(trimmed.contains('://') ? trimmed : 'https://$trimmed');
+  final host = parsed?.host ?? '';
+  const suffix = '.smartschool.be';
+  if (host.endsWith(suffix)) {
+    return host.substring(0, host.length - suffix.length);
+  }
+  if (host.isNotEmpty) return host.split('.').first;
+  return trimmed;
+}
+
+String _firstNonEmpty(String preferred, String fallback) =>
+    preferred.trim().isNotEmpty ? preferred.trim() : fallback;

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -108,7 +108,22 @@ Future<ReconcileServices> bootstrapReconcile({
         config: sqlConfig,
         tokens: sqlTokens,
       );
-  final settings = await store.load();
+  final AppSettings settings;
+  try {
+    settings = await store.load();
+  } on Object catch (e) {
+    // IM002 is the ODBC driver manager's "no such driver" state: the
+    // machine is missing the msodbcsql18 prerequisite, not misconfigured
+    // settings — surface that as the actionable problem.
+    if (e.toString().contains('IM002')) {
+      throw const ReconcileConfigException(
+        'The Microsoft ODBC Driver 18 for SQL Server is not installed on '
+        'this machine, so the settings store cannot be reached. Install it '
+        '(winget install Microsoft.msodbcsql.18) and try again.',
+      );
+    }
+    rethrow;
+  }
 
   final secrets = secretProvider ??
       KeyVaultSecretProvider(

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -110,6 +110,15 @@ Future<ReconcileServices> bootstrapReconcile({
       );
   final AppSettings settings;
   try {
+    // First-run provisioning on the real SQL path: the schema DDL ships with
+    // account_state as idempotent statements (IF OBJECT_ID ... IS NULL), so
+    // running it on every launch is a cheap no-op once the tables exist and
+    // saves the team a manual deployment step. The person-identity table is
+    // included because the resolver hits it at the first link. An injected
+    // settings store means a test (or another persistence backend) — no DDL.
+    if (settingsStore == null) {
+      await _provisionSchema(factory, sqlConfig, sqlTokens);
+    }
     settings = await store.load();
   } on Object catch (e) {
     // IM002 is the ODBC driver manager's "no such driver" state: the
@@ -257,6 +266,29 @@ Future<ReconcileServices> bootstrapReconcile({
     ),
     log: logBuffer,
   );
+}
+
+/// Runs the idempotent schema DDL for the tables this screen touches: the
+/// settings singleton + import rules (read at bootstrap) and the person-id
+/// identity map (read/minted at every link). The password-queue table is
+/// deliberately not provisioned here — password distribution is a follow-up
+/// slice and its adapter can provision its own table when it lands.
+Future<void> _provisionSchema(
+  SqlConnectionFactory factory,
+  AzureSqlConfig config,
+  AadTokenProvider tokens,
+) async {
+  final connection = await factory.open(config, tokens);
+  try {
+    for (final ddl in <String>[
+      ...settingsSchemaStatements,
+      ...personIdentitySchemaStatements,
+    ]) {
+      await connection.execute(ddl);
+    }
+  } finally {
+    await connection.close();
+  }
 }
 
 /// The Smartschool class-tree live-config, derived from the persisted

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -1,0 +1,446 @@
+import 'package:account_actions/account_actions.dart' as actions;
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart';
+import 'package:flutter/foundation.dart';
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+import 'log_buffer.dart';
+
+/// What the reconcile screen is doing right now.
+enum ReconcilePhase {
+  /// Nothing has run yet this session.
+  idle,
+
+  /// A sync (or drift check) is pulling snapshots.
+  syncing,
+
+  /// The linked view is being recomputed.
+  linking,
+
+  /// A dry-run or apply pass is walking the pending actions.
+  applying,
+
+  /// The last pass finished; [ReconcileController.linked] is current.
+  ready,
+}
+
+/// One pending action, shaped for display: which family it belongs to, the
+/// record it targets, and its pure change description.
+class PendingActionView {
+  const PendingActionView({
+    required this.family,
+    required this.target,
+    required this.changes,
+    this.canApply = true,
+  });
+
+  /// `student`, `staff`, or `group` — the dispatcher family.
+  final String family;
+
+  /// Human label of the record the action targets.
+  final String target;
+
+  /// The action's pure diff ([actions.StudentAction.describeChanges] et al.).
+  final actions.ChangeSet changes;
+
+  /// False for the informational group actions (e.g. an orphan Smartschool
+  /// class): they tell the operator something but have no automated write, so
+  /// the dry-run/apply passes skip them.
+  final bool canApply;
+}
+
+/// The outcome of one action in a dry-run or apply pass, for the results list.
+class ActionOutcomeEntry {
+  const ActionOutcomeEntry({
+    required this.target,
+    required this.changes,
+    required this.outcome,
+    this.error,
+  });
+
+  /// Human label of the record the action targets.
+  final String target;
+
+  /// The action's own change description (summary + field diff).
+  final actions.ChangeSet changes;
+
+  final actions.ActionOutcome outcome;
+
+  /// The failure cause when [outcome] is [actions.ActionOutcome.failed].
+  final Object? error;
+}
+
+/// Drives the reconcile loop over the State layer (#99): **sync → linked
+/// overview → pending actions → dry-run → apply**, with progress and failures
+/// reported through the shared [LogBuffer].
+///
+/// The smart-sync behaviour is the product-direction piece: [sync] retains the
+/// previous WISA snapshot (via [ApplicationState]'s [SystemState]) and diffs
+/// the fresh pull against it. When WISA is unchanged and a linked view already
+/// exists, it reports "no account changes needed" and stops — no re-link, no
+/// action churn. Smartschool / Azure are pulled only when still missing this
+/// session; re-reading them is the explicit [checkDrift] action (someone
+/// edited via another tool), not the default.
+class ReconcileController extends ChangeNotifier {
+  ReconcileController({
+    required this.app,
+    required this.applier,
+    required this.log,
+  });
+
+  /// The three connector snapshots (owned by the State layer).
+  final ApplicationState app;
+
+  /// Runs actions (dry-run capable) and keeps the snapshots consistent.
+  final StateApplier applier;
+
+  /// Shared sink for progress and failure messages.
+  final LogBuffer log;
+
+  ReconcilePhase _phase = ReconcilePhase.idle;
+  LinkedState? _linked;
+  bool _noChangesNeeded = false;
+  String? _error;
+  List<ActionOutcomeEntry>? _dryRunResults;
+  List<ActionOutcomeEntry>? _applyResults;
+
+  ReconcilePhase get phase => _phase;
+
+  /// Whether a pass is running (buttons disable on this).
+  bool get busy =>
+      _phase == ReconcilePhase.syncing ||
+      _phase == ReconcilePhase.linking ||
+      _phase == ReconcilePhase.applying;
+
+  /// The current derived view, or `null` before the first successful sync.
+  LinkedState? get linked => _linked;
+
+  /// True when the last [sync] found WISA unchanged — the "no account changes
+  /// needed" banner.
+  bool get noChangesNeeded => _noChangesNeeded;
+
+  /// The last pass's failure, or `null`. Shown inline; details go to [log].
+  String? get error => _error;
+
+  /// Results of the last dry-run pass, or `null` when none ran since the last
+  /// sync/apply.
+  List<ActionOutcomeEntry>? get dryRunResults => _dryRunResults;
+
+  /// Results of the last apply pass, or `null`.
+  List<ActionOutcomeEntry>? get applyResults => _applyResults;
+
+  /// All pending actions of the current linked view, student → staff → group.
+  List<Object> get pendingActions {
+    final l = _linked;
+    if (l == null) return const [];
+    return [...l.studentActions, ...l.staffActions, ...l.groupActions];
+  }
+
+  /// The pending actions shaped for the list UI, in [pendingActions] order.
+  List<PendingActionView> get pendingViews {
+    final l = _linked;
+    if (l == null) return const [];
+    return [
+      for (final a in l.studentActions)
+        PendingActionView(
+          family: 'student',
+          target: _accountLabel(a.target),
+          changes: a.describeChanges(),
+        ),
+      for (final a in l.staffActions)
+        PendingActionView(
+          family: 'staff',
+          target: _staffLabel(a.target),
+          changes: a.describeChanges(),
+        ),
+      for (final a in l.groupActions)
+        PendingActionView(
+          family: 'group',
+          target: _groupLabel(a.target),
+          changes: a.describeChanges(),
+          canApply: a.canApply,
+        ),
+    ];
+  }
+
+  /// How many pending actions an apply pass would actually write (the
+  /// informational group actions are excluded).
+  int get applyableCount {
+    final l = _linked;
+    if (l == null) return 0;
+    return l.studentActions.length +
+        l.staffActions.length +
+        l.groupActions.where((a) => a.canApply).length;
+  }
+
+  /// Runs the smart sync: pull WISA, diff against the retained snapshot, and
+  /// only when something changed (or nothing is linked yet) pull the still-
+  /// missing systems and re-link.
+  Future<void> sync() async {
+    if (busy) return;
+    _begin(ReconcilePhase.syncing);
+    try {
+      final previous = app.wisa.snapshot;
+      log.addMessage(core.Origin.wisa, 'Syncing WISA…');
+      final fresh = await app.sync(core.Origin.wisa) as wapi.WisaSnapshot;
+      log.addMessage(
+        core.Origin.wisa,
+        'WISA sync done: ${fresh.students.length} students, '
+        '${fresh.staff.length} staff, ${fresh.classGroups.length} classes.',
+      );
+
+      if (previous != null &&
+          _linked != null &&
+          wisaSnapshotUnchanged(previous, fresh)) {
+        _noChangesNeeded = true;
+        log.addMessage(
+          core.Origin.wisa,
+          'WISA is unchanged since the previous sync — '
+          'no account changes needed.',
+        );
+        _finish(ReconcilePhase.ready);
+        return;
+      }
+
+      // First pass of the session: the linked view needs all three systems.
+      if (app.smartschool.snapshot == null) {
+        log.addMessage(core.Origin.smartschool, 'Syncing Smartschool…');
+        await app.sync(core.Origin.smartschool);
+      }
+      if (app.azure.snapshot == null) {
+        log.addMessage(core.Origin.azure, 'Syncing Azure AD…');
+        await app.sync(core.Origin.azure);
+      }
+
+      await _relink();
+      _finish(ReconcilePhase.ready);
+    } on Object catch (e) {
+      _fail(e);
+    }
+  }
+
+  /// Explicitly re-reads Smartschool and Azure (drift introduced by edits made
+  /// through other tools) and re-links. WISA is not re-pulled — that is what
+  /// [sync] is for.
+  Future<void> checkDrift() async {
+    if (busy) return;
+    _begin(ReconcilePhase.syncing);
+    try {
+      log.addMessage(
+        core.Origin.smartschool,
+        'Checking Smartschool for drift…',
+      );
+      await app.sync(core.Origin.smartschool);
+      log.addMessage(core.Origin.azure, 'Checking Azure AD for drift…');
+      await app.sync(core.Origin.azure);
+
+      if (app.wisa.snapshot == null) {
+        log.addMessage(core.Origin.wisa, 'Syncing WISA…');
+        await app.sync(core.Origin.wisa);
+      }
+
+      await _relink();
+      _finish(ReconcilePhase.ready);
+    } on Object catch (e) {
+      _fail(e);
+    }
+  }
+
+  /// Dry-runs every pending action (PAIN-3): the full apply path, zero writes.
+  /// Results land in [dryRunResults].
+  Future<void> dryRun() => _applyAll(dry: true);
+
+  /// Applies every pending action for real, refreshing the linked view from
+  /// the State layer's incremental patches as it goes. Results land in
+  /// [applyResults].
+  Future<void> applyAll() => _applyAll(dry: false);
+
+  Future<void> _applyAll({required bool dry}) async {
+    final l = _linked;
+    if (busy || l == null) return;
+    _begin(ReconcilePhase.applying);
+
+    final options =
+        dry ? actions.ApplyOptions.dry : const actions.ApplyOptions();
+    final results = <ActionOutcomeEntry>[];
+    final label = dry ? 'Dry-run' : 'Apply';
+    log.addMessage(
+      core.Origin.all,
+      '$label started for $applyableCount of ${pendingActions.length} '
+      'pending action(s).',
+    );
+
+    try {
+      // Walk the lists captured before the pass: each action is bound to its
+      // target, and on a real write the applier patches the snapshot and
+      // returns a fresh linked view we adopt as we go.
+      for (final action in l.studentActions) {
+        results.add(await _applyOne(
+          () => applier.applyStudent(action, options: options),
+          _accountLabel(action.target),
+          action.describeChanges(),
+        ));
+      }
+      for (final action in l.staffActions) {
+        results.add(await _applyOne(
+          () => applier.applyStaff(action, options: options),
+          _staffLabel(action.target),
+          action.describeChanges(),
+        ));
+      }
+      for (final action in l.groupActions) {
+        // Informational actions (canApply false) carry no automated write —
+        // their apply() throws by contract, so the pass leaves them out.
+        if (!action.canApply) continue;
+        results.add(await _applyOne(
+          () => applier.applyGroup(action, options: options),
+          _groupLabel(action.target),
+          action.describeChanges(),
+        ));
+      }
+
+      final failed =
+          results.where((r) => r.outcome == actions.ActionOutcome.failed);
+      log.addMessage(
+        core.Origin.all,
+        '$label finished: ${results.length - failed.length} ok, '
+        '${failed.length} failed.',
+      );
+      if (dry) {
+        _dryRunResults = results;
+      } else {
+        _applyResults = results;
+        _dryRunResults = null;
+      }
+      _finish(ReconcilePhase.ready);
+    } on Object catch (e) {
+      // _applyOne swallows per-action failures; reaching here means the pass
+      // itself broke (e.g. the post-write re-link). Keep partial results.
+      if (dry) {
+        _dryRunResults = results;
+      } else {
+        _applyResults = results;
+      }
+      _fail(e);
+    }
+  }
+
+  Future<ActionOutcomeEntry> _applyOne(
+    Future<ApplyResult> Function() run,
+    String target,
+    actions.ChangeSet changes,
+  ) async {
+    try {
+      final applied = await run();
+      if (applied.refreshed) _linked = applied.linked;
+      final result = applied.result;
+      if (result.outcome == actions.ActionOutcome.failed) {
+        log.addError(
+          changes.system,
+          '$target — ${changes.summary}: ${result.error}',
+        );
+      } else {
+        log.addMessage(core.Origin.all, '$target — ${changes.summary}');
+      }
+      return ActionOutcomeEntry(
+        target: target,
+        changes: changes,
+        outcome: result.outcome,
+        error: result.error,
+      );
+    } on Object catch (e) {
+      // An action that throws (instead of returning failed) must not abort
+      // the rest of the pass.
+      log.addError(changes.system, '$target — ${changes.summary}: $e');
+      return ActionOutcomeEntry(
+        target: target,
+        changes: changes,
+        outcome: actions.ActionOutcome.failed,
+        error: e,
+      );
+    }
+  }
+
+  Future<void> _relink() async {
+    _phase = ReconcilePhase.linking;
+    notifyListeners();
+    _linked = await applier.link();
+    final s = _linked!.snapshot;
+    log.addMessage(
+      core.Origin.all,
+      'Linked: ${s.accounts.length} students, ${s.staff.length} staff, '
+      '${s.groups.length} groups; ${pendingActions.length} pending '
+      'action(s), ${s.warnings.length} warning(s).',
+    );
+  }
+
+  void _begin(ReconcilePhase phase) {
+    _phase = phase;
+    _error = null;
+    _noChangesNeeded = false;
+    _dryRunResults = null;
+    _applyResults = null;
+    notifyListeners();
+  }
+
+  void _finish(ReconcilePhase phase) {
+    _phase = phase;
+    notifyListeners();
+  }
+
+  void _fail(Object e) {
+    _error = e.toString();
+    log.addError(core.Origin.all, e.toString());
+    _finish(ReconcilePhase.ready);
+  }
+
+  // The core linked records only carry the linking keys; the human names live
+  // on the concrete connector records, which is what a LinkedState built from
+  // real snapshots always holds — hence the type checks with key fallbacks.
+
+  static String _accountLabel(core.LinkedAccount a) {
+    final wisa = a.wisa;
+    if (wisa is wapi.WisaStudent) {
+      return _nonEmpty('${wisa.firstName} ${wisa.name}') ??
+          wisa.wisaId.toString();
+    }
+    return _personLabel(a.smartschool, a.azure) ??
+        wisa?.wisaId.toString() ??
+        '(account)';
+  }
+
+  static String _staffLabel(core.LinkedStaff s) {
+    final wisa = s.wisa;
+    if (wisa is wapi.WisaStaff) {
+      return _nonEmpty('${wisa.firstName} ${wisa.lastName}') ??
+          wisa.code.toString();
+    }
+    return _personLabel(s.smartschool, s.azure) ??
+        wisa?.code.toString() ??
+        '(staff member)';
+  }
+
+  static String _groupLabel(core.LinkedGroup g) =>
+      _nonEmpty(g.wisa?.name ?? '') ??
+      _nonEmpty(g.smartschool?.name ?? '') ??
+      g.azure?.displayName ??
+      '(group)';
+
+  static String? _personLabel(
+    core.SmartschoolAccount? smartschool,
+    core.AzureUser? azure,
+  ) {
+    if (smartschool is ss.SmartschoolAccount) {
+      return _nonEmpty('${smartschool.givenName} ${smartschool.surname}') ??
+          smartschool.uid;
+    }
+    if (smartschool != null) return smartschool.uid;
+    return azure?.upn;
+  }
+
+  static String? _nonEmpty(String s) {
+    final trimmed = s.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+}

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -1,0 +1,724 @@
+import 'package:account_actions/account_actions.dart' as actions;
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart' show LinkedState;
+import 'package:flutter/material.dart';
+import 'package:plink_design_system/plink_design_system.dart';
+
+import '../reconcile/log_buffer.dart';
+import '../reconcile/reconcile_bootstrap.dart';
+import '../reconcile/reconcile_controller.dart';
+
+/// The core screen of the app (#99): drives the reconcile loop — sync →
+/// linked overview → pending actions → dry-run → apply — with the inline log
+/// panel underneath.
+///
+/// The heavy lifting lives in [ReconcileController]; this widget renders its
+/// state and owns the (lazy) bootstrap: the services are only assembled the
+/// first time the screen is opened, after sign-in has completed.
+class ReconcileScreen extends StatefulWidget {
+  const ReconcileScreen({super.key, required this.bootstrap});
+
+  /// Assembles the reconcile stack, or `null` when Azure AD is not configured
+  /// for this build (no sign-in, so no stores or connectors to reach).
+  final Future<ReconcileServices> Function()? bootstrap;
+
+  @override
+  State<ReconcileScreen> createState() => _ReconcileScreenState();
+}
+
+class _ReconcileScreenState extends State<ReconcileScreen> {
+  ReconcileServices? _services;
+  Object? _bootstrapError;
+  bool _bootstrapping = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _bootstrap();
+  }
+
+  Future<void> _bootstrap() async {
+    final make = widget.bootstrap;
+    if (make == null) return;
+    setState(() {
+      _bootstrapping = true;
+      _bootstrapError = null;
+    });
+    try {
+      final services = await make();
+      if (mounted) setState(() => _services = services);
+    } on Object catch (e) {
+      if (mounted) setState(() => _bootstrapError = e);
+    } finally {
+      if (mounted) setState(() => _bootstrapping = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.bootstrap == null) {
+      return const _MessagePanel(
+        eyebrow: 'Arcadia · reconcile',
+        title: 'Not configured',
+        message: 'Azure AD is not configured for this build, so the settings '
+            'store and connectors cannot be reached. Provide the AAD '
+            '--dart-define values and restart.',
+      );
+    }
+    final error = _bootstrapError;
+    if (error != null) {
+      return _MessagePanel(
+        eyebrow: 'Arcadia · reconcile',
+        title: 'Could not prepare the reconcile screen',
+        message: error.toString(),
+        action: FilledButton(
+          key: const ValueKey('reconcile-bootstrap-retry'),
+          onPressed: _bootstrap,
+          child: const Text('Try again'),
+        ),
+      );
+    }
+    final services = _services;
+    if (_bootstrapping || services == null) {
+      return const _MessagePanel(
+        eyebrow: 'Arcadia · reconcile',
+        title: 'Preparing…',
+        message: 'Loading the settings and connection profiles.',
+        progress: true,
+      );
+    }
+    return _ReconcileBody(
+      controller: services.controller,
+      log: services.log,
+    );
+  }
+}
+
+class _ReconcileBody extends StatelessWidget {
+  const _ReconcileBody({required this.controller, required this.log});
+
+  final ReconcileController controller;
+  final LogBuffer log;
+
+  Future<void> _confirmApply(BuildContext context) async {
+    final count = controller.applyableCount;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Apply pending actions?'),
+        content: Text(
+          'This writes $count change(s) to Smartschool and Azure AD. '
+          'Run a dry-run first to preview the exact changes.',
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            key: const ValueKey('reconcile-apply-confirm'),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Apply'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed ?? false) await controller.applyAll();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (context, _) {
+        final linked = controller.linked;
+        return Column(
+          children: <Widget>[
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(PlinkSpacing.s6),
+                child: Center(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 960),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        _Header(controller: controller),
+                        const SizedBox(height: PlinkSpacing.s5),
+                        _StatusBanner(controller: controller),
+                        if (linked != null) ...<Widget>[
+                          const SizedBox(height: PlinkSpacing.s5),
+                          _OverviewSection(linked: linked),
+                          const SizedBox(height: PlinkSpacing.s5),
+                          _ActionsSection(
+                            controller: controller,
+                            onApply: () => _confirmApply(context),
+                          ),
+                        ],
+                        ..._results(context),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const Divider(height: 1, thickness: 1),
+            _LogPanel(log: log),
+          ],
+        );
+      },
+    );
+  }
+
+  List<Widget> _results(BuildContext context) {
+    final dry = controller.dryRunResults;
+    final applied = controller.applyResults;
+    return <Widget>[
+      if (dry != null) ...<Widget>[
+        const SizedBox(height: PlinkSpacing.s5),
+        _ResultsSection(
+          title: 'Dry-run result',
+          subtitle: 'No changes were written. This is what an apply would do.',
+          results: dry,
+        ),
+      ],
+      if (applied != null) ...<Widget>[
+        const SizedBox(height: PlinkSpacing.s5),
+        _ResultsSection(
+          title: 'Apply result',
+          subtitle: 'Written to the target systems.',
+          results: applied,
+        ),
+      ],
+    ];
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.controller});
+
+  final ReconcileController controller;
+
+  String? _freshness() {
+    final app = controller.app;
+    String stamp(DateTime? t) => t == null
+        ? '—'
+        : '${t.toLocal().hour.toString().padLeft(2, '0')}:'
+            '${t.toLocal().minute.toString().padLeft(2, '0')}';
+    if (app.wisa.lastSync == null &&
+        app.smartschool.lastSync == null &&
+        app.azure.lastSync == null) {
+      return null;
+    }
+    return 'Last sync — WISA ${stamp(app.wisa.lastSync)} · '
+        'Smartschool ${stamp(app.smartschool.lastSync)} · '
+        'Azure ${stamp(app.azure.lastSync)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final bool ink = Theme.of(context).brightness == Brightness.dark;
+    final freshness = _freshness();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Eyebrow('Arcadia · reconcile', onInk: ink),
+        const SizedBox(height: PlinkSpacing.s4),
+        Text('Reconcile', style: text.headlineMedium),
+        const SizedBox(height: PlinkSpacing.s4),
+        Wrap(
+          spacing: PlinkSpacing.s3,
+          runSpacing: PlinkSpacing.s2,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: <Widget>[
+            FilledButton.icon(
+              key: const ValueKey('reconcile-sync'),
+              onPressed: controller.busy ? null : controller.sync,
+              icon: const Icon(Icons.sync),
+              label: const Text('Synchronise'),
+            ),
+            OutlinedButton.icon(
+              key: const ValueKey('reconcile-drift'),
+              onPressed: controller.busy ? null : controller.checkDrift,
+              icon: const Icon(Icons.difference_outlined),
+              label: const Text('Check for drift'),
+            ),
+            if (freshness != null) Text(freshness, style: text.bodySmall),
+          ],
+        ),
+        if (controller.busy) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s4),
+          const LinearProgressIndicator(),
+        ],
+      ],
+    );
+  }
+}
+
+class _StatusBanner extends StatelessWidget {
+  const _StatusBanner({required this.controller});
+
+  final ReconcileController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final TextTheme text = Theme.of(context).textTheme;
+
+    final error = controller.error;
+    if (error != null) {
+      return _bordered(
+        context,
+        color: colors.error,
+        child: Row(
+          children: <Widget>[
+            Icon(Icons.error_outline, color: colors.error),
+            const SizedBox(width: PlinkSpacing.s3),
+            Expanded(
+              child: Text(
+                error,
+                style: text.bodyMedium?.copyWith(color: colors.error),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+    if (controller.noChangesNeeded) {
+      return _bordered(
+        context,
+        color: colors.primary,
+        child: Row(
+          children: <Widget>[
+            Icon(Icons.check_circle_outline, color: colors.primary),
+            const SizedBox(width: PlinkSpacing.s3),
+            Expanded(
+              child: Text(
+                'WISA is unchanged since the previous sync — '
+                'no account changes needed.',
+                style: text.bodyMedium,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+    if (controller.phase == ReconcilePhase.idle) {
+      return Text(
+        'Synchronise pulls WISA and diffs it against the previous snapshot; '
+        'Smartschool and Azure are read once per session. Use "Check for '
+        'drift" when accounts were edited through another tool.',
+        style: text.bodyMedium,
+      );
+    }
+    return const SizedBox.shrink();
+  }
+
+  Widget _bordered(
+    BuildContext context, {
+    required Color color,
+    required Widget child,
+  }) =>
+      Container(
+        padding: const EdgeInsets.all(PlinkSpacing.s4),
+        decoration: BoxDecoration(
+          border: Border.all(color: color),
+          borderRadius:
+              const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+        ),
+        child: child,
+      );
+}
+
+class _OverviewSection extends StatelessWidget {
+  const _OverviewSection({required this.linked});
+
+  final LinkedState linked;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final snapshot = linked.snapshot;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text('Linked overview', style: text.titleMedium),
+        const SizedBox(height: PlinkSpacing.s3),
+        Wrap(
+          spacing: PlinkSpacing.s4,
+          runSpacing: PlinkSpacing.s4,
+          children: <Widget>[
+            _CountTile(system: 'WISA', counts: snapshot.wisa),
+            _CountTile(system: 'Smartschool', counts: snapshot.smartschool),
+            _CountTile(system: 'Azure AD', counts: snapshot.azure),
+          ],
+        ),
+        if (snapshot.warnings.isNotEmpty) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s3),
+          ...snapshot.warnings.map((w) => _WarningLine(warning: w)),
+        ],
+      ],
+    );
+  }
+}
+
+class _CountTile extends StatelessWidget {
+  const _CountTile({required this.system, required this.counts});
+
+  final String system;
+  final core.LinkCounts counts;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final Color hairline = Theme.of(context).dividerColor;
+
+    return Container(
+      width: 200,
+      padding: const EdgeInsets.all(PlinkSpacing.s4),
+      decoration: BoxDecoration(
+        border: Border.all(color: hairline),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          PlinkBadge(system),
+          const SizedBox(height: PlinkSpacing.s3),
+          Text(
+            '${counts.linked} / ${counts.total}',
+            style: text.headlineSmall,
+          ),
+          const SizedBox(height: PlinkSpacing.s1),
+          Text(
+            counts.unlinked == 0
+                ? 'fully linked'
+                : '${counts.unlinked} not in every system',
+            style: text.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WarningLine extends StatelessWidget {
+  const _WarningLine({required this.warning});
+
+  final core.LinkWarning warning;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final String message = switch (warning) {
+      core.ResolveDuplicateMail(:final mail, :final accounts) =>
+        'Duplicate mail "$mail" on ${accounts.length} Smartschool accounts.',
+    };
+    return Padding(
+      padding: const EdgeInsets.only(top: PlinkSpacing.s1),
+      child: Row(
+        children: <Widget>[
+          Icon(Icons.warning_amber_outlined, size: 16, color: colors.error),
+          const SizedBox(width: PlinkSpacing.s2),
+          Expanded(
+            child: Text(message, style: Theme.of(context).textTheme.bodySmall),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActionsSection extends StatelessWidget {
+  const _ActionsSection({required this.controller, required this.onApply});
+
+  final ReconcileController controller;
+  final VoidCallback onApply;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final pending = controller.pendingViews;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text('Pending actions (${pending.length})', style: text.titleMedium),
+        const SizedBox(height: PlinkSpacing.s3),
+        if (pending.isEmpty)
+          Text(
+            'Everything is in sync — no pending actions.',
+            style: text.bodyMedium,
+          )
+        else ...<Widget>[
+          Wrap(
+            spacing: PlinkSpacing.s3,
+            children: <Widget>[
+              OutlinedButton.icon(
+                key: const ValueKey('reconcile-dry-run'),
+                onPressed: controller.busy || controller.applyableCount == 0
+                    ? null
+                    : controller.dryRun,
+                icon: const Icon(Icons.visibility_outlined),
+                label: const Text('Dry-run all'),
+              ),
+              FilledButton.icon(
+                key: const ValueKey('reconcile-apply'),
+                onPressed: controller.busy || controller.applyableCount == 0
+                    ? null
+                    : onApply,
+                icon: const Icon(Icons.play_arrow_outlined),
+                label: const Text('Apply all'),
+              ),
+            ],
+          ),
+          const SizedBox(height: PlinkSpacing.s3),
+          ...pending.map((p) => _PendingActionTile(view: p)),
+        ],
+      ],
+    );
+  }
+}
+
+class _PendingActionTile extends StatelessWidget {
+  const _PendingActionTile({required this.view});
+
+  final PendingActionView view;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final Color hairline = Theme.of(context).dividerColor;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
+      decoration: BoxDecoration(
+        border: Border.all(color: hairline),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: ExpansionTile(
+        shape: const Border(),
+        collapsedShape: const Border(),
+        leading: PlinkBadge(view.family),
+        title: Text(view.target, style: text.bodyLarge),
+        subtitle: Text(
+          view.canApply
+              ? view.changes.summary
+              : '${view.changes.summary} (manual — not applied automatically)',
+          style: text.bodySmall,
+        ),
+        childrenPadding: const EdgeInsets.fromLTRB(
+          PlinkSpacing.s5,
+          0,
+          PlinkSpacing.s5,
+          PlinkSpacing.s4,
+        ),
+        expandedCrossAxisAlignment: CrossAxisAlignment.start,
+        children: view.changes.fields.isEmpty
+            ? <Widget>[
+                Text(
+                  'Lifecycle action — no per-field diff.',
+                  style: text.bodySmall,
+                ),
+              ]
+            : <Widget>[
+                for (final f in view.changes.fields)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
+                    child: Text(
+                      '${f.field}: ${f.before ?? '∅'} → ${f.after ?? '∅'}',
+                      style: text.bodySmall,
+                    ),
+                  ),
+              ],
+      ),
+    );
+  }
+}
+
+class _ResultsSection extends StatelessWidget {
+  const _ResultsSection({
+    required this.title,
+    required this.subtitle,
+    required this.results,
+  });
+
+  final String title;
+  final String subtitle;
+  final List<ActionOutcomeEntry> results;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(title, style: text.titleMedium),
+        const SizedBox(height: PlinkSpacing.s1),
+        Text(subtitle, style: text.bodySmall),
+        const SizedBox(height: PlinkSpacing.s3),
+        for (final r in results)
+          Padding(
+            padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Icon(
+                  r.outcome == actions.ActionOutcome.failed
+                      ? Icons.close
+                      : Icons.check,
+                  size: 16,
+                  color: r.outcome == actions.ActionOutcome.failed
+                      ? colors.error
+                      : colors.primary,
+                ),
+                const SizedBox(width: PlinkSpacing.s2),
+                Expanded(
+                  child: Text(
+                    r.outcome == actions.ActionOutcome.failed
+                        ? '${r.target} — ${r.changes.summary}: ${r.error}'
+                        : '${r.target} — ${r.changes.summary}',
+                    style: text.bodySmall,
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _LogPanel extends StatelessWidget {
+  const _LogPanel({required this.log});
+
+  final LogBuffer log;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    return SizedBox(
+      height: 160,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              PlinkSpacing.s4,
+              PlinkSpacing.s2,
+              PlinkSpacing.s4,
+              0,
+            ),
+            child: Row(
+              children: <Widget>[
+                Text('Log', style: text.titleSmall),
+                const Spacer(),
+                ListenableBuilder(
+                  listenable: log,
+                  builder: (context, _) => TextButton(
+                    onPressed: log.entries.isEmpty ? null : log.clear,
+                    child: const Text('Clear'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListenableBuilder(
+              listenable: log,
+              builder: (context, _) {
+                final entries = log.entries.reversed.toList(growable: false);
+                if (entries.isEmpty) {
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: PlinkSpacing.s4,
+                    ),
+                    child: Text('No messages yet.', style: text.bodySmall),
+                  );
+                }
+                // Newest first, anchored to the top — reads like a tail.
+                return ListView.builder(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: PlinkSpacing.s4,
+                    vertical: PlinkSpacing.s2,
+                  ),
+                  itemCount: entries.length,
+                  itemBuilder: (context, i) {
+                    final e = entries[i];
+                    final time = '${e.time.hour.toString().padLeft(2, '0')}:'
+                        '${e.time.minute.toString().padLeft(2, '0')}:'
+                        '${e.time.second.toString().padLeft(2, '0')}';
+                    return Text(
+                      '$time  [${e.origin.name}]  ${e.message}',
+                      style: text.bodySmall?.copyWith(
+                        color: e.isError ? colors.error : null,
+                        fontFamily: 'monospace',
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MessagePanel extends StatelessWidget {
+  const _MessagePanel({
+    required this.eyebrow,
+    required this.title,
+    required this.message,
+    this.action,
+    this.progress = false,
+  });
+
+  final String eyebrow;
+  final String title;
+  final String message;
+  final Widget? action;
+  final bool progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final bool ink = Theme.of(context).brightness == Brightness.dark;
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: Padding(
+          padding: const EdgeInsets.all(PlinkSpacing.s6),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Eyebrow(eyebrow, onInk: ink),
+              const SizedBox(height: PlinkSpacing.s4),
+              Text(title, style: text.headlineSmall),
+              const SizedBox(height: PlinkSpacing.s4),
+              Text(message, style: text.bodyMedium),
+              if (progress) ...<Widget>[
+                const SizedBox(height: PlinkSpacing.s5),
+                const LinearProgressIndicator(),
+              ],
+              if (action != null) ...<Widget>[
+                const SizedBox(height: PlinkSpacing.s5),
+                action!,
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -30,6 +30,7 @@ class _ReconcileScreenState extends State<ReconcileScreen> {
   ReconcileServices? _services;
   Object? _bootstrapError;
   bool _bootstrapping = false;
+  int _attempts = 0;
 
   @override
   void initState() {
@@ -41,6 +42,7 @@ class _ReconcileScreenState extends State<ReconcileScreen> {
     final make = widget.bootstrap;
     if (make == null) return;
     setState(() {
+      _attempts++;
       _bootstrapping = true;
       _bootstrapError = null;
     });
@@ -67,10 +69,13 @@ class _ReconcileScreenState extends State<ReconcileScreen> {
     }
     final error = _bootstrapError;
     if (error != null) {
+      // A fast failure makes a retry look like a dead button — say the
+      // attempt happened.
+      final retryNote = _attempts > 1 ? '\n\n(Attempt $_attempts failed.)' : '';
       return _MessagePanel(
         eyebrow: 'Arcadia · reconcile',
         title: 'Could not prepare the reconcile screen',
-        message: error.toString(),
+        message: '$error$retryNote',
         action: FilledButton(
           key: const ValueKey('reconcile-bootstrap-retry'),
           onPressed: _bootstrap,

--- a/account_manager/lib/src/shell/app_shell.dart
+++ b/account_manager/lib/src/shell/app_shell.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
+import '../reconcile/reconcile_bootstrap.dart';
 import '../screens/home_screen.dart';
+import '../screens/reconcile_screen.dart';
 
 /// One navigable destination in the [AppShell].
 class ShellDestination {
@@ -18,31 +20,47 @@ class ShellDestination {
 
 /// The navigation frame for the whole app.
 ///
-/// Deliberately minimal: a single Home destination today. Each Phase C view
-/// slice (reconcile, settings, passwords, …) adds one entry to [_destinations]
-/// — the shell is built to grow, not to mirror the seven legacy WPF pages up
+/// Deliberately minimal: Home plus the reconcile screen today. Each Phase C
+/// view slice (settings, passwords, …) adds one entry to the destinations —
+/// the shell is built to grow, not to mirror the seven legacy WPF pages up
 /// front.
 class AppShell extends StatefulWidget {
-  const AppShell({super.key});
+  const AppShell({super.key, this.reconcileBootstrap});
+
+  /// Assembles the reconcile stack on first use, or `null` when Azure AD is
+  /// not configured for this build.
+  final Future<ReconcileServices> Function()? reconcileBootstrap;
 
   @override
   State<AppShell> createState() => _AppShellState();
 }
 
 class _AppShellState extends State<AppShell> {
-  static final List<ShellDestination> _destinations = <ShellDestination>[
+  late final List<ShellDestination> _destinations = <ShellDestination>[
     ShellDestination(
       label: 'Home',
       icon: Icons.home_outlined,
       builder: (_) => const HomeScreen(),
     ),
+    ShellDestination(
+      label: 'Reconcile',
+      icon: Icons.sync_alt_outlined,
+      builder: (_) => ReconcileScreen(bootstrap: widget.reconcileBootstrap),
+    ),
   ];
 
   int _selected = 0;
 
+  /// The reconcile stack is assembled once and kept across tab switches, so
+  /// the screens are kept alive rather than rebuilt per selection.
+  late final List<Widget?> _built = List<Widget?>.filled(
+    _destinations.length,
+    null,
+  );
+
   @override
   Widget build(BuildContext context) {
-    final ShellDestination current = _destinations[_selected];
+    _built[_selected] ??= _destinations[_selected].builder(context);
     return Scaffold(
       // The per-product identity rule spans the top of the whole shell (its
       // intended placement — a full-width accent bar), with the navigation
@@ -67,7 +85,15 @@ class _AppShellState extends State<AppShell> {
                   ],
                 ),
                 const VerticalDivider(width: 1, thickness: 1),
-                Expanded(child: current.builder(context)),
+                Expanded(
+                  child: IndexedStack(
+                    index: _selected,
+                    children: <Widget>[
+                      for (var i = 0; i < _destinations.length; i++)
+                        _built[i] ?? const SizedBox.shrink(),
+                    ],
+                  ),
+                ),
               ],
             ),
           ),

--- a/account_manager/pubspec.yaml
+++ b/account_manager/pubspec.yaml
@@ -37,6 +37,10 @@ dependencies:
   # another resource's scopes (oauth2.Credentials.refresh with newScopes).
   oauth2: ^2.0.0
 
+  # FFI helpers (malloc, Utf16) for the DPAPI cipher that encrypts the
+  # persisted token cache at rest (#103).
+  ffi: ^2.1.0
+
   # Plink Labs design system — Flutter binding, external to this workspace
   # (not on pub.dev). Consumed as a git dependency so it resolves everywhere
   # (CI + fresh clones), pinned to a commit for reproducibility. To hack on the

--- a/account_manager/pubspec.yaml
+++ b/account_manager/pubspec.yaml
@@ -33,6 +33,10 @@ dependencies:
   # endpoint), shared with the OAuthAuthProvider reused from azure_api.
   http: ^1.2.0
 
+  # The loopback broker's silent leg redeems the held refresh token for
+  # another resource's scopes (oauth2.Credentials.refresh with newScopes).
+  oauth2: ^2.0.0
+
   # Plink Labs design system — Flutter binding, external to this workspace
   # (not on pub.dev). Consumed as a git dependency so it resolves everywhere
   # (CI + fresh clones), pinned to a commit for reproducibility. To hack on the

--- a/account_manager/pubspec.yaml
+++ b/account_manager/pubspec.yaml
@@ -17,6 +17,14 @@ dependencies:
   # Bare version: resolved through the root workspace.
   account_state:
 
+  # Directly-imported lower layers of the reconcile screen: the domain types
+  # (ILog, Origin, linked records), the action engine (dry-run/apply), and the
+  # WISA + Smartschool connectors the bootstrap wires up.
+  account_core:
+  account_actions:
+  wisa_api:
+  smartschool_api:
+
   # The Graph connector: needed here for the auth seam types the sign-in layer
   # implements (AzureAuthProvider, AzureCredentials, TokenCache).
   azure_api:

--- a/account_manager/test/auth/loopback_aad_broker_test.dart
+++ b/account_manager/test/auth/loopback_aad_broker_test.dart
@@ -2,7 +2,12 @@ import 'dart:convert';
 
 import 'package:account_manager/src/auth/auth.dart';
 import 'package:azure_api/azure_api.dart'
-    show AzureAuthException, AzureAuthProvider, AzureCredentials;
+    show
+        AzureAuthException,
+        AzureAuthProvider,
+        AzureCredentials,
+        InMemoryTokenCache,
+        TokenCache;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -100,6 +105,7 @@ void main() {
     /// refresh request and each authorizer invocation.
     (LoopbackAadBroker, List<Map<String, String>>, List<Uri>) build({
       bool rejectRefresh = false,
+      TokenCache Function(String resourceId)? cacheFactory,
     }) {
       final refreshRequests = <Map<String, String>>[];
       final authorizerCalls = <Uri>[];
@@ -108,6 +114,7 @@ void main() {
         tenantId: 'tenant-abc',
         azureDomain: 'school.example',
         schoolPrefix: 'GBS',
+        cacheFactory: cacheFactory,
         authorizer: (authUrl, redirect) async {
           authorizerCalls.add(authUrl);
           return {'code': 'auth-code-xyz'};
@@ -174,6 +181,28 @@ void main() {
 
       expect(await broker.acquireSilent(AadResource.sql), isNull);
       expect(refreshRequests, isNotEmpty, reason: 'the redeem was attempted');
+    });
+
+    test('a persistent cache survives a "restart" — silent, no browser',
+        () async {
+      // The same backing store handed to two broker instances models an app
+      // restart with the DPAPI file cache (#103): the second run signs in
+      // with no interactive prompt at all.
+      final store = <String, TokenCache>{};
+      TokenCache persistent(String id) =>
+          store.putIfAbsent(id, InMemoryTokenCache.new);
+
+      final (first, _, firstAuthorizer) = build(cacheFactory: persistent);
+      await first.acquireInteractive(graph);
+      expect(firstAuthorizer, hasLength(1));
+
+      final (second, _, secondAuthorizer) = build(cacheFactory: persistent);
+      final token = await second.acquireSilent(graph);
+
+      expect(token, isNotNull);
+      expect(token!.accessToken, 'INTERACTIVE-AT',
+          reason: 'the persisted, still-valid token is reused as-is');
+      expect(secondAuthorizer, isEmpty, reason: 'no browser on the re-run');
     });
   });
 }

--- a/account_manager/test/auth/loopback_aad_broker_test.dart
+++ b/account_manager/test/auth/loopback_aad_broker_test.dart
@@ -1,7 +1,11 @@
+import 'dart:convert';
+
 import 'package:account_manager/src/auth/auth.dart';
 import 'package:azure_api/azure_api.dart'
     show AzureAuthException, AzureAuthProvider, AzureCredentials;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 
 /// A per-resource auth provider stand-in for [OAuthAuthProvider].
 class _FakeProvider implements AzureAuthProvider {
@@ -26,7 +30,7 @@ void main() {
     schoolPrefix: 'p',
   ));
 
-  test('acquireSilent never prompts — it always returns null', () async {
+  test('acquireSilent without a silent acquirer returns null', () async {
     final broker = LoopbackAadBroker(
       providerFactory: (_) => _FakeProvider('SHOULD-NOT-BE-USED'),
     );
@@ -73,5 +77,103 @@ void main() {
       throwsA(isA<AadBrokerException>()
           .having((e) => e.message, 'message', 'sign-in was denied')),
     );
+  });
+
+  group('oauth factory silent leg', () {
+    // oauth2 requires the token endpoint to declare a JSON content type.
+    http.Response jsonResp(Map<String, Object?> body) => http.Response(
+          jsonEncode(body),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+
+    Map<String, Object?> tokenBody(String accessToken, {String? scope}) => {
+          'token_type': 'Bearer',
+          'access_token': accessToken,
+          'expires_in': 3600,
+          'refresh_token': 'refresh-for-$accessToken',
+          if (scope != null) 'scope': scope,
+        };
+
+    /// The production broker over a scripted token endpoint: interactive
+    /// exchanges an auth code, silent redeems refresh tokens. Records every
+    /// refresh request and each authorizer invocation.
+    (LoopbackAadBroker, List<Map<String, String>>, List<Uri>) build({
+      bool rejectRefresh = false,
+    }) {
+      final refreshRequests = <Map<String, String>>[];
+      final authorizerCalls = <Uri>[];
+      final broker = LoopbackAadBroker.oauth(
+        clientId: 'client-123',
+        tenantId: 'tenant-abc',
+        azureDomain: 'school.example',
+        schoolPrefix: 'GBS',
+        authorizer: (authUrl, redirect) async {
+          authorizerCalls.add(authUrl);
+          return {'code': 'auth-code-xyz'};
+        },
+        httpClient: MockClient((req) async {
+          final fields = req.bodyFields;
+          if (fields['grant_type'] == 'refresh_token') {
+            refreshRequests.add(fields);
+            if (rejectRefresh) {
+              return http.Response(
+                jsonEncode({'error': 'invalid_grant'}),
+                400,
+                headers: {'content-type': 'application/json'},
+              );
+            }
+            return jsonResp(tokenBody('REFRESHED-AT'));
+          }
+          return jsonResp(tokenBody('INTERACTIVE-AT'));
+        }),
+      );
+      return (broker, refreshRequests, authorizerCalls);
+    }
+
+    test('returns null when no resource has signed in yet', () async {
+      final (broker, refreshRequests, authorizerCalls) = build();
+
+      expect(await broker.acquireSilent(AadResource.sql), isNull);
+      expect(refreshRequests, isEmpty);
+      expect(authorizerCalls, isEmpty);
+    });
+
+    test('redeems another resource\'s refresh token — no browser round-trip',
+        () async {
+      final (broker, refreshRequests, authorizerCalls) = build();
+
+      // Graph pays the one interactive prompt…
+      await broker.acquireInteractive(graph);
+      expect(authorizerCalls, hasLength(1));
+
+      // …then SQL is minted silently from Graph's refresh token, with the
+      // SQL scopes requested on the refresh grant.
+      final sql = await broker.acquireSilent(AadResource.sql);
+      expect(sql, isNotNull);
+      expect(sql!.accessToken, 'REFRESHED-AT');
+      expect(authorizerCalls, hasLength(1), reason: 'no second prompt');
+      expect(refreshRequests, hasLength(1));
+      expect(
+        refreshRequests.single['scope'],
+        contains('https://database.windows.net/.default'),
+      );
+
+      // The minted credentials are cached: a repeat silent acquisition needs
+      // neither the authorizer nor the token endpoint.
+      final again = await broker.acquireSilent(AadResource.sql);
+      expect(again!.accessToken, 'REFRESHED-AT');
+      expect(refreshRequests, hasLength(1));
+    });
+
+    test('a rejected refresh token yields null (fall back to interactive)',
+        () async {
+      final (broker, refreshRequests, _) = build(rejectRefresh: true);
+
+      await broker.acquireInteractive(graph);
+
+      expect(await broker.acquireSilent(AadResource.sql), isNull);
+      expect(refreshRequests, isNotEmpty, reason: 'the redeem was attempted');
+    });
   });
 }

--- a/account_manager/test/auth/persistent_token_cache_test.dart
+++ b/account_manager/test/auth/persistent_token_cache_test.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+
+import 'package:account_manager/src/auth/auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final onWindows = Platform.isWindows;
+
+  group('Dpapi', () {
+    test(
+      'protects and unprotects a payload round-trip',
+      () {
+        const marker = 'super-secret-refresh-token-value';
+        const secret = '{"accessToken":"AT","refreshToken":"$marker"}';
+        final ciphertext = Dpapi.protect(secret);
+        expect(ciphertext, isNot(contains(marker)),
+            reason: 'ciphertext must not leak the plaintext');
+        expect(Dpapi.unprotect(ciphertext), secret);
+      },
+      skip: onWindows ? false : 'DPAPI is Windows-only',
+    );
+
+    test(
+      'a tampered payload throws FormatException (the corrupt-cache signal)',
+      () {
+        final ciphertext = Dpapi.protect('payload');
+        // Corrupt the tail of the blob (the ciphertext/MAC region — the
+        // leading DPAPI header is not integrity-relevant everywhere).
+        final i = ciphertext.length - 20;
+        final tampered =
+            ciphertext.replaceRange(i, i + 1, ciphertext[i] == 'A' ? 'B' : 'A');
+        expect(() => Dpapi.unprotect(tampered), throwsFormatException);
+        expect(
+          () => Dpapi.unprotect('not base64 at all!'),
+          throwsFormatException,
+        );
+      },
+      skip: onWindows ? false : 'DPAPI is Windows-only',
+    );
+  });
+
+  group('FileTokenCache', () {
+    late Directory dir;
+
+    setUp(() => dir = Directory.systemTemp.createTempSync('token-cache'));
+    tearDown(() => dir.deleteSync(recursive: true));
+
+    test('round-trips through a file it creates (directories included)', () {
+      final cache = FileTokenCache('${dir.path}/auth/graph.token');
+      return () async {
+        expect(await cache.read(), isNull, reason: 'nothing stored yet');
+        await cache.write('ciphertext-1');
+        expect(await cache.read(), 'ciphertext-1');
+        await cache.write('ciphertext-2');
+        expect(await cache.read(), 'ciphertext-2');
+        await cache.clear();
+        expect(await cache.read(), isNull);
+        await cache.clear(); // idempotent
+      }();
+    });
+
+    test('an empty file reads as no cache', () async {
+      final path = '${dir.path}/empty.token';
+      File(path).writeAsStringSync('');
+      expect(await FileTokenCache(path).read(), isNull);
+    });
+  });
+}

--- a/account_manager/test/reconcile/reconcile_bootstrap_test.dart
+++ b/account_manager/test/reconcile/reconcile_bootstrap_test.dart
@@ -1,0 +1,190 @@
+import 'package:account_manager/src/auth/aad_app_config.dart';
+import 'package:account_manager/src/auth/sign_in_session.dart';
+import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
+import 'package:account_state/account_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../auth/fake_broker.dart';
+
+const _aad = AadAppConfig(
+  clientId: 'client-123',
+  tenantId: 'tenant-abc',
+  azureDomain: 'school.example',
+  schoolPrefix: 'GBS',
+);
+
+/// A settings store whose [load] throws — models a broken SQL path.
+class _ThrowingStore implements SettingsStore {
+  const _ThrowingStore(this.error);
+
+  final Object error;
+
+  @override
+  Future<AppSettings> load() async => throw error;
+
+  @override
+  Future<void> save(AppSettings settings) async {}
+}
+
+/// The bootstrap never opens a SQL connection itself when the settings store
+/// is injected, so any [open] call is a wiring regression.
+class _UnreachableFactory implements SqlConnectionFactory {
+  @override
+  Future<SqlConnection> open(AzureSqlConfig config, AadTokenProvider tokens) =>
+      throw StateError('bootstrap must not open a SQL connection');
+}
+
+AppSettings _settings({
+  String server = 'wisa.local',
+  String port = '9000',
+  String smartschoolUri = 'https://demo.smartschool.be',
+}) =>
+    AppSettings(
+      schoolPrefix: 'GBS',
+      wisa: WisaConnection(
+        server: server,
+        port: port,
+        database: 'wisadb',
+        username: 'operator',
+      ),
+      smartschool: SmartschoolConnection(uri: smartschoolUri),
+      azure: const AzureConnection(domain: 'school.example'),
+    );
+
+InMemorySecretProvider _secrets({bool wisa = true, bool smartschool = true}) =>
+    InMemorySecretProvider({
+      if (wisa) const SecretRef('wisa.password'): 'geheim',
+      if (smartschool) const SecretRef('smartschool.passphrase'): 'zin',
+    });
+
+Future<ReconcileServices> _bootstrap({
+  SettingsStore? store,
+  SecretProvider? secrets,
+}) =>
+    bootstrapReconcile(
+      session: SignInSession(FakeBroker()),
+      aad: _aad,
+      settingsStore: store ?? InMemorySettingsStore(_settings()),
+      secretProvider: secrets ?? _secrets(),
+      sqlFactory: _UnreachableFactory(),
+    );
+
+void main() {
+  group('bootstrapReconcile', () {
+    test('assembles the full stack from settings + secrets', () async {
+      final services = await _bootstrap();
+
+      expect(services.settings.schoolPrefix, 'GBS');
+      expect(services.app.wisa.snapshot, isNull,
+          reason: 'nothing synced yet at bootstrap');
+      expect(services.controller.linked, isNull);
+      expect(identical(services.controller.log, services.log), isTrue);
+    });
+
+    test('a missing WISA password is an actionable config error', () {
+      expect(
+        () => _bootstrap(secrets: _secrets(wisa: false)),
+        throwsA(isA<ReconcileConfigException>().having(
+          (e) => e.message,
+          'message',
+          contains('wisa.password'),
+        )),
+      );
+    });
+
+    test('a missing Smartschool passphrase is an actionable config error', () {
+      expect(
+        () => _bootstrap(secrets: _secrets(smartschool: false)),
+        throwsA(isA<ReconcileConfigException>().having(
+          (e) => e.message,
+          'message',
+          contains('smartschool.passphrase'),
+        )),
+      );
+    });
+
+    test('an incomplete WISA profile is an actionable config error', () {
+      expect(
+        () => _bootstrap(store: InMemorySettingsStore(_settings(port: 'nan'))),
+        throwsA(isA<ReconcileConfigException>().having(
+          (e) => e.message,
+          'message',
+          contains('WISA connection profile'),
+        )),
+      );
+    });
+
+    test('a missing ODBC driver (IM002) names the msodbcsql18 prerequisite',
+        () {
+      expect(
+        () => _bootstrap(
+          store: const _ThrowingStore(
+            'OdbcException(SQLDriverConnect): [IM002] [Microsoft]'
+            '[ODBC Driver Manager] Data source name not found and no '
+            'default driver specified',
+          ),
+        ),
+        throwsA(isA<ReconcileConfigException>().having(
+          (e) => e.message,
+          'message',
+          contains('ODBC Driver 18'),
+        )),
+      );
+    });
+
+    test('other settings-store failures propagate unmapped', () {
+      expect(
+        () => _bootstrap(store: const _ThrowingStore('login timed out')),
+        throwsA('login timed out'),
+      );
+    });
+  });
+
+  group('smartschoolSiteFrom', () {
+    test('extracts the site from a full smartschool.be URL', () {
+      expect(
+        smartschoolSiteFrom('https://demo.smartschool.be/Webservices/V3'),
+        'demo',
+      );
+    });
+
+    test('extracts the site from a bare smartschool.be host', () {
+      expect(smartschoolSiteFrom('demo.smartschool.be'), 'demo');
+    });
+
+    test('accepts a bare site name as-is', () {
+      expect(smartschoolSiteFrom('demo'), 'demo');
+    });
+
+    test('is empty for an empty setting', () {
+      expect(smartschoolSiteFrom('  '), '');
+    });
+  });
+
+  group('classTreeFrom', () {
+    test('uses years only when the school enables them', () {
+      final on = classTreeFrom(SmartschoolConnection(
+        useYears: true,
+        years: ['Y1', 'Y2', 'Y3', 'Y4', 'Y5', 'Y6', 'Y7'],
+        studentGroup: 'LLN',
+      ));
+      expect(on.years, isNotEmpty);
+      expect(on.grades, isEmpty);
+      expect(on.path, 'LLN');
+
+      final off = classTreeFrom(SmartschoolConnection(
+        years: ['Y1', 'Y2', 'Y3', 'Y4', 'Y5', 'Y6', 'Y7'],
+      ));
+      expect(off.years, isEmpty);
+    });
+
+    test('uses grades only when the school enables them', () {
+      final tree = classTreeFrom(SmartschoolConnection(
+        useGrades: true,
+        grades: ['G1', 'G2', 'G3'],
+      ));
+      expect(tree.grades, isNotEmpty);
+      expect(tree.years, isEmpty);
+    });
+  });
+}

--- a/account_manager/test/reconcile/reconcile_bootstrap_test.dart
+++ b/account_manager/test/reconcile/reconcile_bootstrap_test.dart
@@ -34,6 +34,47 @@ class _UnreachableFactory implements SqlConnectionFactory {
       throw StateError('bootstrap must not open a SQL connection');
 }
 
+/// Records every statement run through it; queries return no rows (an
+/// unprovisioned/empty database).
+class _RecordingConnection implements SqlConnection {
+  _RecordingConnection(this.executed);
+
+  final List<String> executed;
+  bool closed = false;
+
+  @override
+  Future<List<SqlRow>> query(String sql, [List<Object?>? params]) async =>
+      const [];
+
+  @override
+  Future<int> execute(String sql, [List<Object?>? params]) async {
+    executed.add(sql);
+    return 0;
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function(SqlConnection tx) action) =>
+      action(this);
+
+  @override
+  Future<void> close() async => closed = true;
+}
+
+class _RecordingFactory implements SqlConnectionFactory {
+  final List<String> executed = <String>[];
+  final List<_RecordingConnection> connections = <_RecordingConnection>[];
+
+  @override
+  Future<SqlConnection> open(
+    AzureSqlConfig config,
+    AadTokenProvider tokens,
+  ) async {
+    final connection = _RecordingConnection(executed);
+    connections.add(connection);
+    return connection;
+  }
+}
+
 AppSettings _settings({
   String server = 'wisa.local',
   String port = '9000',
@@ -137,6 +178,38 @@ void main() {
         () => _bootstrap(store: const _ThrowingStore('login timed out')),
         throwsA('login timed out'),
       );
+    });
+
+    test('the real SQL path provisions the schema before the first load',
+        () async {
+      // No injected settings store → the Azure SQL store over the (fake)
+      // factory. The empty database yields a default AppSettings, whose blank
+      // WISA profile then fails validation — but by that point the idempotent
+      // DDL for the settings and person-identity tables must have run.
+      final factory = _RecordingFactory();
+
+      await expectLater(
+        bootstrapReconcile(
+          session: SignInSession(FakeBroker()),
+          aad: _aad,
+          secretProvider: _secrets(),
+          sqlFactory: factory,
+        ),
+        throwsA(isA<ReconcileConfigException>().having(
+          (e) => e.message,
+          'message',
+          contains('WISA connection profile'),
+        )),
+      );
+
+      final ddl = factory.executed.join('\n');
+      expect(ddl, contains('CREATE TABLE dbo.AppSettings'));
+      expect(ddl, contains('CREATE TABLE dbo.ImportRules'));
+      expect(ddl, contains('CREATE TABLE dbo.PersonIdentity'));
+      expect(ddl, isNot(contains('dbo.PasswordQueue')),
+          reason: 'the password queue is a follow-up slice');
+      expect(factory.connections.every((c) => c.closed), isTrue,
+          reason: 'the provisioning connection must not leak');
     });
   });
 

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -1,0 +1,203 @@
+import 'package:account_actions/account_actions.dart' as actions;
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_manager/src/reconcile/log_buffer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'reconcile_fakes.dart';
+
+void main() {
+  group('first sync', () {
+    test('pulls all three systems and derives the linked view + actions',
+        () async {
+      final h = ReconcileHarness();
+
+      await h.controller.sync();
+
+      expect(h.wisaSyncs, 1);
+      expect(h.ssSyncs, 1);
+      expect(h.azSyncs, 1);
+      expect(h.controller.error, isNull);
+      expect(h.controller.noChangesNeeded, isFalse);
+      expect(h.controller.linked, isNotNull);
+      // The fixture's one deterministic action: WISA says 3C, Smartschool 2B.
+      expect(
+        h.controller.linked!.studentActions
+            .whereType<actions.MoveToSmartschoolClassGroup>(),
+        hasLength(1),
+      );
+      expect(h.controller.pendingViews, isNotEmpty);
+      expect(h.log.entries.where((e) => e.isError), isEmpty);
+    });
+  });
+
+  group('smart WISA diff', () {
+    test('an unchanged WISA re-sync reports "no changes needed" and stops',
+        () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+      final linkedBefore = h.controller.linked;
+
+      // Fresh pull, identical content (a new fetchedAt must not count).
+      h.wisaResult =
+          wisaSnap(fetchedAt: kFixtureDate.add(const Duration(hours: 1)));
+      await h.controller.sync();
+
+      expect(h.controller.noChangesNeeded, isTrue);
+      expect(h.wisaSyncs, 2, reason: 'WISA itself is re-pulled to diff');
+      expect(h.ssSyncs, 1, reason: 'Smartschool is not re-read by default');
+      expect(h.azSyncs, 1, reason: 'Azure is not re-read by default');
+      expect(identical(h.controller.linked, linkedBefore), isTrue,
+          reason: 'the existing linked view is kept, no re-link');
+      expect(
+        h.log.entries.map((e) => e.message),
+        contains(contains('no account changes needed')),
+      );
+    });
+
+    test('a changed WISA pull re-links without re-reading the other systems',
+        () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+      final linkedBefore = h.controller.linked;
+
+      h.wisaResult = wisaSnap(
+        fetchedAt: kFixtureDate.add(const Duration(hours: 1)),
+        students: [wisaStudent(classGroup: '3D')],
+      );
+      await h.controller.sync();
+
+      expect(h.controller.noChangesNeeded, isFalse);
+      expect(h.wisaSyncs, 2);
+      expect(h.ssSyncs, 1);
+      expect(h.azSyncs, 1);
+      expect(identical(h.controller.linked, linkedBefore), isFalse,
+          reason: 'a WISA change re-derives the linked view');
+    });
+  });
+
+  group('check for drift', () {
+    test('re-reads Smartschool and Azure and re-links', () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+
+      await h.controller.checkDrift();
+
+      expect(h.ssSyncs, 2);
+      expect(h.azSyncs, 2);
+      expect(h.wisaSyncs, 1, reason: 'drift check does not re-pull WISA');
+      expect(h.controller.linked, isNotNull);
+    });
+  });
+
+  group('failures', () {
+    test('a failing WISA sync surfaces the error and keeps the old view',
+        () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+      final linkedBefore = h.controller.linked;
+
+      h.wisaError = StateError('WISA host unreachable');
+      await h.controller.sync();
+
+      expect(h.controller.error, contains('WISA host unreachable'));
+      expect(h.controller.busy, isFalse);
+      expect(identical(h.controller.linked, linkedBefore), isTrue);
+      expect(h.log.hasErrors, isTrue);
+    });
+  });
+
+  group('dry-run', () {
+    test('walks every applyable action with zero writes', () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+
+      await h.controller.dryRun();
+
+      final results = h.controller.dryRunResults;
+      expect(results, isNotNull);
+      expect(results, isNotEmpty);
+      expect(
+        results!.map((r) => r.outcome),
+        everyElement(actions.ActionOutcome.dryRun),
+      );
+      expect(
+        results.map((r) => r.changes.summary),
+        contains('Wijzig de klas in Smartschool'),
+      );
+      expect(h.soap.soapActions, isEmpty, reason: 'a dry run writes nothing');
+      expect(h.graph.requests, isEmpty, reason: 'a dry run writes nothing');
+      expect(h.controller.applyResults, isNull);
+    });
+  });
+
+  group('apply', () {
+    test('writes the pending actions and refreshes the linked view', () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+      final linkedBefore = h.controller.linked;
+
+      await h.controller.applyAll();
+
+      final results = h.controller.applyResults;
+      expect(results, isNotNull);
+      expect(
+        results!
+            .where((r) => r.changes.summary == 'Wijzig de klas in Smartschool')
+            .single
+            .outcome,
+        actions.ActionOutcome.applied,
+      );
+      expect(h.soap.soapActions, isNotEmpty,
+          reason: 'the class move is a real Smartschool write');
+      expect(identical(h.controller.linked, linkedBefore), isFalse,
+          reason: 'a real write re-links from the patched snapshot');
+    });
+
+    test('informational group actions are listed but never applied', () async {
+      // An orphan Smartschool class (no WISA counterpart) surfaces the
+      // informational DoNotImportFromSmartschool — visible in the pending
+      // list, skipped by the apply pass (its apply() throws by contract).
+      final h = ReconcileHarness(
+        smartschool: ssSnap(
+          groups: [
+            ssGroup('2B', code: '2B_ss'),
+            ssGroup('3C', code: '3C_ss'),
+            ssGroup('9Z', code: '9Z_ss'),
+          ],
+        ),
+      );
+      await h.controller.sync();
+
+      final informational = h.controller.pendingViews.where((v) => !v.canApply);
+      expect(informational, isNotEmpty);
+      expect(h.controller.applyableCount,
+          lessThan(h.controller.pendingActions.length));
+
+      await h.controller.applyAll();
+
+      expect(h.controller.error, isNull);
+      expect(
+        h.controller.applyResults!.map((r) => r.outcome),
+        isNot(contains(actions.ActionOutcome.failed)),
+      );
+    });
+  });
+
+  group('LogBuffer', () {
+    test('caps its entries and reports errors', () {
+      final log = LogBuffer(capacity: 3, clock: () => kFixtureDate);
+      for (var i = 0; i < 5; i++) {
+        log.addMessage(core.Origin.wisa, 'message $i');
+      }
+      expect(log.entries, hasLength(3));
+      expect(log.entries.first.message, 'message 2');
+      expect(log.hasErrors, isFalse);
+
+      log.addError(core.Origin.azure, 'boom');
+      expect(log.hasErrors, isTrue);
+
+      log.clear();
+      expect(log.entries, isEmpty);
+    });
+  });
+}

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1,0 +1,299 @@
+/// Shared offline fixtures for the reconcile widget and integration tests:
+/// record/snapshot builders, recording transports (so a real action `apply`
+/// runs with zero network), and a [ReconcileHarness] that assembles the real
+/// State layer over scripted syncers.
+///
+/// The fixture scenario mirrors `account_state`'s `linked_state_test`: one
+/// student fully linked across the three systems whose WISA class (3C)
+/// differs from her Smartschool membership (2B), so the dispatchers derive
+/// exactly one deterministic pending action (`MoveToSmartschoolClassGroup`).
+library;
+
+import 'package:account_actions/account_actions.dart' as actions;
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_manager/src/reconcile/log_buffer.dart';
+import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
+import 'package:account_manager/src/reconcile/reconcile_controller.dart';
+import 'package:account_state/account_state.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+final DateTime kFixtureDate = DateTime.utc(2026, 7, 1);
+
+const core.Address _addr = core.Address(
+  street: '',
+  houseNumber: '',
+  postalCode: '',
+  city: '',
+  country: '',
+);
+
+// ---------------------------------------------------------------------------
+// Recording fake transports: a real action `apply()` runs offline while the
+// test asserts exactly what was written (a dry run must record nothing).
+// ---------------------------------------------------------------------------
+
+class RecordingSoap implements ss.SmartschoolSoapTransport {
+  final List<String> soapActions = <String>[];
+
+  @override
+  Future<String> send({
+    required Uri endpoint,
+    required String soapAction,
+    required String envelope,
+  }) async {
+    soapActions.add(soapAction);
+    // Every recorded write succeeds (return code 0).
+    return '<?xml version="1.0" encoding="utf-8"?>'
+        '<soap:Envelope '
+        'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        '<soap:Body><response><return>0</return></response>'
+        '</soap:Body></soap:Envelope>';
+  }
+}
+
+class RecordingGraph implements az.GraphTransport {
+  final List<az.GraphRequest> requests = <az.GraphRequest>[];
+
+  @override
+  Future<az.GraphResponse> send(az.GraphRequest request) async {
+    requests.add(request);
+    return const az.GraphResponse(statusCode: 204);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Record + snapshot builders.
+// ---------------------------------------------------------------------------
+
+wapi.WisaStudent wisaStudent({
+  String wisaId = '1',
+  String classGroup = '3C',
+}) =>
+    wapi.WisaStudent(
+      wisaId: core.WisaId(wisaId),
+      classGroup: classGroup,
+      classSubGroup: '',
+      name: 'Doe',
+      firstName: 'Jane',
+      preferredName: '',
+      birthDate: kFixtureDate,
+      stemId: '',
+      gender: core.Gender.female,
+      nationalId: '',
+      birthPlace: '',
+      nationality: '',
+      address: _addr,
+      classChange: kFixtureDate,
+      schoolId: 1,
+    );
+
+ss.SmartschoolAccount ssAccount({
+  String uid = 'jane',
+  String accountId = '1',
+  String mail = 'jane.doe@student.school.example',
+}) =>
+    ss.SmartschoolAccount(
+      uid: uid,
+      accountId: accountId,
+      mail: mail,
+      registerId: '',
+      stemId: 0,
+      role: core.PersonRole.student,
+      givenName: 'Jane',
+      surname: 'Doe',
+      extraNames: '',
+      initials: '',
+      preferredName: '',
+      gender: core.Gender.female,
+      birthDate: null,
+      birthPlace: '',
+      birthCountry: '',
+      address: _addr,
+      mobilePhone: '',
+      homePhone: '',
+      fax: '',
+      untisId: '',
+      status: 'actief',
+    );
+
+az.AzureUser azUser({
+  String id = 'az1',
+  String upn = 'jane.doe@student.school.example',
+  String? employeeId = '1',
+}) =>
+    az.AzureUser(
+      id: id,
+      upn: upn,
+      employeeId: employeeId,
+      companyName: 'GBS',
+    );
+
+core.Group ssGroup(
+  String name, {
+  String? code,
+  bool official = true,
+  core.GroupType type = core.GroupType.classGroup,
+}) =>
+    core.Group(
+      id: core.GroupId(code ?? name),
+      name: name,
+      description: '',
+      type: type,
+      official: official,
+      origin: core.Origin.smartschool,
+    );
+
+ss.SmartschoolMembership member(String uid, String groupCode) =>
+    ss.SmartschoolMembership(uid: uid, groupId: core.GroupId(groupCode));
+
+wapi.WisaSnapshot wisaSnap({
+  DateTime? fetchedAt,
+  List<wapi.WisaStudent>? students,
+}) =>
+    wapi.WisaSnapshot(
+      fetchedAt: fetchedAt ?? kFixtureDate,
+      students: students ?? [wisaStudent()],
+      staff: const [],
+      classGroups: const [],
+      schools: const [],
+    );
+
+ss.SmartschoolSnapshot ssSnap({
+  List<core.Group>? groups,
+  List<ss.SmartschoolAccount>? accounts,
+  List<ss.SmartschoolMembership>? memberships,
+}) =>
+    ss.SmartschoolSnapshot(
+      fetchedAt: kFixtureDate,
+      groups: groups ??
+          [ssGroup('2B', code: '2B_ss'), ssGroup('3C', code: '3C_ss')],
+      accounts: accounts ?? [ssAccount()],
+      memberships: memberships ?? [member('jane', '2B_ss')],
+    );
+
+az.AzureSnapshot azSnap({List<az.AzureUser>? users}) => az.AzureSnapshot(
+      fetchedAt: kFixtureDate,
+      users: users ?? [azUser()],
+      groups: const [],
+    );
+
+/// Deterministic in-memory resolver (mirrors the linker's test fixture).
+class SeqResolver implements core.PersonIdResolver {
+  final Map<String, String> _seen = <String, String>{};
+
+  @override
+  core.PersonId resolve(String naturalKey) =>
+      core.PersonId(_seen.putIfAbsent(naturalKey, () => 'p${_seen.length}'));
+}
+
+// ---------------------------------------------------------------------------
+// The harness: the real State layer over scripted syncers.
+// ---------------------------------------------------------------------------
+
+/// One assembled reconcile stack against fakes: scripted per-system syncers
+/// (with call counters), a [StateApplier] wired to recording connectors, and
+/// the [ReconcileController] under test.
+class ReconcileHarness {
+  ReconcileHarness({
+    wapi.WisaSnapshot? wisa,
+    ss.SmartschoolSnapshot? smartschool,
+    az.AzureSnapshot? azure,
+  })  : wisaResult = (wisa ?? wisaSnap()),
+        ssResult = (smartschool ?? ssSnap()),
+        azResult = (azure ?? azSnap()) {
+    log = LogBuffer(clock: () => kFixtureDate);
+    final wisaRules = WisaImportRules();
+
+    app = ApplicationState(
+      wisa: SystemState<wapi.WisaSnapshot>(
+        system: core.Origin.wisa,
+        syncer: (_) async {
+          wisaSyncs++;
+          final error = wisaError;
+          if (error != null) throw error;
+          return wisaResult;
+        },
+      ),
+      smartschool: SystemState<ss.SmartschoolSnapshot>(
+        system: core.Origin.smartschool,
+        syncer: (_) async {
+          ssSyncs++;
+          return ssResult;
+        },
+      ),
+      azure: SystemState<az.AzureSnapshot>(
+        system: core.Origin.azure,
+        syncer: (_) async {
+          azSyncs++;
+          return azResult;
+        },
+      ),
+    );
+
+    applier = StateApplier(
+      app: app,
+      connectors: actions.Connectors(
+        smartschool: ss.SmartschoolConnector.fromParts(
+          site: 'demo',
+          accessCode: 'secret',
+          transport: soap,
+        ),
+        azure: az.AzureConnector(
+          credentials: az.AzureCredentials(
+            clientId: 'c',
+            tenantId: 't',
+            azureDomain: 'school.example',
+            schoolPrefix: 'GBS',
+          ),
+          authProvider: const az.StaticAuthProvider('token'),
+          transport: graph,
+        ),
+      ),
+      resolver: SeqResolver(),
+      wisaRules: wisaRules,
+      studentConfig: actions.StudentActionConfig(
+        schoolPrefix: 'GBS',
+        azureDomain: 'school.example',
+      ),
+      staffConfig: actions.StaffActionConfig(
+        schoolPrefix: 'GBS',
+        azureDomain: 'school.example',
+      ),
+    );
+
+    controller = ReconcileController(app: app, applier: applier, log: log);
+  }
+
+  /// What the next sync of each system returns. Mutate to simulate a change
+  /// between syncs; [wisaError] (when set) makes the next WISA sync throw.
+  wapi.WisaSnapshot wisaResult;
+  ss.SmartschoolSnapshot ssResult;
+  az.AzureSnapshot azResult;
+  Object? wisaError;
+
+  int wisaSyncs = 0;
+  int ssSyncs = 0;
+  int azSyncs = 0;
+
+  final RecordingSoap soap = RecordingSoap();
+  final RecordingGraph graph = RecordingGraph();
+
+  late final LogBuffer log;
+  late final ApplicationState app;
+  late final StateApplier applier;
+  late final ReconcileController controller;
+
+  /// The bundle the screen's bootstrap seam expects.
+  ReconcileServices get services => ReconcileServices(
+        settings: const AppSettings(),
+        app: app,
+        applier: applier,
+        controller: controller,
+        log: log,
+      );
+
+  /// A ready-made bootstrap closure for [ReconcileScreen]/[AccountManagerApp].
+  Future<ReconcileServices> Function() get bootstrap => () async => services;
+}

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -48,6 +48,24 @@ void main() {
     expect(find.byKey(const ValueKey('reconcile-sync')), findsOneWidget);
   });
 
+  testWidgets('a retry that fails again visibly reports the new attempt',
+      (WidgetTester tester) async {
+    // A fast repeat failure re-renders an identical panel, which reads as a
+    // dead button — the attempt note is the feedback that the retry ran.
+    await tester.pumpWidget(_wrap(ReconcileScreen(
+      bootstrap: () async =>
+          throw const ReconcileConfigException('driver missing'),
+    )));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('(Attempt'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-bootstrap-retry')));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('(Attempt 2 failed.)'), findsOneWidget);
+  });
+
   testWidgets(
       'sync → overview → pending actions → dry-run → apply → unchanged banner',
       (WidgetTester tester) async {

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -1,0 +1,153 @@
+import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
+import 'package:account_manager/src/screens/reconcile_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'reconcile_fakes.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  testWidgets('shows the not-configured panel when AAD is absent',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_wrap(const ReconcileScreen(bootstrap: null)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Not configured'), findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-sync')), findsNothing);
+  });
+
+  testWidgets('a failed bootstrap shows the error with a working retry',
+      (WidgetTester tester) async {
+    final harness = ReconcileHarness();
+    var attempts = 0;
+    await tester.pumpWidget(_wrap(ReconcileScreen(
+      bootstrap: () async {
+        attempts++;
+        if (attempts == 1) {
+          throw const ReconcileConfigException(
+            'The WISA password (secret "wisa.password") is not set in the '
+            'Key Vault.',
+          );
+        }
+        return harness.services;
+      },
+    )));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Could not prepare the reconcile screen'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('wisa.password'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-bootstrap-retry')));
+    await tester.pumpAndSettle();
+
+    expect(attempts, 2);
+    expect(find.byKey(const ValueKey('reconcile-sync')), findsOneWidget);
+  });
+
+  testWidgets(
+      'sync → overview → pending actions → dry-run → apply → unchanged banner',
+      (WidgetTester tester) async {
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    // Idle: the explainer is shown, no overview yet.
+    expect(find.text('Linked overview'), findsNothing);
+
+    // 1. Sync: all three systems pull, the linked overview and pending
+    //    actions render.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Linked overview'), findsOneWidget);
+    expect(find.text('WISA'), findsOneWidget);
+    expect(find.text('SMARTSCHOOL'), findsOneWidget); // PlinkBadge uppercases
+    expect(find.textContaining('Pending actions'), findsOneWidget);
+    expect(find.text('Jane Doe'), findsWidgets);
+    expect(find.text('Wijzig de klas in Smartschool'), findsWidgets);
+
+    // The log panel carries the sync trail (its list virtualizes, so the
+    // older entries sit past the viewport — hence skipOffstage: false).
+    expect(
+      find.textContaining('Syncing WISA', skipOffstage: false),
+      findsOneWidget,
+    );
+
+    // 2. Dry-run: results section appears, nothing written.
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-dry-run')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-dry-run')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dry-run result'), findsOneWidget);
+    expect(harness.soap.soapActions, isEmpty);
+
+    // 3. Apply: confirmation dialog, then the write happens.
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-apply')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-apply')));
+    await tester.pumpAndSettle();
+    expect(find.text('Apply pending actions?'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Apply result'), findsOneWidget);
+    expect(harness.soap.soapActions, isNotEmpty);
+
+    // 4. A second sync with unchanged WISA: the no-changes banner. The view
+    //    is scrolled down after the apply, so bring the button back first.
+    harness.wisaResult =
+        wisaSnap(fetchedAt: kFixtureDate.add(const Duration(hours: 1)));
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('no account changes needed'), findsWidgets);
+  });
+
+  testWidgets('cancelling the apply dialog writes nothing',
+      (WidgetTester tester) async {
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-apply')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-apply')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(harness.soap.soapActions, isEmpty);
+    expect(find.text('Apply result'), findsNothing);
+  });
+
+  testWidgets('the log panel clears on demand', (WidgetTester tester) async {
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining('Syncing WISA', skipOffstage: false),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('Clear'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No messages yet.'), findsOneWidget);
+  });
+}

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -576,6 +576,11 @@ String _naturalKey(_Record rec) {
   final azureId = _norm(rec.azure?.id);
   if (azureId != null) return 'azure:$azureId';
 
+  // A Smartschool-only account may carry neither an accountId nor a mail
+  // (real data: e.g. intern accounts) — its uid is then the only identity.
+  final uid = _norm(rec.smartschool?.uid);
+  if (uid != null) return 'ss:$uid';
+
   // Unreachable: every record carries at least one identifying field.
   throw StateError('LinkedAccount record has no identifying key: $rec');
 }
@@ -623,6 +628,11 @@ String _naturalStaffKey(_StaffRecord rec) {
 
   final azureId = _norm(rec.azure?.id);
   if (azureId != null) return 'staff:azure:$azureId';
+
+  // A Smartschool-only account may carry neither an accountId nor a mail
+  // (real data: e.g. intern accounts) — its uid is then the only identity.
+  final uid = _norm(rec.smartschool?.uid);
+  if (uid != null) return 'staff:ss:$uid';
 
   // Unreachable: every record carries at least one identifying field.
   throw StateError('LinkedStaff record has no identifying key: $rec');

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -615,5 +615,25 @@ void main() {
       // No Azure (and no wisaId to bridge it) ⇒ medium.
       expect(s.confidence, LinkConfidence.medium);
     });
+
+    test('a Smartschool-only account with no accountId or mail keys by uid',
+        () {
+      // Real tenant data (found live in #99): intern accounts carry neither
+      // the WISA-id convention nor a mail address, so the uid is their only
+      // identity. This used to hit the "no identifying key" StateError.
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap([
+          ssAccount(uid: 'stagiair1', accountId: '', mail: ''),
+          ssStaffAccount(uid: 'begeleider', accountId: '', mail: ''),
+        ]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      expect(snapshot.accounts.single.smartschool?.uid, 'stagiair1');
+      expect(snapshot.staff.single.smartschool?.uid, 'begeleider');
+    });
   });
 }

--- a/packages/account_linker/test/natural_keys_test.dart
+++ b/packages/account_linker/test/natural_keys_test.dart
@@ -82,6 +82,25 @@ void main() {
       );
     });
 
+    test('uid-only records keep the seam contract via the ss: fallback', () {
+      // Intern-style accounts with no accountId and no mail key by uid; the
+      // enumerator must hand the same fallback keys to a DB-backed resolver.
+      final uidOnly = ssSnap([
+        ssAccount(uid: 'stagiair1', accountId: '', mail: ''),
+        ssStaffAccount(uid: 'begeleider', accountId: '', mail: ''),
+      ]);
+      final recorder = _RecordingResolver();
+      link(wisaSnap(const []), uidOnly, azSnap(const []), recorder,
+          schoolPrefix: 'SMA');
+
+      final keys = naturalKeysFor(wisaSnap(const []), uidOnly, azSnap(const []),
+          schoolPrefix: 'SMA');
+
+      expect(keys, equals(recorder.resolved.toSet()));
+      expect(
+          keys, containsAll(<String>['ss:stagiair1', 'staff:ss:begeleider']));
+    });
+
     test('is a pure function of the snapshots — no group keys, stable', () {
       // Groups carry no PersonId; the enumerated set is unchanged whether or not
       // the resolver would be called, and repeated calls agree.

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -80,3 +80,4 @@ export 'src/sql/settings_schema.dart';
 export 'src/sql/sql_connection.dart';
 export 'src/sync/application_state.dart';
 export 'src/sync/system_state.dart';
+export 'src/sync/wisa_snapshot_diff.dart';

--- a/packages/account_state/lib/src/sql/azure_sql_person_id_resolver.dart
+++ b/packages/account_state/lib/src/sql/azure_sql_person_id_resolver.dart
@@ -76,6 +76,10 @@ class AzureSqlPersonIdResolver implements PreparablePersonIdResolver {
   /// is split into this-sized chunks. Kept well under the ceiling for headroom.
   static const int maxKeysPerLookup = 2000;
 
+  /// The maximum rows in one multi-row guarded insert — each row binds two
+  /// parameters (key + id), so this stays under the same statement cap.
+  static const int maxRowsPerInsert = maxKeysPerLookup ~/ 2;
+
   static String _defaultMint() => const Uuid().v4();
 
   @override
@@ -108,18 +112,30 @@ class AzureSqlPersonIdResolver implements PreparablePersonIdResolver {
       ];
       if (missing.isEmpty) return;
 
-      // Mint-or-fetch the genuinely new keys atomically (see the class doc): the
-      // guarded insert plus its read-back is the "converge on one id" step, so
-      // it runs inside a single transaction as the seam intends (#85).
+      // Mint-or-fetch the genuinely new keys atomically (see the class doc):
+      // the guarded insert plus its read-back is the "converge on one id"
+      // step, so it runs inside a single transaction as the seam intends
+      // (#85). Set-based on purpose: one multi-row guarded INSERT plus one
+      // batched read-back per chunk. The original per-key loop cost two
+      // network round-trips per new key, which froze a first run over a real
+      // school (~1500 fresh keys ⇒ ~3000 sequential round-trips, #99).
       await connection.transaction((tx) async {
-        for (final key in missing) {
-          await tx.execute(_insertIfAbsentSql, [key, _mintId(), key]);
-          final winner = await tx.query(_selectOneSql, [key]);
-          if (winner.isEmpty) {
-            // Unreachable: the key either pre-existed or we just inserted it.
-            throw StateError('PersonIdentity row vanished for key: $key');
+        for (var i = 0; i < missing.length; i += maxRowsPerInsert) {
+          final chunk = missing.sublist(
+              i, math.min(i + maxRowsPerInsert, missing.length));
+          await tx.execute(_insertIfAbsentSql(chunk.length), [
+            for (final key in chunk) ...[key, _mintId()],
+          ]);
+          for (final row in await tx.query(_selectInSql(chunk.length), chunk)) {
+            _cache[_string(row['NaturalKey'])] =
+                PersonId(_string(row['PersonId']));
           }
-          _cache[key] = PersonId(_string(winner.first['PersonId']));
+          for (final key in chunk) {
+            if (!_cache.containsKey(key)) {
+              // Unreachable: the key either pre-existed or was just inserted.
+              throw StateError('PersonIdentity row vanished for key: $key');
+            }
+          }
         }
       });
     } finally {
@@ -150,19 +166,21 @@ String _selectInSql(int count) =>
     'SELECT NaturalKey, PersonId FROM $personIdentityTableName '
     'WHERE NaturalKey IN (${List.filled(count, '?').join(', ')})';
 
-/// Reads back the row that owns [NaturalKey] after a guarded insert — either the
-/// id this operator just minted or the one a concurrent operator committed first.
-const String _selectOneSql =
-    'SELECT PersonId FROM $personIdentityTableName WHERE NaturalKey = ?';
-
-/// Inserts a freshly minted id **only if the key is still absent**. The
-/// `UPDLOCK, HOLDLOCK` takes a serializable key-range lock so two operators
-/// minting the same new key are ordered: the loser's `NOT EXISTS` sees the
-/// winner's row and inserts nothing. Params: `[naturalKey, personId, naturalKey]`.
-const String _insertIfAbsentSql = 'INSERT INTO $personIdentityTableName '
-    '(NaturalKey, PersonId) SELECT ?, ? WHERE NOT EXISTS ('
+/// Inserts a batch of freshly minted ids, each row **only if its key is still
+/// absent**. The `UPDLOCK, HOLDLOCK` takes a serializable key-range lock per
+/// key so two operators minting the same new key are ordered: the loser's
+/// `NOT EXISTS` sees the winner's row and inserts nothing for that key. The
+/// read-back (the batched `_selectInSql` over the same chunk) then returns
+/// whichever id won. Params: `[key1, id1, key2, id2, …]` — two per row; the
+/// placeholders are generated, never interpolated data.
+String _insertIfAbsentSql(int rows) => 'INSERT INTO $personIdentityTableName '
+    '(NaturalKey, PersonId) '
+    'SELECT v.NaturalKey, v.PersonId '
+    'FROM (VALUES ${List.filled(rows, '(?, ?)').join(', ')}) '
+    'AS v(NaturalKey, PersonId) '
+    'WHERE NOT EXISTS ('
     'SELECT 1 FROM $personIdentityTableName WITH (UPDLOCK, HOLDLOCK) '
-    'WHERE NaturalKey = ?)';
+    'WHERE NaturalKey = v.NaturalKey)';
 
 /// Reads a driver value as a non-null string. The identity columns are declared
 /// `NOT NULL`, so a null here would be a schema violation; coercing keeps the

--- a/packages/account_state/lib/src/sql/odbc/odbc_sql_connection.dart
+++ b/packages/account_state/lib/src/sql/odbc/odbc_sql_connection.dart
@@ -131,7 +131,11 @@ class _OdbcSqlConnection implements SqlConnection {
     try {
       _prepare(stmt, sql);
       _bindParams(stmt, params, allocations);
-      _check(_b, _b.execute(stmt), 'SQLExecute', sqlHandleStmt, stmt);
+      final ret = _b.execute(stmt);
+      // SQL_NO_DATA is success-with-nothing (a searched UPDATE/DELETE that
+      // matched zero rows), not a failure — there is no result to read.
+      if (ret == sqlNoData) return const [];
+      _check(_b, ret, 'SQLExecute', sqlHandleStmt, stmt);
       return _readRows(stmt);
     } finally {
       for (final p in allocations) {
@@ -149,7 +153,13 @@ class _OdbcSqlConnection implements SqlConnection {
     try {
       _prepare(stmt, sql);
       _bindParams(stmt, params, allocations);
-      _check(_b, _b.execute(stmt), 'SQLExecute', sqlHandleStmt, stmt);
+      final ret = _b.execute(stmt);
+      // SQL_NO_DATA is success-with-nothing (a searched UPDATE/DELETE that
+      // matched zero rows, e.g. clearing an already-empty table), not a
+      // failure. The settings store's whole-config replace and the PersonId
+      // resolver's insert-if-absent both hit this legitimately.
+      if (ret == sqlNoData) return 0;
+      _check(_b, ret, 'SQLExecute', sqlHandleStmt, stmt);
 
       final rowsPtr = malloc<IntPtr>();
       try {

--- a/packages/account_state/lib/src/sync/wisa_snapshot_diff.dart
+++ b/packages/account_state/lib/src/sync/wisa_snapshot_diff.dart
@@ -1,0 +1,22 @@
+import 'package:wisa_api/wisa_api.dart';
+
+/// Whether two WISA snapshots hold the same content — the "smart sync" test
+/// (#99): after a fresh WISA pull, the reconcile flow diffs it against the
+/// previously retained snapshot and, when nothing changed, reports "no account
+/// changes needed" instead of re-linking and re-deriving actions.
+///
+/// Content equality only: `fetchedAt` is deliberately ignored (a re-pull always
+/// carries a new timestamp), and so is row order — WISA assembles the snapshot
+/// per school, so a reordering without a record change is still "unchanged".
+/// The comparison leans on the value equality of the four record types
+/// ([WisaStudent], [WisaStaff], [WisaClassGroup], [WisaSchool]).
+bool wisaSnapshotUnchanged(WisaSnapshot previous, WisaSnapshot fresh) =>
+    _sameRecords(previous.students, fresh.students) &&
+    _sameRecords(previous.staff, fresh.staff) &&
+    _sameRecords(previous.classGroups, fresh.classGroups) &&
+    _sameRecords(previous.schools, fresh.schools);
+
+/// Order-insensitive list comparison. A plain set comparison would treat
+/// duplicate records as one, so both the length and the set must match.
+bool _sameRecords<T>(List<T> a, List<T> b) =>
+    a.length == b.length && Set<T>.of(a).containsAll(b);

--- a/packages/account_state/test/sql/azure_sql_person_id_resolver_test.dart
+++ b/packages/account_state/test/sql/azure_sql_person_id_resolver_test.dart
@@ -13,13 +13,16 @@ class _FakePersonIdDb implements SqlConnection {
   /// The persisted map — the singular source of truth all connections share.
   final Map<String, String> table = {};
 
-  /// When true, the keyed lookup reports no rows even though [table] may hold
-  /// them: the "stale load" a concurrent minter races against.
+  /// When true, the keyed lookup **outside a transaction** reports no rows even
+  /// though [table] may hold them: the "stale load" a concurrent minter races
+  /// against. The read-back inside the mint transaction always sees committed
+  /// rows — that is exactly the visibility the guarded insert relies on.
   final bool hideOnLoad;
 
-  /// The parameter list of each `WHERE NaturalKey IN (...)` lookup, in order —
-  /// so a test can assert the warm cache only fetches uncached keys and that a
-  /// large key set is chunked under the parameter limit.
+  /// The parameter list of each warm-cache `WHERE NaturalKey IN (...)` lookup
+  /// (outside the mint transaction), in order — so a test can assert the warm
+  /// cache only fetches uncached keys and that a large key set is chunked under
+  /// the parameter limit.
   final List<List<Object?>> lookups = [];
 
   final List<String> statements = [];
@@ -27,6 +30,7 @@ class _FakePersonIdDb implements SqlConnection {
   int opens = 0;
   int closes = 0;
   int transactions = 0;
+  bool _inTransaction = false;
 
   @override
   Future<List<SqlRow>> query(String sql, [List<Object?> p = const []]) async {
@@ -34,24 +38,16 @@ class _FakePersonIdDb implements SqlConnection {
     params.add(p);
     // Keyed lookup: SELECT NaturalKey, PersonId FROM ... WHERE NaturalKey IN (?, ...)
     if (sql.contains('SELECT NaturalKey, PersonId')) {
-      lookups.add(p);
-      if (hideOnLoad) return [];
+      if (!_inTransaction) {
+        lookups.add(p);
+        if (hideOnLoad) return [];
+      }
       final keys = p.cast<String>();
       return [
         for (final key in keys)
           if (table.containsKey(key))
             {'NaturalKey': key, 'PersonId': table[key]!},
       ];
-    }
-    // Read-back of one row: SELECT PersonId FROM ... WHERE NaturalKey = ?
-    if (sql.contains('SELECT PersonId FROM')) {
-      final key = p.single as String;
-      final id = table[key];
-      return id == null
-          ? []
-          : [
-              {'PersonId': id},
-            ];
     }
     throw StateError('unexpected query: $sql');
   }
@@ -60,13 +56,18 @@ class _FakePersonIdDb implements SqlConnection {
   Future<int> execute(String sql, [List<Object?> p = const []]) async {
     statements.add(sql);
     params.add(p);
-    // Guarded insert: params are [naturalKey, personId, naturalKey].
+    // Multi-row guarded insert: params are [key1, id1, key2, id2, …]; a row
+    // is written only when its key is still absent.
     if (sql.contains('INSERT INTO') && sql.contains('WHERE NOT EXISTS')) {
-      final key = p[0] as String;
-      final id = p[1] as String;
-      if (table.containsKey(key)) return 0; // key present ⇒ insert nothing
-      table[key] = id;
-      return 1;
+      var inserted = 0;
+      for (var i = 0; i < p.length; i += 2) {
+        final key = p[i] as String;
+        final id = p[i + 1] as String;
+        if (table.containsKey(key)) continue; // key present ⇒ insert nothing
+        table[key] = id;
+        inserted++;
+      }
+      return inserted;
     }
     throw StateError('unexpected execute: $sql');
   }
@@ -74,6 +75,7 @@ class _FakePersonIdDb implements SqlConnection {
   @override
   Future<T> transaction<T>(Future<T> Function(SqlConnection tx) action) async {
     transactions++;
+    _inTransaction = true;
     final snapshot = Map<String, String>.of(table);
     try {
       return await action(this);
@@ -82,6 +84,8 @@ class _FakePersonIdDb implements SqlConnection {
         ..clear()
         ..addAll(snapshot);
       rethrow;
+    } finally {
+      _inTransaction = false;
     }
   }
 
@@ -283,6 +287,31 @@ void main() {
       final resolver = resolverOver(db);
       await resolver.prepare(['wisa:1', 'wisa:2']);
       expect(db.transactions, 1);
+    });
+
+    test('minting is set-based: a few statements, never two per key (#99)',
+        () async {
+      // A first run over a real school mints ~1500 fresh keys; the per-key
+      // loop cost two network round-trips each and froze the UI. The batch
+      // shape is the fix, so pin it: 2500 fresh keys must produce two
+      // warm-cache lookups (2000-key limit), then per 1000-row insert chunk
+      // one INSERT and one read-back — 8 statements, not 5000.
+      final db = _FakePersonIdDb();
+      final resolver = resolverOver(db);
+      const rows = AzureSqlPersonIdResolver.maxRowsPerInsert;
+      final keys = [for (var i = 0; i < rows * 2 + 500; i++) 'wisa:$i'];
+
+      await resolver.prepare(keys);
+
+      final inserts =
+          db.statements.where((s) => s.contains('INSERT INTO')).length;
+      expect(inserts, 3, reason: '2500 keys in 1000-row insert chunks');
+      expect(db.statements, hasLength(2 + 3 + 3),
+          reason: 'lookups + inserts + read-backs, all batched');
+      // Every key resolved, all ids persisted.
+      expect(db.table, hasLength(keys.length));
+      expect(resolver.resolve('wisa:0').value, isNotEmpty);
+      expect(resolver.resolve('wisa:${keys.length - 1}').value, isNotEmpty);
     });
 
     test('keys and ids are bound as parameters, never interpolated', () async {

--- a/packages/account_state/test/wisa_snapshot_diff_test.dart
+++ b/packages/account_state/test/wisa_snapshot_diff_test.dart
@@ -1,0 +1,150 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+final DateTime _first = DateTime.utc(2026, 7, 1);
+final DateTime _second = DateTime.utc(2026, 7, 2);
+
+const core.Address _addr = core.Address(
+  street: '',
+  houseNumber: '',
+  postalCode: '',
+  city: '',
+  country: '',
+);
+
+WisaStudent _student({
+  String wisaId = 'W1',
+  String firstName = 'Jan',
+  String classGroup = '3A',
+}) =>
+    WisaStudent(
+      wisaId: core.WisaId(wisaId),
+      classGroup: classGroup,
+      classSubGroup: '00',
+      name: 'Peeters',
+      firstName: firstName,
+      preferredName: '',
+      birthDate: DateTime.utc(2010),
+      stemId: '',
+      gender: core.Gender.male,
+      nationalId: '',
+      birthPlace: '',
+      nationality: '',
+      address: _addr,
+      classChange: DateTime.utc(2025, 9, 1),
+      schoolId: 1,
+    );
+
+WisaStaff _staff({String code = 'SMIT'}) => WisaStaff(
+      code: core.WisaStaffCode(code),
+      wisaId: const core.WisaId('42'),
+      firstName: 'Anna',
+      lastName: 'Smit',
+    );
+
+WisaClassGroup _classGroup({String name = '3A'}) => WisaClassGroup(
+      name: name,
+      groupName: '00',
+      description: 'Derde jaar A',
+      adminCode: '3A',
+      schoolCode: '012345',
+      schoolId: 1,
+    );
+
+WisaSchool _school({int id = 1, bool isVirtual = false}) => WisaSchool(
+      id: id,
+      name: 'SMA',
+      description: 'Sint-Michiel',
+      isVirtual: isVirtual,
+    );
+
+WisaSnapshot _snap({
+  DateTime? fetchedAt,
+  List<WisaStudent>? students,
+  List<WisaStaff>? staff,
+  List<WisaClassGroup>? classGroups,
+  List<WisaSchool>? schools,
+}) =>
+    WisaSnapshot(
+      fetchedAt: fetchedAt ?? _first,
+      students: students ?? [_student()],
+      staff: staff ?? [_staff()],
+      classGroups: classGroups ?? [_classGroup()],
+      schools: schools ?? [_school()],
+    );
+
+void main() {
+  group('wisaSnapshotUnchanged', () {
+    test('same content with a fresh fetchedAt is unchanged', () {
+      expect(
+        wisaSnapshotUnchanged(_snap(), _snap(fetchedAt: _second)),
+        isTrue,
+      );
+    });
+
+    test('record order does not count as a change', () {
+      final previous = _snap(
+        students: [_student(wisaId: 'W1'), _student(wisaId: 'W2')],
+      );
+      final fresh = _snap(
+        fetchedAt: _second,
+        students: [_student(wisaId: 'W2'), _student(wisaId: 'W1')],
+      );
+      expect(wisaSnapshotUnchanged(previous, fresh), isTrue);
+    });
+
+    test('an added student is a change', () {
+      final fresh = _snap(
+        fetchedAt: _second,
+        students: [_student(), _student(wisaId: 'W2')],
+      );
+      expect(wisaSnapshotUnchanged(_snap(), fresh), isFalse);
+    });
+
+    test('a removed student is a change', () {
+      final fresh = _snap(fetchedAt: _second, students: const []);
+      expect(wisaSnapshotUnchanged(_snap(), fresh), isFalse);
+    });
+
+    test('a modified student field is a change', () {
+      final fresh = _snap(
+        fetchedAt: _second,
+        students: [_student(classGroup: '3B')],
+      );
+      expect(wisaSnapshotUnchanged(_snap(), fresh), isFalse);
+    });
+
+    test('a duplicated record is a change, not collapsed away', () {
+      // Same record twice vs once: a set comparison alone would call these
+      // equal; the length guard must catch it.
+      final fresh = _snap(
+        fetchedAt: _second,
+        students: [_student(), _student()],
+      );
+      expect(wisaSnapshotUnchanged(_snap(), fresh), isFalse);
+    });
+
+    test('a staff change is a change', () {
+      final fresh = _snap(fetchedAt: _second, staff: [_staff(code: 'JANS')]);
+      expect(wisaSnapshotUnchanged(_snap(), fresh), isFalse);
+    });
+
+    test('a class-group change is a change', () {
+      final fresh = _snap(
+        fetchedAt: _second,
+        classGroups: [_classGroup(name: '3B')],
+      );
+      expect(wisaSnapshotUnchanged(_snap(), fresh), isFalse);
+    });
+
+    test('a school change (including the virtual flag) is a change', () {
+      final fresh = _snap(
+        fetchedAt: _second,
+        schools: [_school(isVirtual: true)],
+      );
+      expect(wisaSnapshotUnchanged(_snap(), fresh), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The core screen of the app: one page drives the reconcile loop over `account_state` — **sync → linked overview → pending actions → dry-run → apply** — with an inline log panel fed by the `ILog` sink. Verified end-to-end against the live school systems (WISA, Smartschool, Azure AD, Azure SQL, Key Vault), which surfaced and fixed four real-data/infra bugs along the way.

## Linked issue

Closes #99
Closes #103

## Changes

**Smart sync (product direction, not a legacy copy)**
- `account_state`: new `wisaSnapshotUnchanged()` — content diff between WISA snapshots (order- and `fetchedAt`-insensitive). `ReconcileController.sync()` pulls WISA, diffs against the retained snapshot, and reports "no account changes needed" when unchanged; Smartschool/Azure are read once per session. Re-reading them is the explicit **Check for drift** action.

**The screen (`account_manager`)**
- `ReconcileController` (ChangeNotifier): smart sync, drift check, dry-run and apply passes over the pending actions (informational group actions are listed but never applied), per-action failure isolation.
- `LogBuffer`: the app's `ILog` sink feeding connectors + controller into the inline log panel.
- `bootstrapReconcile`: composition root — settings from the Azure SQL `SettingsStore`, WISA password + Smartschool passphrase from Key Vault (operator tokens via the #98 session), the three connectors, `ApplicationState` → `StateApplier`. Provisions the idempotent SQL schema on first run; maps a missing ODBC driver (IM002) to an actionable message.
- `ReconcileScreen` + shell destination: overview count tiles, pending-action list with per-field diffs, confirmation-gated apply, log panel; not-configured / bootstrap-error / preparing states.

**Sign-in (closes #103)**
- Loopback broker gained a real silent leg: an AAD refresh token is per-client, so one interactive sign-in silently mints the SQL and Key Vault tokens (no browser per resource).
- Persistent token cache: per-resource files under `%APPDATA%\AccountManager\auth\`, encrypted with user-scoped DPAPI (`dart:ffi` over crypt32) through azure_api's `EncryptedTokenCache` seam — a returning operator signs in with no browser at all.
- New `AadResource.vault` + `VaultSessionTokenProvider`; the desktop app registration got the Key Vault `user_impersonation` delegated scope (admin-consented).

**Bugs found by the live bring-up**
- ODBC layer: `SQL_NO_DATA` from `SQLExecute` (zero-row UPDATE/DELETE) is success-with-nothing, not an error.
- Linker: Smartschool-only accounts with no `accountId` and no mail (real intern accounts) now key by `uid` (`ss:<uid>`), consistently in `link()` and `naturalKeysFor`.
- PersonId resolver: the mint is set-based (multi-row guarded INSERT + batched read-back) — a first run over ~1500 fresh keys went from ~3000 sequential round-trips (frozen UI) to ~6 statements.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed packages account_manager` clean
- [x] `flutter analyze` clean (no issues)
- [x] Unit/widget tests pass: `account_state` 183, `account_linker` 40, `account_manager` 67 (`dart test` / `flutter test`) — including the "WISA unchanged → no changes needed" path, drift check, sync failure, dry-run-writes-nothing, apply-refreshes-view, DPAPI round-trip/tamper, and the batching/regression tests for each live-found bug
- [x] Integration/e2e: `flutter test integration_test -d windows` — 5 tests pass, including the new end-to-end scenario driving the real app (sign-in → Reconcile tab → sync → overview → dry-run → confirmed apply → unchanged re-sync) against the offline harness
- [x] Manual live run on the dev laptop: sign-in with no repeat prompts, real WISA/Smartschool/Azure sync, linked overview + pending actions render

🤖 Generated with [Claude Code](https://claude.com/claude-code)