### PR TITLE
Persist connector snapshots as cold storage across sessions (#107)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -137,6 +137,38 @@ void main() {
     expect(harness.azSyncs, 1);
   });
 
+  testWidgets(
+      'a resumed session trusts the stored state: Synchronise pulls no '
+      'Smartschool/Azure (#107)', (WidgetTester tester) async {
+    // Session 1 (offline harness over a shared cold-snapshot store): a full
+    // sync persists all three connector snapshots.
+    final store = InMemorySnapshotStore();
+    await ReconcileHarness(store: store).controller.sync();
+
+    // Session 2 is the real app, freshly bootstrapped over the *same* store —
+    // its SystemStates seed from what session 1 persisted.
+    final resumed = await ReconcileHarness.resume(store: store);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: resumed.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('reconcile-sync')), findsOneWidget);
+
+    // Drive Synchronise from the real UI: WISA is re-read for the smart diff,
+    // but Smartschool and Azure are trusted from the store — no connector pull.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(resumed.wisaSyncs, 1);
+    expect(resumed.ssSyncs, 0, reason: 'Smartschool seeded from the store');
+    expect(resumed.azSyncs, 0, reason: 'Azure seeded from the store');
+    expect(find.text('Linked overview'), findsOneWidget);
+  });
+
   testWidgets('silent sign-in leads straight into the shell',
       (WidgetTester tester) async {
     final broker = _FakeBroker(silent: (_) => _token('AT'));

--- a/account_manager/lib/src/auth/aad_resource.dart
+++ b/account_manager/lib/src/auth/aad_resource.dart
@@ -47,4 +47,12 @@ class AadResource {
     id: 'vault',
     scopes: <String>['https://vault.azure.net/.default'],
   );
+
+  /// The centralized Blob Storage account (`https://storage.azure.com`), where
+  /// cold snapshot payloads too large for a Cosmos document overflow (#107). The
+  /// operator holds a *Storage Blob Data Contributor* data-plane role.
+  static const AadResource storage = AadResource(
+    id: 'storage',
+    scopes: <String>['https://storage.azure.com/.default'],
+  );
 }

--- a/account_manager/lib/src/auth/sign_in_session.dart
+++ b/account_manager/lib/src/auth/sign_in_session.dart
@@ -1,5 +1,5 @@
 import 'package:account_state/account_state.dart'
-    show CosmosTokenProvider, KeyVaultTokenProvider;
+    show BlobTokenProvider, CosmosTokenProvider, KeyVaultTokenProvider;
 import 'package:azure_api/azure_api.dart'
     show AzureAuthException, AzureAuthProvider;
 
@@ -130,4 +130,16 @@ class VaultSessionTokenProvider implements KeyVaultTokenProvider {
 
   @override
   Future<String> vaultAccessToken() => _session.tokenFor(AadResource.vault);
+}
+
+/// Adapts a [SignInSession] to the Blob auth seam ([BlobTokenProvider]) so
+/// cold-snapshot overflow blobs are read/written with the operator's own AAD
+/// identity (Storage Blob Data Contributor), no stored account key (#107).
+class BlobSessionTokenProvider implements BlobTokenProvider {
+  BlobSessionTokenProvider(this._session);
+
+  final SignInSession _session;
+
+  @override
+  Future<String> blobAccessToken() => _session.tokenFor(AadResource.storage);
 }

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -19,6 +19,8 @@ class StoreEndpoints {
     required this.cosmosEndpoint,
     required this.cosmosDatabase,
     required this.vaultUri,
+    required this.blobEndpoint,
+    required this.blobContainer,
   });
 
   factory StoreEndpoints.fromEnvironment() => const StoreEndpoints(
@@ -35,11 +37,26 @@ class StoreEndpoints {
           'KEY_VAULT_URI',
           defaultValue: 'https://accountmanager-kv.vault.azure.net/',
         ),
+        blobEndpoint: String.fromEnvironment(
+          'BLOB_ENDPOINT',
+          defaultValue: 'https://accountmanagerarcadia.blob.core.windows.net',
+        ),
+        blobContainer: String.fromEnvironment(
+          'BLOB_SNAPSHOTS_CONTAINER',
+          defaultValue: 'snapshots',
+        ),
       );
 
   final String cosmosEndpoint;
   final String cosmosDatabase;
   final String vaultUri;
+
+  /// The Blob Storage account endpoint holding cold-snapshot overflow payloads
+  /// (#107).
+  final String blobEndpoint;
+
+  /// The container within [blobEndpoint] the snapshot overflow blobs live in.
+  final String blobContainer;
 }
 
 /// The assembled reconcile stack for one signed-in session: settings loaded
