### PR TITLE
Pending actions: one entry per account, mutually-exclusive alternatives as a choice, per-row apply (#110)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -154,6 +154,71 @@ void main() {
   });
 
   testWidgets(
+      'the pending list groups one entry per account and applies the chosen '
+      'alternative: choose delete → delete, not unregister (#110)',
+      (WidgetTester tester) async {
+    // A WISA-departed student: a Smartschool-only active account (no WISA, no
+    // Azure) whose dispatcher yields the mutually-exclusive unregister/delete
+    // resolutions — the exact situation #110 fixes.
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(students: const []),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: [
+          ssAccount(
+            uid: 'jane',
+            accountId: '1',
+            mail: 'jane.doe@student.school.example',
+          ),
+        ],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // One entry for the departed account (not two independent rows).
+    final entry = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student');
+    final id = entry.targetId;
+    expect(entry.choices.single.isChoice, isTrue,
+        reason: 'unregister vs delete collapse into a single choice');
+    expect(find.byKey(ValueKey('entry-student-$id')), findsOneWidget);
+
+    // Expand the entry, choose delete (the non-default), apply just this row.
+    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(ValueKey('alt-$id-DeleteStudentFromSmartschool')));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Apply result'), findsOneWidget);
+    expect(harness.soap.soapActions, isNotEmpty);
+    final summaries =
+        harness.controller.applyResults!.map((r) => r.changes.summary);
+    expect(summaries, contains('Verwijder dit account uit Smartschool'));
+    expect(summaries, isNot(contains('Schrijf de leerling uit in Smartschool')),
+        reason: 'only the chosen resolution ran — never both');
+  });
+
+  testWidgets(
       'a resumed session trusts the stored state: Synchronise pulls no '
       'Smartschool/Azure (#107)', (WidgetTester tester) async {
     // Session 1 (offline harness over a shared cold-snapshot store): a full

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -73,6 +73,119 @@ class ActionOutcomeEntry {
   final Object? error;
 }
 
+/// One selectable resolution inside a [PendingAccountEntry] (#110).
+///
+/// Wraps the live action to run when this alternative is chosen, plus the pure
+/// description the list renders. [group] is the [actions.StudentAction]-style
+/// alternative-group key — non-null only when this option is one of several
+/// mutually-exclusive alternatives.
+class PendingActionOption {
+  const PendingActionOption({
+    required this.action,
+    required this.kind,
+    required this.group,
+    required this.isDefault,
+    required this.family,
+    required this.target,
+    required this.changes,
+    required this.canApply,
+  });
+
+  /// The live `StudentAction` / `StaffAction` / `GroupAction` this option runs.
+  final Object action;
+
+  /// The action's class name — the stable discriminator a decision keys on.
+  final String kind;
+
+  /// The mutually-exclusive-alternative key, or `null` when the option stands
+  /// alone (see [actions.StudentAction.alternativeGroup]).
+  final String? group;
+
+  /// Whether this is the pre-selected default of its alternative group.
+  final bool isDefault;
+
+  /// `student`, `staff`, or `group`.
+  final String family;
+
+  /// Human label of the target this option acts on (for the result rows).
+  final String target;
+
+  /// The action's pure diff (summary + field changes).
+  final actions.ChangeSet changes;
+
+  /// Whether an apply pass would actually write this option.
+  final bool canApply;
+}
+
+/// One decision point within a [PendingAccountEntry]: either a lone action or a
+/// set of mutually-exclusive alternatives, exactly one of which is [selected].
+///
+/// A departed student's "unregister *vs* delete" pair is a single choice with
+/// two [alternatives]; an ordinary modify action is a choice of one. Rendering
+/// the alternatives as one choice — rather than independent rows — is the core
+/// of #110: the operator picks one resolution and never runs both.
+class PendingChoice {
+  PendingChoice({required this.alternatives, required this.selected})
+      : assert(alternatives.isNotEmpty);
+
+  /// The mutually-exclusive options (one or more).
+  final List<PendingActionOption> alternatives;
+
+  /// The currently-chosen option (defaults to the group's default).
+  final PendingActionOption selected;
+
+  /// True when this is a real choice the operator must resolve (more than one
+  /// alternative), false for a lone action.
+  bool get isChoice => alternatives.length > 1;
+
+  /// The situation this choice resolves — the alternative-group key for a real
+  /// choice, else the single action kind. Drives the "same situation" grouping
+  /// so two departed students share one bulk-apply subset.
+  String get situationId => alternatives.first.group ?? alternatives.first.kind;
+}
+
+/// The pending actions for **one** linked account, staff member, or class group
+/// — the "one entry per account" the list renders (#110).
+class PendingAccountEntry {
+  const PendingAccountEntry({
+    required this.family,
+    required this.targetId,
+    required this.target,
+    required this.choices,
+  });
+
+  /// `student`, `staff`, or `group`.
+  final String family;
+
+  /// The stable key of the target this entry groups (the account/staff/group id).
+  final String targetId;
+
+  /// Human label of the target.
+  final String target;
+
+  /// The decision points for this target, in dispatch order.
+  final List<PendingChoice> choices;
+
+  /// A stable signature of this entry's *situation* — its family plus the sorted
+  /// set of its choices' [PendingChoice.situationId]. Two entries with the same
+  /// key are "in the same situation", so a bulk apply can act on the subset.
+  String get situationKey {
+    final ids = choices.map((c) => c.situationId).toList()..sort();
+    return '$family|${ids.join(',')}';
+  }
+
+  /// A short human description of the situation (the choices' summaries), used as
+  /// the header of a same-situation subset.
+  String get situationLabel => choices.map((c) {
+        if (!c.isChoice) return c.selected.changes.summary;
+        return c.alternatives.map((a) => a.changes.summary).join(' / ');
+      }).join('; ');
+
+  /// Whether an apply pass would write anything for this entry — at least one
+  /// selected option is applyable.
+  bool get canApply => choices.any((c) => c.selected.canApply);
+}
+
 /// Drives the reconcile loop over the State layer (#99): **sync → linked
 /// overview → pending actions → dry-run → apply**, with progress and failures
 /// reported through the shared [LogBuffer].
@@ -152,6 +265,11 @@ class ReconcileController extends ChangeNotifier {
   /// is read and folded into the shared store on persist (#108).
   final Map<core.Origin, SystemSyncMeta> _pulled = {};
 
+  /// The operator's chosen alternative per situation (#110), keyed by
+  /// `<targetId>|<alternativeGroup>` → the chosen action kind. A missing entry
+  /// means the situation still shows its default alternative.
+  final Map<String, String> _choices = {};
+
   ReconcilePhase get phase => _phase;
 
   /// Whether a pass is running (buttons disable on this).
@@ -209,6 +327,159 @@ class ReconcileController extends ChangeNotifier {
           canApply: a.canApply,
         ),
     ];
+  }
+
+  /// The pending actions grouped **one entry per target** (#110): each linked
+  /// account/staff/group becomes a single [PendingAccountEntry], and its
+  /// mutually-exclusive actions (unregister *vs* delete) collapse into one
+  /// [PendingChoice] rather than independent rows. Rebuilt from the live view on
+  /// every read; the operator's picks live in [_choices] so a rebuild preserves
+  /// them.
+  List<PendingAccountEntry> get pendingEntries {
+    final l = _linked;
+    if (l == null) return const [];
+    final entries = <PendingAccountEntry>[];
+    entries.addAll(_entriesFor(
+      family: 'student',
+      actionList: l.studentActions,
+      targetId: (a) => a.target.id.value,
+      label: (a) => _accountLabel(a.target),
+      group: (a) => a.alternativeGroup,
+      isDefault: (a) => a.isDefaultAlternative,
+      changes: (a) => a.describeChanges(),
+      canApply: (_) => true,
+    ));
+    entries.addAll(_entriesFor(
+      family: 'staff',
+      actionList: l.staffActions,
+      targetId: (a) => a.target.id.value,
+      label: (a) => _staffLabel(a.target),
+      group: (a) => a.alternativeGroup,
+      isDefault: (a) => a.isDefaultAlternative,
+      changes: (a) => a.describeChanges(),
+      canApply: (_) => true,
+    ));
+    entries.addAll(_entriesFor(
+      family: 'group',
+      actionList: l.groupActions,
+      targetId: (a) => _groupLabel(a.target),
+      label: (a) => _groupLabel(a.target),
+      group: (a) => a.alternativeGroup,
+      isDefault: (a) => a.isDefaultAlternative,
+      changes: (a) => a.describeChanges(),
+      canApply: (a) => a.canApply,
+    ));
+    return entries;
+  }
+
+  /// The pending entries grouped into "same situation" subsets (#110), in
+  /// first-seen order. Each subset shares a [PendingAccountEntry.situationKey],
+  /// so it can be bulk-applied ("apply this resolution to all departed
+  /// students") while each entry keeps its own chosen alternative.
+  List<List<PendingAccountEntry>> get pendingSituations {
+    final order = <String>[];
+    final bySituation = <String, List<PendingAccountEntry>>{};
+    for (final e in pendingEntries) {
+      final key = e.situationKey;
+      if (!bySituation.containsKey(key)) order.add(key);
+      (bySituation[key] ??= <PendingAccountEntry>[]).add(e);
+    }
+    return [for (final key in order) bySituation[key]!];
+  }
+
+  /// Builds one [PendingAccountEntry] per target from [actionList], collapsing
+  /// mutually-exclusive alternatives (shared non-null [group]) into a single
+  /// [PendingChoice].
+  List<PendingAccountEntry> _entriesFor<T>({
+    required String family,
+    required List<T> actionList,
+    required String Function(T) targetId,
+    required String Function(T) label,
+    required String? Function(T) group,
+    required bool Function(T) isDefault,
+    required actions.ChangeSet Function(T) changes,
+    required bool Function(T) canApply,
+  }) {
+    final order = <String>[];
+    final byTarget = <String, List<T>>{};
+    final labels = <String, String>{};
+    for (final a in actionList) {
+      final id = targetId(a);
+      if (!byTarget.containsKey(id)) order.add(id);
+      (byTarget[id] ??= <T>[]).add(a);
+      labels[id] = label(a);
+    }
+
+    return [
+      for (final id in order)
+        PendingAccountEntry(
+          family: family,
+          targetId: id,
+          target: labels[id]!,
+          choices: _choicesFor(
+            id,
+            [
+              for (final a in byTarget[id]!)
+                PendingActionOption(
+                  action: a as Object,
+                  kind: a.runtimeType.toString(),
+                  group: group(a),
+                  isDefault: isDefault(a),
+                  family: family,
+                  target: labels[id]!,
+                  changes: changes(a),
+                  canApply: canApply(a),
+                ),
+            ],
+          ),
+        ),
+    ];
+  }
+
+  /// Partitions one target's [options] into [PendingChoice]s: options sharing a
+  /// non-null [PendingActionOption.group] become one mutually-exclusive choice
+  /// (its selection honoured from [_choices], defaulting to the group default);
+  /// every other option is a choice of one.
+  List<PendingChoice> _choicesFor(
+    String targetId,
+    List<PendingActionOption> options,
+  ) {
+    final choices = <PendingChoice>[];
+    final groupOrder = <String>[];
+    final byGroup = <String, List<PendingActionOption>>{};
+    for (final o in options) {
+      final g = o.group;
+      if (g == null) {
+        choices.add(PendingChoice(alternatives: [o], selected: o));
+      } else {
+        if (!byGroup.containsKey(g)) groupOrder.add(g);
+        (byGroup[g] ??= <PendingActionOption>[]).add(o);
+      }
+    }
+    for (final g in groupOrder) {
+      final alts = byGroup[g]!;
+      final defaultKind =
+          alts.firstWhere((a) => a.isDefault, orElse: () => alts.first).kind;
+      final chosenKind = _choices['$targetId|$g'] ?? defaultKind;
+      final selected = alts.firstWhere(
+        (a) => a.kind == chosenKind,
+        orElse: () => alts.firstWhere((a) => a.kind == defaultKind),
+      );
+      choices.add(PendingChoice(alternatives: alts, selected: selected));
+    }
+    return choices;
+  }
+
+  /// Records the operator's pick of a mutually-exclusive alternative (#110):
+  /// within [entry]'s choice keyed by [group], select the option of [kind]. A
+  /// no-op for a lone action. Notifies so the list re-renders the new selection.
+  void chooseAlternative({
+    required PendingAccountEntry entry,
+    required String group,
+    required String kind,
+  }) {
+    _choices['${entry.targetId}|$group'] = kind;
+    notifyListeners();
   }
 
   /// The stored freshness + generation marker of the materialized view.
@@ -279,15 +550,22 @@ class ReconcileController extends ChangeNotifier {
   /// Whether a group drill-down read is in flight.
   bool get loadingGroups => _loadingGroups;
 
-  /// How many pending actions an apply pass would actually write (the
-  /// informational group actions are excluded).
-  int get applyableCount {
-    final l = _linked;
-    if (l == null) return 0;
-    return l.studentActions.length +
-        l.staffActions.length +
-        l.groupActions.where((a) => a.canApply).length;
-  }
+  /// How many pending actions an apply pass would actually write — the
+  /// **selected** applyable option of each choice (#110). A departed student
+  /// counts once (the chosen resolution), not twice, and the informational group
+  /// actions are excluded.
+  int get applyableCount => _selectedActions(pendingEntries).length;
+
+  /// The live actions to run for [entries]: the selected, applyable option of
+  /// every choice, in order.
+  List<PendingActionOption> _selectedActions(
+    Iterable<PendingAccountEntry> entries,
+  ) =>
+      [
+        for (final e in entries)
+          for (final c in e.choices)
+            if (c.selected.canApply) c.selected,
+      ];
 
   /// Runs the smart sync: pull WISA, diff against the retained snapshot, and
   /// only when something changed (or nothing is linked yet) pull the still-
@@ -505,18 +783,53 @@ class ReconcileController extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Dry-runs every pending action (PAIN-3): the full apply path, zero writes.
-  /// Results land in [dryRunResults].
-  Future<void> dryRun() => _applyAll(dry: true);
+  /// Dry-runs the chosen resolution of **every** pending entry (PAIN-3): the
+  /// full apply path, zero writes. Results land in [dryRunResults].
+  Future<void> dryRun() => _run(_selectedActions(pendingEntries), dry: true);
 
-  /// Applies every pending action for real, refreshing the linked view from
-  /// the State layer's incremental patches as it goes. Results land in
+  /// Applies the chosen resolution of every pending entry for real, refreshing
+  /// the linked view from the State layer's incremental patches as it goes.
+  /// Only the **selected** alternative of each choice runs — a departed student
+  /// is unregistered *or* deleted, never both (#110). Results land in
   /// [applyResults].
-  Future<void> applyAll() => _applyAll(dry: false);
+  Future<void> applyAll() => _run(_selectedActions(pendingEntries), dry: false);
 
-  Future<void> _applyAll({required bool dry}) async {
-    final l = _linked;
-    if (busy || l == null) return;
+  /// Dry-runs one entry's chosen resolution (#110): the per-row preview.
+  Future<void> dryRunEntry(PendingAccountEntry entry) =>
+      _run(_selectedActions([entry]), dry: true);
+
+  /// Applies one entry's chosen resolution (#110): the per-row apply.
+  Future<void> applyEntry(PendingAccountEntry entry) =>
+      _run(_selectedActions([entry]), dry: false);
+
+  /// Applies the chosen resolution to every entry in the same situation (#110):
+  /// "apply this resolution to all departed students". Each entry keeps its own
+  /// chosen alternative. [situationKey] matches [PendingAccountEntry.situationKey].
+  Future<void> applySituation(String situationKey) => _run(
+        _selectedActions(
+          pendingEntries.where((e) => e.situationKey == situationKey),
+        ),
+        dry: false,
+      );
+
+  /// Dry-runs every entry in the same situation (#110).
+  Future<void> dryRunSituation(String situationKey) => _run(
+        _selectedActions(
+          pendingEntries.where((e) => e.situationKey == situationKey),
+        ),
+        dry: true,
+      );
+
+  /// Runs [selected] — the pre-resolved, applyable options — through the apply
+  /// path (dry or real). Shared by the global, per-entry, and per-situation
+  /// affordances so all three behave identically (#110). Each option is bound to
+  /// its own target; on a real write the applier patches the snapshot and
+  /// returns a fresh linked view we adopt as the pass proceeds.
+  Future<void> _run(
+    List<PendingActionOption> selected, {
+    required bool dry,
+  }) async {
+    if (busy || _linked == null) return;
     _begin(ReconcilePhase.applying);
 
     final options =
@@ -525,36 +838,16 @@ class ReconcileController extends ChangeNotifier {
     final label = dry ? 'Dry-run' : 'Apply';
     log.addMessage(
       core.Origin.all,
-      '$label started for $applyableCount of ${pendingActions.length} '
+      '$label started for ${selected.length} of ${pendingActions.length} '
       'pending action(s).',
     );
 
     try {
-      // Walk the lists captured before the pass: each action is bound to its
-      // target, and on a real write the applier patches the snapshot and
-      // returns a fresh linked view we adopt as we go.
-      for (final action in l.studentActions) {
+      for (final option in selected) {
         results.add(await _applyOne(
-          () => applier.applyStudent(action, options: options),
-          _accountLabel(action.target),
-          action.describeChanges(),
-        ));
-      }
-      for (final action in l.staffActions) {
-        results.add(await _applyOne(
-          () => applier.applyStaff(action, options: options),
-          _staffLabel(action.target),
-          action.describeChanges(),
-        ));
-      }
-      for (final action in l.groupActions) {
-        // Informational actions (canApply false) carry no automated write —
-        // their apply() throws by contract, so the pass leaves them out.
-        if (!action.canApply) continue;
-        results.add(await _applyOne(
-          () => applier.applyGroup(action, options: options),
-          _groupLabel(action.target),
-          action.describeChanges(),
+          () => _applyAny(option.action, options),
+          option.target,
+          option.changes,
         ));
       }
 
@@ -582,6 +875,17 @@ class ReconcileController extends ChangeNotifier {
       }
       _fail(e);
     }
+  }
+
+  /// Dispatches one live action to the applier by its family.
+  Future<ApplyResult> _applyAny(Object action, actions.ApplyOptions options) {
+    if (action is actions.StudentAction) {
+      return applier.applyStudent(action, options: options);
+    }
+    if (action is actions.StaffAction) {
+      return applier.applyStaff(action, options: options);
+    }
+    return applier.applyGroup(action as actions.GroupAction, options: options);
   }
 
   Future<ActionOutcomeEntry> _applyOne(

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -111,32 +111,6 @@ class _ReconcileBody extends StatelessWidget {
   final ReconcileController controller;
   final LogBuffer log;
 
-  Future<void> _confirmApply(BuildContext context) async {
-    final count = controller.applyableCount;
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Apply pending actions?'),
-        content: Text(
-          'This writes $count change(s) to Smartschool and Azure AD. '
-          'Run a dry-run first to preview the exact changes.',
-        ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            key: const ValueKey('reconcile-apply-confirm'),
-            onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('Apply'),
-          ),
-        ],
-      ),
-    );
-    if (confirmed ?? false) await controller.applyAll();
-  }
-
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
@@ -171,10 +145,7 @@ class _ReconcileBody extends StatelessWidget {
                           const SizedBox(height: PlinkSpacing.s5),
                           _OverviewSection(linked: linked),
                           const SizedBox(height: PlinkSpacing.s5),
-                          _ActionsSection(
-                            controller: controller,
-                            onApply: () => _confirmApply(context),
-                          ),
+                          _ActionsSection(controller: controller),
                         ],
                         ..._results(context),
                       ],
@@ -486,28 +457,68 @@ class _WarningLine extends StatelessWidget {
   }
 }
 
+/// Shows the apply-confirmation dialog and, on confirm, runs [apply] (#110).
+/// Shared by the global, per-situation, and per-entry apply affordances so a
+/// write is always one deliberate confirmation.
+Future<void> _confirmAndApply(
+  BuildContext context, {
+  required String title,
+  required int count,
+  required Future<void> Function() apply,
+}) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(title),
+      content: Text(
+        'This writes $count change(s) to Smartschool and Azure AD. '
+        'Run a dry-run first to preview the exact changes.',
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          key: const ValueKey('reconcile-apply-confirm'),
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Apply'),
+        ),
+      ],
+    ),
+  );
+  if (confirmed ?? false) await apply();
+}
+
+/// The pending-actions list (#110): **one entry per account**, mutually
+/// exclusive resolutions rendered as a choice, and per-entry / per-situation
+/// apply as the primary affordances. The global "apply all" is kept as a
+/// secondary escape hatch, not the headline.
 class _ActionsSection extends StatelessWidget {
-  const _ActionsSection({required this.controller, required this.onApply});
+  const _ActionsSection({required this.controller});
 
   final ReconcileController controller;
-  final VoidCallback onApply;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
-    final pending = controller.pendingViews;
+    final entries = controller.pendingEntries;
+    final situations = controller.pendingSituations;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Pending actions (${pending.length})', style: text.titleMedium),
+        Text('Pending actions (${entries.length})', style: text.titleMedium),
         const SizedBox(height: PlinkSpacing.s3),
-        if (pending.isEmpty)
+        if (entries.isEmpty)
           Text(
             'Everything is in sync — no pending actions.',
             style: text.bodyMedium,
           )
         else ...<Widget>[
+          for (final subset in situations)
+            _SituationSection(controller: controller, entries: subset),
+          const SizedBox(height: PlinkSpacing.s3),
           Wrap(
             spacing: PlinkSpacing.s3,
             children: <Widget>[
@@ -519,33 +530,112 @@ class _ActionsSection extends StatelessWidget {
                 icon: const Icon(Icons.visibility_outlined),
                 label: const Text('Dry-run all'),
               ),
-              FilledButton.icon(
+              TextButton.icon(
                 key: const ValueKey('reconcile-apply'),
                 onPressed: controller.busy || controller.applyableCount == 0
                     ? null
-                    : onApply,
+                    : () => _confirmAndApply(
+                          context,
+                          title: 'Apply pending actions?',
+                          count: controller.applyableCount,
+                          apply: controller.applyAll,
+                        ),
                 icon: const Icon(Icons.play_arrow_outlined),
                 label: const Text('Apply all'),
               ),
             ],
           ),
-          const SizedBox(height: PlinkSpacing.s3),
-          ...pending.map((p) => _PendingActionTile(view: p)),
         ],
       ],
     );
   }
 }
 
