### PR TITLE
Materialize group actions into the shared view (#119)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -225,6 +225,52 @@ void main() {
   });
 
   testWidgets(
+      'a passive session surfaces pending group actions in the drill-down '
+      'with no pull and no link() (#119)', (WidgetTester tester) async {
+    // Session 1 (offline harness) syncs and materializes the shared view. The
+    // fixture's two Smartschool-only classes (2B, 3C) raise the informational
+    // orphan-class notice — the group-action family.
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+        .controller
+        .sync();
+
+    // Session 2 is the real app over the same stores. It never syncs.
+    final resumed = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: resumed.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+
+    // The class-group node is part of the shared overview, straight from the
+    // store — no Synchronise tapped.
+    expect(find.text('Overzicht'), findsOneWidget);
+    expect(find.text('Klasgroepen'), findsWidgets);
+
+    // Drilling into it lists the orphan Smartschool classes with their notice.
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('reconcile-groups-back')), findsOneWidget);
+    expect(
+        find.textContaining('Deze klas bestaat in Smartschool'), findsWidgets);
+    // …all without a single connector pull or link().
+    expect(resumed.wisaSyncs, 0);
+    expect(resumed.ssSyncs, 0);
+    expect(resumed.azSyncs, 0);
+    expect(resumed.controller.linked, isNull);
+  });
+
+  testWidgets(
       'a passive session shows the shared freshness and, while another '
       'operator holds the sync lease, disables Synchronise (#108)',
       (WidgetTester tester) async {

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -143,6 +143,9 @@ class ReconcileController extends ChangeNotifier {
   Rollup? _selectedClassroom;
   List<MaterializedAccount>? _classroomAccounts;
   bool _loadingClassroom = false;
+  bool _showingGroups = false;
+  List<MaterializedGroup>? _groupDocs;
+  bool _loadingGroups = false;
   SyncLease? _lock;
 
   /// The per-system last-sync metadata this pass pulled, stamped as each system
@@ -256,6 +259,25 @@ class ReconcileController extends ChangeNotifier {
 
   /// Whether a classroom drill-down read is in flight.
   bool get loadingClassroom => _loadingClassroom;
+
+  /// The single "Klasgroepen" rollup node (#119), or `null` when no group has a
+  /// pending action to drill into.
+  Rollup? get groupRollup {
+    for (final r in _rollups) {
+      if (r.level == RollupLevel.groups) return r;
+    }
+    return null;
+  }
+
+  /// Whether the group ("Klasgroepen") drill-down is currently open.
+  bool get showingGroups => _showingGroups;
+
+  /// The per-group docs of the open group drill-down, lazily loaded from the
+  /// store; `null` until the "Klasgroepen" node is opened (#119).
+  List<MaterializedGroup>? get groupDocs => _groupDocs;
+
+  /// Whether a group drill-down read is in flight.
+  bool get loadingGroups => _loadingGroups;
 
   /// How many pending actions an apply pass would actually write (the
   /// informational group actions are excluded).
@@ -393,6 +415,13 @@ class ReconcileController extends ChangeNotifier {
         log.addError(core.Origin.all, 'Could not refresh ${open.label}: $e');
       }
     }
+    if (_showingGroups) {
+      try {
+        _groupDocs = await store.readGroups();
+      } on Object catch (e) {
+        log.addError(core.Origin.all, 'Could not refresh the class groups: $e');
+      }
+    }
     notifyListeners();
   }
 
@@ -421,6 +450,34 @@ class ReconcileController extends ChangeNotifier {
   void closeClassroom() {
     _selectedClassroom = null;
     _classroomAccounts = null;
+    notifyListeners();
+  }
+
+  /// Opens the "Klasgroepen" drill-down (#119), lazily reading the per-group
+  /// docs from the store (no pull, no `link()`) — the group-family counterpart
+  /// of [openClassroom].
+  Future<void> openGroups() async {
+    _showingGroups = true;
+    _selectedClassroom = null;
+    _classroomAccounts = null;
+    _groupDocs = null;
+    _loadingGroups = true;
+    notifyListeners();
+    try {
+      _groupDocs = await store.readGroups();
+    } on Object catch (e) {
+      log.addError(core.Origin.all, 'Could not open the class groups: $e');
+      _groupDocs = const [];
+    } finally {
+      _loadingGroups = false;
+      notifyListeners();
+    }
+  }
+
+  /// Closes the group drill-down, back to the overview.
+  void closeGroups() {
+    _showingGroups = false;
+    _groupDocs = null;
     notifyListeners();
   }
 
@@ -569,11 +626,13 @@ class ReconcileController extends ChangeNotifier {
       );
       final merge = mergeDecisions(
         accounts: view.accounts,
+        groups: view.groups,
         existing: await store.readDecisions(),
       );
       final merged = MaterializedView(
         generation: view.generation,
         accounts: merge.accounts,
+        groups: merge.groups,
         rollups: view.rollups,
       );
       final at = _now();
@@ -598,6 +657,8 @@ class ReconcileController extends ChangeNotifier {
       // A re-sync invalidates any open drill-down; the next open re-reads.
       _selectedClassroom = null;
       _classroomAccounts = null;
+      _showingGroups = false;
+      _groupDocs = null;
     } on Object catch (e) {
       log.addError(core.Origin.all, 'Could not persist the linked view: $e');
     }

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:account_actions/account_actions.dart' as actions;
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart'
-    show LinkedState, MaterializedAccount, Rollup;
+    show LinkedState, MaterializedAccount, MaterializedGroup, Rollup;
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
@@ -160,6 +160,9 @@ class _ReconcileBody extends StatelessWidget {
                         if (controller.selectedClassroom != null) ...<Widget>[
                           const SizedBox(height: PlinkSpacing.s5),
                           _ClassroomDetail(controller: controller),
+                        ] else if (controller.showingGroups) ...<Widget>[
+                          const SizedBox(height: PlinkSpacing.s5),
+                          _GroupsDetail(controller: controller),
                         ] else if (controller.hasOverview) ...<Widget>[
                           const SizedBox(height: PlinkSpacing.s5),
                           _DrillDownSection(controller: controller),
@@ -617,6 +620,7 @@ class _DrillDownSection extends StatelessWidget {
     final TextTheme text = Theme.of(context).textTheme;
     final Color hairline = Theme.of(context).dividerColor;
     final schools = controller.schoolRollups;
+    final groups = controller.groupRollup;
     final freshness = _freshness();
 
     return Column(
@@ -628,9 +632,9 @@ class _DrillDownSection extends StatelessWidget {
           Text(freshness, style: text.bodySmall),
         ],
         const SizedBox(height: PlinkSpacing.s3),
-        if (schools.isEmpty)
+        if (schools.isEmpty && groups == null)
           Text('Nog geen gematerialiseerd overzicht.', style: text.bodyMedium)
-        else
+        else ...<Widget>[
           for (final school in schools)
             Container(
               margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
@@ -651,7 +655,120 @@ class _DrillDownSection extends StatelessWidget {
                 ],
               ),
             ),
+          // The group-family node (#119): class-group actions live outside the
+          // school → grade-year → classroom tree, so they get their own entry.
+          if (groups != null)
+            Container(
+              margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
+              decoration: BoxDecoration(
+                border: Border.all(color: hairline),
+                borderRadius:
+                    const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+              ),
+              child: ListTile(
+                key: const ValueKey('rollup-groups'),
+                title: Text(groups.label, style: text.bodyLarge),
+                subtitle: Text('${groups.accountCount} klasgroep(en)',
+                    style: text.bodySmall),
+                trailing: _PendingBadge(count: groups.pendingCount),
+                onTap: controller.openGroups,
+              ),
+            ),
+        ],
       ],
+    );
+  }
+}
+
+/// The "Klasgroepen" drill-down (#119): the per-group docs for the group-action
+/// family, lazily loaded from the store — the group counterpart of
+/// [_ClassroomDetail]. Renders even in a passive session that never linked.
+class _GroupsDetail extends StatelessWidget {
+  const _GroupsDetail({required this.controller});
+
+  final ReconcileController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final groups = controller.groupDocs;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            TextButton.icon(
+              key: const ValueKey('reconcile-groups-back'),
+              onPressed: controller.closeGroups,
+              icon: const Icon(Icons.arrow_back, size: 16),
+              label: const Text('Overzicht'),
+            ),
+            const SizedBox(width: PlinkSpacing.s2),
+            Text(controller.groupRollup?.label ?? 'Klasgroepen',
+                style: text.titleMedium),
+          ],
+        ),
+        const SizedBox(height: PlinkSpacing.s3),
+        if (controller.loadingGroups)
+          const LinearProgressIndicator()
+        else if (groups == null || groups.isEmpty)
+          Text('Geen klasgroepen met openstaande acties.',
+              style: text.bodyMedium)
+        else
+          for (final group in groups) _GroupTile(group: group),
+      ],
+    );
+  }
+}
+
+class _GroupTile extends StatelessWidget {
+  const _GroupTile({required this.group});
+
+  final MaterializedGroup group;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final Color hairline = Theme.of(context).dividerColor;
+    final systems = <String>[
+      if (group.inWisa) 'WISA',
+      if (group.inSmartschool) 'Smartschool',
+      if (group.inAzure) 'Azure',
+    ];
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
+      padding: const EdgeInsets.all(PlinkSpacing.s4),
+      decoration: BoxDecoration(
+        border: Border.all(color: hairline),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(child: Text(group.label, style: text.bodyLarge)),
+              _PendingBadge(
+                  count: group.candidates.where((c) => c.canApply).length),
+            ],
+          ),
+          const SizedBox(height: PlinkSpacing.s2),
+          Wrap(
+            spacing: PlinkSpacing.s2,
+            children: <Widget>[for (final s in systems) PlinkBadge(s)],
+          ),
+          for (final c in group.candidates)
+            Padding(
+              padding: const EdgeInsets.only(top: PlinkSpacing.s1),
+              child: Text(
+                c.canApply ? '• ${c.summary}' : '• ${c.summary} (manueel)',
+                style: text.bodySmall,
+              ),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -342,6 +342,58 @@ void main() {
     });
   });
 