@@ -91,6 +108,8 @@ Future<ReconcileServices> bootstrapReconcile({
   SettingsStore? settingsStore,
   SecretProvider? secretProvider,
   CosmosClient? cosmosClient,
+  BlobStore? blobStore,
+  SnapshotStore? snapshotStore,
   LogBuffer? log,
   DateTime Function()? clock,
 }) async {
@@ -110,6 +129,23 @@ Future<ReconcileServices> bootstrapReconcile({
 
   final store = settingsStore ?? CosmosSettingsStore(client);
   final settings = await store.load();
+
+  // The cold snapshot store (#107): a fresh session seeds its SystemStates from
+  // here instead of pulling, and every successful sync writes the fresh
+  // snapshot back. Only the sync/drift process reads or writes it.
+  final blobs = blobStore ??
+      HttpBlobStore(
+        config: BlobConfig(
+          endpoint: ends.blobEndpoint,
+          container: ends.blobContainer,
+        ),
+        transport: HttpBlobTransport(),
+        tokens: BlobSessionTokenProvider(session),
+      );
+  final snapshots = snapshotStore ?? CosmosSnapshotStore(client, blobs);
+  final syncedBy = session.account ?? '';
+  void logSnapshotIssue(core.Origin system, Object error) =>
+      logBuffer.addError(system, 'Snapshot store: $error');
 
   final secrets = secretProvider ??
       KeyVaultSecretProvider(
@@ -178,34 +214,83 @@ Future<ReconcileServices> bootstrapReconcile({
 
   final wisaRules = WisaImportRules(initial: settings.wisaRules);
 
+  // Seed each SystemState from the stored cold snapshot so a fresh session
+  // trusts the persisted state (#107): WISA seeds the smart-diff baseline,
+  // Smartschool/Azure are reused rather than re-pulled, and the Azure seed
+  // restores the delta token so the next sync resumes `/users/delta`.
+  final wisaSeed = await seedSnapshot<wapi.WisaSnapshot>(
+    system: core.Origin.wisa,
+    store: snapshots,
+    fromPayload: wapi.WisaSnapshot.fromJson,
+    onError: (e) => logSnapshotIssue(core.Origin.wisa, e),
+  );
+  final ssSeed = await seedSnapshot<ss.SmartschoolSnapshot>(
+    system: core.Origin.smartschool,
+    store: snapshots,
+    fromPayload: ss.SmartschoolSnapshot.fromJson,
+    onError: (e) => logSnapshotIssue(core.Origin.smartschool, e),
+  );
+  final azureSeed = await seedSnapshot<az.AzureSnapshot>(
+    system: core.Origin.azure,
+    store: snapshots,
+    fromPayload: az.AzureSnapshot.fromJson,
+    onError: (e) => logSnapshotIssue(core.Origin.azure, e),
+  );
+
   final app = ApplicationState(
     wisa: SystemState<wapi.WisaSnapshot>(
       system: core.Origin.wisa,
+      initial: wisaSeed,
       // Schools are re-read per sync so a WISA-side school change is picked
       // up; MarkAsVirtual rules are applied to them before the row pulls, the
       // other rules at snapshot construction. Rules are read live from the
       // shared holder so a DontImportFromWisa apply affects the re-sync (#72).
-      syncer: (_) async {
-        final schools = wapi.WisaConnector.applySchoolRules(
-          await wisaConnector.loadSchools(),
-          wisaRules.rules,
-        );
-        final at = now();
-        return wisaConnector.sync(
-          schools: schools,
-          workDate: settings.wisa.workDate.resolve(at),
-          virtualWorkDate: settings.wisa.virtualWorkDate.resolve(at),
-          rules: wisaRules.rules,
-        );
-      },
+      // The pull is wrapped so each fresh snapshot is persisted (#107).
+      syncer: persistingSyncer<wapi.WisaSnapshot>(
+        system: core.Origin.wisa,
+        store: snapshots,
+        syncedBy: syncedBy,
+        payloadOf: (s) => s.toJson(),
+        onError: (e) => logSnapshotIssue(core.Origin.wisa, e),
+        inner: (_) async {
+          final schools = wapi.WisaConnector.applySchoolRules(
+            await wisaConnector.loadSchools(),
+            wisaRules.rules,
+          );
+          final at = now();
+          return wisaConnector.sync(
+            schools: schools,
+            workDate: settings.wisa.workDate.resolve(at),
+            virtualWorkDate: settings.wisa.virtualWorkDate.resolve(at),
+            rules: wisaRules.rules,
+          );
+        },
+      ),
     ),
     smartschool: SystemState<ss.SmartschoolSnapshot>(
       system: core.Origin.smartschool,
-      syncer: (_) => ssConnector.sync(rules: settings.smartschoolRules),
+      initial: ssSeed,
+      syncer: persistingSyncer<ss.SmartschoolSnapshot>(
+        system: core.Origin.smartschool,
+        store: snapshots,
+        syncedBy: syncedBy,
+        payloadOf: (s) => s.toJson(),
+        onError: (e) => logSnapshotIssue(core.Origin.smartschool, e),
+        inner: (_) => ssConnector.sync(rules: settings.smartschoolRules),
+      ),
     ),
     azure: SystemState<az.AzureSnapshot>(
       system: core.Origin.azure,
-      syncer: azureSyncer(azConnector),
+      initial: azureSeed,
+      syncer: persistingSyncer<az.AzureSnapshot>(
+        system: core.Origin.azure,
+        store: snapshots,
+        syncedBy: syncedBy,
+        payloadOf: (s) => s.toJson(),
+        deltaTokenOf: (s) => s.deltaToken,
+        onError: (e) => logSnapshotIssue(core.Origin.azure, e),
+        inner: azureSyncer(azConnector),
+      ),
     ),
   );
 

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:account_actions/account_actions.dart' as actions;
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_manager/src/reconcile/log_buffer.dart';
+import 'package:azure_api/azure_api.dart' as az;
 import 'package:flutter_test/flutter_test.dart';
 
 import 'reconcile_fakes.dart';
@@ -86,6 +87,88 @@ void main() {
       expect(h.azSyncs, 2);
       expect(h.wisaSyncs, 1, reason: 'drift check does not re-pull WISA');
       expect(h.controller.linked, isNotNull);
+    });
+  });
+
+  group('cross-session snapshot persistence (#107)', () {
+    test('a first sync persists all three snapshots to the store', () async {
+      final store = InMemorySnapshotStore();
+      final h = ReconcileHarness(store: store);
+
+      await h.controller.sync();
+
+      expect(
+        store.storedSystems,
+        containsAll([
+          core.Origin.wisa,
+          core.Origin.smartschool,
+          core.Origin.azure,
+        ]),
+      );
+      expect(
+          store.peek(core.Origin.azure)!.syncedBy, 'operator@school.example');
+    });
+
+    test('a fresh session seeded from the store reuses Smartschool + Azure',
+        () async {
+      final store = InMemorySnapshotStore();
+      // Session 1 pulls and persists everything.
+      await ReconcileHarness(store: store).controller.sync();
+
+      // Session 2: a fresh controller over the same store.
+      final resumed = await ReconcileHarness.resume(store: store);
+      await resumed.controller.sync();
+
+      // WISA is still pulled (the smart diff needs a fresh WISA read), but the
+      // Smartschool and Azure snapshots are trusted from the store — no pull.
+      expect(resumed.wisaSyncs, 1);
+      expect(resumed.ssSyncs, 0,
+          reason: 'Smartschool is seeded from the store, not re-pulled');
+      expect(resumed.azSyncs, 0,
+          reason: 'Azure is seeded from the store, not re-pulled');
+      expect(resumed.controller.linked, isNotNull,
+          reason: 'the linked view is derived from the seeded snapshots');
+      expect(resumed.log.entries.where((e) => e.isError), isEmpty);
+    });
+
+    test('check-for-drift re-pulls and replaces the stored copies', () async {
+      final store = InMemorySnapshotStore();
+      await ReconcileHarness(store: store).controller.sync();
+      expect(store.peek(core.Origin.smartschool)!.fetchedAt, kFixtureDate);
+
+      final resumed = await ReconcileHarness.resume(store: store);
+      // The drift pull returns snapshots stamped later than the stored copies.
+      final driftAt = kFixtureDate.add(const Duration(hours: 3));
+      resumed.ssResult = ssSnap(fetchedAt: driftAt);
+      resumed.azResult = azSnap(fetchedAt: driftAt);
+
+      await resumed.controller.checkDrift();
+
+      // A drift check re-reads Smartschool + Azure from the connectors…
+      expect(resumed.ssSyncs, 1);
+      expect(resumed.azSyncs, 1);
+      // …and replaces the stored snapshots with the fresh pulls.
+      expect(store.peek(core.Origin.smartschool)!.fetchedAt, driftAt);
+      expect(store.peek(core.Origin.azure)!.fetchedAt, driftAt);
+    });
+
+    test('the Azure delta token survives across sessions', () async {
+      final store = InMemorySnapshotStore();
+      final s1 = ReconcileHarness(
+        store: store,
+        azure: az.AzureSnapshot(
+          fetchedAt: kFixtureDate,
+          deltaToken: 'DELTA-42',
+          users: [azUser()],
+          groups: const [],
+        ),
+      );
+      await s1.controller.sync();
+
+      // The seeded Azure snapshot carries the delta token forward, priming the
+      // next incremental /users/delta.
+      final resumed = await ReconcileHarness.resume(store: store);
+      expect(resumed.app.azure.snapshot?.deltaToken, 'DELTA-42');
     });
   });
 

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -161,20 +161,22 @@ wapi.WisaSnapshot wisaSnap({
     );
 
 ss.SmartschoolSnapshot ssSnap({
+  DateTime? fetchedAt,
   List<core.Group>? groups,
   List<ss.SmartschoolAccount>? accounts,
   List<ss.SmartschoolMembership>? memberships,
 }) =>
     ss.SmartschoolSnapshot(
-      fetchedAt: kFixtureDate,
+      fetchedAt: fetchedAt ?? kFixtureDate,
       groups: groups ??
           [ssGroup('2B', code: '2B_ss'), ssGroup('3C', code: '3C_ss')],
       accounts: accounts ?? [ssAccount()],
       memberships: memberships ?? [member('jane', '2B_ss')],
     );
 
-az.AzureSnapshot azSnap({List<az.AzureUser>? users}) => az.AzureSnapshot(
-      fetchedAt: kFixtureDate,
+az.AzureSnapshot azSnap({DateTime? fetchedAt, List<az.AzureUser>? users}) =>
+    az.AzureSnapshot(
+      fetchedAt: fetchedAt ?? kFixtureDate,
       users: users ?? [azUser()],
       groups: const [],
     );
@@ -186,6 +188,38 @@ class SeqResolver implements core.PersonIdResolver {
   @override
   core.PersonId resolve(String naturalKey) =>
       core.PersonId(_seen.putIfAbsent(naturalKey, () => 'p${_seen.length}'));
+}
+
+/// An in-memory [SnapshotStore] shared across two "sessions" of a test, so a
+/// second [ReconcileHarness] can seed from what the first persisted (#107). The
+/// Cosmos+Blob overflow behaviour is covered by `account_state`'s unit tests;
+/// here only the seed/reuse/drift wiring matters.
+class InMemorySnapshotStore implements SnapshotStore {
+  final Map<core.Origin, StoredSnapshot> _byOrigin = {};
+
+  /// Which systems currently have a stored snapshot — for test assertions.
+  Iterable<core.Origin> get storedSystems => _byOrigin.keys;
+
+  StoredSnapshot? peek(core.Origin system) => _byOrigin[system];
+
+  @override
+  Future<StoredSnapshot?> load(core.Origin system) async => _byOrigin[system];
+
+  @override
+  Future<void> save(
+    core.Origin system, {
+    required Map<String, dynamic> payload,
+    required DateTime fetchedAt,
+    required String syncedBy,
+    String? deltaToken,
+  }) async {
+    _byOrigin[system] = StoredSnapshot(
+      payload: payload,
+      fetchedAt: fetchedAt,
+      syncedBy: syncedBy,
+      deltaToken: deltaToken,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -200,35 +234,75 @@ class ReconcileHarness {
     wapi.WisaSnapshot? wisa,
     ss.SmartschoolSnapshot? smartschool,
     az.AzureSnapshot? azure,
+    this.store,
+    wapi.WisaSnapshot? wisaInitial,
+    ss.SmartschoolSnapshot? ssInitial,
+    az.AzureSnapshot? azureInitial,
   })  : wisaResult = (wisa ?? wisaSnap()),
         ssResult = (smartschool ?? ssSnap()),
         azResult = (azure ?? azSnap()) {
     log = LogBuffer(clock: () => kFixtureDate);
     final wisaRules = WisaImportRules();
 
+    // The scripted per-system pulls (with call counters). When a [store] is
+    // wired, each is wrapped so a successful pull persists — mirroring how
+    // bootstrap composes persistence over the real syncers (#107).
+    Syncer<wapi.WisaSnapshot> wisaSync = (_) async {
+      wisaSyncs++;
+      final error = wisaError;
+      if (error != null) throw error;
+      return wisaResult;
+    };
+    Syncer<ss.SmartschoolSnapshot> ssSync = (_) async {
+      ssSyncs++;
+      return ssResult;
+    };
+    Syncer<az.AzureSnapshot> azSync = (_) async {
+      azSyncs++;
+      return azResult;
+    };
+
+    final s = store;
+    if (s != null) {
+      wisaSync = persistingSyncer<wapi.WisaSnapshot>(
+        system: core.Origin.wisa,
+        store: s,
+        syncedBy: 'operator@school.example',
+        payloadOf: (snap) => snap.toJson(),
+        inner: wisaSync,
+      );
+      ssSync = persistingSyncer<ss.SmartschoolSnapshot>(
+        system: core.Origin.smartschool,
+        store: s,
+        syncedBy: 'operator@school.example',
+        payloadOf: (snap) => snap.toJson(),
+        inner: ssSync,
+      );
+      azSync = persistingSyncer<az.AzureSnapshot>(
+        system: core.Origin.azure,
+        store: s,
+        syncedBy: 'operator@school.example',
+        payloadOf: (snap) => snap.toJson(),
+        deltaTokenOf: (snap) => snap.deltaToken,
+        inner: azSync,
+      );
+    }
+
     app = ApplicationState(
       wisa: SystemState<wapi.WisaSnapshot>(
         system: core.Origin.wisa,
-        syncer: (_) async {
-          wisaSyncs++;
-          final error = wisaError;
-          if (error != null) throw error;
-          return wisaResult;
-        },
+        initial: wisaInitial,
+        syncer: wisaSync,
       ),
       smartschool: SystemState<ss.SmartschoolSnapshot>(
         system: core.Origin.smartschool,
-        syncer: (_) async {
-          ssSyncs++;
-          return ssResult;
-        },
+        initial: ssInitial,
+        syncer: ssSync,
       ),
       azure: SystemState<az.AzureSnapshot>(
         system: core.Origin.azure,
-        syncer: (_) async {
-          azSyncs++;
-          return azResult;
-        },
+        initial: azureInitial,
+        syncer: azSync,
       ),
     );
 
@@ -264,6 +338,45 @@ class ReconcileHarness {
     );
 
     controller = ReconcileController(app: app, applier: applier, log: log);
+  }
+
+  /// The shared cold-snapshot store, when this harness models the persistence
+  /// wiring (#107). `null` for the plain in-memory scenarios.
+  final SnapshotStore? store;
+
+  /// Builds a "second session" seeded from [store] — a fresh controller over
+  /// the state another harness already persisted, the way bootstrap seeds each
+  /// [SystemState] from the store on app open (#107).
+  static Future<ReconcileHarness> resume({
+    required SnapshotStore store,
+    wapi.WisaSnapshot? wisa,
+    ss.SmartschoolSnapshot? smartschool,
+    az.AzureSnapshot? azure,
+  }) async {
+    final wisaSeed = await seedSnapshot<wapi.WisaSnapshot>(
+      system: core.Origin.wisa,
+      store: store,
+      fromPayload: wapi.WisaSnapshot.fromJson,
+    );
+    final ssSeed = await seedSnapshot<ss.SmartschoolSnapshot>(
+      system: core.Origin.smartschool,
+      store: store,
+      fromPayload: ss.SmartschoolSnapshot.fromJson,
+    );
+    final azSeed = await seedSnapshot<az.AzureSnapshot>(
+      system: core.Origin.azure,
+      store: store,
+      fromPayload: az.AzureSnapshot.fromJson,
+    );
+    return ReconcileHarness(
+      wisa: wisa,
+      smartschool: smartschool,
+      azure: azure,
+      store: store,
+      wisaInitial: wisaSeed,
+      ssInitial: ssSeed,
+      azureInitial: azSeed,
+    );
   }
 
   /// What the next sync of each system returns. Mutate to simulate a change

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -14,6 +14,12 @@
 ///   AAD-only, so each request is authenticated with a per-operator bearer
 ///   token; [HttpCosmosClient] binds the pure-Dart HTTPS+JSON data plane, so
 ///   there is no native driver dependency.
+/// - [SnapshotStore] — the cold store the three connector snapshots (WISA,
+///   Smartschool, Azure + delta token) persist to, so a fresh session seeds
+///   from the store instead of re-pulling (#107). [CosmosSnapshotStore] keeps
+///   the metadata in Cosmos and overflows large payloads to a [BlobStore]
+///   ([HttpBlobStore] over the same AAD-token discipline). [persistingSyncer]
+///   and [seedSnapshot] compose that persistence over a [SystemState]'s syncer.
 ///
 /// Every seam has an in-memory default so the layer is testable headlessly
 /// with zero network and zero infra. The persist-vs-derive split — what is
@@ -53,6 +59,9 @@ export 'package:account_store/account_store.dart' show FilePersonIdResolver;
 
 export 'src/apply/state_applier.dart';
 export 'src/apply/wisa_import_rules.dart';
+export 'src/blob/blob_store.dart';
+export 'src/blob/blob_token_provider.dart';
+export 'src/blob/blob_transport.dart';
 export 'src/keyvault/key_vault_config.dart';
 export 'src/keyvault/key_vault_live_config.dart';
 export 'src/keyvault/key_vault_secret_provider.dart';
@@ -74,8 +83,10 @@ export 'src/cosmos/cosmos_live_config.dart';
 export 'src/cosmos/cosmos_password_queue_store.dart';
 export 'src/cosmos/cosmos_person_id_resolver.dart';
 export 'src/cosmos/cosmos_settings_store.dart';
+export 'src/cosmos/cosmos_snapshot_store.dart';
 export 'src/cosmos/cosmos_token_provider.dart';
 export 'src/cosmos/cosmos_transport.dart';
 export 'src/sync/application_state.dart';
+export 'src/sync/snapshot_persistence.dart';
 export 'src/sync/system_state.dart';
 export 'src/sync/wisa_snapshot_diff.dart';

--- a/packages/account_state/lib/src/blob/blob_store.dart
+++ b/packages/account_state/lib/src/blob/blob_store.dart
@@ -1,0 +1,191 @@
+import 'blob_token_provider.dart';
+import 'blob_transport.dart';
+
+/// The overflow store for cold snapshot payloads too large for a Cosmos
+/// document (Cosmos caps a document at 2 MB; a whole-school WISA or Azure
+/// snapshot can exceed that).
+///
+/// The seam the `SnapshotStore` writes the raw payload through when it does not
+/// fit inline. Kept deliberately small — a keyed put / get / delete of an
+/// opaque UTF-8 string — so it is unit-testable against an in-memory fake and
+/// only [HttpBlobStore] binds the Blob REST protocol. The `SnapshotStore`
+/// records the returned reference in its Cosmos metadata document and hands it
+/// back to [read] to fetch the payload on the next sync.
+abstract interface class BlobStore {
+  /// Uploads [content] (UTF-8 JSON) under the deterministic [name], overwriting
+  /// any previous blob of that name, and returns the reference to persist. The
+  /// reference is what [read]/[delete] take back — callers treat it as opaque.
+  Future<String> write(String name, String content);
+
+  /// Reads the blob referenced by [ref] (as returned by [write]), or `null`
+  /// when it no longer exists.
+  Future<String?> read(String ref);
+
+  /// Removes the blob referenced by [ref]. Idempotent — a missing blob is a
+  /// success, so a snapshot that shrank back under the inline limit can drop
+  /// its overflow blob without a pre-check.
+  Future<void> delete(String ref);
+}
+
+/// The connection target for the centralized Blob Storage account.
+///
+/// Names *where* the overflow container lives — the blob endpoint and the
+/// container — and nothing more. Carries no credential: authentication is the
+/// separate [BlobTokenProvider] seam, so the target can round-trip through
+/// settings or a log line without leaking a secret (the same discipline
+/// [CosmosConfig] applies).
+class BlobConfig {
+  const BlobConfig({required this.endpoint, required this.container});
+
+  /// The account's blob endpoint, e.g.
+  /// `https://accountmanagerarcadia.blob.core.windows.net`. A trailing slash is
+  /// tolerated — [HttpBlobStore] normalizes it when building request URLs.
+  final String endpoint;
+
+  /// The container holding the snapshot overflow blobs, e.g. `snapshots`. The
+  /// container is provisioned out of band (data-plane RBAC cannot create it).
+  final String container;
+
+  @override
+  bool operator ==(Object other) =>
+      other is BlobConfig &&
+      other.endpoint == endpoint &&
+      other.container == container;
+
+  @override
+  int get hashCode => Object.hash(endpoint, container);
+
+  @override
+  String toString() => 'BlobConfig($endpoint/$container)';
+}
+
+/// The default [BlobStore], speaking the Azure Blob Storage REST data plane over
+/// a swappable [BlobTransport] (mirroring [HttpCosmosClient] over
+/// [CosmosTransport]).
+///
+/// **Auth.** The account is AAD-only, so every request carries a
+/// `Bearer` token for `https://storage.azure.com` from [BlobTokenProvider],
+/// plus the required `x-ms-date` (RFC 1123) and `x-ms-version` headers. A write
+/// is a single block-blob `PUT` (`x-ms-blob-type: BlockBlob`); a read is a
+/// `GET`; a delete is a `DELETE`. The token is read fresh per request so a
+/// request never outlives its short-lived bearer token.
+class HttpBlobStore implements BlobStore {
+  HttpBlobStore({
+    required BlobConfig config,
+    required BlobTransport transport,
+    required BlobTokenProvider tokens,
+    DateTime Function()? now,
+  })  : _config = config,
+        _transport = transport,
+        _tokens = tokens,
+        _now = now ?? DateTime.now;
+
+  final BlobConfig _config;
+  final BlobTransport _transport;
+  final BlobTokenProvider _tokens;
+  final DateTime Function() _now;
+
+  /// The Blob REST API version. Any recent value works for the operations used
+  /// here; pinned so behaviour does not drift under the account.
+  static const String apiVersion = '2021-12-02';
+
+  @override
+  Future<String> write(String name, String content) async {
+    final resp = await _send(
+      'PUT',
+      name,
+      body: content,
+      extraHeaders: const {
+        'x-ms-blob-type': 'BlockBlob',
+        'Content-Type': 'application/json',
+      },
+    );
+    _ensureSuccess(resp);
+    return name;
+  }
+
+  @override
+  Future<String?> read(String ref) async {
+    final resp = await _send('GET', ref);
+    if (resp.isNotFound) return null;
+    _ensureSuccess(resp);
+    return resp.body;
+  }
+
+  @override
+  Future<void> delete(String ref) async {
+    final resp = await _send('DELETE', ref);
+    if (resp.isNotFound) return;
+    _ensureSuccess(resp);
+  }
+
+  Future<BlobResponse> _send(
+    String method,
+    String blob, {
+    String? body,
+    Map<String, String> extraHeaders = const {},
+  }) async {
+    final token = await _tokens.blobAccessToken();
+    final headers = <String, String>{
+      'authorization': 'Bearer $token',
+      'x-ms-date': _rfc1123(_now().toUtc()),
+      'x-ms-version': apiVersion,
+      ...extraHeaders,
+    };
+    return _transport.send(BlobRequest(
+      method: method,
+      url: Uri.parse('${_base()}/${_config.container}/'
+          '${Uri.encodeComponent(blob)}'),
+      headers: headers,
+      body: body,
+    ));
+  }
+
+  /// The endpoint without a trailing slash, so `$base/$container/$blob` joins
+  /// cleanly regardless of how the endpoint was configured.
+  String _base() {
+    final e = _config.endpoint;
+    return e.endsWith('/') ? e.substring(0, e.length - 1) : e;
+  }
+
+  void _ensureSuccess(BlobResponse resp) {
+    if (!resp.isSuccess) throw BlobException(resp.statusCode, resp.body);
+  }
+}
+
+const List<String> _weekdays = [
+  'Mon',
+  'Tue',
+  'Wed',
+  'Thu',
+  'Fri',
+  'Sat',
+  'Sun',
+];
+
+const List<String> _months = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+/// Formats [utc] as an RFC 1123 date, the shape Blob Storage requires for
+/// `x-ms-date`. Built by hand (fixed English day/month names, always GMT) so the
+/// library needs no `intl` dependency and never depends on the host locale.
+/// [utc] must already be in UTC.
+String _rfc1123(DateTime utc) {
+  String two(int n) => n.toString().padLeft(2, '0');
+  final wd = _weekdays[utc.weekday - 1];
+  final mon = _months[utc.month - 1];
+  return '$wd, ${two(utc.day)} $mon ${utc.year} '
+      '${two(utc.hour)}:${two(utc.minute)}:${two(utc.second)} GMT';
+}

--- a/packages/account_state/lib/src/blob/blob_token_provider.dart
+++ b/packages/account_state/lib/src/blob/blob_token_provider.dart
@@ -1,0 +1,31 @@
+/// The authentication seam for the centralized Blob Storage account.
+///
+/// Like the Cosmos account, storage is reached with the operator's own Azure AD
+/// identity (holding a data-plane role such as *Storage Blob Data Contributor*)
+/// — no account key, no stored secret. Each request needs a short-lived bearer
+/// token minted for the storage resource (`https://storage.azure.com`).
+///
+/// Mirrors [CosmosTokenProvider]: production wires the app's session-backed
+/// implementation, while tests and headless runs inject a
+/// [StaticBlobTokenProvider]. Nothing above the seam knows which.
+abstract interface class BlobTokenProvider {
+  /// Returns a valid bearer token for the storage resource
+  /// (`https://storage.azure.com`). Implementations may cache and refresh;
+  /// callers treat each value as short-lived and re-read before a request.
+  Future<String> blobAccessToken();
+}
+
+/// A [BlobTokenProvider] that returns a pre-acquired token verbatim.
+///
+/// The default for headless tests and the opt-in live check: the token is
+/// minted outside the process (e.g. `az account get-access-token --resource
+/// https://storage.azure.com`) and handed in, so the package never shells out
+/// or drives an interactive sign-in. Mirrors [StaticCosmosTokenProvider].
+class StaticBlobTokenProvider implements BlobTokenProvider {
+  const StaticBlobTokenProvider(this._token);
+
+  final String _token;
+
+  @override
+  Future<String> blobAccessToken() async => _token;
+}

--- a/packages/account_state/lib/src/blob/blob_transport.dart
+++ b/packages/account_state/lib/src/blob/blob_transport.dart
@@ -1,0 +1,90 @@
+import 'package:http/http.dart' as http;
+
+/// A single Azure Blob Storage HTTP request.
+///
+/// The Blob counterpart of `CosmosRequest`: a plain value object carrying the
+/// method, url, headers (including the `authorization` bearer built by
+/// [BlobStore]) and body, so the in-memory fake transport in tests can assert
+/// on the outgoing call without a network or a storage account.
+class BlobRequest {
+  final String method;
+  final Uri url;
+  final Map<String, String> headers;
+  final String? body;
+
+  const BlobRequest({
+    required this.method,
+    required this.url,
+    this.headers = const {},
+    this.body,
+  });
+
+  @override
+  String toString() => '$method ${url.toString()}';
+}
+
+/// An Azure Blob Storage HTTP response.
+class BlobResponse {
+  final int statusCode;
+  final Map<String, String> headers;
+  final String body;
+
+  const BlobResponse({
+    required this.statusCode,
+    this.headers = const {},
+    this.body = '',
+  });
+
+  bool get isSuccess => statusCode >= 200 && statusCode < 300;
+
+  bool get isNotFound => statusCode == 404;
+}
+
+/// Thrown when Blob Storage returns an unexpected non-2xx response (i.e.
+/// anything other than a benign 404 on read/delete). Mirrors [CosmosException]:
+/// [toString] surfaces the status and the (usually XML) error body for the log.
+class BlobException implements Exception {
+  final int statusCode;
+  final String body;
+
+  const BlobException(this.statusCode, this.body);
+
+  @override
+  String toString() => 'BlobException($statusCode): $body';
+}
+
+/// Issues a single Blob data-plane HTTP request and returns the raw response.
+///
+/// Abstracted the same way [CosmosTransport] is, so [HttpBlobStore]'s
+/// URL/header building and status handling are unit-testable against an
+/// in-memory fake that replays recorded responses and records the outgoing
+/// requests — no network, no storage account.
+abstract interface class BlobTransport {
+  Future<BlobResponse> send(BlobRequest request);
+}
+
+/// Default transport backed by `package:http`.
+class HttpBlobTransport implements BlobTransport {
+  final http.Client _client;
+
+  HttpBlobTransport({http.Client? client}) : _client = client ?? http.Client();
+
+  @override
+  Future<BlobResponse> send(BlobRequest request) async {
+    final resp = await _client.send(
+      http.Request(request.method, request.url)
+        ..headers.addAll(request.headers)
+        ..body = request.body ?? '',
+    );
+    final body = await resp.stream.bytesToString();
+    return BlobResponse(
+      statusCode: resp.statusCode,
+      headers: resp.headers,
+      body: body,
+    );
+  }
+
+  /// Releases the underlying HTTP client. Cheap no-op if a custom client was
+  /// provided.
+  void close() => _client.close();
+}

--- a/packages/account_state/lib/src/cosmos/cosmos_config.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_config.dart
@@ -88,3 +88,12 @@ const String passwordQueueDocumentId = 'queue';
 
 /// The constant partition-key value the password-queue document carries.
 const String passwordQueuePartitionKeyValue = 'queue';
+
+/// The cold-snapshot metadata container (#107): one document per system
+/// (`wisa` / `smartschool` / `azure`) holding `fetchedAt`, `syncedBy`, the Azure
+/// `deltaToken`, and either the raw payload inline or a `blobRef` when the
+/// payload exceeds Cosmos's 2 MB document limit. Partitioned by `/id`, so each
+/// system's document is its own logical partition and a point read/upsert is
+/// atomic. Only the sync/drift process reads these — the dashboard never does.
+/// Provisioned out of band (data-plane RBAC cannot create containers).
+const String snapshotsContainer = 'snapshots';

--- a/packages/account_state/lib/src/cosmos/cosmos_snapshot_store.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_snapshot_store.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+
+import 'package:account_core/account_core.dart' as core;
+
+import '../blob/blob_store.dart';
+import 'cosmos_client.dart';
+import 'cosmos_config.dart';
+
+/// A cold snapshot as it comes back from the store: the raw connector payload
+/// plus the metadata the sync/drift process reads to decide freshness.
+///
+/// [payload] is the JSON the owning connector's `Snapshot.fromJson` reconstructs
+/// from (`WisaSnapshot.fromJson`, `SmartschoolSnapshot.fromJson`,
+/// `AzureSnapshot.fromJson`). [deltaToken] is surfaced in the metadata (not only
+/// buried in the Azure payload) so the sync process can read the token to
+/// resume `/users/delta` **without** fetching a possibly-Blob-sized payload.
+class StoredSnapshot {
+  const StoredSnapshot({
+    required this.payload,
+    required this.fetchedAt,
+    required this.syncedBy,
+    this.deltaToken,
+  });
+
+  final Map<String, dynamic> payload;
+  final DateTime fetchedAt;
+
+  /// The operator (UPN) whose session produced this snapshot.
+  final String syncedBy;
+
+  /// The Azure `$deltatoken` for the next incremental sync; `null` for WISA and
+  /// Smartschool (which read fully each time).
+  final String? deltaToken;
+}
+
+/// Persists the WISA, Smartschool and Azure snapshots as **cold storage** so a
+/// fresh session seeds from the store instead of re-pulling, and a passive
+/// session pulls nothing at all (#107, part of #112).
+///
+/// Only the sync/drift process reads or writes through this seam — the
+/// dashboard never touches it. Keeping it an interface (with the Cosmos+Blob
+/// [CosmosSnapshotStore] as the production implementation and an in-memory fake
+/// in tests) mirrors the other persistence seams in this package.
+abstract interface class SnapshotStore {
+  /// Loads the stored snapshot for [system], or `null` when none has been
+  /// persisted yet (first ever run) — so first-run has no special case.
+  Future<StoredSnapshot?> load(core.Origin system);
+
+  /// Replaces the stored snapshot for [system] with [payload] and its metadata.
+  /// [deltaToken] is the Azure delta token (omit for WISA/Smartschool).
+  Future<void> save(
+    core.Origin system, {
+    required Map<String, dynamic> payload,
+    required DateTime fetchedAt,
+    required String syncedBy,
+    String? deltaToken,
+  });
+}
+
+/// The [SnapshotStore] backed by the Cosmos `snapshots` container plus a
+/// [BlobStore] overflow.
+///
+/// Each system's snapshot is one metadata document (`{ id, pk, system,
+/// fetchedAt, syncedBy, deltaToken }`) that carries the raw payload one of two
+/// ways: **inline** in a `payload` field when it fits, or a **`blobRef`** to the
+/// [BlobStore] when the encoded payload would push the document past Cosmos's
+/// 2 MB limit (a whole-school WISA or Azure snapshot easily can). The read path
+/// is symmetric: a `blobRef` document fetches the payload from Blob, an inline
+/// one reads it straight from the document.
+class CosmosSnapshotStore implements SnapshotStore {
+  CosmosSnapshotStore(
+    this._client,
+    this._blobs, {
+    int inlineLimitBytes = _defaultInlineLimitBytes,
+  }) : _inlineLimitBytes = inlineLimitBytes;
+
+  final CosmosClient _client;
+  final BlobStore _blobs;
+  final int _inlineLimitBytes;
+
+  /// The inline-payload byte ceiling. Cosmos caps a whole document at 2 MB;
+  /// this leaves headroom for the metadata fields and Cosmos's own envelope, so
+  /// a payload under it is safe to inline.
+  static const int _defaultInlineLimitBytes = 1900 * 1024;
+
+  @override
+  Future<StoredSnapshot?> load(core.Origin system) async {
+    final id = _docId(system);
+    final doc = await _client.readDocument(
+      container: snapshotsContainer,
+      id: id,
+      partitionKey: id,
+    );
+    if (doc == null) return null;
+
+    final Map<String, dynamic> payload;
+    final blobRef = doc['blobRef'];
+    if (blobRef is String) {
+      final raw = await _blobs.read(blobRef);
+      // The metadata points at a payload that is gone; treat the whole snapshot
+      // as absent so the caller falls back to pulling rather than half-reading.
+      if (raw == null) return null;
+      payload = jsonDecode(raw) as Map<String, dynamic>;
+    } else {
+      final inline = doc['payload'];
+      payload = inline is Map<String, dynamic> ? inline : <String, dynamic>{};
+    }
+
+    return StoredSnapshot(
+      payload: payload,
+      fetchedAt: DateTime.parse(doc['fetchedAt'] as String),
+      syncedBy: (doc['syncedBy'] as String?) ?? '',
+      deltaToken: doc['deltaToken'] as String?,
+    );
+  }
+
+  @override
+  Future<void> save(
+    core.Origin system, {
+    required Map<String, dynamic> payload,
+    required DateTime fetchedAt,
+    required String syncedBy,
+    String? deltaToken,
+  }) async {
+    final id = _docId(system);
+    final doc = <String, dynamic>{
+      'id': id,
+      'pk': id,
+      'system': system.toJson(),
+      'fetchedAt': fetchedAt.toIso8601String(),
+      'syncedBy': syncedBy,
+      if (deltaToken != null) 'deltaToken': deltaToken,
+    };
+
+    final encoded = jsonEncode(payload);
+    if (utf8.encode(encoded).length > _inlineLimitBytes) {
+      doc['blobRef'] = await _blobs.write(_blobName(system), encoded);
+    } else {
+      doc['payload'] = payload;
+    }
+
+    await _client.upsertDocument(
+      container: snapshotsContainer,
+      partitionKey: id,
+      document: doc,
+    );
+  }
+
+  /// The metadata document id (and partition-key value) for [system].
+  static String _docId(core.Origin system) => _systemName(system);
+
+  /// The deterministic overflow-blob name for [system]. Deterministic so a
+  /// re-sync overwrites the same blob rather than leaking a new one each time.
+  static String _blobName(core.Origin system) =>
+      'snapshot-${_systemName(system)}.json';
+
+  static String _systemName(core.Origin system) {
+    switch (system) {
+      case core.Origin.wisa:
+      case core.Origin.smartschool:
+      case core.Origin.azure:
+        return system.toJson();
+      case core.Origin.all:
+      case core.Origin.other:
+        throw ArgumentError.value(
+          system,
+          'system',
+          'snapshots are stored per concrete system (wisa/smartschool/azure)',
+        );
+    }
+  }
+}

--- a/packages/account_state/lib/src/sync/snapshot_persistence.dart
+++ b/packages/account_state/lib/src/sync/snapshot_persistence.dart
@@ -1,0 +1,65 @@
+import 'package:account_core/account_core.dart' as core;
+
+import '../cosmos/cosmos_snapshot_store.dart';
+import 'system_state.dart';
+
+/// Wraps [inner] so each successful pull is persisted to [store] as the cold
+/// snapshot the next session seeds from (#107).
+///
+/// Persistence is **best-effort**: a store write that fails is reported to
+/// [onError] and swallowed, never failing an otherwise-good pull. The operator
+/// still gets fresh data this session; the only cost of a failed write is that
+/// the next session re-pulls instead of seeding. This keeps a transient Cosmos
+/// or Blob hiccup from turning a good sync into a sync error.
+///
+/// [payloadOf] serializes the fresh snapshot (`Snapshot.toJson`); [deltaTokenOf]
+/// extracts the Azure delta token (omit for WISA/Smartschool). [syncedBy] is the
+/// operator (UPN) recorded on the stored metadata.
+Syncer<S> persistingSyncer<S extends core.Snapshot>({
+  required core.Origin system,
+  required Syncer<S> inner,
+  required SnapshotStore store,
+  required String syncedBy,
+  required Map<String, dynamic> Function(S snapshot) payloadOf,
+  String? Function(S snapshot)? deltaTokenOf,
+  void Function(Object error)? onError,
+}) {
+  return (previous) async {
+    final fresh = await inner(previous);
+    try {
+      await store.save(
+        system,
+        payload: payloadOf(fresh),
+        fetchedAt: fresh.fetchedAt,
+        syncedBy: syncedBy,
+        deltaToken: deltaTokenOf?.call(fresh),
+      );
+    } on Object catch (e) {
+      onError?.call(e);
+    }
+    return fresh;
+  };
+}
+
+/// Loads the stored snapshot for [system] and reconstructs it via [fromPayload],
+/// to seed a [SystemState.initial] so a fresh session trusts the stored state
+/// instead of pulling (#107).
+///
+/// Returns `null` when nothing is stored yet (first ever run) **or** the stored
+/// payload can't be reconstructed (schema drift after an upgrade) — reported to
+/// [onError] — so a bad stored copy degrades to a re-pull rather than a crash.
+Future<S?> seedSnapshot<S extends core.Snapshot>({
+  required core.Origin system,
+  required SnapshotStore store,
+  required S Function(Map<String, dynamic> payload) fromPayload,
+  void Function(Object error)? onError,
+}) async {
+  final stored = await store.load(system);
+  if (stored == null) return null;
+  try {
+    return fromPayload(stored.payload);
+  } on Object catch (e) {
+    onError?.call(e);
+    return null;
+  }
+}

--- a/packages/account_state/test/blob/fake_blob_store.dart
+++ b/packages/account_state/test/blob/fake_blob_store.dart
@@ -1,0 +1,37 @@
+import 'package:account_state/account_state.dart';
+
+/// An in-memory [BlobStore] that models write / read / idempotent-delete by
+/// name, so the `CosmosSnapshotStore` overflow path is testable with no storage
+/// account. Records the write count and the last content written per name so a
+/// test can assert the overflow actually hit Blob rather than staying inline.
+class FakeBlobStore implements BlobStore {
+  final Map<String, String> _blobs = <String, String>{};
+
+  int writes = 0;
+  int reads = 0;
+  int deletes = 0;
+
+  /// Direct peek for assertions.
+  String? contentOf(String ref) => _blobs[ref];
+
+  int get count => _blobs.length;
+
+  @override
+  Future<String> write(String name, String content) async {
+    writes++;
+    _blobs[name] = content;
+    return name;
+  }
+
+  @override
+  Future<String?> read(String ref) async {
+    reads++;
+    return _blobs[ref];
+  }
+
+  @override
+  Future<void> delete(String ref) async {
+    deletes++;
+    _blobs.remove(ref);
+  }
+}

--- a/packages/account_state/test/cosmos/cosmos_snapshot_store_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_snapshot_store_test.dart
@@ -1,0 +1,158 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+
+import '../blob/fake_blob_store.dart';
+import 'fake_cosmos_client.dart';
+
+void main() {
+  group('CosmosSnapshotStore', () {
+    late FakeCosmosClient cosmos;
+    late FakeBlobStore blobs;
+    late CosmosSnapshotStore store;
+
+    setUp(() {
+      cosmos = FakeCosmosClient();
+      blobs = FakeBlobStore();
+      store = CosmosSnapshotStore(cosmos, blobs);
+    });
+
+    test('load returns null before anything is saved (first run)', () async {
+      expect(await store.load(core.Origin.wisa), isNull);
+    });
+
+    test('inline save/load round-trips payload and metadata', () async {
+      await store.save(
+        core.Origin.smartschool,
+        payload: {'accounts': 2, 'note': 'inline'},
+        fetchedAt: DateTime.utc(2026, 7, 4, 10),
+        syncedBy: 'op@school.example',
+      );
+
+      final loaded = await store.load(core.Origin.smartschool);
+      expect(loaded, isNotNull);
+      expect(loaded!.payload, {'accounts': 2, 'note': 'inline'});
+      expect(loaded.fetchedAt, DateTime.utc(2026, 7, 4, 10));
+      expect(loaded.syncedBy, 'op@school.example');
+      expect(loaded.deltaToken, isNull);
+      // Small payload stays inline — Blob is untouched.
+      expect(blobs.writes, 0);
+    });
+
+    test('Azure delta token round-trips through the metadata', () async {
+      await store.save(
+        core.Origin.azure,
+        payload: {'users': 1, 'deltaToken': 'TOK-1'},
+        fetchedAt: DateTime.utc(2026, 7, 4, 11),
+        syncedBy: 'op@school.example',
+        deltaToken: 'TOK-1',
+      );
+
+      final loaded = await store.load(core.Origin.azure);
+      expect(loaded!.deltaToken, 'TOK-1');
+
+      // The metadata document carries the token so the sync process can resume
+      // /users/delta without fetching the payload.
+      final doc = await cosmos.readDocument(
+        container: snapshotsContainer,
+        id: 'azure',
+        partitionKey: 'azure',
+      );
+      expect(doc!['deltaToken'], 'TOK-1');
+    });
+
+    test('a payload over the inline limit overflows to Blob', () async {
+      // A 1-byte inline ceiling forces every payload to Blob.
+      final tiny = CosmosSnapshotStore(cosmos, blobs, inlineLimitBytes: 1);
+      await tiny.save(
+        core.Origin.wisa,
+        payload: {'students': List.generate(50, (i) => 'student-$i')},
+        fetchedAt: DateTime.utc(2026, 7, 4, 12),
+        syncedBy: 'op@school.example',
+      );
+
+      expect(blobs.writes, 1);
+      final doc = await cosmos.readDocument(
+        container: snapshotsContainer,
+        id: 'wisa',
+        partitionKey: 'wisa',
+      );
+      // The document holds a blobRef, not the payload.
+      expect(doc!.containsKey('blobRef'), isTrue);
+      expect(doc.containsKey('payload'), isFalse);
+
+      // Load transparently fetches the payload back from Blob.
+      final loaded = await tiny.load(core.Origin.wisa);
+      expect(loaded!.payload['students'], hasLength(50));
+      expect(blobs.reads, 1);
+    });
+
+    test('overflow blob name is deterministic (re-sync overwrites)', () async {
+      final tiny = CosmosSnapshotStore(cosmos, blobs, inlineLimitBytes: 1);
+      await tiny.save(
+        core.Origin.wisa,
+        payload: {'v': 1},
+        fetchedAt: DateTime.utc(2026, 7, 4, 12),
+        syncedBy: 'op',
+      );
+      await tiny.save(
+        core.Origin.wisa,
+        payload: {'v': 2},
+        fetchedAt: DateTime.utc(2026, 7, 4, 13),
+        syncedBy: 'op',
+      );
+      // Two writes, but a single blob (same name overwritten) — no leak.
+      expect(blobs.writes, 2);
+      expect(blobs.count, 1);
+      expect((await tiny.load(core.Origin.wisa))!.payload, {'v': 2});
+    });
+
+    test('load returns null when a blobRef points at a vanished blob',
+        () async {
+      final tiny = CosmosSnapshotStore(cosmos, blobs, inlineLimitBytes: 1);
+      await tiny.save(
+        core.Origin.azure,
+        payload: {'users': 1},
+        fetchedAt: DateTime.utc(2026, 7, 4, 12),
+        syncedBy: 'op',
+      );
+      // Simulate the blob being gone while the metadata survives.
+      await blobs.delete('snapshot-azure.json');
+
+      expect(await tiny.load(core.Origin.azure), isNull);
+    });
+
+    test('re-save replaces the stored snapshot (drift)', () async {
+      await store.save(
+        core.Origin.smartschool,
+        payload: {'v': 1},
+        fetchedAt: DateTime.utc(2026, 7, 4, 9),
+        syncedBy: 'op',
+      );
+      await store.save(
+        core.Origin.smartschool,
+        payload: {'v': 2},
+        fetchedAt: DateTime.utc(2026, 7, 4, 15),
+        syncedBy: 'op2',
+      );
+
+      final loaded = await store.load(core.Origin.smartschool);
+      expect(loaded!.payload, {'v': 2});
+      expect(loaded.fetchedAt, DateTime.utc(2026, 7, 4, 15));
+      expect(loaded.syncedBy, 'op2');
+    });
+
+    test('the wildcard origins are not storable', () async {
+      expect(
+        () => store.save(
+          core.Origin.all,
+          payload: const {},
+          fetchedAt: DateTime.utc(2026),
+          syncedBy: 'op',
+        ),
+        throwsArgumentError,
+      );
+      expect(() => store.load(core.Origin.other), throwsArgumentError);
+    });
+  });
+}

--- a/packages/account_state/test/sync/snapshot_persistence_test.dart
+++ b/packages/account_state/test/sync/snapshot_persistence_test.dart
@@ -1,0 +1,158 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart';
+import 'package:azure_api/azure_api.dart';
+import 'package:test/test.dart';
+
+/// An in-memory [SnapshotStore] that records saves, for testing the
+/// seed/persist wiring without Cosmos or Blob.
+class _MemorySnapshotStore implements SnapshotStore {
+  final Map<core.Origin, StoredSnapshot> _byOrigin = {};
+  int saves = 0;
+  Object? failWith;
+
+  @override
+  Future<StoredSnapshot?> load(core.Origin system) async => _byOrigin[system];
+
+  @override
+  Future<void> save(
+    core.Origin system, {
+    required Map<String, dynamic> payload,
+    required DateTime fetchedAt,
+    required String syncedBy,
+    String? deltaToken,
+  }) async {
+    if (failWith != null) throw failWith!;
+    saves++;
+    _byOrigin[system] = StoredSnapshot(
+      payload: payload,
+      fetchedAt: fetchedAt,
+      syncedBy: syncedBy,
+      deltaToken: deltaToken,
+    );
+  }
+}
+
+AzureSnapshot _azSnap({String? deltaToken}) => AzureSnapshot(
+      fetchedAt: DateTime.utc(2026, 7, 4, 10),
+      deltaToken: deltaToken,
+      users: const [AzureUser(id: 'i1', upn: 'a@b', employeeId: 'W1')],
+      groups: const [],
+    );
+
+void main() {
+  group('persistingSyncer', () {
+    test('persists the fresh snapshot after a successful pull', () async {
+      final store = _MemorySnapshotStore();
+      final syncer = persistingSyncer<AzureSnapshot>(
+        system: core.Origin.azure,
+        store: store,
+        syncedBy: 'op@school.example',
+        payloadOf: (s) => s.toJson(),
+        deltaTokenOf: (s) => s.deltaToken,
+        inner: (_) async => _azSnap(deltaToken: 'TOK-9'),
+      );
+
+      final fresh = await syncer(null);
+
+      expect(fresh.deltaToken, 'TOK-9');
+      expect(store.saves, 1);
+      final stored = await store.load(core.Origin.azure);
+      expect(stored!.syncedBy, 'op@school.example');
+      expect(stored.deltaToken, 'TOK-9');
+      // The payload reconstructs the snapshot (token included).
+      expect(AzureSnapshot.fromJson(stored.payload).deltaToken, 'TOK-9');
+    });
+
+    test('a store write failure is best-effort: pull still succeeds', () async {
+      final store = _MemorySnapshotStore()
+        ..failWith = StateError('cosmos down');
+      Object? reported;
+      final syncer = persistingSyncer<AzureSnapshot>(
+        system: core.Origin.azure,
+        store: store,
+        syncedBy: 'op',
+        payloadOf: (s) => s.toJson(),
+        onError: (e) => reported = e,
+        inner: (_) async => _azSnap(),
+      );
+
+      final fresh = await syncer(null);
+
+      // The operator still gets the fresh snapshot this session…
+      expect(fresh, isA<AzureSnapshot>());
+      // …the failure is surfaced, not swallowed silently…
+      expect(reported, isA<StateError>());
+      // …and nothing was persisted.
+      expect(store.saves, 0);
+    });
+
+    test('a failing inner pull is not persisted and propagates', () async {
+      final store = _MemorySnapshotStore();
+      final syncer = persistingSyncer<AzureSnapshot>(
+        system: core.Origin.azure,
+        store: store,
+        syncedBy: 'op',
+        payloadOf: (s) => s.toJson(),
+        inner: (_) async => throw Exception('network'),
+      );
+
+      await expectLater(syncer(null), throwsException);
+      expect(store.saves, 0);
+    });
+  });
+
+  group('seedSnapshot', () {
+    test('reconstructs the stored snapshot for a fresh session', () async {
+      final store = _MemorySnapshotStore();
+      await store.save(
+        core.Origin.azure,
+        payload: _azSnap(deltaToken: 'TOK-SEED').toJson(),
+        fetchedAt: DateTime.utc(2026, 7, 4, 10),
+        syncedBy: 'op',
+        deltaToken: 'TOK-SEED',
+      );
+
+      final seed = await seedSnapshot<AzureSnapshot>(
+        system: core.Origin.azure,
+        store: store,
+        fromPayload: AzureSnapshot.fromJson,
+      );
+
+      expect(seed, isNotNull);
+      // The delta token is restored, so the next sync resumes /users/delta.
+      expect(seed!.deltaToken, 'TOK-SEED');
+      expect(seed.users, hasLength(1));
+    });
+
+    test('returns null when nothing is stored (first ever run)', () async {
+      final seed = await seedSnapshot<AzureSnapshot>(
+        system: core.Origin.azure,
+        store: _MemorySnapshotStore(),
+        fromPayload: AzureSnapshot.fromJson,
+      );
+      expect(seed, isNull);
+    });
+
+    test('a corrupt stored payload degrades to null (re-pull), not a crash',
+        () async {
+      final store = _MemorySnapshotStore();
+      await store.save(
+        core.Origin.azure,
+        payload: const {'unexpected': 'shape'},
+        fetchedAt: DateTime.utc(2026, 7, 4),
+        syncedBy: 'op',
+      );
+      Object? reported;
+
+      final seed = await seedSnapshot<AzureSnapshot>(
+        system: core.Origin.azure,
+        store: store,
+        fromPayload: AzureSnapshot.fromJson,
+        onError: (e) => reported = e,
+      );
+
+      expect(seed, isNull);
+      expect(reported, isNotNull);
+    });
+  });
+}

--- a/packages/smartschool_api/lib/src/models/co_account_slot.dart
+++ b/packages/smartschool_api/lib/src/models/co_account_slot.dart
@@ -32,6 +32,28 @@ class CoAccountSlot {
     required this.type,
   });
 
+  /// Serializes to the connector's own snapshot shape. Round-trips with
+  /// [CoAccountSlot.fromJson] for the persisted cold snapshot (#107).
+  Map<String, dynamic> toJson() => {
+        'slot': slot,
+        'firstName': firstName,
+        'lastName': lastName,
+        'email': email,
+        'phone': phone,
+        'mobile': mobile,
+        'type': type,
+      };
+
+  factory CoAccountSlot.fromJson(Map<String, dynamic> json) => CoAccountSlot(
+        slot: json['slot'] as int,
+        firstName: json['firstName'] as String,
+        lastName: json['lastName'] as String,
+        email: json['email'] as String,
+        phone: json['phone'] as String,
+        mobile: json['mobile'] as String,
+        type: json['type'] as String,
+      );
+
   /// The [core.AccountType] this slot corresponds to
   /// (`coAccount1`..`coAccount6`).
   core.AccountType get accountType =>

--- a/packages/smartschool_api/lib/src/models/smartschool_account.dart
+++ b/packages/smartschool_api/lib/src/models/smartschool_account.dart
@@ -151,6 +151,66 @@ class SmartschoolAccount implements core.SmartschoolAccount {
         coAccounts: coAccounts ?? this.coAccounts,
       );
 
+  /// Serializes to the connector's own snapshot shape. Round-trips with
+  /// [SmartschoolAccount.fromJson] for the persisted cold snapshot (#107).
+  Map<String, dynamic> toJson() => {
+        'uid': uid,
+        'accountId': accountId,
+        'mail': mail,
+        'registerId': registerId,
+        'stemId': stemId,
+        if (role != null) 'role': role!.toJson(),
+        'givenName': givenName,
+        'surname': surname,
+        'extraNames': extraNames,
+        'initials': initials,
+        'preferredName': preferredName,
+        'gender': gender.toJson(),
+        if (birthDate != null) 'birthDate': birthDate!.toIso8601String(),
+        'birthPlace': birthPlace,
+        'birthCountry': birthCountry,
+        'address': address.toJson(),
+        'mobilePhone': mobilePhone,
+        'homePhone': homePhone,
+        'fax': fax,
+        'untisId': untisId,
+        'status': status,
+        'coAccounts': [for (final c in coAccounts) c.toJson()],
+      };
+
+  factory SmartschoolAccount.fromJson(Map<String, dynamic> json) =>
+      SmartschoolAccount(
+        uid: json['uid'] as String,
+        accountId: json['accountId'] as String,
+        mail: json['mail'] as String,
+        registerId: json['registerId'] as String,
+        stemId: json['stemId'] as int,
+        role: json['role'] == null
+            ? null
+            : core.PersonRole.fromJson(json['role'] as String),
+        givenName: json['givenName'] as String,
+        surname: json['surname'] as String,
+        extraNames: json['extraNames'] as String,
+        initials: json['initials'] as String,
+        preferredName: json['preferredName'] as String,
+        gender: core.Gender.fromJson(json['gender'] as String),
+        birthDate: json['birthDate'] == null
+            ? null
+            : DateTime.parse(json['birthDate'] as String),
+        birthPlace: json['birthPlace'] as String,
+        birthCountry: json['birthCountry'] as String,
+        address: core.Address.fromJson(json['address'] as Map<String, dynamic>),
+        mobilePhone: json['mobilePhone'] as String,
+        homePhone: json['homePhone'] as String,
+        fax: json['fax'] as String,
+        untisId: json['untisId'] as String,
+        status: json['status'] as String,
+        coAccounts: [
+          for (final e in (json['coAccounts'] as List<dynamic>? ?? const []))
+            CoAccountSlot.fromJson(e as Map<String, dynamic>),
+        ],
+      );
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/packages/smartschool_api/lib/src/models/smartschool_membership.dart
+++ b/packages/smartschool_api/lib/src/models/smartschool_membership.dart
@@ -32,6 +32,21 @@ class SmartschoolMembership {
     this.accountType = core.AccountType.student,
   });
 
+  /// Serializes to the connector's own snapshot shape. Round-trips with
+  /// [SmartschoolMembership.fromJson] for the persisted cold snapshot (#107).
+  Map<String, dynamic> toJson() => {
+        'uid': uid,
+        'groupId': groupId.toJson(),
+        'accountType': accountType.toJson(),
+      };
+
+  factory SmartschoolMembership.fromJson(Map<String, dynamic> json) =>
+      SmartschoolMembership(
+        uid: json['uid'] as String,
+        groupId: core.GroupId(json['groupId'] as String),
+        accountType: core.AccountType.fromJson(json['accountType'] as String),
+      );
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/packages/smartschool_api/lib/src/snapshot.dart
+++ b/packages/smartschool_api/lib/src/snapshot.dart
@@ -35,4 +35,32 @@ class SmartschoolSnapshot implements core.Snapshot {
   })  : groups = UnmodifiableListView(List.of(groups)),
         accounts = UnmodifiableListView(List.of(accounts)),
         memberships = UnmodifiableListView(List.of(memberships));
+
+  /// Serializes the whole snapshot to a JSON-encodable map. Round-trips with
+  /// [SmartschoolSnapshot.fromJson] — the payload form the cold `snapshots`
+  /// store persists so a passive session trusts the stored Smartschool state
+  /// instead of re-pulling it (#107).
+  Map<String, dynamic> toJson() => {
+        'fetchedAt': fetchedAt.toIso8601String(),
+        'groups': [for (final g in groups) g.toJson()],
+        'accounts': [for (final a in accounts) a.toJson()],
+        'memberships': [for (final m in memberships) m.toJson()],
+      };
+
+  factory SmartschoolSnapshot.fromJson(Map<String, dynamic> json) =>
+      SmartschoolSnapshot(
+        fetchedAt: DateTime.parse(json['fetchedAt'] as String),
+        groups: [
+          for (final e in (json['groups'] as List<dynamic>? ?? const []))
+            core.Group.fromJson(e as Map<String, dynamic>),
+        ],
+        accounts: [
+          for (final e in (json['accounts'] as List<dynamic>? ?? const []))
+            SmartschoolAccount.fromJson(e as Map<String, dynamic>),
+        ],
+        memberships: [
+          for (final e in (json['memberships'] as List<dynamic>? ?? const []))
+            SmartschoolMembership.fromJson(e as Map<String, dynamic>),
+        ],
+      );
 }

--- a/packages/smartschool_api/test/snapshot_test.dart
+++ b/packages/smartschool_api/test/snapshot_test.dart
@@ -40,4 +40,74 @@ void main() {
   test('is a core.Snapshot', () {
     expect(snapshot, isA<core.Snapshot>());
   });
+
+  test('toJson/fromJson round-trips groups, accounts, memberships (#107)', () {
+    final full = SmartschoolSnapshot(
+      fetchedAt: DateTime.utc(2026, 6, 5, 8, 15),
+      groups: [
+        const core.Group(
+          id: core.GroupId('C1A'),
+          name: '1A',
+          description: 'First',
+          type: core.GroupType.classGroup,
+          official: true,
+          untis: '1A',
+          origin: core.Origin.smartschool,
+        ),
+      ],
+      accounts: const [
+        SmartschoolAccount(
+          uid: 'jand',
+          accountId: '150001',
+          mail: 'jan.doe@student.school.example',
+          registerId: '01010112345',
+          stemId: 20000001,
+          role: core.PersonRole.student,
+          givenName: 'Jan',
+          surname: 'Doe',
+          extraNames: '',
+          initials: 'JD',
+          preferredName: 'Jantje',
+          gender: core.Gender.male,
+          birthDate: null,
+          birthPlace: 'Gent',
+          birthCountry: 'BE',
+          address: core.Address(
+            street: 'Kerkstraat',
+            houseNumber: '1',
+            postalCode: '9000',
+            city: 'Gent',
+            country: 'BE',
+          ),
+          mobilePhone: '',
+          homePhone: '',
+          fax: '',
+          untisId: '',
+          status: 'actief',
+          coAccounts: [
+            CoAccountSlot(
+              slot: 1,
+              firstName: 'Mama',
+              lastName: 'Doe',
+              email: 'mama@doe.example',
+              phone: '',
+              mobile: '0470',
+              type: 'Moeder',
+            ),
+          ],
+        ),
+      ],
+      memberships: const [
+        SmartschoolMembership(uid: 'jand', groupId: core.GroupId('C1A')),
+      ],
+    );
+
+    final restored = SmartschoolSnapshot.fromJson(full.toJson());
+    expect(restored.fetchedAt, full.fetchedAt);
+    expect(restored.groups, full.groups);
+    expect(restored.accounts, full.accounts);
+    expect(restored.memberships, full.memberships);
+    // Co-account slots survive the round-trip (they were the point of #21).
+    expect(restored.accounts.single.coAccounts, hasLength(1));
+  });
 }

--- a/packages/wisa_api/lib/src/models/wisa_class_group.dart
+++ b/packages/wisa_api/lib/src/models/wisa_class_group.dart
@@ -30,6 +30,26 @@ class WisaClassGroup {
     required this.schoolId,
   });
 
+  /// Serializes to the connector's own snapshot shape. Round-trips with
+  /// [WisaClassGroup.fromJson] for the persisted cold snapshot (#107).
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'groupName': groupName,
+        'description': description,
+        'adminCode': adminCode,
+        'schoolCode': schoolCode,
+        'schoolId': schoolId,
+      };
+
+  factory WisaClassGroup.fromJson(Map<String, dynamic> json) => WisaClassGroup(
+        name: json['name'] as String,
+        groupName: json['groupName'] as String,
+        description: json['description'] as String,
+        adminCode: json['adminCode'] as String,
+        schoolCode: json['schoolCode'] as String,
+        schoolId: json['schoolId'] as int,
+      );
+
   /// `"name groupName"` when subgroups apply, otherwise just `name`.
   /// Mirrors legacy `ClassGroup.FullName`.
   String get fullName => groupName == '00' ? name : '$name $groupName';

--- a/packages/wisa_api/lib/src/models/wisa_school.dart
+++ b/packages/wisa_api/lib/src/models/wisa_school.dart
@@ -21,6 +21,22 @@ class WisaSchool {
     this.isVirtual = false,
   });
 
