### PR TITLE
Coordinate multi-operator sync: lease, per-system freshness, stale reload (#108)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -223,6 +223,52 @@ void main() {
     expect(resumed.azSyncs, 0);
   });
 
+  testWidgets(
+      'a passive session shows the shared freshness and, while another '
+      'operator holds the sync lease, disables Synchronise (#108)',
+      (WidgetTester tester) async {
+    // Session 1 (offline harness) syncs, materializing the shared view and
+    // stamping per-system freshness into the LinkedStore both sessions share.
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+        .controller
+        .sync();
+    // A different operator is mid-sync, holding the coarse sync/drift lease.
+    await linkedStore.acquireLease(owner: 'mieke@school', now: kFixtureDate);
+
+    // Session 2 is the real app over the same stores. It never syncs.
+    final resumed = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: resumed.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+
+    // The shared per-system freshness line renders (who last synced each
+    // system, from the store — not this passive session).
+    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
+    expect(find.textContaining('by operator@school.example'), findsOneWidget);
+
+    // The lock is surfaced by name and Synchronise/Check-for-drift are disabled
+    // so two operators cannot sync at once.
+    expect(find.byKey(const ValueKey('reconcile-sync-lock')), findsOneWidget);
+    expect(find.textContaining('mieke@school'), findsOneWidget);
+    final sync = tester.widget<FilledButton>(
+      find.byKey(const ValueKey('reconcile-sync')),
+    );
+    expect(sync.onPressed, isNull);
+    expect(resumed.wisaSyncs, 0,
+        reason: 'a blocked passive session never pulls');
+  });
+
   testWidgets('silent sign-in leads straight into the shell',
       (WidgetTester tester) async {
     final broker = _FakeBroker(silent: (_) => _token('AT'));

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -123,6 +123,11 @@ class ReconcileController extends ChangeNotifier {
   Rollup? _selectedClassroom;
   List<MaterializedAccount>? _classroomAccounts;
   bool _loadingClassroom = false;
+  SyncLease? _lock;
+
+  /// The per-system last-sync metadata this pass pulled, stamped as each system
+  /// is read and folded into the shared store on persist (#108).
+  final Map<core.Origin, SystemSyncMeta> _pulled = {};
 
   ReconcilePhase get phase => _phase;
 
@@ -186,6 +191,18 @@ class ReconcileController extends ChangeNotifier {
   /// The stored freshness + generation marker of the materialized view.
   SyncState get syncState => _syncState;
 
+  /// The coarse sync/drift lease held by **another** operator, or `null` when the
+  /// lock is free (or held by this session's own in-flight pass). While non-null,
+  /// Synchronise and Check-for-drift are disabled and the holder is named (#108).
+  SyncLease? get syncLock => _lock;
+
+  /// Whether another operator is currently syncing, blocking this session's
+  /// Synchronise / Check-for-drift.
+  bool get syncLockedByOther => _lock != null;
+
+  /// The operator (UPN) holding the sync/drift lease, when [syncLockedByOther].
+  String? get syncLockOwner => _lock?.owner;
+
   /// Whether the store holds a materialized overview (rollups) to drill into —
   /// true after any session has synced, even without a pull this session.
   bool get hasOverview => _rollups.isNotEmpty;
@@ -235,11 +252,13 @@ class ReconcileController extends ChangeNotifier {
   /// missing systems and re-link.
   Future<void> sync() async {
     if (busy) return;
+    if (!await _acquireLock()) return;
     _begin(ReconcilePhase.syncing);
     try {
       final previous = app.wisa.snapshot;
       log.addMessage(core.Origin.wisa, 'Syncing WISA…');
       final fresh = await app.sync(core.Origin.wisa) as wapi.WisaSnapshot;
+      _recordPull(core.Origin.wisa, fresh);
       log.addMessage(
         core.Origin.wisa,
         'WISA sync done: ${fresh.students.length} students, '
@@ -255,24 +274,30 @@ class ReconcileController extends ChangeNotifier {
           'WISA is unchanged since the previous sync — '
           'no account changes needed.',
         );
+        await _persistSystemMeta();
         _finish(ReconcilePhase.ready);
         return;
       }
 
       // First pass of the session: the linked view needs all three systems.
       if (app.smartschool.snapshot == null) {
+        await _renewLock();
         log.addMessage(core.Origin.smartschool, 'Syncing Smartschool…');
-        await app.sync(core.Origin.smartschool);
+        _recordPull(
+            core.Origin.smartschool, await app.sync(core.Origin.smartschool));
       }
       if (app.azure.snapshot == null) {
+        await _renewLock();
         log.addMessage(core.Origin.azure, 'Syncing Azure AD…');
-        await app.sync(core.Origin.azure);
+        _recordPull(core.Origin.azure, await app.sync(core.Origin.azure));
       }
 
       await _relink();
       _finish(ReconcilePhase.ready);
     } on Object catch (e) {
       _fail(e);
+    } finally {
+      await _releaseLock();
     }
   }
 
@@ -281,25 +306,31 @@ class ReconcileController extends ChangeNotifier {
   /// [sync] is for.
   Future<void> checkDrift() async {
     if (busy) return;
+    if (!await _acquireLock()) return;
     _begin(ReconcilePhase.syncing);
     try {
       log.addMessage(
         core.Origin.smartschool,
         'Checking Smartschool for drift…',
       );
-      await app.sync(core.Origin.smartschool);
+      _recordPull(
+          core.Origin.smartschool, await app.sync(core.Origin.smartschool));
+      await _renewLock();
       log.addMessage(core.Origin.azure, 'Checking Azure AD for drift…');
-      await app.sync(core.Origin.azure);
+      _recordPull(core.Origin.azure, await app.sync(core.Origin.azure));
 
       if (app.wisa.snapshot == null) {
+        await _renewLock();
         log.addMessage(core.Origin.wisa, 'Syncing WISA…');
-        await app.sync(core.Origin.wisa);
+        _recordPull(core.Origin.wisa, await app.sync(core.Origin.wisa));
       }
 
       await _relink();
       _finish(ReconcilePhase.ready);
     } on Object catch (e) {
       _fail(e);
+    } finally {
+      await _releaseLock();
     }
   }
 
@@ -312,11 +343,37 @@ class ReconcileController extends ChangeNotifier {
     try {
       _syncState = await store.readSyncState();
       _rollups = await store.readRollups();
+      await _refreshLock();
       if (_phase == ReconcilePhase.idle) _phase = ReconcilePhase.ready;
       notifyListeners();
     } on Object catch (e) {
       log.addError(core.Origin.all, 'Could not load the overview: $e');
     }
+  }
+
+  /// Reacts to another operator's sync bumping the stored generation past this
+  /// session's cached copy (#108): refetch the shared overview and re-read any
+  /// open classroom so a passive session catches up — no pull, no `link()`. The
+  /// realtime transport (#116) drives this from a SignalR change notification;
+  /// until then it is exercised directly. A stale-or-equal [generation] is a
+  /// no-op, so a duplicate notification does no work.
+  Future<void> onStoreChanged(int generation) async {
+    if (busy || generation <= _syncState.generation) return;
+    _syncState = await store.readSyncState();
+    _rollups = await store.readRollups();
+    await _refreshLock();
+    final open = _selectedClassroom;
+    if (open != null) {
+      try {
+        _classroomAccounts = await store.readClassroom(
+          school: open.school,
+          classroom: open.classroom,
+        );
+      } on Object catch (e) {
+        log.addError(core.Origin.all, 'Could not refresh ${open.label}: $e');
+      }
+    }
+    notifyListeners();
   }
 
   /// Opens a classroom in the drill-down, lazily reading its per-account docs
@@ -505,12 +562,15 @@ class ReconcileController extends ChangeNotifier {
         syncedBy: syncedBy,
         at: at,
         droppedDecisions: merge.dropped,
+        systemSyncs: _pulled,
       );
       _rollups = merged.rollups;
       _syncState = SyncState(
         generation: view.generation,
         updatedAt: at,
         updatedBy: syncedBy,
+        // The store merges this pass's pulls over what it had; mirror that here.
+        systems: {...previous.systems, ..._pulled},
       );
       // A re-sync invalidates any open drill-down; the next open re-reads.
       _selectedClassroom = null;
@@ -533,7 +593,101 @@ class ReconcileController extends ChangeNotifier {
     _noChangesNeeded = false;
     _dryRunResults = null;
     _applyResults = null;
+    _pulled.clear();
     notifyListeners();
+  }
+
+  /// Stamps [snapshot]'s fetch time against [system] for this pass, folded into
+  /// the shared store's per-system freshness on persist (#108).
+  void _recordPull(core.Origin system, core.Snapshot snapshot) {
+    _pulled[system] =
+        SystemSyncMeta(syncedBy: syncedBy, at: snapshot.fetchedAt);
+  }
+
+  /// Stamps the smart-sync "WISA unchanged" path: nothing was re-linked, so the
+  /// view is untouched, but WISA was still pulled — record its freshness with a
+  /// light metadata write that does not bump the generation (#108).
+  Future<void> _persistSystemMeta() async {
+    if (_pulled.isEmpty) return;
+    try {
+      await store.recordSystemSync(_pulled);
+      _syncState = SyncState(
+        generation: _syncState.generation,
+        updatedAt: _syncState.updatedAt,
+        updatedBy: _syncState.updatedBy,
+        systems: {..._syncState.systems, ..._pulled},
+      );
+    } on Object catch (e) {
+      log.addError(core.Origin.all, 'Could not record sync metadata: $e');
+    }
+  }
+
+  /// Takes the coarse sync/drift lease before a heavy pass (#108). Returns true
+  /// when this session may proceed — it acquired the lease, or the lease store
+  /// is unreachable (a coordination hiccup must not turn Synchronise into a dead
+  /// button; the pass's own writes would surface a real outage). Returns false,
+  /// naming the holder, when another operator is already syncing.
+  Future<bool> _acquireLock() async {
+    try {
+      final outcome = await store.acquireLease(owner: syncedBy, now: _now());
+      if (outcome.acquired) {
+        _lock = null;
+        return true;
+      }
+      _lock = outcome.lease;
+      log.addMessage(
+        core.Origin.all,
+        '${outcome.lease.owner} is bezig met synchroniseren — probeer straks '
+        'opnieuw.',
+      );
+      notifyListeners();
+      return false;
+    } on Object catch (e) {
+      log.addError(core.Origin.all, 'Could not take the sync lock: $e');
+      return true;
+    }
+  }
+
+  /// Heart-beats the held lease between the per-system pulls, so its expiry
+  /// tracks the work done rather than a wall clock (#108). Best-effort: a failed
+  /// heartbeat is logged but never aborts an in-flight pass. Losing the lease
+  /// (expired and taken over) is surfaced but the current write still finishes.
+  Future<void> _renewLock() async {
+    try {
+      final outcome = await store.renewLease(owner: syncedBy, now: _now());
+      if (!outcome.acquired) {
+        log.addError(
+          core.Origin.all,
+          'Sync-vergrendeling verlopen; ${outcome.lease.owner} heeft ze '
+          'overgenomen.',
+        );
+      }
+    } on Object catch (e) {
+      log.addError(core.Origin.all, 'Could not renew the sync lock: $e');
+    }
+  }
+
+  /// Releases the held lease at the end of a pass, freeing the next operator.
+  /// Best-effort; an abandoned lease also expires on its own (#108).
+  Future<void> _releaseLock() async {
+    try {
+      await store.releaseLease(owner: syncedBy);
+    } on Object catch (e) {
+      log.addError(core.Origin.all, 'Could not release the sync lock: $e');
+    }
+  }
+
+  /// Reads the current lease and records whether **another** operator holds it,
+  /// so a passive session disables Synchronise/Check-for-drift and names the
+  /// holder (#108). Our own lease never blocks us.
+  Future<void> _refreshLock() async {
+    try {
+      final lease = await store.readLease(_now());
+      _lock = (lease != null && lease.owner != syncedBy) ? lease : null;
+    } on Object catch (_) {
+      // Leave the last-known lock state; a transient read failure must not
+      // spuriously enable or disable the buttons.
+    }
   }
 
   void _finish(ReconcilePhase phase) {

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -217,27 +217,40 @@ class _Header extends StatelessWidget {
 
   final ReconcileController controller;
 
+  /// The shared per-system freshness line ("Last sync — WISA 09:12 by jan@…"),
+  /// read from the materialized store so it names *whichever* operator last
+  /// synced each system — not just this session (#108). Null before any sync.
   String? _freshness() {
-    final app = controller.app;
-    String stamp(DateTime? t) => t == null
-        ? '—'
-        : '${t.toLocal().hour.toString().padLeft(2, '0')}:'
-            '${t.toLocal().minute.toString().padLeft(2, '0')}';
-    if (app.wisa.lastSync == null &&
-        app.smartschool.lastSync == null &&
-        app.azure.lastSync == null) {
-      return null;
+    final systems = controller.syncState.systems;
+    String? stamp(core.Origin system, String label) {
+      final meta = systems[system];
+      if (meta == null) return null;
+      final t = meta.at.toLocal();
+      final hhmm = '${t.hour.toString().padLeft(2, '0')}:'
+          '${t.minute.toString().padLeft(2, '0')}';
+      final by = meta.syncedBy.isEmpty ? '' : ' by ${meta.syncedBy}';
+      return '$label $hhmm$by';
     }
-    return 'Last sync — WISA ${stamp(app.wisa.lastSync)} · '
-        'Smartschool ${stamp(app.smartschool.lastSync)} · '
-        'Azure ${stamp(app.azure.lastSync)}';
+
+    final parts = <String>[
+      for (final (system, label) in const [
+        (core.Origin.wisa, 'WISA'),
+        (core.Origin.smartschool, 'Smartschool'),
+        (core.Origin.azure, 'Azure'),
+      ])
+        if (stamp(system, label) case final s?) s,
+    ];
+    if (parts.isEmpty) return null;
+    return 'Last sync — ${parts.join(' · ')}';
   }
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
     final bool ink = Theme.of(context).brightness == Brightness.dark;
     final freshness = _freshness();
+    final lockedByOther = controller.syncLockedByOther;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -253,19 +266,39 @@ class _Header extends StatelessWidget {
           children: <Widget>[
             FilledButton.icon(
               key: const ValueKey('reconcile-sync'),
-              onPressed: controller.busy ? null : controller.sync,
+              onPressed:
+                  controller.busy || lockedByOther ? null : controller.sync,
               icon: const Icon(Icons.sync),
               label: const Text('Synchronise'),
             ),
             OutlinedButton.icon(
               key: const ValueKey('reconcile-drift'),
-              onPressed: controller.busy ? null : controller.checkDrift,
+              onPressed: controller.busy || lockedByOther
+                  ? null
+                  : controller.checkDrift,
               icon: const Icon(Icons.difference_outlined),
               label: const Text('Check for drift'),
             ),
             if (freshness != null) Text(freshness, style: text.bodySmall),
           ],
         ),
+        if (lockedByOther) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s3),
+          Row(
+            key: const ValueKey('reconcile-sync-lock'),
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(Icons.lock_clock_outlined, size: 16, color: colors.primary),
+              const SizedBox(width: PlinkSpacing.s2),
+              Flexible(
+                child: Text(
+                  '${controller.syncLockOwner} is aan het synchroniseren…',
+                  style: text.bodySmall,
+                ),
+              ),
+            ],
+          ),
+        ],
         if (controller.busy) ...<Widget>[
           const SizedBox(height: PlinkSpacing.s4),
           const LinearProgressIndicator(),

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -377,6 +377,154 @@ void main() {
     });
   });
 
+  group('multi-operator coordination (#108)', () {
+    test('a sync records per-system freshness (who/when) in the shared store',
+        () async {
+      final h = ReconcileHarness();
+
+      await h.controller.sync();
+
+      final systems = (await h.linkedStore.readSyncState()).systems;
+      expect(
+          systems.keys,
+          containsAll(<core.Origin>[
+            core.Origin.wisa,
+            core.Origin.smartschool,
+            core.Origin.azure,
+          ]));
+      expect(systems[core.Origin.wisa]?.syncedBy, 'operator@school.example');
+      expect(systems[core.Origin.wisa]?.at, kFixtureDate);
+      // …and the controller mirrors it for the header.
+      expect(h.controller.syncState.systems[core.Origin.azure]?.syncedBy,
+          'operator@school.example');
+    });
+
+    test('the "WISA unchanged" path still stamps WISA freshness', () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+      // A later, identical WISA pull: no re-link, but WISA was still read.
+      final later = kFixtureDate.add(const Duration(hours: 1));
+      h.wisaResult = wisaSnap(fetchedAt: later);
+
+      await h.controller.sync();
+
+      expect(h.controller.noChangesNeeded, isTrue);
+      final systems = (await h.linkedStore.readSyncState()).systems;
+      expect(systems[core.Origin.wisa]?.at, later,
+          reason: 'WISA freshness advances even with no view change');
+      expect((await h.linkedStore.readSyncState()).generation, 1,
+          reason: 'an unchanged sync does not bump the generation');
+    });
+
+    test('a sync takes and releases the lease', () async {
+      final h = ReconcileHarness();
+
+      await h.controller.sync();
+
+      // Released at the end of the pass — free for the next operator.
+      expect(await h.linkedStore.readLease(kFixtureDate), isNull);
+      expect(h.controller.syncLockedByOther, isFalse);
+    });
+
+    test("another operator's live lease blocks this session's sync", () async {
+      final linkedStore = InMemoryLinkedStore();
+      final h = ReconcileHarness(linkedStore: linkedStore);
+      // A different operator is mid-sync.
+      await linkedStore.acquireLease(owner: 'mieke@school', now: kFixtureDate);
+
+      await h.controller.sync();
+
+      expect(h.wisaSyncs, 0, reason: 'the blocked sync never pulls');
+      expect(h.controller.syncLockedByOther, isTrue);
+      expect(h.controller.syncLockOwner, 'mieke@school');
+      expect(
+        h.log.entries.map((e) => e.message),
+        contains(contains('mieke@school')),
+      );
+    });
+
+    test('a foreign lease blocks check-for-drift too', () async {
+      final linkedStore = InMemoryLinkedStore();
+      final h = ReconcileHarness(linkedStore: linkedStore);
+      await linkedStore.acquireLease(owner: 'mieke@school', now: kFixtureDate);
+
+      await h.controller.checkDrift();
+
+      expect(h.ssSyncs, 0);
+      expect(h.controller.syncLockedByOther, isTrue);
+    });
+
+    test('loadOverview surfaces a lock held by another operator', () async {
+      final linkedStore = InMemoryLinkedStore();
+      // Session 1 materializes an overview.
+      await ReconcileHarness(linkedStore: linkedStore).controller.sync();
+      // A second operator grabs the lease.
+      await linkedStore.acquireLease(owner: 'mieke@school', now: kFixtureDate);
+
+      final passive = ReconcileHarness(linkedStore: linkedStore);
+      await passive.controller.loadOverview();
+
+      expect(passive.controller.syncLockedByOther, isTrue);
+      expect(passive.controller.syncLockOwner, 'mieke@school');
+    });
+
+    test('onStoreChanged refetches the overview and the open classroom',
+        () async {
+      final linkedStore = InMemoryLinkedStore();
+      final snapshots = InMemorySnapshotStore();
+
+      // Session 1 materializes generation 1 (the student sits in 3C).
+      final s1 = ReconcileHarness(store: snapshots, linkedStore: linkedStore);
+      await s1.controller.sync();
+
+      // Session 2 renders the shared overview and drills into 3C.
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      await s2.controller.loadOverview();
+      final classroom3c = s2.controller.schoolRollups
+          .expand((s) => s2.controller.childrenOf(s.key))
+          .expand((g) => s2.controller.childrenOf(g.key))
+          .singleWhere((c) => c.classroom == '3C');
+      await s2.controller.openClassroom(classroom3c);
+      expect(s2.controller.classroomAccounts, hasLength(1));
+
+      // Session 1 moves the student to 3D and re-syncs → generation 2.
+      s1.wisaResult = wisaSnap(
+        fetchedAt: kFixtureDate.add(const Duration(hours: 1)),
+        students: [wisaStudent(classGroup: '3D')],
+      );
+      await s1.controller.sync();
+      expect((await linkedStore.readSyncState()).generation, 2);
+
+      // The realtime layer (#116) will call this on the generation bump.
+      await s2.controller.onStoreChanged(2);
+
+      expect(s2.controller.syncState.generation, 2);
+      // The open 3C shard was refetched — the student has left it.
+      expect(s2.controller.classroomAccounts, isEmpty);
+      // …and 3D now exists in the refreshed rollups.
+      expect(
+        s2.controller.schoolRollups
+            .expand((s) => s2.controller.childrenOf(s.key))
+            .expand((g) => s2.controller.childrenOf(g.key))
+            .map((c) => c.classroom),
+        contains('3D'),
+      );
+    });
+
+    test('onStoreChanged is a no-op for a stale-or-equal generation', () async {
+      final linkedStore = InMemoryLinkedStore();
+      final h = ReconcileHarness(linkedStore: linkedStore);
+      await h.controller.sync();
+
+      // Same generation the controller already holds → nothing refetched.
+      await h.controller.onStoreChanged(1);
+      expect(h.controller.syncState.generation, 1);
+    });
+  });
+
   group('LogBuffer', () {
     test('caps its entries and reports errors', () {
       final log = LogBuffer(capacity: 3, clock: () => kFixtureDate);

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -239,6 +239,7 @@ class ReconcileHarness {
     wapi.WisaSnapshot? wisaInitial,
     ss.SmartschoolSnapshot? ssInitial,
     az.AzureSnapshot? azureInitial,
+    this.syncedBy = 'operator@school.example',
   })  : wisaResult = (wisa ?? wisaSnap()),
         ssResult = (smartschool ?? ssSnap()),
         azResult = (azure ?? azSnap()),
@@ -269,21 +270,21 @@ class ReconcileHarness {
       wisaSync = persistingSyncer<wapi.WisaSnapshot>(
         system: core.Origin.wisa,
         store: s,
-        syncedBy: 'operator@school.example',
+        syncedBy: syncedBy,
         payloadOf: (snap) => snap.toJson(),
         inner: wisaSync,
       );
       ssSync = persistingSyncer<ss.SmartschoolSnapshot>(
         system: core.Origin.smartschool,
         store: s,
-        syncedBy: 'operator@school.example',
+        syncedBy: syncedBy,
         payloadOf: (snap) => snap.toJson(),
         inner: ssSync,
       );
       azSync = persistingSyncer<az.AzureSnapshot>(
         system: core.Origin.azure,
         store: s,
-        syncedBy: 'operator@school.example',
+        syncedBy: syncedBy,
         payloadOf: (snap) => snap.toJson(),
         deltaTokenOf: (snap) => snap.deltaToken,
         inner: azSync,
@@ -344,7 +345,7 @@ class ReconcileHarness {
       applier: applier,
       log: log,
       store: this.linkedStore,
-      syncedBy: 'operator@school.example',
+      syncedBy: syncedBy,
       clock: () => kFixtureDate,
     );
   }
@@ -357,6 +358,11 @@ class ReconcileHarness {
   /// The shared cold-snapshot store, when this harness models the persistence
   /// wiring (#107). `null` for the plain in-memory scenarios.
   final SnapshotStore? store;
+
+  /// The operator (UPN) this session syncs as — the lease owner and the
+  /// per-system sync-metadata author (#108). Vary it to model a second operator
+  /// sharing the same [linkedStore].
+  final String syncedBy;
 
   /// Builds a "second session" seeded from [store] — a fresh controller over
   /// the state another harness already persisted, the way bootstrap seeds each

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -1,5 +1,6 @@
 import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
 import 'package:account_manager/src/screens/reconcile_screen.dart';
+import 'package:account_state/account_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -147,6 +148,86 @@ void main() {
 
     expect(harness.soap.soapActions, isEmpty);
     expect(find.text('Apply result'), findsNothing);
+  });
+
+  testWidgets(
+      'a lease held by another operator disables sync/drift and names them '
+      '(#108)', (WidgetTester tester) async {
+    final linkedStore = InMemoryLinkedStore();
+    // A different operator is mid-sync when this session opens.
+    await linkedStore.acquireLease(owner: 'mieke@school', now: kFixtureDate);
+    final harness = ReconcileHarness(linkedStore: linkedStore);
+
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    // The lock indicator names the holder…
+    expect(find.byKey(const ValueKey('reconcile-sync-lock')), findsOneWidget);
+    expect(find.textContaining('mieke@school'), findsOneWidget);
+
+    // …and both heavy actions are disabled.
+    final sync = tester.widget<FilledButton>(
+      find.byKey(const ValueKey('reconcile-sync')),
+    );
+    final drift = tester.widget<OutlinedButton>(
+      find.byKey(const ValueKey('reconcile-drift')),
+    );
+    expect(sync.onPressed, isNull);
+    expect(drift.onPressed, isNull);
+  });
+
+  testWidgets('the header shows the shared per-system freshness (#108)',
+      (WidgetTester tester) async {
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // Who/when synced each system, read from the shared store.
+    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
+    expect(
+      find.textContaining('by operator@school.example'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
+      "a generation bump refetches the passive session's overview "
+      '(#108)', (WidgetTester tester) async {
+    final linkedStore = InMemoryLinkedStore();
+    final snapshots = InMemorySnapshotStore();
+
+    // Session 1 materializes generation 1.
+    final s1 = ReconcileHarness(store: snapshots, linkedStore: linkedStore);
+    await s1.controller.sync();
+
+    // Session 2 renders the shared overview passively.
+    final s2 = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(_wrap(ReconcileScreen(bootstrap: s2.bootstrap)));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Generatie 1'), findsOneWidget);
+
+    // Session 1 re-syncs a change → generation 2. The realtime layer (#116)
+    // will call onStoreChanged on the bump; here we drive it directly.
+    s1.wisaResult = wisaSnap(
+      fetchedAt: kFixtureDate.add(const Duration(hours: 1)),
+      students: [wisaStudent(classGroup: '3D')],
+    );
+    await s1.controller.sync();
+    await s2.controller.onStoreChanged(2);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Generatie 2'), findsOneWidget);
+    expect(find.textContaining('Generatie 1'), findsNothing);
   });
 
   testWidgets('the log panel clears on demand', (WidgetTester tester) async {

--- a/packages/account_state/lib/src/cosmos/cosmos_config.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_config.dart
@@ -124,3 +124,11 @@ const String syncStateContainer = 'syncState';
 
 /// The id (and partition-key value) of the singleton sync-state document.
 const String syncStateDocumentId = 'syncState';
+
+/// The id (and partition-key value) of the sync/drift **lease** document (#108),
+/// a second singleton in the [syncStateContainer]. Its presence marks the lease
+/// held; it carries `owner` / `heartbeatAt` / `expiresAt` plus a Cosmos `ttl` so
+/// a crashed holder's lease is physically swept, freeing a fresh `create` to
+/// acquire it. The container must have time-to-live enabled for that sweep
+/// (provisioned out of band, like the other containers).
+const String syncLeaseDocumentId = 'syncLease';

--- a/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
@@ -1,3 +1,5 @@
+import 'package:account_core/account_core.dart' as core;
+
 import '../materialize/linked_store.dart';
 import '../materialize/materialized_state.dart';
 import 'cosmos_client.dart';
@@ -74,7 +76,14 @@ class CosmosLinkedStore implements LinkedStore {
     required String syncedBy,
     required DateTime at,
     List<AccountDecision> droppedDecisions = const [],
+    Map<core.Origin, SystemSyncMeta> systemSyncs = const {},
   }) async {
+    // Merge the systems pulled this pass over whatever the last write recorded,
+    // so a system this pass did not pull keeps its earlier stamp (#108).
+    final systems = {
+      ...(await readSyncState()).systems,
+      ...systemSyncs,
+    };
     // Per-account docs: upsert the fresh set, then delete the stragglers no
     // longer present so a departed account's doc does not linger.
     await _replaceContainer(
@@ -114,10 +123,142 @@ class CosmosLinkedStore implements LinkedStore {
           generation: view.generation,
           updatedAt: at,
           updatedBy: syncedBy,
+          systems: systems,
         ).toJson(),
       },
     );
   }
+
+  @override
+  Future<void> recordSystemSync(
+    Map<core.Origin, SystemSyncMeta> systemSyncs,
+  ) async {
+    if (systemSyncs.isEmpty) return;
+    // Merge into the existing sync-state doc, preserving the generation and the
+    // materialize freshness — this is a metadata-only touch, not a view rewrite.
+    final current = await readSyncState();
+    await _client.upsertDocument(
+      container: syncStateContainer,
+      partitionKey: syncStateDocumentId,
+      document: {
+        'id': syncStateDocumentId,
+        ...SyncState(
+          generation: current.generation,
+          updatedAt: current.updatedAt,
+          updatedBy: current.updatedBy,
+          systems: {...current.systems, ...systemSyncs},
+        ).toJson(),
+      },
+    );
+  }
+
+  @override
+  Future<SyncLease?> readLease(DateTime now) async {
+    final doc = await _client.readDocument(
+      container: syncStateContainer,
+      id: syncLeaseDocumentId,
+      partitionKey: syncLeaseDocumentId,
+    );
+    if (doc == null) return null;
+    final lease = SyncLease.fromJson(doc);
+    return lease.isExpiredAt(now) ? null : lease;
+  }
+
+  @override
+  Future<LeaseOutcome> acquireLease({
+    required String owner,
+    required DateTime now,
+  }) async {
+    // Fast path: an atomic create wins iff no lease document exists (a released
+    // lease is deleted, and a crashed holder's is TTL-swept). This is the hot,
+    // contended path and it is race-free — two acquirers cannot both create.
+    final created = await _client.createDocument(
+      container: syncStateContainer,
+      partitionKey: syncLeaseDocumentId,
+      document: _leaseDoc(owner, now),
+    );
+    if (created) {
+      return LeaseOutcome(acquired: true, lease: _lease(owner, now));
+    }
+    // A document already exists. Read it to decide.
+    final doc = await _client.readDocument(
+      container: syncStateContainer,
+      id: syncLeaseDocumentId,
+      partitionKey: syncLeaseDocumentId,
+    );
+    // Vanished between create and read (TTL sweep / release) — try once more.
+    if (doc == null) return acquireLease(owner: owner, now: now);
+    final existing = SyncLease.fromJson(doc);
+    // Live lease held by someone else — blocked.
+    if (existing.isLiveAt(now) && existing.owner != owner) {
+      return LeaseOutcome(acquired: false, lease: existing);
+    }
+    // Ours already, or a crashed holder's the TTL has not yet swept: take it.
+    // Overwriting an expired lease races only on crash-recovery (rare); the
+    // hot path above never reaches here. Hardened further by #121.
+    await _writeLease(owner, now);
+    return LeaseOutcome(acquired: true, lease: _lease(owner, now));
+  }
+
+  @override
+  Future<LeaseOutcome> renewLease({
+    required String owner,
+    required DateTime now,
+  }) async {
+    final doc = await _client.readDocument(
+      container: syncStateContainer,
+      id: syncLeaseDocumentId,
+      partitionKey: syncLeaseDocumentId,
+    );
+    if (doc != null) {
+      final existing = SyncLease.fromJson(doc);
+      if (existing.isLiveAt(now) && existing.owner != owner) {
+        // Lost it: it expired while we worked and another operator took over.
+        return LeaseOutcome(acquired: false, lease: existing);
+      }
+    }
+    await _writeLease(owner, now);
+    return LeaseOutcome(acquired: true, lease: _lease(owner, now));
+  }
+
+  @override
+  Future<void> releaseLease({required String owner}) async {
+    final doc = await _client.readDocument(
+      container: syncStateContainer,
+      id: syncLeaseDocumentId,
+      partitionKey: syncLeaseDocumentId,
+    );
+    if (doc == null) return;
+    if (SyncLease.fromJson(doc).owner != owner) return; // taken over — leave it
+    await _client.deleteDocument(
+      container: syncStateContainer,
+      id: syncLeaseDocumentId,
+      partitionKey: syncLeaseDocumentId,
+    );
+  }
+
+  SyncLease _lease(String owner, DateTime now) => SyncLease(
+        owner: owner,
+        heartbeatAt: now,
+        expiresAt: now.add(syncLeaseTtl),
+      );
+
+  Future<void> _writeLease(String owner, DateTime now) =>
+      _client.upsertDocument(
+        container: syncStateContainer,
+        partitionKey: syncLeaseDocumentId,
+        document: _leaseDoc(owner, now),
+      );
+
+  /// The lease document: the [SyncLease] fields plus the id/partition key and a
+  /// Cosmos `ttl` (seconds) so an abandoned lease is physically swept, freeing a
+  /// fresh acquire.
+  Map<String, dynamic> _leaseDoc(String owner, DateTime now) => {
+        'id': syncLeaseDocumentId,
+        'pk': syncLeaseDocumentId,
+        'ttl': syncLeaseTtl.inSeconds,
+        ..._lease(owner, now).toJson(),
+      };
 
   @override
   Future<void> putDecision(AccountDecision decision) async {

--- a/packages/account_state/lib/src/materialize/linked_store.dart
+++ b/packages/account_state/lib/src/materialize/linked_store.dart
@@ -1,3 +1,5 @@
+import 'package:account_core/account_core.dart' as core;
+
 import 'materialized_state.dart';
 
 /// The persistence seam for the materialized reconcile view (#115, keystone of
@@ -33,19 +35,59 @@ abstract interface class LinkedStore {
 
   /// Replaces the derived view with [view] — per-account docs and rollups — and
   /// bumps the stored generation to [MaterializedView.generation]. Deletes the
-  /// [droppedDecisions] a merge found no longer applicable. Only the sync/drift
-  /// process calls this.
+  /// [droppedDecisions] a merge found no longer applicable. Records the per-system
+  /// last-sync metadata in [systemSyncs] (the systems this pass pulled), merged
+  /// into the stored map so a system not pulled this pass keeps its earlier
+  /// stamp (#108). Only the sync/drift process calls this.
   Future<void> writeMaterialized(
     MaterializedView view, {
     required String syncedBy,
     required DateTime at,
     List<AccountDecision> droppedDecisions = const [],
+    Map<core.Origin, SystemSyncMeta> systemSyncs = const {},
   });
 
   /// Creates or replaces one operator decision. The write seam #109/#110 use;
   /// this issue ships no UI that calls it, but tests and the merge round-trip
   /// through it.
   Future<void> putDecision(AccountDecision decision);
+
+  /// Merges [systemSyncs] into the stored per-system last-sync metadata
+  /// **without** rewriting the view or bumping the generation (#108) — the light
+  /// write the smart-sync "WISA unchanged" path uses to still stamp who/when it
+  /// pulled, so passive sessions see fresh per-system freshness even when the
+  /// materialized view did not change.
+  Future<void> recordSystemSync(Map<core.Origin, SystemSyncMeta> systemSyncs);
+
+  /// The live sync/drift lease as of [now], or `null` when none is held (never
+  /// taken, released, or expired). Used to disable a passive session's
+  /// Synchronise/Check-for-drift while another operator is syncing (#108).
+  Future<SyncLease?> readLease(DateTime now);
+
+  /// Attempts to take the coarse sync/drift lease for [owner] as of [now].
+  ///
+  /// Succeeds ([LeaseOutcome.acquired]) when the lease is free — never taken,
+  /// released, expired, or already [owner]'s — writing a fresh lease that
+  /// expires at `now + syncLeaseTtl`. Fails when another operator holds a live
+  /// lease, returning that holder in [LeaseOutcome.lease] so the caller can name
+  /// them. Only the sync/drift process calls this.
+  Future<LeaseOutcome> acquireLease({
+    required String owner,
+    required DateTime now,
+  });
+
+  /// Heart-beats [owner]'s lease as of [now], pushing its expiry to
+  /// `now + syncLeaseTtl`. Returns [LeaseOutcome.acquired] false when the lease
+  /// was lost meanwhile (expired and taken by another operator), so a long sync
+  /// can notice it no longer holds the lease.
+  Future<LeaseOutcome> renewLease({
+    required String owner,
+    required DateTime now,
+  });
+
+  /// Releases the lease if it is [owner]'s. A no-op when someone else already
+  /// holds it (a taken-over lease must not be released out from under them).
+  Future<void> releaseLease({required String owner});
 }
 
 /// The stable document id for a decision: one per account + kind + situation.
@@ -63,6 +105,7 @@ class InMemoryLinkedStore implements LinkedStore {
   List<Rollup> _rollups = const [];
   final Map<String, AccountDecision> _decisions = {};
   SyncState _syncState = SyncState.initial;
+  SyncLease? _lease;
 
   /// How many accounts are currently stored — for test assertions.
   int get accountCount => _accounts.length;
@@ -93,6 +136,7 @@ class InMemoryLinkedStore implements LinkedStore {
     required String syncedBy,
     required DateTime at,
     List<AccountDecision> droppedDecisions = const [],
+    Map<core.Origin, SystemSyncMeta> systemSyncs = const {},
   }) async {
     _accounts
       ..clear()
@@ -105,6 +149,8 @@ class InMemoryLinkedStore implements LinkedStore {
       generation: view.generation,
       updatedAt: at,
       updatedBy: syncedBy,
+      // Merge: a system not pulled this pass keeps its earlier stamp.
+      systems: {..._syncState.systems, ...systemSyncs},
     );
   }
 
@@ -112,4 +158,59 @@ class InMemoryLinkedStore implements LinkedStore {
   Future<void> putDecision(AccountDecision decision) async {
     _decisions[decisionDocId(decision)] = decision;
   }
+
+  @override
+  Future<void> recordSystemSync(
+    Map<core.Origin, SystemSyncMeta> systemSyncs,
+  ) async {
+    _syncState = SyncState(
+      generation: _syncState.generation,
+      updatedAt: _syncState.updatedAt,
+      updatedBy: _syncState.updatedBy,
+      systems: {..._syncState.systems, ...systemSyncs},
+    );
+  }
+
+  @override
+  Future<SyncLease?> readLease(DateTime now) async {
+    final lease = _lease;
+    if (lease == null || lease.isExpiredAt(now)) return null;
+    return lease;
+  }
+
+  @override
+  Future<LeaseOutcome> acquireLease({
+    required String owner,
+    required DateTime now,
+  }) async {
+    final lease = _lease;
+    if (lease != null && lease.isLiveAt(now) && lease.owner != owner) {
+      return LeaseOutcome(acquired: false, lease: lease);
+    }
+    return LeaseOutcome(acquired: true, lease: _take(owner, now));
+  }
+
+  @override
+  Future<LeaseOutcome> renewLease({
+    required String owner,
+    required DateTime now,
+  }) async {
+    final lease = _lease;
+    if (lease != null && lease.isLiveAt(now) && lease.owner != owner) {
+      // Expired while we worked and another operator took over.
+      return LeaseOutcome(acquired: false, lease: lease);
+    }
+    return LeaseOutcome(acquired: true, lease: _take(owner, now));
+  }
+
+  @override
+  Future<void> releaseLease({required String owner}) async {
+    if (_lease?.owner == owner) _lease = null;
+  }
+
+  SyncLease _take(String owner, DateTime now) => _lease = SyncLease(
+        owner: owner,
+        heartbeatAt: now,
+        expiresAt: now.add(syncLeaseTtl),
+      );
 }

--- a/packages/account_state/lib/src/materialize/materialized_state.dart
+++ b/packages/account_state/lib/src/materialize/materialized_state.dart
@@ -380,35 +380,77 @@ class Rollup {
       );
 }
 
+/// Who last synced one system, and when (#108).
+///
+/// Recorded per concrete system (WISA / Smartschool / Azure) so the reconcile
+/// screen can show "Last sync — WISA 09:12 by jan@…" from the *shared* store,
+/// not just this session's in-process [SystemState.lastSync]. Written into the
+/// [SyncState.systems] map by the operator whose sync pulled that system.
+class SystemSyncMeta {
+  const SystemSyncMeta({required this.syncedBy, required this.at});
+
+  /// The operator (AAD UPN) whose session pulled this system.
+  final String syncedBy;
+
+  /// When that pull's snapshot was fetched.
+  final DateTime at;
+
+  Map<String, dynamic> toJson() => {
+        'syncedBy': syncedBy,
+        'at': at.toIso8601String(),
+      };
+
+  factory SystemSyncMeta.fromJson(Map<String, dynamic> json) => SystemSyncMeta(
+        syncedBy: json['syncedBy'] as String,
+        at: DateTime.parse(json['at'] as String),
+      );
+}
+
 /// Freshness + version marker for the whole materialized view.
 ///
 /// [generation] is bumped on every sync that rewrites the view, so a
 /// just-connected client can detect a stale local copy (used more fully by the
-/// SignalR work in #116). [updatedAt] / [updatedBy] record who last synced.
+/// SignalR work in #116). [updatedAt] / [updatedBy] record who last ran the
+/// materialize; [systems] records who last pulled each individual system (#108).
 class SyncState {
   const SyncState({
     required this.generation,
     this.updatedAt,
     this.updatedBy,
+    this.systems = const {},
   });
 
   final int generation;
   final DateTime? updatedAt;
   final String? updatedBy;
 
+  /// Per-system last-sync metadata, keyed by concrete [core.Origin]
+  /// (wisa/smartschool/azure). Empty before the first sync of a given system.
+  final Map<core.Origin, SystemSyncMeta> systems;
+
   /// The initial state before any sync has ever run.
   static const SyncState initial = SyncState(generation: 0);
 
-  SyncState bumped({DateTime? at, String? by}) => SyncState(
+  SyncState bumped({
+    DateTime? at,
+    String? by,
+    Map<core.Origin, SystemSyncMeta>? systems,
+  }) =>
+      SyncState(
         generation: generation + 1,
         updatedAt: at ?? updatedAt,
         updatedBy: by ?? updatedBy,
+        systems: systems ?? this.systems,
       );
 
   Map<String, dynamic> toJson() => {
         'generation': generation,
         if (updatedAt != null) 'updatedAt': updatedAt!.toIso8601String(),
         if (updatedBy != null) 'updatedBy': updatedBy,
+        if (systems.isNotEmpty)
+          'systems': {
+            for (final e in systems.entries) e.key.toJson(): e.value.toJson(),
+          },
       };
 
   factory SyncState.fromJson(Map<String, dynamic> json) => SyncState(
@@ -417,7 +459,84 @@ class SyncState {
             ? null
             : DateTime.parse(json['updatedAt'] as String),
         updatedBy: json['updatedBy'] as String?,
+        systems: {
+          for (final e
+              in (json['systems'] as Map<String, dynamic>? ?? const {}).entries)
+            core.Origin.fromJson(e.key):
+                SystemSyncMeta.fromJson(e.value as Map<String, dynamic>),
+        },
       );
+}
+
+/// The coarse, serialized **sync/drift lease** (#108).
+///
+/// Synchronise and Check-for-drift are rare, heavy, and global, so they run
+/// under a single lease rather than concurrently: while one operator holds it,
+/// every other operator's sync/drift is disabled. The lease carries its [owner]
+/// (AAD UPN), the last [heartbeatAt] the holder refreshed it, and an [expiresAt]
+/// so a *crashed* holder cannot keep it forever — once [expiresAt] passes the
+/// lease is free for the taking (backed in Cosmos by the document's TTL, so an
+/// abandoned lease is also physically swept).
+///
+/// Per-record apply / password changes are deliberately **not** gated by this
+/// lease — they are frequent and concurrent, guarded instead by per-document
+/// optimistic concurrency (#121).
+class SyncLease {
+  const SyncLease({
+    required this.owner,
+    required this.heartbeatAt,
+    required this.expiresAt,
+  });
+
+  /// The operator (AAD UPN) currently holding the lease.
+  final String owner;
+
+  /// When the holder last renewed the lease.
+  final DateTime heartbeatAt;
+
+  /// When the lease lapses if not renewed — a crashed holder's lease expires
+  /// here so another operator can take over.
+  final DateTime expiresAt;
+
+  /// Whether the lease has lapsed as of [now] (holder stopped heart-beating).
+  bool isExpiredAt(DateTime now) => !now.isBefore(expiresAt);
+
+  /// Whether the lease is still live and held by [owner] as of [now].
+  bool isLiveAt(DateTime now) => !isExpiredAt(now);
+
+  Map<String, dynamic> toJson() => {
+        'owner': owner,
+        'heartbeatAt': heartbeatAt.toIso8601String(),
+        'expiresAt': expiresAt.toIso8601String(),
+      };
+
+  factory SyncLease.fromJson(Map<String, dynamic> json) => SyncLease(
+        owner: json['owner'] as String,
+        heartbeatAt: DateTime.parse(json['heartbeatAt'] as String),
+        expiresAt: DateTime.parse(json['expiresAt'] as String),
+      );
+}
+
+/// How long a freshly acquired or renewed [SyncLease] stays live before it must
+/// be heart-beaten again. A holder renews well within this window; a crashed
+/// holder's lease frees after it (#108).
+const Duration syncLeaseTtl = Duration(seconds: 90);
+
+/// The outcome of an [LinkedStore.acquireLease] / [LinkedStore.renewLease]
+/// attempt: whether the caller [acquired] (now holds) the lease, and the
+/// [lease] as it currently stands — the caller's own when [acquired], otherwise
+/// the live lease held by another operator.
+class LeaseOutcome {
+  const LeaseOutcome({required this.acquired, required this.lease});
+
+  /// True when the caller now holds the lease (freshly taken or already theirs).
+  final bool acquired;
+
+  /// The current lease: the caller's when [acquired], else the blocking holder.
+  final SyncLease lease;
+
+  /// True when another operator holds a live lease, blocking the caller.
+  bool get heldByOther => !acquired;
 }
 
 /// The complete materialized output of one sync: the per-account docs plus the

--- a/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
@@ -34,7 +34,12 @@ class _FakeClient implements CosmosClient {
     required Map<String, dynamic> document,
     required String partitionKey,
   }) async {
-    _c(container)[document['id'] as String] = Map.of(document);
+    final id = document['id'] as String;
+    // Model Cosmos's atomic create: a 409 (→ false) when the id already exists.
+    // The sync/drift lease relies on this to keep two acquirers from both
+    // "creating" the lease document.
+    if (_c(container).containsKey(id)) return false;
+    _c(container)[id] = Map.of(document);
     return true;
   }
 
@@ -189,6 +194,95 @@ void main() {
       final store = CosmosLinkedStore(_FakeClient());
       expect((await store.readSyncState()).generation, 0);
       expect(await store.readRollups(), isEmpty);
+    });
+
+    test('writeMaterialized persists per-system sync metadata (#108)',
+        () async {
+      final store = CosmosLinkedStore(_FakeClient());
+
+      await store.writeMaterialized(
+        _view([_account('p0')]),
+        syncedBy: 'jan@school',
+        at: _d,
+        systemSyncs: {
+          core.Origin.wisa: SystemSyncMeta(syncedBy: 'jan@school', at: _d),
+        },
+      );
+
+      final state = await store.readSyncState();
+      expect(state.systems[core.Origin.wisa]?.syncedBy, 'jan@school');
+      expect(state.systems[core.Origin.wisa]?.at, _d);
+    });
+
+    test('recordSystemSync merges into the doc without bumping generation',
+        () async {
+      final store = CosmosLinkedStore(_FakeClient());
+      await store.writeMaterialized(
+        _view([_account('p0')]),
+        syncedBy: 'jan@school',
+        at: _d,
+        systemSyncs: {
+          core.Origin.wisa: SystemSyncMeta(syncedBy: 'jan@school', at: _d),
+        },
+      );
+
+      final later = _d.add(const Duration(hours: 2));
+      await store.recordSystemSync({
+        core.Origin.azure: SystemSyncMeta(syncedBy: 'mieke@school', at: later),
+      });
+
+      final state = await store.readSyncState();
+      expect(state.generation, 1, reason: 'metadata touch is not a view write');
+      expect(state.systems[core.Origin.wisa]?.syncedBy, 'jan@school');
+      expect(state.systems[core.Origin.azure]?.syncedBy, 'mieke@school');
+    });
+  });
+
+  group('CosmosLinkedStore sync/drift lease (#108)', () {
+    test('acquire creates the lease doc; readLease returns it', () async {
+      final store = CosmosLinkedStore(_FakeClient());
+
+      final out = await store.acquireLease(owner: 'jan@school', now: _d);
+      expect(out.acquired, isTrue);
+      expect((await store.readLease(_d))?.owner, 'jan@school');
+    });
+
+    test('a second operator is blocked by a live lease', () async {
+      final client = _FakeClient();
+      final a = CosmosLinkedStore(client);
+      final b = CosmosLinkedStore(client);
+      await a.acquireLease(owner: 'jan@school', now: _d);
+
+      final out = await b.acquireLease(owner: 'mieke@school', now: _d);
+      expect(out.acquired, isFalse);
+      expect(out.lease.owner, 'jan@school');
+    });
+
+    test('release deletes the doc so the next acquire succeeds', () async {
+      final client = _FakeClient();
+      final a = CosmosLinkedStore(client);
+      final b = CosmosLinkedStore(client);
+      await a.acquireLease(owner: 'jan@school', now: _d);
+
+      await a.releaseLease(owner: 'jan@school');
+      expect(await a.readLease(_d), isNull);
+
+      final out = await b.acquireLease(owner: 'mieke@school', now: _d);
+      expect(out.acquired, isTrue);
+    });
+
+    test('an expired lease is taken over, and readLease treats it as gone',
+        () async {
+      final client = _FakeClient();
+      final a = CosmosLinkedStore(client);
+      final b = CosmosLinkedStore(client);
+      await a.acquireLease(owner: 'jan@school', now: _d);
+      final afterExpiry = _d.add(syncLeaseTtl).add(const Duration(seconds: 1));
+
+      expect(await b.readLease(afterExpiry), isNull);
+      final out = await b.acquireLease(owner: 'mieke@school', now: afterExpiry);
+      expect(out.acquired, isTrue);
+      expect((await b.readLease(afterExpiry))?.owner, 'mieke@school');
     });
   });
 }

--- a/packages/account_state/test/materialize/linked_store_test.dart
+++ b/packages/account_state/test/materialize/linked_store_test.dart
@@ -1,0 +1,193 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+
+/// Unit coverage for the multi-operator coordination the [InMemoryLinkedStore]
+/// models (#108): the sync/drift lease (acquire / renew / expire / block) and
+/// the per-system last-sync metadata merge. The Cosmos wire shape is covered
+/// separately by `cosmos_linked_store_test`.
+void main() {
+  final t0 = DateTime.utc(2026, 7, 4, 9, 0);
+  MaterializedView view({int generation = 1}) => MaterializedView(
+        generation: generation,
+        accounts: const [],
+        rollups: const [],
+      );
+
+  group('sync/drift lease', () {
+    test('acquire succeeds when free and readLease returns the live lease',
+        () async {
+      final store = InMemoryLinkedStore();
+
+      final out = await store.acquireLease(owner: 'jan@school', now: t0);
+      expect(out.acquired, isTrue);
+      expect(out.lease.owner, 'jan@school');
+      expect(out.lease.expiresAt, t0.add(syncLeaseTtl));
+
+      expect((await store.readLease(t0))?.owner, 'jan@school');
+    });
+
+    test('a second operator is blocked while a live lease is held', () async {
+      final store = InMemoryLinkedStore();
+      await store.acquireLease(owner: 'jan@school', now: t0);
+
+      final out = await store.acquireLease(owner: 'mieke@school', now: t0);
+      expect(out.acquired, isFalse);
+      expect(out.heldByOther, isTrue);
+      expect(out.lease.owner, 'jan@school',
+          reason: 'names the blocking holder');
+    });
+
+    test('re-acquiring your own live lease succeeds (idempotent)', () async {
+      final store = InMemoryLinkedStore();
+      await store.acquireLease(owner: 'jan@school', now: t0);
+
+      final out = await store.acquireLease(
+        owner: 'jan@school',
+        now: t0.add(const Duration(seconds: 10)),
+      );
+      expect(out.acquired, isTrue);
+    });
+
+    test('an expired lease frees for another operator to take over', () async {
+      final store = InMemoryLinkedStore();
+      await store.acquireLease(owner: 'jan@school', now: t0);
+      final afterExpiry = t0.add(syncLeaseTtl).add(const Duration(seconds: 1));
+
+      // The lease reads as gone once expired…
+      expect(await store.readLease(afterExpiry), isNull);
+      // …and another operator can take it.
+      final out =
+          await store.acquireLease(owner: 'mieke@school', now: afterExpiry);
+      expect(out.acquired, isTrue);
+      expect(out.lease.owner, 'mieke@school');
+    });
+
+    test('renew pushes the expiry so the lease is not lost mid-work', () async {
+      final store = InMemoryLinkedStore();
+      await store.acquireLease(owner: 'jan@school', now: t0);
+
+      // Heartbeat just before expiry.
+      final beat = t0.add(syncLeaseTtl).subtract(const Duration(seconds: 5));
+      final renewed = await store.renewLease(owner: 'jan@school', now: beat);
+      expect(renewed.acquired, isTrue);
+
+      // A moment after the *original* expiry the lease is still live.
+      final pastOriginal = t0.add(syncLeaseTtl).add(const Duration(seconds: 1));
+      expect((await store.readLease(pastOriginal))?.owner, 'jan@school');
+    });
+
+    test('renew reports the lease was lost after expiry + takeover', () async {
+      final store = InMemoryLinkedStore();
+      await store.acquireLease(owner: 'jan@school', now: t0);
+      final afterExpiry = t0.add(syncLeaseTtl).add(const Duration(seconds: 1));
+      await store.acquireLease(owner: 'mieke@school', now: afterExpiry);
+
+      final lost =
+          await store.renewLease(owner: 'jan@school', now: afterExpiry);
+      expect(lost.acquired, isFalse);
+      expect(lost.lease.owner, 'mieke@school');
+    });
+
+    test('release frees the lease immediately for the next operator', () async {
+      final store = InMemoryLinkedStore();
+      await store.acquireLease(owner: 'jan@school', now: t0);
+
+      await store.releaseLease(owner: 'jan@school');
+      expect(await store.readLease(t0), isNull);
+
+      final out = await store.acquireLease(owner: 'mieke@school', now: t0);
+      expect(out.acquired, isTrue);
+    });
+
+    test('release by a non-owner is a no-op (cannot free a taken lease)',
+        () async {
+      final store = InMemoryLinkedStore();
+      await store.acquireLease(owner: 'jan@school', now: t0);
+
+      await store.releaseLease(owner: 'mieke@school');
+      expect((await store.readLease(t0))?.owner, 'jan@school');
+    });
+  });
+
+  group('per-system sync metadata', () {
+    test('writeMaterialized records the systems pulled this pass', () async {
+      final store = InMemoryLinkedStore();
+
+      await store.writeMaterialized(
+        view(),
+        syncedBy: 'jan@school',
+        at: t0,
+        systemSyncs: {
+          core.Origin.wisa: SystemSyncMeta(syncedBy: 'jan@school', at: t0),
+        },
+      );
+
+      final state = await store.readSyncState();
+      expect(state.systems[core.Origin.wisa]?.syncedBy, 'jan@school');
+      expect(state.systems[core.Origin.wisa]?.at, t0);
+    });
+
+    test('a system not pulled this pass keeps its earlier stamp', () async {
+      final store = InMemoryLinkedStore();
+      // Pass 1 pulls WISA.
+      await store.writeMaterialized(
+        view(),
+        syncedBy: 'jan@school',
+        at: t0,
+        systemSyncs: {
+          core.Origin.wisa: SystemSyncMeta(syncedBy: 'jan@school', at: t0),
+        },
+      );
+      // Pass 2 (drift) pulls only Azure, by a different operator.
+      final t1 = t0.add(const Duration(hours: 1));
+      await store.writeMaterialized(
+        view(generation: 2),
+        syncedBy: 'mieke@school',
+        at: t1,
+        systemSyncs: {
+          core.Origin.azure: SystemSyncMeta(syncedBy: 'mieke@school', at: t1),
+        },
+      );
+
+      final state = await store.readSyncState();
+      expect(state.systems[core.Origin.wisa]?.syncedBy, 'jan@school',
+          reason: 'WISA keeps pass 1');
+      expect(state.systems[core.Origin.azure]?.syncedBy, 'mieke@school');
+    });
+
+    test('recordSystemSync merges without bumping the generation', () async {
+      final store = InMemoryLinkedStore();
+      await store.writeMaterialized(view(), syncedBy: 'jan@school', at: t0);
+      expect((await store.readSyncState()).generation, 1);
+
+      final t1 = t0.add(const Duration(hours: 1));
+      await store.recordSystemSync({
+        core.Origin.wisa: SystemSyncMeta(syncedBy: 'jan@school', at: t1),
+      });
+
+      final state = await store.readSyncState();
+      expect(state.generation, 1, reason: 'a metadata touch is not a new view');
+      expect(state.systems[core.Origin.wisa]?.at, t1);
+    });
+  });
+
+  group('SyncState / SystemSyncMeta round-trip', () {
+    test('json survives with per-system metadata', () {
+      final state = SyncState(
+        generation: 3,
+        updatedAt: t0,
+        updatedBy: 'jan@school',
+        systems: {
+          core.Origin.smartschool:
+              SystemSyncMeta(syncedBy: 'mieke@school', at: t0),
+        },
+      );
+
+      final back = SyncState.fromJson(state.toJson());
+      expect(back.generation, 3);
+      expect(back.systems[core.Origin.smartschool]?.syncedBy, 'mieke@school');
+      expect(back.systems[core.Origin.smartschool]?.at, t0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Makes the reconcile flow behave correctly with 20–40 concurrent operators instead of single-user. Three coordination pieces, all built pure-Dart and testable against fakes:

- **Per-system sync metadata** — who (AAD UPN) and when last pulled each of WISA / Smartschool / Azure, persisted in the shared `syncState` document and shown on the reconcile header ("Last sync — WISA 09:12 by jan@…"), read from the shared store rather than this session's in-process `lastSync`.
- **Coarse sync/drift lease** — a lease row (owner + heartbeat + expiry) so Synchronise and Check-for-drift **serialize** across operators; while held, other operators' buttons are disabled and the holder is named. A crashed holder's lease frees via expiry (Cosmos document TTL). Acquisition uses an **atomic create** on the hot contended path (race-free); crash-recovery takeover is the only best-effort branch and self-heals on TTL sweep.
- **Generation-driven stale reload** — `onStoreChanged(generation)` refetches the overview + open classroom when another operator's sync bumps the generation past the cached copy. The realtime transport (SignalR, #116) will drive this; here it is exercised directly.

Per-record apply / password writes are deliberately **not** gated by the lease.

## Linked issue

Closes #108

## Scope decisions

- **ETag optimistic concurrency** for concurrent apply/password writes (the `CosmosClient` has no `If-Match` support today) is split into its own issue, **#121** — this PR ships the coordination core without it.
- **Real-time delivery** of the lease state + generation is **#116** (SignalR). This PR builds the store + state + widget mechanism behind the `onStoreChanged` refresh seam; #116 drives it over the wire.

## Changes

- `materialized_state.dart`: `SystemSyncMeta`, `SyncState.systems`, `SyncLease`, `LeaseOutcome`, `syncLeaseTtl`.
- `linked_store.dart`: interface + `InMemoryLinkedStore` — per-system metadata merge on `writeMaterialized`, plus `recordSystemSync`, `readLease`, `acquireLease`, `renewLease`, `releaseLease`.
- `cosmos_linked_store.dart` / `cosmos_config.dart`: Cosmos-backed lease as a second singleton in the `syncState` container (atomic create + TTL); per-system metadata written into the syncState doc.
- `reconcile_controller.dart`: acquire lease before a heavy pass (bail + name holder if held), heartbeat between per-system pulls, release in `finally`; stamp per-system freshness on persist (and on the "WISA unchanged" path via a light metadata-only write); `onStoreChanged` stale reload; lock getters.
- `reconcile_screen.dart`: shared per-system freshness line; Synchronise/Check-for-drift disabled and holder named while a foreign lease is live.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed` clean (applied)
- [x] `dart analyze` (account_state + account_manager) clean
- [x] Unit — `account_state`: 203 pass, incl. new in-memory + Cosmos lease (acquire/renew/expire/block/release), per-system metadata merge, `recordSystemSync` (no generation bump), JSON round-trip
- [x] Unit/widget — `account_manager`: 85 pass, incl. new controller tests (metadata recorded, foreign lease blocks sync/drift, `loadOverview` surfaces the lock, `onStoreChanged` refetch, stale-generation no-op) and screen tests (lock disables + names, shared freshness line, generation bump re-renders drill-down)
- [x] Integration/e2e (`flutter test integration_test -d windows`): 8 pass, incl. a new end-to-end #108 scenario — a passive real-app session shows the shared freshness and has Synchronise disabled + the holder named while another operator holds the lease

🤖 Generated with [Claude Code](https://claude.com/claude-code)