+  group('materialized group actions (#119)', () {
+    test('a sync materializes group docs + a group rollup', () async {
+      // The fixture's two Smartschool-only classes (2B, 3C) raise the
+      // informational orphan notice — the group family.
+      final h = ReconcileHarness();
+
+      await h.controller.sync();
+
+      expect(h.linkedStore.groupCount, greaterThan(0));
+      final groups = await h.linkedStore.readGroups();
+      expect(groups.map((g) => g.label), containsAll(['2B', '3C']));
+      expect(h.controller.groupRollup, isNotNull);
+      expect(h.controller.groupRollup!.accountCount, groups.length);
+    });
+
+    test(
+        'a passive session opens the Klasgroepen drill-down with no pull or '
+        'link()', () async {
+      final snapshots = InMemorySnapshotStore();
+      final linkedStore = InMemoryLinkedStore();
+
+      // Session 1 syncs and materializes the shared view.
+      await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+          .controller
+          .sync();
+
+      // Session 2: a fresh, passive controller over the same stores.
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      await s2.controller.loadOverview();
+
+      expect(s2.controller.groupRollup, isNotNull,
+          reason: 'the group rollup came from the shared store');
+
+      await s2.controller.openGroups();
+
+      expect(s2.controller.showingGroups, isTrue);
+      expect(s2.controller.groupDocs, isNotEmpty);
+      // No connector pull and no linked view derived this session.
+      expect(s2.wisaSyncs, 0);
+      expect(s2.ssSyncs, 0);
+      expect(s2.azSyncs, 0);
+      expect(s2.controller.linked, isNull);
+
+      s2.controller.closeGroups();
+      expect(s2.controller.showingGroups, isFalse);
+      expect(s2.controller.groupDocs, isNull);
+    });
+  });
+
   group('passive session reads the store (#115)', () {
     test(
         'a resumed session renders the overview and drills into a classroom '

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -323,6 +323,47 @@ void main() {
     expect(find.textContaining('Generatie 1'), findsNothing);
   });
 
+  testWidgets(
+      'the drill-down surfaces the Klasgroepen node and opens the group '
+      'detail (#119)', (WidgetTester tester) async {
+    final linkedStore = InMemoryLinkedStore();
+    final snapshots = InMemorySnapshotStore();
+
+    // Session 1 syncs and materializes the shared view (the fixture's two
+    // Smartschool-only classes raise the informational orphan notice).
+    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+        .controller
+        .sync();
+
+    // Session 2 renders the shared overview passively.
+    final s2 = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(_wrap(ReconcileScreen(bootstrap: s2.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The group node sits in the drill-down beside the school tree.
+    expect(find.text('Overzicht'), findsOneWidget);
+    expect(find.byKey(const ValueKey('rollup-groups')), findsOneWidget);
+    expect(find.text('Klasgroepen'), findsWidgets);
+
+    // Opening it lists the orphan classes with their notice — no pull, no link.
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('reconcile-groups-back')), findsOneWidget);
+    expect(find.text('2B'), findsWidgets);
+    expect(
+        find.textContaining('Deze klas bestaat in Smartschool'), findsWidgets);
+    expect(s2.controller.linked, isNull);
+
+    // Back to the overview.
+    await tester.tap(find.byKey(const ValueKey('reconcile-groups-back')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-groups')), findsOneWidget);
+  });
+
   testWidgets('the log panel clears on demand', (WidgetTester tester) async {
     final harness = ReconcileHarness();
     await tester.pumpWidget(

--- a/packages/account_state/lib/src/cosmos/cosmos_config.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_config.dart
@@ -105,9 +105,19 @@ const String snapshotsContainer = 'snapshots';
 /// only reads them on drill-down.
 const String linkedAccountsContainer = 'linkedAccounts';
 
+/// The materialized linked-groups container (#119): one document per class
+/// group that carries a pending group action (an orphan Smartschool class, a
+/// WISA class to create/modify), `{ id, pk, … }`. Every document shares the one
+/// [groupsPartition] logical partition — class groups have no natural school
+/// partition — so a passive session reads them all in one partition query when
+/// the "Klasgroepen" node is opened. Rewritten wholesale by the sync process,
+/// like [linkedAccountsContainer]. Provisioned out of band.
+const String linkedGroupsContainer = 'linkedGroups';
+
 /// The rollup-aggregates container (#115): the small school / grade-year /
 /// classroom count documents that drive the drill-down without touching the
-/// per-account docs. Partitioned by `/pk` (school).
+/// per-account docs. Partitioned by `/pk` (school). Also holds the single group
+/// rollup node (#119), partitioned under the [groupsPartition].
 const String rollupsContainer = 'rollups';
 
 /// The operator-decisions container (#115): one document per decision

--- a/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
@@ -62,6 +62,18 @@ class CosmosLinkedStore implements LinkedStore {
   }
 
   @override
+  Future<List<MaterializedGroup>> readGroups() async {
+    // The whole group set lives in one logical partition (groupsPartition) and
+    // is small, so a single scoped query returns it all (#119).
+    final docs = await _client.queryDocuments(
+      container: linkedGroupsContainer,
+      query: 'SELECT * FROM c',
+      partitionKey: groupsPartition,
+    );
+    return [for (final d in docs) MaterializedGroup.fromJson(d)];
+  }
+
+  @override
   Future<List<AccountDecision>> readDecisions() async {
     final docs = await _client.queryDocuments(
       container: decisionsContainer,
@@ -92,6 +104,16 @@ class CosmosLinkedStore implements LinkedStore {
       docsById: {
         for (final a in view.accounts)
           a.id.value: (pk: a.school, doc: a.toJson()),
+      },
+    );
+    // Per-group docs: same wholesale replace, in the single groups partition
+    // (#119).
+    await _replaceContainer(
+      container: linkedGroupsContainer,
+      freshIds: {for (final g in view.groups) g.id.value},
+      docsById: {
+        for (final g in view.groups)
+          g.id.value: (pk: g.school, doc: g.toJson()),
       },
     );
     // Rollups: same replace, keyed by the rollup node key.

--- a/packages/account_state/lib/src/materialize/decisions_merge.dart
+++ b/packages/account_state/lib/src/materialize/decisions_merge.dart
@@ -1,10 +1,11 @@
 import 'materialized_state.dart';
 
 /// The result of merging persisted operator [AccountDecision]s into a freshly
-/// materialized set of accounts.
+/// materialized set of accounts and groups.
 class DecisionsMerge {
   const DecisionsMerge({
     required this.accounts,
+    this.groups = const [],
     required this.surviving,
     required this.dropped,
   });
@@ -12,59 +13,73 @@ class DecisionsMerge {
   /// The input accounts, each with its still-applicable decisions re-attached.
   final List<MaterializedAccount> accounts;
 
-  /// Every decision whose situation still exists (attached to [accounts]).
+  /// The input groups, each with its still-applicable decisions re-attached
+  /// (#119).
+  final List<MaterializedGroup> groups;
+
+  /// Every decision whose situation still exists (attached to an account or
+  /// group).
   final List<AccountDecision> surviving;
 
-  /// Every decision whose situation is gone — the account vanished or no longer
+  /// Every decision whose situation is gone — the target vanished or no longer
   /// carries the matching candidate/warning. These are deleted from the store.
   final List<AccountDecision> dropped;
 }
 
-/// Re-attaches persisted operator decisions to the freshly recomputed accounts,
-/// dropping only those whose situation no longer exists (#115).
+/// Re-attaches persisted operator decisions to the freshly recomputed accounts
+/// and groups, dropping only those whose situation no longer exists (#115, #119).
 ///
-/// A sync rewrites the derived per-account docs wholesale, so operator intent
-/// lives in separate [AccountDecision] documents. This merge is what keeps a
-/// re-sync from clobbering in-progress work: a decision is kept while its
-/// account still carries the situation it resolves —
+/// A sync rewrites the derived per-account and per-group docs wholesale, so
+/// operator intent lives in separate [AccountDecision] documents. This merge is
+/// what keeps a re-sync from clobbering in-progress work: a decision is kept
+/// while its target (account **or** group) still carries the situation it
+/// resolves —
 ///
-/// - [DecisionKind.chosenAlternative] / [DecisionKind.appliedStatus]: the
-///   account still has a candidate whose [CandidateAction.kind] matches the
-///   decision's [AccountDecision.targetKind];
-/// - [DecisionKind.acceptedDuplicate]: the account still carries a warning (the
+/// - [DecisionKind.chosenAlternative] / [DecisionKind.appliedStatus]: the target
+///   still has a candidate whose [CandidateAction.kind] matches the decision's
+///   [AccountDecision.targetKind];
+/// - [DecisionKind.acceptedDuplicate]: the target still carries a warning (the
 ///   collision is still present).
 ///
-/// A decision for an account that vanished, or whose situation is resolved, is
-/// [DecisionsMerge.dropped].
+/// Accounts and groups share one decisions container, so both are considered in
+/// a single pass — a group decision is never dropped merely because it does not
+/// match an account. A decision whose target vanished, or whose situation is
+/// resolved, is [DecisionsMerge.dropped].
 DecisionsMerge mergeDecisions({
   required List<MaterializedAccount> accounts,
+  List<MaterializedGroup> groups = const [],
   required List<AccountDecision> existing,
 }) {
-  final byAccount = <String, List<AccountDecision>>{};
+  final byTarget = <String, List<AccountDecision>>{};
   for (final d in existing) {
-    (byAccount[d.accountId.value] ??= <AccountDecision>[]).add(d);
+    (byTarget[d.accountId.value] ??= <AccountDecision>[]).add(d);
   }
 
-  final merged = <MaterializedAccount>[];
   final surviving = <AccountDecision>[];
-  final matchedAccountKeys = <String>{};
 
+  final mergedAccounts = <MaterializedAccount>[];
   for (final account in accounts) {
-    final candidates = byAccount[account.id.value] ?? const <AccountDecision>[];
-    if (candidates.isEmpty) {
-      merged.add(account);
-      continue;
-    }
-    matchedAccountKeys.add(account.id.value);
+    final decisions = byTarget[account.id.value] ?? const <AccountDecision>[];
     final kept = [
-      for (final d in candidates)
-        if (_situationExists(account, d)) d,
+      for (final d in decisions)
+        if (_situationExists(account.candidates, account.warnings, d)) d,
     ];
     surviving.addAll(kept);
-    merged.add(kept.isEmpty ? account : account.withDecisions(kept));
+    mergedAccounts.add(kept.isEmpty ? account : account.withDecisions(kept));
   }
 
-  // Anything not kept — including decisions whose account is gone entirely — is
+  final mergedGroups = <MaterializedGroup>[];
+  for (final group in groups) {
+    final decisions = byTarget[group.id.value] ?? const <AccountDecision>[];
+    final kept = [
+      for (final d in decisions)
+        if (_situationExists(group.candidates, const [], d)) d,
+    ];
+    surviving.addAll(kept);
+    mergedGroups.add(kept.isEmpty ? group : group.withDecisions(kept));
+  }
+
+  // Anything not kept — including decisions whose target is gone entirely — is
   // dropped from the store.
   final survivingIds = surviving.toSet();
   final dropped = [
@@ -73,18 +88,23 @@ DecisionsMerge mergeDecisions({
   ];
 
   return DecisionsMerge(
-    accounts: merged,
+    accounts: mergedAccounts,
+    groups: mergedGroups,
     surviving: surviving,
     dropped: dropped,
   );
 }
 
-bool _situationExists(MaterializedAccount account, AccountDecision d) {
+bool _situationExists(
+  List<CandidateAction> candidates,
+  List<String> warnings,
+  AccountDecision d,
+) {
   switch (d.kind) {
     case DecisionKind.acceptedDuplicate:
-      return account.warnings.isNotEmpty;
+      return warnings.isNotEmpty;
     case DecisionKind.chosenAlternative:
     case DecisionKind.appliedStatus:
-      return account.candidates.any((c) => c.kind == d.targetKind);
+      return candidates.any((c) => c.kind == d.targetKind);
   }
 }

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -12,11 +12,12 @@ import 'materialized_state.dart';
 /// drill-down.
 ///
 /// Pure — no I/O. The sync process calls this after `link()`, then hands the
-/// result (with decisions merged in) to the `LinkedStore`. Group actions are
-/// **not** materialized here: they target a `LinkedGroup`, not an account, so
-/// they do not fit the per-account/classroom shape and are tracked separately
-/// (follow-up). The account and staff families — everything the drill-down
-/// renders — are covered.
+/// result (with decisions merged in) to the `LinkedStore`. Group actions target
+/// a `LinkedGroup`, not an account, so they do not fit the per-account/classroom
+/// shape: each targeted group becomes its own [MaterializedGroup] in the
+/// [groupsPartition], and a single group [Rollup] ("Klasgroepen") surfaces them
+/// in the drill-down beside the school tree (#119). The account, staff, and
+/// group families — everything the drill-down renders — are covered.
 ///
 /// [schoolLabels] maps a WISA school id to its human name (from the WISA
 /// snapshot's schools list); a student's school partition falls back to the id
@@ -81,10 +82,67 @@ MaterializedView materialize(
     ));
   }
 
+  final groups = _materializeGroups(linked.groupActions);
+
+  final rollups = buildRollups(accounts);
+  final groupsRollup = _buildGroupsRollup(groups);
+
   return MaterializedView(
     generation: generation,
     accounts: accounts,
-    rollups: buildRollups(accounts),
+    groups: groups,
+    rollups: [...rollups, if (groupsRollup != null) groupsRollup],
+  );
+}
+
+/// Turns the dispatched group actions into one [MaterializedGroup] per targeted
+/// class group, in first-seen (snapshot) order. Each targeted group carries the
+/// candidate actions raised against it — including the informational ones
+/// (`canApply == false`), which surface an orphan/empty-class notice.
+List<MaterializedGroup> _materializeGroups(
+  List<actions.GroupAction> groupActions,
+) {
+  final byGroup = <String, List<CandidateAction>>{};
+  final targets = <String, core.LinkedGroup>{};
+  for (final a in groupActions) {
+    final key = _groupKey(a.target);
+    (byGroup[key] ??= <CandidateAction>[])
+        .add(_candidate('group', a, a.describeChanges(), canApply: a.canApply));
+    targets.putIfAbsent(key, () => a.target);
+  }
+  return [
+    for (final entry in targets.entries)
+      MaterializedGroup(
+        id: core.LinkedAccountId(entry.key),
+        label: _groupLabel(entry.value),
+        confidence: entry.value.confidence,
+        inWisa: entry.value.wisa != null,
+        inSmartschool: entry.value.smartschool != null,
+        inAzure: entry.value.azure != null,
+        candidates: byGroup[entry.key]!,
+      ),
+  ];
+}
+
+/// The single "Klasgroepen" [Rollup] over every [MaterializedGroup], or `null`
+/// when no group has a pending action (nothing to drill into). [accountCount] is
+/// the number of group docs, [pendingCount] their applyable actions.
+Rollup? _buildGroupsRollup(List<MaterializedGroup> groups) {
+  if (groups.isEmpty) return null;
+  var pending = 0;
+  for (final g in groups) {
+    pending += g.candidates.where((c) => c.canApply).length;
+  }
+  return Rollup(
+    level: RollupLevel.groups,
+    key: groupsPartition,
+    parentKey: null,
+    school: groupsPartition,
+    label: _groupsLabel,
+    gradeYear: '',
+    classroom: '',
+    accountCount: groups.length,
+    pendingCount: pending,
   );
 }
 
@@ -152,6 +210,7 @@ const String _unassignedSchool = 'unassigned';
 const String _unassignedLabel = 'Niet toegewezen';
 const String _noGrade = 'Overig';
 const String _noClassroom = 'Zonder klas';
+const String _groupsLabel = 'Klasgroepen';
 
 class _Placement {
   const _Placement({
@@ -271,6 +330,19 @@ String _staffMemberLabel(core.LinkedStaff s) {
       wisa?.code.value ??
       '(personeelslid)';
 }
+
+/// The stable cross-system key for a group document (#119): its name (the
+/// linker's cross-system match key), namespaced so it never collides with an
+/// account id. A group always carries at least one system record.
+String _groupKey(core.LinkedGroup g) => 'group|${_groupName(g) ?? '?'}';
+
+/// Display label for a group — its WISA / Smartschool / Azure name.
+String _groupLabel(core.LinkedGroup g) => _groupName(g) ?? '(groep)';
+
+String? _groupName(core.LinkedGroup g) =>
+    _nonEmpty(g.wisa?.name ?? '') ??
+    _nonEmpty(g.smartschool?.name ?? '') ??
+    _nonEmpty(g.azure?.displayName ?? '');
 
 String? _personLabel(
     core.SmartschoolAccount? smartschool, core.AzureUser? azure) {

--- a/packages/account_state/lib/src/materialize/linked_store.dart
+++ b/packages/account_state/lib/src/materialize/linked_store.dart
@@ -30,6 +30,11 @@ abstract interface class LinkedStore {
     required String classroom,
   });
 
+  /// Every per-group doc (#119), loaded lazily when the "Klasgroepen" node is
+  /// opened. Reads the single [groupsPartition]; there are few, so no narrower
+  /// filter is needed.
+  Future<List<MaterializedGroup>> readGroups();
+
   /// Every persisted operator decision (read by the sync path to merge).
   Future<List<AccountDecision>> readDecisions();
 
@@ -102,6 +107,7 @@ String decisionDocId(AccountDecision d) =>
 /// wire behaviour is covered separately by `CosmosLinkedStore`'s unit tests.
 class InMemoryLinkedStore implements LinkedStore {
   final Map<String, MaterializedAccount> _accounts = {};
+  final Map<String, MaterializedGroup> _groups = {};
   List<Rollup> _rollups = const [];
   final Map<String, AccountDecision> _decisions = {};
   SyncState _syncState = SyncState.initial;
@@ -109,6 +115,9 @@ class InMemoryLinkedStore implements LinkedStore {
 
   /// How many accounts are currently stored — for test assertions.
   int get accountCount => _accounts.length;
+
+  /// How many group docs are currently stored — for test assertions.
+  int get groupCount => _groups.length;
 
   @override
   Future<SyncState> readSyncState() async => _syncState;
@@ -127,6 +136,9 @@ class InMemoryLinkedStore implements LinkedStore {
       ];
 
   @override
+  Future<List<MaterializedGroup>> readGroups() async => List.of(_groups.values);
+
+  @override
   Future<List<AccountDecision>> readDecisions() async =>
       List.of(_decisions.values);
 
@@ -141,6 +153,9 @@ class InMemoryLinkedStore implements LinkedStore {
     _accounts
       ..clear()
       ..addEntries(view.accounts.map((a) => MapEntry(a.id.value, a)));
+    _groups
+      ..clear()
+      ..addEntries(view.groups.map((g) => MapEntry(g.id.value, g)));
     _rollups = List.of(view.rollups);
     for (final d in droppedDecisions) {
       _decisions.remove(decisionDocId(d));

--- a/packages/account_state/lib/src/materialize/materialized_state.dart
+++ b/packages/account_state/lib/src/materialize/materialized_state.dart
@@ -112,12 +112,18 @@ enum DecisionKind {
   static DecisionKind fromJson(String s) => values.byName(s);
 }
 
-/// A persisted operator decision about one account.
+/// A persisted operator decision about one account **or class group**.
 ///
 /// [targetKind] is the "situation" the decision resolves — the [kind] of the
 /// [CandidateAction] it applies to, or a warning id for [acceptedDuplicate]. On
-/// the next sync the merge keeps this decision only while an account still has
+/// the next sync the merge keeps this decision only while its target still has
 /// a matching situation (see [mergeDecisions]).
+///
+/// [accountId] is the stable key of the target the decision belongs to: a
+/// [MaterializedAccount.id] for an account/staff decision, or a
+/// [MaterializedGroup.id] for a group decision (#119). Both share this one
+/// decisions container, so the merge considers accounts and groups together and
+/// never drops a group decision just because it is not an account.
 class AccountDecision {
   const AccountDecision({
     required this.accountId,
@@ -128,6 +134,8 @@ class AccountDecision {
     required this.decidedAt,
   });
 
+  /// The stable key of the target (an account/staff id, or a group id) this
+  /// decision belongs to.
   final core.LinkedAccountId accountId;
   final DecisionKind kind;
 
@@ -300,11 +308,120 @@ class MaterializedAccount {
       );
 }
 
+/// The synthetic partition (and rollup school) every [MaterializedGroup] and the
+/// group [Rollup] share (#119). Class groups have no natural school partition the
+/// way a student does, so they live in one logical partition of their own — the
+/// mirror of the `staff` bucket accounts use.
+const String groupsPartition = 'groups';
+
+/// One linked **class group** as a stored document (#119).
+///
+/// The group-family counterpart of [MaterializedAccount]: where a per-account
+/// doc drills down through school / grade-year / classroom, a group action
+/// targets a `LinkedGroup` (an orphan Smartschool class, a WISA class that needs
+/// creating downstream, a class whose data drifted), which does not fit that
+/// per-account shape. So the materializer emits these as their own documents in
+/// the [groupsPartition], surfaced by the passive drill-down under a single
+/// "Klasgroepen" node rather than inside a classroom.
+///
+/// Like [MaterializedAccount] it is rewritten wholesale every sync, carries the
+/// per-system presence and the computed [candidates], and re-attaches the
+/// still-applicable operator [decisions] the last merge kept.
+class MaterializedGroup {
+  const MaterializedGroup({
+    required this.id,
+    required this.label,
+    required this.confidence,
+    required this.inWisa,
+    required this.inSmartschool,
+    required this.inAzure,
+    this.candidates = const [],
+    this.decisions = const [],
+  });
+
+  /// The stable cross-system key of the group — the document id, and the key an
+  /// [AccountDecision] targets a group by.
+  final core.LinkedAccountId id;
+
+  /// Display name for the group (its WISA/Smartschool/Azure name).
+  final String label;
+
+  final core.LinkConfidence confidence;
+
+  final bool inWisa;
+  final bool inSmartschool;
+  final bool inAzure;
+
+  /// The computed candidate group actions (e.g. an orphan-class notice, a
+  /// create/modify). Some are informational (`canApply == false`).
+  final List<CandidateAction> candidates;
+
+  /// Still-applicable operator decisions re-attached by the last sync.
+  final List<AccountDecision> decisions;
+
+  /// The partition every group document shares — [groupsPartition].
+  String get school => groupsPartition;
+
+  /// Whether an apply pass would write anything here: at least one applyable
+  /// candidate (the informational notices do not count).
+  bool get hasPending => candidates.any((c) => c.canApply);
+
+  MaterializedGroup withDecisions(List<AccountDecision> decisions) =>
+      MaterializedGroup(
+        id: id,
+        label: label,
+        confidence: confidence,
+        inWisa: inWisa,
+        inSmartschool: inSmartschool,
+        inAzure: inAzure,
+        candidates: candidates,
+        decisions: decisions,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id.toJson(),
+        'pk': groupsPartition,
+        'label': label,
+        'confidence': confidence.toJson(),
+        'inWisa': inWisa,
+        'inSmartschool': inSmartschool,
+        'inAzure': inAzure,
+        if (candidates.isNotEmpty)
+          'candidates': [for (final c in candidates) c.toJson()],
+        if (decisions.isNotEmpty)
+          'decisions': [for (final d in decisions) d.toJson()],
+      };
+
+  factory MaterializedGroup.fromJson(Map<String, dynamic> json) =>
+      MaterializedGroup(
+        id: core.LinkedAccountId(json['id'] as String),
+        label: json['label'] as String,
+        confidence: core.LinkConfidence.fromJson(json['confidence'] as String),
+        inWisa: json['inWisa'] as bool? ?? false,
+        inSmartschool: json['inSmartschool'] as bool? ?? false,
+        inAzure: json['inAzure'] as bool? ?? false,
+        candidates: [
+          for (final c in (json['candidates'] as List? ?? const []))
+            CandidateAction.fromJson(c as Map<String, dynamic>),
+        ],
+        decisions: [
+          for (final d in (json['decisions'] as List? ?? const []))
+            AccountDecision.fromJson(d as Map<String, dynamic>),
+        ],
+      );
+}
+
 /// Which level of the drill-down a [Rollup] aggregates.
 enum RollupLevel {
   school,
   gradeYear,
   classroom,
+
+  /// The single top-level "Klasgroepen" node aggregating every
+  /// [MaterializedGroup] (#119). It sits outside the school → grade-year →
+  /// classroom tree; its [Rollup.accountCount] counts the group docs and
+  /// [Rollup.pendingCount] their applyable actions.
+  groups,
   ;
 
   String toJson() => name;
@@ -539,16 +656,21 @@ class LeaseOutcome {
   bool get heldByOther => !acquired;
 }
 
-/// The complete materialized output of one sync: the per-account docs plus the
-/// derived [rollups], stamped with the [generation] the store will write.
+/// The complete materialized output of one sync: the per-account docs, the
+/// per-group docs (#119), and the derived [rollups] (which include the single
+/// group node), stamped with the [generation] the store will write.
 class MaterializedView {
   const MaterializedView({
     required this.generation,
     required this.accounts,
     required this.rollups,
+    this.groups = const [],
   });
 
   final int generation;
   final List<MaterializedAccount> accounts;
+
+  /// The per-group documents for the group-action family (#119).
+  final List<MaterializedGroup> groups;
   final List<Rollup> rollups;
 }

--- a/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
@@ -126,11 +126,33 @@ MaterializedAccount _account(String id,
       ],
     );
 
-MaterializedView _view(List<MaterializedAccount> accounts,
-        {int generation = 1}) =>
+MaterializedGroup _group(String name) => MaterializedGroup(
+      id: core.LinkedAccountId('group|$name'),
+      label: name,
+      confidence: core.LinkConfidence.medium,
+      inWisa: false,
+      inSmartschool: true,
+      inAzure: false,
+      candidates: const [
+        CandidateAction(
+          family: 'group',
+          kind: 'DoNotImportFromSmartschool',
+          system: core.Origin.smartschool,
+          summary: 'Orphan',
+          canApply: false,
+        ),
+      ],
+    );
+
+MaterializedView _view(
+  List<MaterializedAccount> accounts, {
+  int generation = 1,
+  List<MaterializedGroup> groups = const [],
+}) =>
     MaterializedView(
       generation: generation,
       accounts: accounts,
+      groups: groups,
       rollups: buildRollups(accounts),
     );
 
@@ -157,6 +179,30 @@ void main() {
 
       final classroom = await store.readClassroom(school: '1', classroom: '3C');
       expect(classroom.map((a) => a.id.value), containsAll(['p0', 'p1']));
+    });
+
+    test('write then read: group docs, deleted on a groupless re-sync (#119)',
+        () async {
+      final client = _FakeClient();
+      final store = CosmosLinkedStore(client);
+
+      await store.writeMaterialized(
+        _view([_account('p0')], groups: [_group('9Z'), _group('8A')]),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+
+      final groups = await store.readGroups();
+      expect(groups.map((g) => g.label), containsAll(['9Z', '8A']));
+      expect(groups.every((g) => g.school == groupsPartition), isTrue);
+
+      // A re-sync with no groups deletes the stragglers.
+      await store.writeMaterialized(
+        _view([_account('p0')], generation: 2),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+      expect(await store.readGroups(), isEmpty);
     });
 
     test('a re-sync deletes the docs no longer present', () async {

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -124,6 +124,61 @@ LinkedState _movePendingLinked() => LinkedState.recompute(
       staffConfig: _staffConfig,
     );
 
+/// A class present in **both** WISA and Smartschool whose institute number
+/// drifts, so the group dispatch yields exactly one *applyable*
+/// `ModifySmartschoolData` — used to prove the group rollup counts pending.
+LinkedState _modifyPendingLinked() => LinkedState.recompute(
+      wisa: wapi.WisaSnapshot(
+        fetchedAt: _d,
+        students: const [],
+        staff: const [],
+        classGroups: [
+          const wapi.WisaClassGroup(
+            name: '3C',
+            groupName: '00',
+            description: '',
+            adminCode: '',
+            schoolCode: '123',
+            schoolId: 1,
+          ),
+        ],
+        schools: const [],
+      ),
+      smartschool: ss.SmartschoolSnapshot(
+        fetchedAt: _d,
+        groups: [_ssGroup('3C', code: '3C_ss')],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: az.AzureSnapshot(fetchedAt: _d, users: const [], groups: const []),
+      resolver: _SeqResolver(),
+      studentConfig: _studentConfig,
+      staffConfig: _staffConfig,
+    );
+
+/// A linked view with no class groups at all (empty on both sides), so the
+/// materializer emits no group docs and no group rollup.
+LinkedState _noGroupsLinked() => LinkedState.recompute(
+      wisa: wapi.WisaSnapshot(
+        fetchedAt: _d,
+        students: [_wStudent()],
+        staff: const [],
+        classGroups: const [],
+        schools: const [],
+      ),
+      smartschool: ss.SmartschoolSnapshot(
+        fetchedAt: _d,
+        groups: const [],
+        accounts: [_ssAccount()],
+        memberships: const [],
+      ),
+      azure:
+          az.AzureSnapshot(fetchedAt: _d, users: [_azUser()], groups: const []),
+      resolver: _SeqResolver(),
+      studentConfig: _studentConfig,
+      staffConfig: _staffConfig,
+    );
+
 MaterializedAccount _account({
   String id = 'p0',
   String school = '1',
@@ -257,6 +312,66 @@ void main() {
     });
   });
 
+  group('materialize groups (#119)', () {
+    test('a group action → a group doc in the groups partition + rollup', () {
+      // The Smartschool-only 2B class raises the informational orphan notice.
+      final view = materialize(_movePendingLinked(), generation: 2);
+
+      expect(view.groups, hasLength(1));
+      final group = view.groups.single;
+      expect(group.id.value, 'group|2B');
+      expect(group.label, '2B');
+      expect(group.school, groupsPartition,
+          reason: 'partition = groups bucket');
+      expect(group.inSmartschool, isTrue);
+      expect(group.inWisa, isFalse);
+      expect(group.candidates, isNotEmpty);
+      expect(group.candidates.every((c) => c.family == 'group'), isTrue);
+      // The orphan notice is informational — nothing to apply.
+      expect(group.hasPending, isFalse);
+
+      final rollup =
+          view.rollups.firstWhere((r) => r.level == RollupLevel.groups);
+      expect(rollup.key, groupsPartition);
+      expect(rollup.school, groupsPartition);
+      expect(rollup.label, 'Klasgroepen');
+      expect(rollup.accountCount, 1);
+      expect(rollup.pendingCount, 0,
+          reason: 'the orphan notice is informational');
+    });
+
+    test('an applyable group action counts toward the group rollup pending',
+        () {
+      final view = materialize(_modifyPendingLinked(), generation: 1);
+
+      final group = view.groups.single;
+      expect(group.inWisa && group.inSmartschool, isTrue);
+      expect(group.candidates.map((c) => c.kind),
+          contains('ModifySmartschoolData'));
+      expect(group.hasPending, isTrue);
+
+      final rollup =
+          view.rollups.firstWhere((r) => r.level == RollupLevel.groups);
+      expect(rollup.pendingCount, greaterThan(0));
+    });
+
+    test('no group actions → no group docs and no group rollup', () {
+      final view = materialize(_noGroupsLinked(), generation: 1);
+      expect(view.groups, isEmpty);
+      expect(view.rollups.where((r) => r.level == RollupLevel.groups), isEmpty);
+    });
+
+    test('every group doc round-trips through JSON', () {
+      final group =
+          materialize(_movePendingLinked(), generation: 1).groups.single;
+      final restored = MaterializedGroup.fromJson(group.toJson());
+      expect(restored.id, group.id);
+      expect(restored.label, group.label);
+      expect(restored.inSmartschool, isTrue);
+      expect(restored.candidates, hasLength(group.candidates.length));
+    });
+  });
+
   group('gradeYearOf', () {
     test('takes the leading digits of the class group', () {
       expect(gradeYearOf('3C'), '3');
@@ -321,6 +436,81 @@ void main() {
       expect(merge.surviving, isEmpty);
     });
 
+    MaterializedGroup group(String key,
+            {List<CandidateAction> candidates = const []}) =>
+        MaterializedGroup(
+          id: id(key),
+          label: key,
+          confidence: core.LinkConfidence.high,
+          inWisa: true,
+          inSmartschool: true,
+          inAzure: false,
+          candidates: candidates,
+        );
+
+    const modifyGroupCandidate = CandidateAction(
+      family: 'group',
+      kind: 'ModifySmartschoolData',
+      system: core.Origin.smartschool,
+      summary: 'Werk de klasgegevens bij in Smartschool',
+    );
+
+    test('re-attaches a group decision whose situation still exists (#119)',
+        () {
+      final merge = mergeDecisions(
+        accounts: const [],
+        groups: [
+          group('group|3C', candidates: const [modifyGroupCandidate]),
+        ],
+        existing: [
+          decision('group|3C', 'ModifySmartschoolData',
+              kind: DecisionKind.appliedStatus),
+        ],
+      );
+
+      expect(merge.surviving, hasLength(1));
+      expect(merge.dropped, isEmpty);
+      expect(merge.groups.single.decisions, hasLength(1));
+    });
+
+    test('drops a group decision whose candidate is gone (#119)', () {
+      final merge = mergeDecisions(
+        accounts: const [],
+        groups: [
+          group('group|3C', candidates: const [modifyGroupCandidate]),
+        ],
+        existing: [
+          decision('group|3C', 'AddToSmartschool',
+              kind: DecisionKind.appliedStatus),
+        ],
+      );
+
+      expect(merge.surviving, isEmpty);
+      expect(merge.dropped, hasLength(1));
+      expect(merge.groups.single.decisions, isEmpty);
+    });
+
+    test('a group decision is not dropped by the account pass (#119)', () {
+      // Accounts and groups share one decisions container; the merge must
+      // consider groups so a group decision is not wrongly dropped for lacking
+      // a matching account.
+      final merge = mergeDecisions(
+        accounts: [
+          _account(id: 'p0', candidates: const [_moveCandidate])
+        ],
+        groups: [
+          group('group|3C', candidates: const [modifyGroupCandidate]),
+        ],
+        existing: [
+          decision('group|3C', 'ModifySmartschoolData',
+              kind: DecisionKind.appliedStatus),
+        ],
+      );
+
+      expect(merge.dropped, isEmpty);
+      expect(merge.surviving, hasLength(1));
+    });
+
     test('an accepted-duplicate survives while the warning is present', () {
       final withWarning = [
         _account(id: 'p0', warnings: const ['Dubbele mail']),
@@ -357,7 +547,11 @@ void main() {
       expect(state.generation, 1);
       expect(state.updatedBy, 'op@school.example');
 
-      expect(await store.readRollups(), hasLength(3));
+      // Three account rollups (school / grade / classroom) plus the single
+      // group rollup (#119).
+      final rollups = await store.readRollups();
+      expect(rollups.where((r) => r.level != RollupLevel.groups), hasLength(3));
+      expect(rollups.where((r) => r.level == RollupLevel.groups), hasLength(1));
 
       final classroom = await store.readClassroom(school: '1', classroom: '3C');
       expect(classroom, hasLength(1));
@@ -387,6 +581,30 @@ void main() {
       );
       expect(store.accountCount, 0);
       expect((await store.readSyncState()).generation, 2);
+    });
+
+    test('write then read: group docs, cleared on a groupless re-sync (#119)',
+        () async {
+      final store = InMemoryLinkedStore();
+      final view = materialize(_movePendingLinked(), generation: 1);
+      expect(view.groups, isNotEmpty);
+
+      await store.writeMaterialized(view,
+          syncedBy: 'op@school.example', at: _d);
+
+      final groups = await store.readGroups();
+      expect(groups.map((g) => g.label), contains('2B'));
+      expect(store.groupCount, view.groups.length);
+
+      // A re-sync whose view has no groups clears the stored group docs.
+      await store.writeMaterialized(
+        const MaterializedView(
+            generation: 2, accounts: [], rollups: [], groups: []),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+      expect(store.groupCount, 0);
+      expect(await store.readGroups(), isEmpty);
     });
 
     test('putDecision persists; writeMaterialized drops the ones passed',


### PR DESCRIPTION
## Summary

Follow-up to #115. The materialize step turned only the **account** and **staff** families into persisted per-account docs + rollups; **group actions were deliberately left out** because they target a `LinkedGroup`, not an account/classroom. As a result a purely passive session (one that reads the materialized view without pulling or re-linking) never saw pending group actions — an orphan Smartschool class, a class that needs creating/modifying, etc.

This persists group actions alongside the per-account docs and surfaces them in the passive drill-down.

## Linked issue

Closes #119

## Design decision

Group actions live in their **own `linkedGroups` documents + a single group rollup** (the first of the two options the issue floats). Class groups have no natural per-school partition the way a student does, so every `MaterializedGroup` and the group rollup share one synthetic `groups` logical partition — the mirror of the existing `staff` bucket. The group node sits *beside* the school → grade-year → classroom tree in the drill-down ("Klasgroepen"), not inside a classroom.

## Changes

- **`materialized_state.dart`** — new `MaterializedGroup` doc type, `groupsPartition` constant, `RollupLevel.groups`, and `MaterializedView.groups`. `AccountDecision` doc generalized to target an account **or** a group.
- **`linked_state_materializer.dart`** — `materialize()` emits one `MaterializedGroup` per targeted group (candidates incl. informational notices) and the single "Klasgroepen" `Rollup`.
- **`decisions_merge.dart`** — `mergeDecisions()` re-attaches still-applicable **group** decisions in the same pass as accounts, so a group decision sharing the one decisions container is never wrongly dropped for lacking a matching account.
- **`linked_store.dart` / `cosmos_linked_store.dart` / `cosmos_config.dart`** — `readGroups()` on the seam, the in-memory fake, and the Cosmos-backed impl over a new `linkedGroups` container, with the same wholesale-replace write path (upsert fresh + delete stragglers).
- **`reconcile_controller.dart`** — exposes `groupRollup` and a lazy `openGroups`/`closeGroups` drill-down (no pull, no `link()`); `_persist` materializes + merges groups; `onStoreChanged` refreshes an open group drill-down.
- **`reconcile_screen.dart`** — a "Klasgroepen" node in the drill-down and a `_GroupsDetail` list of group docs with their action summaries.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `dart analyze` clean (workspace-wide, no issues)
- [x] Unit tests — `dart test packages/account_state` (233 pass). New coverage: group docs + group rollup from `materialize()`, applyable vs informational pending counts, no-groups → no rollup, JSON round-trip, group-decision re-attach/drop (incl. "not dropped by the account pass"), InMemory + Cosmos `readGroups` write/clear/delete.
- [x] Widget/controller tests — `flutter test` (95 pass). New: controller materializes group docs + rollup; passive session opens the Klasgroepen drill-down with no pull/link; screen renders and opens the group node.
- [x] Integration/e2e — `flutter test integration_test -d windows` (10 pass). New #119 scenario: a passive session (real app, real fonts/navigation) surfaces pending group actions in the drill-down and lists the orphan-class notices, with zero connector pulls and no `link()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)