+  /// Serializes to the connector's own snapshot shape. Round-trips with
+  /// [WisaSchool.fromJson] for the persisted cold snapshot (#107).
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'description': description,
+        'isVirtual': isVirtual,
+      };
+
+  factory WisaSchool.fromJson(Map<String, dynamic> json) => WisaSchool(
+        id: json['id'] as int,
+        name: json['name'] as String,
+        description: json['description'] as String,
+        isVirtual: (json['isVirtual'] as bool?) ?? false,
+      );
+
   WisaSchool copyWith({bool? isVirtual}) => WisaSchool(
         id: id,
         name: name,

--- a/packages/wisa_api/lib/src/models/wisa_staff.dart
+++ b/packages/wisa_api/lib/src/models/wisa_staff.dart
@@ -24,6 +24,24 @@ class WisaStaff implements core.WisaStaff {
     required this.lastName,
   });
 
+  /// Serializes to the connector's own snapshot shape. Round-trips with
+  /// [WisaStaff.fromJson] for the persisted cold snapshot (#107).
+  Map<String, dynamic> toJson() => {
+        'code': code.toJson(),
+        if (wisaId != null) 'wisaId': wisaId!.toJson(),
+        'firstName': firstName,
+        'lastName': lastName,
+      };
+
+  factory WisaStaff.fromJson(Map<String, dynamic> json) => WisaStaff(
+        code: core.WisaStaffCode(json['code'] as String),
+        wisaId: json['wisaId'] == null
+            ? null
+            : core.WisaId(json['wisaId'] as String),
+        firstName: json['firstName'] as String,
+        lastName: json['lastName'] as String,
+      );
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/packages/wisa_api/lib/src/models/wisa_student.dart
+++ b/packages/wisa_api/lib/src/models/wisa_student.dart
@@ -43,6 +43,44 @@ class WisaStudent implements core.WisaStudent {
     required this.schoolId,
   });
 