-class _PendingActionTile extends StatelessWidget {
-  const _PendingActionTile({required this.view});
+/// One "same situation" subset (#110): the entries whose situation matches, with
+/// a bulk "apply this resolution to all" affordance that honours each entry's
+/// own chosen alternative. The bulk header only appears when more than one
+/// account is in the situation — a lone entry is resolved from its own tile.
+class _SituationSection extends StatelessWidget {
+  const _SituationSection({required this.controller, required this.entries});
 
-  final PendingActionView view;
+  final ReconcileController controller;
+  final List<PendingAccountEntry> entries;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final key = entries.first.situationKey;
+    final applyable = entries.where((e) => e.canApply).length;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        if (entries.length > 1) ...<Widget>[
+          Padding(
+            padding: const EdgeInsets.only(
+              top: PlinkSpacing.s2,
+              bottom: PlinkSpacing.s2,
+            ),
+            child: Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    '${entries.first.situationLabel} — ${entries.length} '
+                    'accounts in the same situation',
+                    style: text.titleSmall,
+                  ),
+                ),
+                const SizedBox(width: PlinkSpacing.s2),
+                OutlinedButton(
+                  key: ValueKey('situation-dry-run-$key'),
+                  onPressed: controller.busy || applyable == 0
+                      ? null
+                      : () => controller.dryRunSituation(key),
+                  child: const Text('Dry-run all'),
+                ),
+                const SizedBox(width: PlinkSpacing.s2),
+                FilledButton(
+                  key: ValueKey('situation-apply-$key'),
+                  onPressed: controller.busy || applyable == 0
+                      ? null
+                      : () => _confirmAndApply(
+                            context,
+                            title: 'Apply to ${entries.length} accounts?',
+                            count: applyable,
+                            apply: () => controller.applySituation(key),
+                          ),
+                  child: Text('Apply to all ($applyable)'),
+                ),
+              ],
+            ),
+          ),
+        ],
+        for (final entry in entries)
+          _PendingEntryTile(controller: controller, entry: entry),
+      ],
+    );
+  }
+}
+
+/// One account's pending resolution (#110): a single expandable row showing the
+/// selected summary, the mutually-exclusive choice (as radios) when there is
+/// one, the per-field diff, and per-entry dry-run / apply.
+class _PendingEntryTile extends StatelessWidget {
+  const _PendingEntryTile({required this.controller, required this.entry});
+
+  final ReconcileController controller;
+  final PendingAccountEntry entry;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     final Color hairline = Theme.of(context).dividerColor;
+
+    String lineFor(PendingChoice c) {
+      final summary = c.selected.changes.summary;
+      if (c.isChoice) return '$summary (keuze)';
+      return c.selected.canApply ? summary : '$summary (manueel)';
+    }
 
     return Container(
       margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
@@ -554,15 +644,18 @@ class _PendingActionTile extends StatelessWidget {
         borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
       ),
       child: ExpansionTile(
+        key: ValueKey('entry-${entry.family}-${entry.targetId}'),
         shape: const Border(),
         collapsedShape: const Border(),
-        leading: PlinkBadge(view.family),
-        title: Text(view.target, style: text.bodyLarge),
-        subtitle: Text(
-          view.canApply
-              ? view.changes.summary
-              : '${view.changes.summary} (manual — not applied automatically)',
-          style: text.bodySmall,
+        leading: PlinkBadge(entry.family),
+        title: Text(entry.target, style: text.bodyLarge),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            for (final c in entry.choices)
+              Text(lineFor(c), style: text.bodySmall),
+          ],
         ),
         childrenPadding: const EdgeInsets.fromLTRB(
           PlinkSpacing.s5,
@@ -571,24 +664,143 @@ class _PendingActionTile extends StatelessWidget {
           PlinkSpacing.s4,
         ),
         expandedCrossAxisAlignment: CrossAxisAlignment.start,
-        children: view.changes.fields.isEmpty
-            ? <Widget>[
-                Text(
-                  'Lifecycle action — no per-field diff.',
-                  style: text.bodySmall,
-                ),
-              ]
-            : <Widget>[
-                for (final f in view.changes.fields)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
-                    child: Text(
-                      '${f.field}: ${f.before ?? '∅'} → ${f.after ?? '∅'}',
-                      style: text.bodySmall,
-                    ),
-                  ),
-              ],
+        children: <Widget>[
+          for (final choice in entry.choices)
+            if (choice.isChoice)
+              _ChoiceControl(
+                controller: controller,
+                entry: entry,
+                choice: choice,
+              )
+            else
+              _OptionDetail(option: choice.selected),
+          const SizedBox(height: PlinkSpacing.s3),
+          Row(
+            children: <Widget>[
+              OutlinedButton(
+                key: ValueKey('entry-dry-run-${entry.targetId}'),
+                onPressed: controller.busy || !entry.canApply
+                    ? null
+                    : () => controller.dryRunEntry(entry),
+                child: const Text('Dry-run'),
+              ),
+              const SizedBox(width: PlinkSpacing.s2),
+              FilledButton(
+                key: ValueKey('entry-apply-${entry.targetId}'),
+                onPressed: controller.busy || !entry.canApply
+                    ? null
+                    : () => _confirmAndApply(
+                          context,
+                          title: 'Apply for ${entry.target}?',
+                          count: entry.choices
+                              .where((c) => c.selected.canApply)
+                              .length,
+                          apply: () => controller.applyEntry(entry),
+                        ),
+                child: const Text('Apply'),
+              ),
+            ],
+          ),
+        ],
       ),
+    );
+  }
+}
+
+/// The radio group for a mutually-exclusive choice (#110): the operator picks
+/// exactly one resolution; the selected one is what an apply runs.
+class _ChoiceControl extends StatelessWidget {
+  const _ChoiceControl({
+    required this.controller,
+    required this.entry,
+    required this.choice,
+  });
+
+  final ReconcileController controller;
+  final PendingAccountEntry entry;
+  final PendingChoice choice;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          'Kies één oplossing:',
+          style: text.bodySmall?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        for (final option in choice.alternatives)
+          InkWell(
+            key: ValueKey('alt-${entry.targetId}-${option.kind}'),
+            onTap: controller.busy
+                ? null
+                : () => controller.chooseAlternative(
+                      entry: entry,
+                      group: option.group!,
+                      kind: option.kind,
+                    ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: PlinkSpacing.s1),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Icon(
+                    option.kind == choice.selected.kind
+                        ? Icons.radio_button_checked
+                        : Icons.radio_button_unchecked,
+                    size: 18,
+                    color: option.kind == choice.selected.kind
+                        ? colors.primary
+                        : Theme.of(context).disabledColor,
+                  ),
+                  const SizedBox(width: PlinkSpacing.s2),
+                  Expanded(
+                    child: Text(option.changes.summary, style: text.bodySmall),
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// The per-field diff (or a lifecycle note) for a single, non-choice option.
+class _OptionDetail extends StatelessWidget {
+  const _OptionDetail({required this.option});
+
+  final PendingActionOption option;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final fields = option.changes.fields;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: fields.isEmpty
+          ? <Widget>[
+              Text(
+                option.canApply
+                    ? 'Lifecycle action — no per-field diff.'
+                    : '${option.changes.summary} '
+                        '(manual — not applied automatically)',
+                style: text.bodySmall,
+              ),
+            ]
+          : <Widget>[
+              for (final f in fields)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
+                  child: Text(
+                    '${f.field}: ${f.before ?? '∅'} → ${f.after ?? '∅'}',
+                    style: text.bodySmall,
+                  ),
+                ),
+            ],
     );
   }
 }

--- a/account_manager/test/reconcile/reconcile_pending_choice_test.dart
+++ b/account_manager/test/reconcile/reconcile_pending_choice_test.dart
@@ -1,0 +1,157 @@
+import 'package:account_actions/account_actions.dart' as actions;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'reconcile_fakes.dart';
+
+/// #110 — the pending list groups one entry per account, renders the mutually
+/// exclusive unregister/delete resolutions as a single choice, and applies only
+/// the chosen alternative (never both), per-entry or per-situation.
+void main() {
+  /// A WISA-departed scenario: two Smartschool accounts with no WISA record and
+  /// no Azure account, so each is an active Smartschool-only account whose
+  /// dispatcher yields the unregister *vs* delete alternatives.
+  ReconcileHarness departedHarness() => ReconcileHarness(
+        wisa: wisaSnap(students: const []),
+        smartschool: ssSnap(
+          groups: const [],
+          accounts: [
+            ssAccount(
+              uid: 'jane',
+              accountId: '1',
+              mail: 'jane.doe@student.school.example',
+            ),
+            ssAccount(
+              uid: 'john',
+              accountId: '2',
+              mail: 'john.roe@student.school.example',
+            ),
+          ],
+          memberships: const [],
+        ),
+        azure: azSnap(users: const []),
+      );
+
+  group('grouping + alternatives (#110)', () {
+    test(
+        'one entry per departed account, each with a single unregister/delete '
+        'choice defaulting to unregister', () async {
+      final h = departedHarness();
+      await h.controller.sync();
+
+      final entries = h.controller.pendingEntries
+          .where((e) => e.family == 'student')
+          .toList();
+      expect(entries, hasLength(2),
+          reason: 'one entry per account, not per action');
+
+      final entry = entries.first;
+      expect(entry.choices, hasLength(1),
+          reason:
+              'the two mutually-exclusive actions collapse into one choice');
+      final choice = entry.choices.single;
+      expect(choice.isChoice, isTrue);
+      expect(choice.alternatives, hasLength(2));
+      expect(
+        choice.alternatives.map((a) => a.kind),
+        containsAll(<String>[
+          'UnregisterStudentFromSmartschool',
+          'DeleteStudentFromSmartschool',
+        ]),
+      );
+      expect(choice.selected.kind, 'UnregisterStudentFromSmartschool',
+          reason: 'unregister (keep the account) is the safe default');
+    });
+
+    test('the two departed accounts share one situation subset', () async {
+      final h = departedHarness();
+      await h.controller.sync();
+
+      final studentSituations = h.controller.pendingSituations
+          .where((s) => s.every((e) => e.family == 'student'))
+          .toList();
+      expect(studentSituations, hasLength(1),
+          reason: 'both departed students are the same situation');
+      expect(studentSituations.single, hasLength(2));
+    });
+  });
+
+  group('apply runs exactly the chosen alternative (#110)', () {
+    test('the default (unregister) applies unregister, not delete', () async {
+      final h = departedHarness();
+      await h.controller.sync();
+      final entry =
+          h.controller.pendingEntries.firstWhere((e) => e.family == 'student');
+
+      await h.controller.applyEntry(entry);
+
+      final summaries =
+          h.controller.applyResults!.map((r) => r.changes.summary).toList();
+      expect(summaries, contains('Schrijf de leerling uit in Smartschool'));
+      expect(
+          summaries, isNot(contains('Verwijder dit account uit Smartschool')));
+      expect(
+        h.controller.applyResults!.map((r) => r.outcome),
+        everyElement(actions.ActionOutcome.applied),
+      );
+    });
+
+    test('choosing delete applies delete, not unregister', () async {
+      final h = departedHarness();
+      await h.controller.sync();
+      final entry =
+          h.controller.pendingEntries.firstWhere((e) => e.family == 'student');
+
+      h.controller.chooseAlternative(
+        entry: entry,
+        group: actions.smartschoolDepartureAlternative,
+        kind: 'DeleteStudentFromSmartschool',
+      );
+      // Re-read the entry after the choice (the list is rebuilt).
+      final chosen = h.controller.pendingEntries
+          .firstWhere((e) => e.targetId == entry.targetId);
+      expect(
+          chosen.choices.single.selected.kind, 'DeleteStudentFromSmartschool');
+
+      await h.controller.applyEntry(chosen);
+
+      final summaries =
+          h.controller.applyResults!.map((r) => r.changes.summary).toList();
+      expect(summaries, contains('Verwijder dit account uit Smartschool'));
+      expect(
+          summaries, isNot(contains('Schrijf de leerling uit in Smartschool')));
+    });
+
+    test('situation bulk apply runs each entry\'s own chosen alternative',
+        () async {
+      final h = departedHarness();
+      await h.controller.sync();
+      final entries = h.controller.pendingEntries
+          .where((e) => e.family == 'student')
+          .toList();
+
+      // Leave the first on the default (unregister); switch the second to delete.
+      h.controller.chooseAlternative(
+        entry: entries[1],
+        group: actions.smartschoolDepartureAlternative,
+        kind: 'DeleteStudentFromSmartschool',
+      );
+
+      final key = entries.first.situationKey;
+      await h.controller.applySituation(key);
+
+      final summaries =
+          h.controller.applyResults!.map((r) => r.changes.summary).toList();
+      expect(summaries, hasLength(2), reason: 'one write per account');
+      expect(summaries, contains('Schrijf de leerling uit in Smartschool'));
+      expect(summaries, contains('Verwijder dit account uit Smartschool'));
+    });
+
+    test('applyableCount counts the chosen resolution once, not both',
+        () async {
+      final h = departedHarness();
+      await h.controller.sync();
+      // Two departed students → two writes (one resolution each), not four.
+      expect(h.controller.applyableCount, 2);
+    });
+  });
+}

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -364,6 +364,108 @@ void main() {
     expect(find.byKey(const ValueKey('rollup-groups')), findsOneWidget);
   });
 