+  /// Serializes to the connector's own snapshot shape. Round-trips with
+  /// [WisaStudent.fromJson] for the persisted cold snapshot (#107).
+  Map<String, dynamic> toJson() => {
+        'wisaId': wisaId.toJson(),
+        'classGroup': classGroup,
+        'classSubGroup': classSubGroup,
+        'name': name,
+        'firstName': firstName,
+        'preferredName': preferredName,
+        'birthDate': birthDate.toIso8601String(),
+        'stemId': stemId,
+        'gender': gender.toJson(),
+        'nationalId': nationalId,
+        'birthPlace': birthPlace,
+        'nationality': nationality,
+        'address': address.toJson(),
+        'classChange': classChange.toIso8601String(),
+        'schoolId': schoolId,
+      };
+
+  factory WisaStudent.fromJson(Map<String, dynamic> json) => WisaStudent(
+        wisaId: core.WisaId(json['wisaId'] as String),
+        classGroup: json['classGroup'] as String,
+        classSubGroup: json['classSubGroup'] as String,
+        name: json['name'] as String,
+        firstName: json['firstName'] as String,
+        preferredName: json['preferredName'] as String,
+        birthDate: DateTime.parse(json['birthDate'] as String),
+        stemId: json['stemId'] as String,
+        gender: core.Gender.fromJson(json['gender'] as String),
+        nationalId: json['nationalId'] as String,
+        birthPlace: json['birthPlace'] as String,
+        nationality: json['nationality'] as String,
+        address: core.Address.fromJson(json['address'] as Map<String, dynamic>),
+        classChange: DateTime.parse(json['classChange'] as String),
+        schoolId: json['schoolId'] as int,
+      );
+
   /// Display name: `preferredName` when non-empty, otherwise `firstName`,
   /// followed by `name`. Mirrors legacy `Student.FullName`.
   String get fullName {

--- a/packages/wisa_api/lib/src/snapshot.dart
+++ b/packages/wisa_api/lib/src/snapshot.dart
@@ -33,4 +33,36 @@ class WisaSnapshot implements core.Snapshot {
         staff = UnmodifiableListView(List.of(staff)),
         classGroups = UnmodifiableListView(List.of(classGroups)),
         schools = UnmodifiableListView(List.of(schools));
+
+  /// Serializes the whole snapshot to a JSON-encodable map. Round-trips with
+  /// [WisaSnapshot.fromJson] — the payload form the cold `snapshots` store
+  /// persists so a fresh session seeds from the store instead of re-pulling
+  /// WISA (#107).
+  Map<String, dynamic> toJson() => {
+        'fetchedAt': fetchedAt.toIso8601String(),
+        'students': [for (final s in students) s.toJson()],
+        'staff': [for (final s in staff) s.toJson()],
+        'classGroups': [for (final g in classGroups) g.toJson()],
+        'schools': [for (final s in schools) s.toJson()],
+      };
+
+  factory WisaSnapshot.fromJson(Map<String, dynamic> json) => WisaSnapshot(
+        fetchedAt: DateTime.parse(json['fetchedAt'] as String),
+        students: [
+          for (final e in (json['students'] as List<dynamic>? ?? const []))
+            WisaStudent.fromJson(e as Map<String, dynamic>),
+        ],
+        staff: [
+          for (final e in (json['staff'] as List<dynamic>? ?? const []))
+            WisaStaff.fromJson(e as Map<String, dynamic>),
+        ],
+        classGroups: [
+          for (final e in (json['classGroups'] as List<dynamic>? ?? const []))
+            WisaClassGroup.fromJson(e as Map<String, dynamic>),
+        ],
+        schools: [
+          for (final e in (json['schools'] as List<dynamic>? ?? const []))
+            WisaSchool.fromJson(e as Map<String, dynamic>),
+        ],
+      );
 }

--- a/packages/wisa_api/test/snapshot_test.dart
+++ b/packages/wisa_api/test/snapshot_test.dart
@@ -49,6 +49,44 @@ void main() {
       mutableSchools.clear();
       expect(snap.schools, hasLength(1));
     });