+  /// Builds a reconcile screen over a WISA-departed scenario: [count]
+  /// Smartschool-only active accounts (no WISA, no Azure), each raising the
+  /// mutually-exclusive unregister/delete choice (#110).
+  ReconcileHarness departedHarness({int count = 1}) => ReconcileHarness(
+        wisa: wisaSnap(students: const []),
+        smartschool: ssSnap(
+          groups: const [],
+          accounts: [
+            for (var i = 0; i < count; i++)
+              ssAccount(
+                uid: 'user$i',
+                accountId: '$i',
+                mail: 'user$i@student.school.example',
+              ),
+          ],
+          memberships: const [],
+        ),
+        azure: azSnap(users: const []),
+      );
+
+  testWidgets(
+      'a departed student renders one entry with a unregister/delete choice; '
+      'picking delete applies delete, not unregister (#110)',
+      (WidgetTester tester) async {
+    final harness = departedHarness();
+    await tester
+        .pumpWidget(_wrap(ReconcileScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // One entry for the departed account (not two independent rows).
+    final entry = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student');
+    final id = entry.targetId;
+    final entryKey = ValueKey('entry-student-$id');
+    expect(find.byKey(entryKey), findsOneWidget);
+
+    // Expand it to reveal the choice.
+    await tester.ensureVisible(find.byKey(entryKey));
+    await tester.tap(find.byKey(entryKey));
+    await tester.pumpAndSettle();
+
+    // Both mutually-exclusive resolutions are offered as one choice.
+    final unregisterAlt = ValueKey('alt-$id-UnregisterStudentFromSmartschool');
+    final deleteAlt = ValueKey('alt-$id-DeleteStudentFromSmartschool');
+    expect(find.byKey(unregisterAlt), findsOneWidget);
+    expect(find.byKey(deleteAlt), findsOneWidget);
+
+    // Pick delete (the non-default), then apply this one entry.
+    await tester.tap(find.byKey(deleteAlt));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Apply result'), findsOneWidget);
+    expect(harness.soap.soapActions, isNotEmpty,
+        reason: 'delete is a real Smartschool write');
+    final summaries =
+        harness.controller.applyResults!.map((r) => r.changes.summary);
+    expect(summaries, contains('Verwijder dit account uit Smartschool'));
+    expect(summaries, isNot(contains('Schrijf de leerling uit in Smartschool')),
+        reason: 'only the chosen alternative runs — never both');
+  });
+
+  testWidgets(
+      'a same-situation subset offers a bulk apply that respects each row\'s '
+      'choice (#110)', (WidgetTester tester) async {
+    final harness = departedHarness(count: 2);
+    await tester
+        .pumpWidget(_wrap(ReconcileScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // The two departed accounts are grouped into one "same situation" subset
+    // with a bulk affordance.
+    expect(
+        find.textContaining('accounts in the same situation'), findsOneWidget);
+    final key = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student')
+        .situationKey;
+    final bulkApply = ValueKey('situation-apply-$key');
+    expect(find.byKey(bulkApply), findsOneWidget);
+
+    await tester.ensureVisible(find.byKey(bulkApply));
+    await tester.tap(find.byKey(bulkApply));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Apply result'), findsOneWidget);
+    // Two accounts, two writes (one chosen resolution each) — not four.
+    expect(harness.controller.applyResults, hasLength(2));
+  });
+
   testWidgets('the log panel clears on demand', (WidgetTester tester) async {
     final harness = ReconcileHarness();
     await tester.pumpWidget(

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -63,6 +63,16 @@ sealed class GroupAction {
   /// (UI / State layer) gate the "apply" affordance on this.
   bool get canApply => true;
 
+  /// The key shared by mutually-exclusive alternatives resolving the same
+  /// situation (#110). No group action has alternatives today, so this is always
+  /// `null`; the getter exists so the pending-list grouping treats every family
+  /// uniformly. See [StudentAction.alternativeGroup].
+  String? get alternativeGroup => null;
+
+  /// Whether this action is the default alternative within its
+  /// [alternativeGroup]. Ignored when [alternativeGroup] is `null`.
+  bool get isDefaultAlternative => false;
+
   /// Performs the change on the target system. Impure. With
   /// [ApplyOptions.dryRun] set, performs **no** writes and returns the
   /// projected [ActionResult] (PAIN-3). Throws [UnsupportedError] when

--- a/packages/account_actions/lib/src/staff_action.dart
+++ b/packages/account_actions/lib/src/staff_action.dart
@@ -50,6 +50,16 @@ sealed class StaffAction {
   /// The field-level diff this action would make. Pure (INV-40).
   ChangeSet describeChanges();
 
+  /// The key shared by mutually-exclusive alternatives resolving the same
+  /// situation (#110). No staff action has alternatives today, so this is always
+  /// `null`; the getter exists so the pending-list grouping treats every family
+  /// uniformly. See [StudentAction.alternativeGroup].
+  String? get alternativeGroup => null;
+
+  /// Whether this action is the default alternative within its
+  /// [alternativeGroup]. Ignored when [alternativeGroup] is `null`.
+  bool get isDefaultAlternative => false;
+
   /// Performs the change on the target system. Impure. With
   /// [ApplyOptions.dryRun] set, performs **no** writes and returns the
   /// projected [ActionResult] (PAIN-3).

--- a/packages/account_actions/lib/src/student_action.dart
+++ b/packages/account_actions/lib/src/student_action.dart
@@ -49,6 +49,19 @@ sealed class StudentAction {
   /// diff UI and the dry-run path.
   ChangeSet describeChanges();
 
+  /// The key shared by the mutually-exclusive alternatives that resolve the
+  /// **same situation** (#110). Two actions bound to the same account that
+  /// return the same non-null key are alternatives — the operator picks one and
+  /// must never run both (e.g. unregister *vs* delete a departed student). A
+  /// `null` key (the default) means the action stands on its own. Pure; lets the
+  /// UI group alternatives without pattern-matching on concrete action types.
+  String? get alternativeGroup => null;
+
+  /// Within an [alternativeGroup], whether this action is the sensible default
+  /// pre-selection. Exactly one alternative in a group should return `true`;
+  /// ignored when [alternativeGroup] is `null`.
+  bool get isDefaultAlternative => false;
+
   /// Performs the change on the target system. Impure. With
   /// [ApplyOptions.dryRun] set, performs **no** writes and returns the
   /// projected [ActionResult] (PAIN-3).
@@ -83,6 +96,12 @@ sealed class StudentAction {
   bool _isOfficialClass(Group group) =>
       group.official && group.type == GroupType.classGroup;
 }
+
+/// The [StudentAction.alternativeGroup] key shared by the two mutually
+/// exclusive resolutions of a WISA-departed Smartschool account (#110):
+/// [UnregisterStudentFromSmartschool] (keep, the default) and
+/// [DeleteStudentFromSmartschool] (remove).
+const String smartschoolDepartureAlternative = 'smartschool-departure';
 
 // ---------------------------------------------------------------------------
 // Lifecycle actions — evaluated only when a system is missing (§6.3).
@@ -323,6 +342,16 @@ class UnregisterStudentFromSmartschool extends StudentAction {
       account.smartschool != null &&
       _ss.status == 'actief';
 
+  /// Unregister and [DeleteStudentFromSmartschool] are the two mutually
+  /// exclusive resolutions of a WISA-departed Smartschool account (#110).
+  @override
+  String? get alternativeGroup => smartschoolDepartureAlternative;
+
+  /// Unregistering keeps the account (the conservative resolution), so it is the
+  /// pre-selected default of the departure choice.
+  @override
+  bool get isDefaultAlternative => true;
+
   @override
   ChangeSet describeChanges() => const ChangeSet(
         system: Origin.smartschool,
@@ -377,6 +406,12 @@ class DeleteStudentFromSmartschool extends StudentAction {
 
   @override
   bool evaluate() => account.wisa == null && account.smartschool != null;
+
+  /// Delete and [UnregisterStudentFromSmartschool] are the two mutually
+  /// exclusive resolutions of a WISA-departed Smartschool account (#110). Delete
+  /// is the destructive alternative, so it is not the default.
+  @override
+  String? get alternativeGroup => smartschoolDepartureAlternative;
 
   @override
   ChangeSet describeChanges() => ChangeSet(

--- a/packages/account_actions/test/student_dispatch_test.dart
+++ b/packages/account_actions/test/student_dispatch_test.dart
@@ -39,6 +39,31 @@ void main() {
       );
     });
 
+    test('unregister and delete are mutually exclusive alternatives (#110)',
+        () {
+      final actions = studentActionsFor(
+        linked(smartschool: ssAccount(status: 'actief')),
+        cfg,
+      );
+      final unregister =
+          actions.whereType<UnregisterStudentFromSmartschool>().single;
+      final delete = actions.whereType<DeleteStudentFromSmartschool>().single;
+
+      // Both expose the same non-null alternative group, so the UI can pair them.
+      expect(unregister.alternativeGroup, smartschoolDepartureAlternative);
+      expect(delete.alternativeGroup, smartschoolDepartureAlternative);
+      expect(unregister.alternativeGroup, delete.alternativeGroup);
+
+      // Unregister (keep the account) is the safe default; delete is not.
+      expect(unregister.isDefaultAlternative, isTrue);
+      expect(delete.isDefaultAlternative, isFalse);
+    });
+
+    test('a lone action carries no alternative group (#110)', () {
+      final actions = studentActionsFor(linked(wisa: wisaStudent()), cfg);
+      expect(actions.single.alternativeGroup, isNull);
+    });
+
     test('disabled Smartschool-only account → Delete only (not Unregister)',
         () {
       final actions = studentActionsFor(


### PR DESCRIPTION
## Summary

The first reconcile run showed **two independent rows** for every WISA-departed
student — "Schrijf de leerling uit in Smartschool" *and* "Verwijder dit account
uit Smartschool" — which are mutually exclusive resolutions of the same
situation, with only global *Dry-run all* / *Apply all* as affordances. This
reworks the pending-actions list into **one entry per account**, renders the
mutually-exclusive alternatives as a **choice** (with a sensible default), and
makes **per-entry** and **per-situation** apply the primary affordances.

## Linked issue

Closes #110

## Changes

- **Action engine (pure).** Actions now expose which candidates are alternatives
  for the same state rather than the UI pattern-matching on types:
  `StudentAction.alternativeGroup` / `isDefaultAlternative`. The departed
  unregister/delete pair shares `smartschoolDepartureAlternative`, with
  **unregister (keep the account) as the safe default**. Staff/group bases carry
  the same getters (always `null`) so grouping treats every family uniformly.
- **Controller.** `pendingEntries` groups the live linked actions **one entry
  per target**, collapsing mutually-exclusive alternatives into a single
  `PendingChoice`. `pendingSituations` buckets entries by a stable
  `situationKey`. `chooseAlternative` records the operator's pick; per-entry
  (`applyEntry`/`dryRunEntry`) and per-situation (`applySituation`/
  `dryRunSituation`) apply run **exactly the chosen alternative — never both**.
  `applyableCount` counts one resolution per entry. Global `applyAll`/`dryRun`
  now also honour the choices.
- **UI.** One expandable row per account; a mutually-exclusive choice renders as
  a radio group; per-row dry-run/apply; a per-situation "apply to all in the
  same situation" header that honours each row's own pick. The global
  *Apply all* is kept as a demoted secondary escape hatch.

## Scope note

Grouping/choice/apply run against the **live in-session** linked view (the same
apply path `Apply all` already used). Persisting the chosen alternative into the
separate `decisions` documents so it survives another operator's re-sync (the
`DecisionKind.chosenAlternative` schema already exists) is the centralized-state
(#112) follow-up and is intentionally out of scope here.

## Test plan

- [x] `dart format --set-exit-if-changed` clean
- [x] `flutter analyze packages account_manager` — no issues
- [x] Unit — action engine: alternatives derived (shared group, unregister is
  default); a lone action carries no group. (`account_actions`)
- [x] Unit/widget — controller: one entry per account, choice with two
  alternatives defaulting to unregister, apply runs the chosen alternative,
  situation bulk apply honours each row's pick, `applyableCount` counts once.
  (`reconcile_pending_choice_test.dart`)
- [x] Widget — screen: departed student renders the choice, pick delete →
  per-row apply writes delete not unregister; same-situation subset offers a
  bulk apply. (`reconcile_screen_test.dart`)
- [x] Integration (Windows) — real app drives choose → apply for one account
  against the reconcile fakes. (`app_launch_test.dart`)
- [x] Full suites green: 107 app + 106 `account_actions` + 245 `account_state`
  unit/widget; 12 integration on `-d windows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)