+
+    test('toJson/fromJson round-trips every list and field (#107)', () {
+      final full = WisaSnapshot(
+        fetchedAt: DateTime.utc(2026, 5, 20, 9, 30, 15),
+        students: [_anyStudent()],
+        staff: const [
+          WisaStaff(
+            code: core.WisaStaffCode('T01'),
+            wisaId: core.WisaId('900001'),
+            firstName: 'Ann',
+            lastName: 'Teacher',
+          ),
+          // A staff member with no numeric id — the nullable branch.
+          WisaStaff(
+              code: core.WisaStaffCode('T02'), firstName: 'Bo', lastName: 'X'),
+        ],
+        classGroups: const [
+          WisaClassGroup(
+            name: '1A',
+            groupName: '00',
+            description: 'First',
+            adminCode: 'A1',
+            schoolCode: '012345',
+            schoolId: 1,
+          ),
+        ],
+        schools: const [
+          WisaSchool(id: 1, name: 'SMA', description: 'X', isVirtual: true),
+        ],
+      );
+
+      final restored = WisaSnapshot.fromJson(full.toJson());
+      expect(restored.fetchedAt, full.fetchedAt);
+      expect(restored.students, full.students);
+      expect(restored.staff, full.staff);
+      expect(restored.classGroups, full.classGroups);
+      expect(restored.schools, full.schools);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

`Synchronise` used to re-pull all three systems on the first sync of every session because the connector snapshots lived only in memory (`SystemState._snapshot`). This persists the WISA, Smartschool and Azure snapshots — including the Azure **delta token** — as **cold storage** that only the sync/drift process reads. A fresh session now **seeds** its `SystemState`s from the store and **reuses** the stored Smartschool/Azure snapshots instead of pulling; `Synchronise` re-reads only WISA (for the #99 smart diff), and re-pulling Smartschool/Azure is the explicit **Check for drift** action.

Scope is the **snapshot-persistence layer only** — the materialized linked-overview read path stays with #115 (the integration test asserts a fresh controller reuses the stored snapshots with no Smartschool/Azure pull, not an overview render).

## Linked issue

Closes #107 · part of #112 · builds on #99 and #114

## Changes

**Snapshot serialization** (Azure already round-tripped; WISA/Smartschool did not)
- `toJson`/`fromJson` on the WISA models (student, staff, class group, school) + `WisaSnapshot`
- `toJson`/`fromJson` on the Smartschool models (account, co-account slot, membership) + `SmartschoolSnapshot`

**New `account_state` seams**
- **Blob store** — `BlobStore` interface, `BlobConfig`, `HttpBlobStore` (AAD-token, `x-ms-*` REST), transport + `BlobTokenProvider`; the overflow target for payloads over Cosmos's 2 MB limit
- **`SnapshotStore` / `CosmosSnapshotStore`** — one metadata document per system (`fetchedAt`, `syncedBy`, `deltaToken`) carrying the raw payload **inline** when it fits or a **`blobRef`** when it overflows; new `snapshots` container constant
- **`persistingSyncer` / `seedSnapshot`** — compose persistence over a `SystemState`'s syncer; persistence is **best-effort** (a store hiccup is logged, never fails an otherwise-good pull) and `seedSnapshot` degrades a corrupt stored payload to a re-pull rather than a crash

**App wiring**
- `bootstrapReconcile` seeds each `SystemState` from the store and wraps each syncer to persist after a successful pull
- New `storage` AAD resource + `BlobSessionTokenProvider`; `blobEndpoint`/`blobContainer` added to `StoreEndpoints` (dart-define overridable)

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` — clean
- [x] `flutter analyze` — clean
- [x] Unit/widget tests pass — account_state **167**, wisa_api **113**, smartschool_api **112**, azure_api **69**, account_manager **70**. New coverage: per-system snapshot round-trip; Azure delta token round-trips through the store; Blob overflow (metadata carries `blobRef`, load fetches from Blob, deterministic blob name, vanished-blob → null); best-effort persist + corrupt-payload seed; fresh session reuses stored Smartschool/Azure with no pull; drift re-pulls and replaces the stored copies; delta token survives across sessions
- [x] Integration/e2e tests pass — `flutter test integration_test -d windows`, **6** scenarios incl. new *"a resumed session trusts the stored state: Synchronise pulls no Smartschool/Azure (#107)"*, which boots the real app over a shared store seeded by a prior session and drives Synchronise from the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)