### PR TITLE
Duplicate-mail warnings: drill-down + accepted-duplicates registry (#109)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -548,6 +548,48 @@ void main() {
     await subscriber.close();
   });
 
+  testWidgets(
+      'a duplicate-mail warning drills down and is accepted end-to-end (#109)',
+      (WidgetTester tester) async {
+    // Two Smartschool accounts share one mail (INV-23) — the deliberate
+    // admin+user collision the operator accepts. The whole run is offline over
+    // the recording transports, driven the way the operator drives it.
+    final linkedStore = InMemoryLinkedStore();
+    final harness = dupMailHarness(linkedStore: linkedStore);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // The collision surfaces one warning line in the real, laid-out app.
+    const mail = 'shared@school.example';
+    final tile = find.byKey(const ValueKey('dup-warning-$mail'));
+    expect(tile, findsOneWidget);
+    expect(find.textContaining('Dubbele mail "$mail"'), findsOneWidget);
+
+    // Drilling it down lists the colliding accounts…
+    await tester.ensureVisible(tile);
+    await tester.tap(tile);
+    await tester.pumpAndSettle();
+    expect(find.textContaining('admin · student'), findsOneWidget);
+    expect(find.textContaining('user · student'), findsOneWidget);
+
+    // …and accepting persists a decision to the shared store and demotes it.
+    await tester.tap(find.byKey(const ValueKey('dup-accept-$mail')));
+    await tester.pumpAndSettle();
+    final decisions = await linkedStore.readDecisions();
+    expect(decisions, hasLength(1));
+    expect(harness.controller.duplicateWarnings.single.accepted, isTrue);
+    expect(find.byKey(const ValueKey('dup-revoke-$mail')), findsOneWidget);
+  });
+
   testWidgets('silent sign-in leads straight into the shell',
       (WidgetTester tester) async {
     final broker = _FakeBroker(silent: (_) => _token('AT'));

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -186,6 +186,57 @@ class PendingAccountEntry {
   bool get canApply => choices.any((c) => c.selected.canApply);
 }
 
+/// One colliding Smartschool account inside a [DuplicateMailWarning] (#109),
+/// flattened for display: the fields the drill-down lists so the operator can
+/// tell the accounts apart before accepting the collision.
+class DuplicateAccountRow {
+  const DuplicateAccountRow({
+    required this.uid,
+    required this.name,
+    required this.accountType,
+    required this.role,
+  });
+
+  /// The Smartschool username / login.
+  final String uid;
+
+  /// Display name (`givenName surname`), or the uid when the concrete record
+  /// carries no name.
+  final String name;
+
+  /// The account type (`student` or a co-account slot).
+  final String accountType;
+
+  /// The account's role, or `onbekend` when unknown.
+  final String role;
+}
+
+/// A duplicate-mail warning (INV-23) shaped for the reconcile screen (#109): the
+/// shared [mail], the colliding [accounts] the drill-down lists, and whether the
+/// operator has [accepted] this exact collision (persisted as a decision). An
+/// accepted collision is demoted, not hidden, so it can be reviewed and revoked.
+class DuplicateMailWarning {
+  const DuplicateMailWarning({
+    required this.mail,
+    required this.accounts,
+    required this.accepted,
+  });
+
+  /// The address the [accounts] share (as the linker normalized it).
+  final String mail;
+
+  /// Every Smartschool account claiming [mail]; at least two.
+  final List<DuplicateAccountRow> accounts;
+
+  /// True when the current colliding set has been accepted as deliberate. A
+  /// changed set (a third account appears) resets this to false so the warning
+  /// re-surfaces.
+  final bool accepted;
+
+  /// The colliding uids, sorted — the stable key an acceptance covers.
+  List<String> get uids => sortedDuplicateUids(accounts.map((a) => a.uid));
+}
+
 /// Drives the reconcile loop over the State layer (#99): **sync → linked
 /// overview → pending actions → dry-run → apply**, with progress and failures
 /// reported through the shared [LogBuffer].
@@ -269,6 +320,11 @@ class ReconcileController extends ChangeNotifier {
   /// `<targetId>|<alternativeGroup>` → the chosen action kind. A missing entry
   /// means the situation still shows its default alternative.
   final Map<String, String> _choices = {};
+
+  /// The persisted operator decisions loaded from the shared store (#109/#110),
+  /// used to tell which duplicate-mail collisions have been accepted. Refreshed
+  /// on every overview read and after each accept/revoke.
+  List<AccountDecision> _decisions = const [];
 
   ReconcilePhase get phase => _phase;
 
@@ -482,6 +538,148 @@ class ReconcileController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// The duplicate-mail warnings of the current linked view (INV-23), each with
+  /// its colliding accounts flattened for the drill-down and tagged with whether
+  /// this exact collision has been [DuplicateMailWarning.accepted] (#109). Empty
+  /// before a sync this session (a passive session has no live snapshot). Ordered
+  /// as the linker raised them.
+  List<DuplicateMailWarning> get duplicateWarnings {
+    final l = _linked;
+    if (l == null) return const [];
+    return [
+      for (final w in l.snapshot.warnings)
+        if (w is core.ResolveDuplicateMail)
+          DuplicateMailWarning(
+            mail: w.mail,
+            accounts: [for (final a in w.accounts) _duplicateRow(a)],
+            accepted: duplicateAccepted(
+              _decisions,
+              mail: w.mail,
+              uids: w.accounts.map((a) => a.uid),
+            ),
+          ),
+    ];
+  }
+
+  DuplicateAccountRow _duplicateRow(core.SmartschoolAccount account) {
+    final concrete = account is ss.SmartschoolAccount ? account : null;
+    final name = concrete == null
+        ? account.uid
+        : (_nonEmpty('${concrete.givenName} ${concrete.surname}') ??
+            account.uid);
+    return DuplicateAccountRow(
+      uid: account.uid,
+      name: name,
+      accountType: account.accountType.toJson(),
+      role: concrete?.role?.toJson() ?? 'onbekend',
+    );
+  }
+
+  /// Accepts the duplicate-mail collision on [mail] as deliberate (#109),
+  /// persisting an [AccountDecision] keyed to one of the colliding accounts so it
+  /// survives a re-sync (re-attached by the decisions merge). A no-op when no
+  /// live warning matches [mail]. The warning is demoted immediately.
+  Future<void> acceptDuplicate(String mail) async {
+    final warning = _duplicateWarningFor(mail);
+    if (warning == null) return;
+    final uids = warning.accounts.map((a) => a.uid);
+    final accountId = _linkedIdForUids(uids);
+    if (accountId == null) {
+      log.addError(
+        core.Origin.smartschool,
+        'Kon geen account vinden voor de dubbele mail "$mail".',
+      );
+      return;
+    }
+    final decision = acceptedDuplicateDecision(
+      accountId: accountId,
+      mail: mail,
+      uids: uids,
+      decidedBy: syncedBy,
+      decidedAt: _now(),
+    );
+    try {
+      await store.putDecision(decision);
+      _decisions = [
+        for (final d in _decisions)
+          if (decisionDocId(d) != decisionDocId(decision)) d,
+        decision,
+      ];
+      log.addMessage(
+        core.Origin.smartschool,
+        'Dubbele mail "$mail" geaccepteerd.',
+      );
+      notifyListeners();
+    } on Object catch (e) {
+      log.addError(
+          core.Origin.smartschool, 'Kon de acceptatie niet opslaan: $e');
+    }
+  }
+
+  /// Revokes a previously accepted duplicate-mail collision on [mail] (#109), so
+  /// it warns again. A no-op when the collision is not currently accepted.
+  Future<void> revokeDuplicate(String mail) async {
+    final warning = _duplicateWarningFor(mail);
+    if (warning == null) return;
+    final decision = findAcceptedDuplicate(
+      _decisions,
+      mail: mail,
+      uids: warning.accounts.map((a) => a.uid),
+    );
+    if (decision == null) return;
+    try {
+      await store.deleteDecision(decision);
+      _decisions = [
+        for (final d in _decisions)
+          if (decisionDocId(d) != decisionDocId(decision)) d,
+      ];
+      log.addMessage(
+        core.Origin.smartschool,
+        'Acceptatie van dubbele mail "$mail" ingetrokken.',
+      );
+      notifyListeners();
+    } on Object catch (e) {
+      log.addError(
+        core.Origin.smartschool,
+        'Kon de acceptatie niet intrekken: $e',
+      );
+    }
+  }
+
+  core.ResolveDuplicateMail? _duplicateWarningFor(String mail) {
+    final l = _linked;
+    if (l == null) return null;
+    final want = normalizeDuplicateMail(mail);
+    for (final w in l.snapshot.warnings) {
+      if (w is core.ResolveDuplicateMail &&
+          normalizeDuplicateMail(w.mail) == want) {
+        return w;
+      }
+    }
+    return null;
+  }
+
+  /// The linked-account id of the first (sorted) [uids] that resolves to a linked
+  /// account or staff member — the stable target an accepted-duplicate decision
+  /// attaches to, so the merge keeps it while that account still carries the
+  /// warning. Null when none of the uids maps (defensive; the colliding accounts
+  /// are always in the snapshot per INV-23).
+  core.LinkedAccountId? _linkedIdForUids(Iterable<String> uids) {
+    final l = _linked;
+    if (l == null) return null;
+    final byUid = <String, core.LinkedAccountId>{
+      for (final a in l.snapshot.accounts)
+        if (a.smartschool?.uid case final uid?) uid: a.id,
+      for (final s in l.snapshot.staff)
+        if (s.smartschool?.uid case final uid?) uid: s.id,
+    };
+    for (final uid in sortedDuplicateUids(uids)) {
+      final id = byUid[uid];
+      if (id != null) return id;
+    }
+    return null;
+  }
+
   /// The stored freshness + generation marker of the materialized view.
   SyncState get syncState => _syncState;
 
@@ -663,6 +861,7 @@ class ReconcileController extends ChangeNotifier {
     try {
       _syncState = await store.readSyncState();
       _rollups = await store.readRollups();
+      _decisions = await store.readDecisions();
       await _refreshLock();
       if (_phase == ReconcilePhase.idle) _phase = ReconcilePhase.ready;
       notifyListeners();
@@ -705,6 +904,7 @@ class ReconcileController extends ChangeNotifier {
   Future<void> _refetchFromStore() async {
     _syncState = await store.readSyncState();
     _rollups = await store.readRollups();
+    _decisions = await store.readDecisions();
     await _refreshLock();
     final open = _selectedClassroom;
     if (open != null) {
@@ -957,6 +1157,9 @@ class ReconcileController extends ChangeNotifier {
         groups: view.groups,
         existing: await store.readDecisions(),
       );
+      // The surviving decisions are what the store keeps; mirror them so the
+      // live duplicate-warning demotion reflects the post-sync truth (#109).
+      _decisions = merge.surviving;
       final merged = MaterializedView(
         generation: view.generation,
         accounts: merge.accounts,

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -143,7 +143,10 @@ class _ReconcileBody extends StatelessWidget {
                         ],
                         if (linked != null) ...<Widget>[
                           const SizedBox(height: PlinkSpacing.s5),
-                          _OverviewSection(linked: linked),
+                          _OverviewSection(
+                            linked: linked,
+                            controller: controller,
+                          ),
                           const SizedBox(height: PlinkSpacing.s5),
                           _ActionsSection(controller: controller),
                         ],
@@ -358,14 +361,16 @@ class _StatusBanner extends StatelessWidget {
 }
 
 class _OverviewSection extends StatelessWidget {
-  const _OverviewSection({required this.linked});
+  const _OverviewSection({required this.linked, required this.controller});
 
   final LinkedState linked;
+  final ReconcileController controller;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     final snapshot = linked.snapshot;
+    final duplicates = controller.duplicateWarnings;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -381,9 +386,10 @@ class _OverviewSection extends StatelessWidget {
             _CountTile(system: 'Azure AD', counts: snapshot.azure),
           ],
         ),
-        if (snapshot.warnings.isNotEmpty) ...<Widget>[
+        if (duplicates.isNotEmpty) ...<Widget>[
           const SizedBox(height: PlinkSpacing.s3),
-          ...snapshot.warnings.map((w) => _WarningLine(warning: w)),
+          for (final w in duplicates)
+            _DuplicateWarningTile(controller: controller, warning: w),
         ],
       ],
     );
@@ -430,26 +436,91 @@ class _CountTile extends StatelessWidget {
   }
 }
 
-class _WarningLine extends StatelessWidget {
-  const _WarningLine({required this.warning});
+/// A duplicate-mail warning as an expandable drill-down (#109): the header
+/// names the collision (demoted when accepted), and expanding it lists every
+/// colliding account (uid, name, account type, role) with an "accept this
+/// duplicate" / "revoke" action. Accepting persists a decision so the collision
+/// stops warning until the colliding set changes.
+class _DuplicateWarningTile extends StatelessWidget {
+  const _DuplicateWarningTile({
+    required this.controller,
+    required this.warning,
+  });
 
-  final core.LinkWarning warning;
+  final ReconcileController controller;
+  final DuplicateMailWarning warning;
 
   @override
   Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
     final ColorScheme colors = Theme.of(context).colorScheme;
-    final String message = switch (warning) {
-      core.ResolveDuplicateMail(:final mail, :final accounts) =>
-        'Duplicate mail "$mail" on ${accounts.length} Smartschool accounts.',
-    };
-    return Padding(
-      padding: const EdgeInsets.only(top: PlinkSpacing.s1),
-      child: Row(
+    final Color hairline = Theme.of(context).dividerColor;
+    final accepted = warning.accepted;
+
+    final headline = 'Dubbele mail "${warning.mail}" op '
+        '${warning.accounts.length} Smartschool-accounts'
+        '${accepted ? ' — geaccepteerd' : ''}.';
+
+    return Container(
+      margin: const EdgeInsets.only(top: PlinkSpacing.s2),
+      decoration: BoxDecoration(
+        border: Border.all(color: hairline),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: ExpansionTile(
+        key: ValueKey('dup-warning-${warning.mail}'),
+        shape: const Border(),
+        collapsedShape: const Border(),
+        leading: Icon(
+          accepted ? Icons.check_circle_outline : Icons.warning_amber_outlined,
+          size: 20,
+          color: accepted ? colors.primary : colors.error,
+        ),
+        title: Text(
+          headline,
+          style: text.bodySmall?.copyWith(
+            color: accepted ? Theme.of(context).disabledColor : null,
+          ),
+        ),
+        childrenPadding: const EdgeInsets.fromLTRB(
+          PlinkSpacing.s5,
+          0,
+          PlinkSpacing.s5,
+          PlinkSpacing.s4,
+        ),
+        expandedCrossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Icon(Icons.warning_amber_outlined, size: 16, color: colors.error),
-          const SizedBox(width: PlinkSpacing.s2),
-          Expanded(
-            child: Text(message, style: Theme.of(context).textTheme.bodySmall),
+          for (final a in warning.accounts)
+            Padding(
+              padding: const EdgeInsets.only(bottom: PlinkSpacing.s2),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(a.name, style: text.bodyMedium),
+                  Text(
+                    '${a.uid} · ${a.accountType} · ${a.role}',
+                    style: text.bodySmall
+                        ?.copyWith(color: Theme.of(context).disabledColor),
+                  ),
+                ],
+              ),
+            ),
+          const SizedBox(height: PlinkSpacing.s2),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: accepted
+                ? OutlinedButton.icon(
+                    key: ValueKey('dup-revoke-${warning.mail}'),
+                    onPressed: () => controller.revokeDuplicate(warning.mail),
+                    icon: const Icon(Icons.undo, size: 16),
+                    label: const Text('Acceptatie intrekken'),
+                  )
+                : FilledButton.icon(
+                    key: ValueKey('dup-accept-${warning.mail}'),
+                    onPressed: () => controller.acceptDuplicate(warning.mail),
+                    icon: const Icon(Icons.check, size: 16),
+                    label: const Text('Deze dubbele mail accepteren'),
+                  ),
           ),
         ],
       ),

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -752,6 +752,84 @@ void main() {
     });
   });
 
+  group('accepted duplicate-mail (#109)', () {
+    test('a synced collision surfaces one warning with its colliding accounts',
+        () async {
+      final h = dupMailHarness();
+      await h.controller.sync();
+
+      final warnings = h.controller.duplicateWarnings;
+      expect(warnings, hasLength(1));
+      final w = warnings.single;
+      expect(w.mail, 'shared@school.example');
+      expect(w.accepted, isFalse);
+      expect(w.accounts.map((a) => a.uid).toSet(), {'admin', 'user'});
+      // The colliding accounts carry their display detail for the drill-down.
+      expect(w.accounts.every((a) => a.name.isNotEmpty), isTrue);
+      expect(w.accounts.every((a) => a.accountType == 'student'), isTrue);
+    });
+
+    test(
+        'accepting persists a decision and demotes the warning; revoke restores',
+        () async {
+      final linkedStore = InMemoryLinkedStore();
+      final h = dupMailHarness(linkedStore: linkedStore);
+      await h.controller.sync();
+
+      await h.controller.acceptDuplicate('shared@school.example');
+      // Persisted as an acceptedDuplicate decision keyed to a colliding account.
+      final stored = await linkedStore.readDecisions();
+      expect(stored, hasLength(1));
+      expect(stored.single.kind, DecisionKind.acceptedDuplicate);
+      // …and the live warning is now demoted (accepted).
+      expect(h.controller.duplicateWarnings.single.accepted, isTrue);
+
+      await h.controller.revokeDuplicate('shared@school.example');
+      expect(await linkedStore.readDecisions(), isEmpty);
+      expect(h.controller.duplicateWarnings.single.accepted, isFalse);
+    });
+
+    test('an accepted collision survives a re-sync (re-attached decision)',
+        () async {
+      final linkedStore = InMemoryLinkedStore();
+      // A snapshot store makes the re-sync path materialize + merge decisions.
+      final h = ReconcileHarness(
+        wisa: wisaSnap(students: const []),
+        smartschool: dupMailSnap(),
+        azure: azSnap(users: const []),
+        store: InMemorySnapshotStore(),
+        linkedStore: linkedStore,
+      );
+      await h.controller.sync();
+      await h.controller.acceptDuplicate('shared@school.example');
+      expect(h.controller.duplicateWarnings.single.accepted, isTrue);
+
+      // Re-read Smartschool/Azure and re-link; the view is rewritten wholesale.
+      await h.controller.checkDrift();
+
+      // The decision survived the rewrite (merge re-attached it), still accepted.
+      expect(await linkedStore.readDecisions(), hasLength(1));
+      expect(h.controller.duplicateWarnings.single.accepted, isTrue);
+    });
+
+    test('a changed colliding set re-warns even after acceptance', () async {
+      final linkedStore = InMemoryLinkedStore();
+      final h = dupMailHarness(linkedStore: linkedStore);
+      await h.controller.sync();
+      await h.controller.acceptDuplicate('shared@school.example');
+      expect(h.controller.duplicateWarnings.single.accepted, isTrue);
+
+      // A third account joins the same mail: re-read Smartschool via drift.
+      h.ssResult = dupMailSnap(uids: const ['admin', 'user', 'intruder']);
+      await h.controller.checkDrift();
+
+      final w = h.controller.duplicateWarnings.single;
+      expect(w.accounts, hasLength(3));
+      expect(w.accepted, isFalse,
+          reason: 'a new colliding account must re-surface the warning');
+    });
+  });
+
   group('LogBuffer', () {
     test('caps its entries and reports errors', () {
       final log = LogBuffer(capacity: 3, clock: () => kFixtureDate);

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -174,6 +174,37 @@ ss.SmartschoolSnapshot ssSnap({
       memberships: memberships ?? [member('jane', '2B_ss')],
     );
 
+/// A Smartschool snapshot whose [uids] accounts all share one [mail] — the
+/// INV-23 duplicate-mail collision the reconcile screen surfaces (#109). No
+/// WISA or Azure counterpart, so the linker keeps every colliding account and
+/// raises exactly one [core.ResolveDuplicateMail] warning over them.
+ss.SmartschoolSnapshot dupMailSnap({
+  List<String> uids = const ['admin', 'user'],
+  String mail = 'shared@school.example',
+}) =>
+    ssSnap(
+      groups: const [],
+      accounts: [
+        for (final u in uids) ssAccount(uid: u, accountId: u, mail: mail),
+      ],
+      memberships: const [],
+    );
+
+/// A reconcile harness over the [dupMailSnap] collision: a WISA-/Azure-empty
+/// scenario so the only linked artifact is the shared-mail warning (#109).
+ReconcileHarness dupMailHarness({
+  List<String> uids = const ['admin', 'user'],
+  InMemoryLinkedStore? linkedStore,
+  String syncedBy = 'operator@school.example',
+}) =>
+    ReconcileHarness(
+      wisa: wisaSnap(students: const []),
+      smartschool: dupMailSnap(uids: uids),
+      azure: azSnap(users: const []),
+      linkedStore: linkedStore,
+      syncedBy: syncedBy,
+    );
+
 az.AzureSnapshot azSnap({DateTime? fetchedAt, List<az.AzureUser>? users}) =>
     az.AzureSnapshot(
       fetchedAt: fetchedAt ?? kFixtureDate,

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -466,6 +466,46 @@ void main() {
     expect(harness.controller.applyResults, hasLength(2));
   });
 
+  testWidgets(
+      'a duplicate-mail warning drills down to its accounts; accepting demotes '
+      'it and revoking restores it (#109)', (WidgetTester tester) async {
+    final linkedStore = InMemoryLinkedStore();
+    final harness = dupMailHarness(linkedStore: linkedStore);
+    await tester
+        .pumpWidget(_wrap(ReconcileScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // The collision is surfaced as one line (not accepted yet).
+    const mail = 'shared@school.example';
+    final tile = find.byKey(const ValueKey('dup-warning-$mail'));
+    expect(tile, findsOneWidget);
+    expect(find.textContaining('Dubbele mail "$mail"'), findsOneWidget);
+
+    // Drilling down lists the colliding accounts (uid + type + role).
+    await tester.ensureVisible(tile);
+    await tester.tap(tile);
+    await tester.pumpAndSettle();
+    expect(find.textContaining('admin · student'), findsOneWidget);
+    expect(find.textContaining('user · student'), findsOneWidget);
+
+    // Accept it → persisted decision, demoted (accept becomes revoke).
+    await tester.tap(find.byKey(const ValueKey('dup-accept-$mail')));
+    await tester.pumpAndSettle();
+    expect(await linkedStore.readDecisions(), hasLength(1));
+    expect(find.textContaining('geaccepteerd'), findsWidgets);
+    expect(find.byKey(const ValueKey('dup-accept-$mail')), findsNothing);
+    expect(find.byKey(const ValueKey('dup-revoke-$mail')), findsOneWidget);
+
+    // Revoke it → decision gone, the warning is un-demoted again.
+    await tester.tap(find.byKey(const ValueKey('dup-revoke-$mail')));
+    await tester.pumpAndSettle();
+    expect(await linkedStore.readDecisions(), isEmpty);
+    expect(find.byKey(const ValueKey('dup-accept-$mail')), findsOneWidget);
+  });
+
   testWidgets('the log panel clears on demand', (WidgetTester tester) async {
     final harness = ReconcileHarness();
     await tester.pumpWidget(

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -75,6 +75,7 @@ export 'src/keyvault/key_vault_token_provider.dart';
 export 'src/keyvault/key_vault_transport.dart';
 export 'src/link/linked_state.dart';
 export 'src/link/placement.dart';
+export 'src/materialize/accepted_duplicates.dart';
 export 'src/materialize/decisions_merge.dart';
 export 'src/materialize/linked_state_materializer.dart';
 export 'src/materialize/linked_store.dart';

--- a/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
@@ -327,6 +327,15 @@ class CosmosLinkedStore implements LinkedStore {
     }
   }
 
+  @override
+  Future<void> deleteDecision(AccountDecision decision) async {
+    await _client.deleteDocument(
+      container: decisionsContainer,
+      id: decisionDocId(decision),
+      partitionKey: decision.accountId.value,
+    );
+  }
+
   /// Upserts every document in [docsById], then deletes any document currently
   /// in [container] whose id is not in [freshIds] — the "replace the whole set"
   /// the derived containers need without a container-level truncate.

--- a/packages/account_state/lib/src/materialize/accepted_duplicates.dart
+++ b/packages/account_state/lib/src/materialize/accepted_duplicates.dart
@@ -1,0 +1,113 @@
+/// Pure helpers for the **accepted duplicate-mail** decisions (#109).
+///
+/// The linker raises a [core.ResolveDuplicateMail] warning whenever two or more
+/// Smartschool accounts share a `mail` (INV-23). In practice every current
+/// collision is deliberate — a person who needs both an admin and a normal user
+/// account — so the operator can mark a collision **accepted**, after which it
+/// stops warning. That acceptance is persisted as an [AccountDecision] of kind
+/// [DecisionKind.acceptedDuplicate] in the shared `decisions` container, so it
+/// survives a re-sync (re-attached by [mergeDecisions]) exactly like the
+/// chosen-alternative / applied-status intent from #110.
+///
+/// The acceptance is scoped to the *exact* colliding set: the payload records
+/// the shared [mail] and the sorted set of colliding Smartschool [uids]. When
+/// the set changes — a third account appears on the same mail — the stored set
+/// no longer matches and the warning re-surfaces, so a new, unreviewed collision
+/// is never silently suppressed.
+///
+/// Pure data — no I/O, no Flutter. The store seam persists the decisions; this
+/// module only builds and matches them.
+library;
+
+import 'package:account_core/account_core.dart' as core;
+
+import 'materialized_state.dart';
+
+/// The JSON payload key holding the shared, normalized mail of an accepted
+/// duplicate.
+const String acceptedDuplicateMailKey = 'mail';
+
+/// The JSON payload key holding the sorted colliding Smartschool uids an
+/// acceptance covers.
+const String acceptedDuplicateUidsKey = 'uids';
+
+/// Normalizes a mail for comparison and keying: trimmed and lower-cased, exactly
+/// as the linker compares mails (INV-12).
+String normalizeDuplicateMail(String mail) => mail.trim().toLowerCase();
+
+/// The sorted, de-duplicated colliding uids — the stable set an acceptance
+/// covers, so two acceptances of the same collision key and compare identically
+/// regardless of the order the linker listed the accounts.
+List<String> sortedDuplicateUids(Iterable<String> uids) =>
+    (uids.toSet().toList())..sort();
+
+/// Builds the [AccountDecision] that records [decidedBy] accepting the
+/// duplicate-mail collision on [mail] shared by [uids], keyed to [accountId]
+/// (one of the colliding accounts, so the merge keeps it while that account
+/// still carries a warning).
+///
+/// [targetKind] is the normalized mail — a stable situation id the re-attach
+/// merge matches by presence of any warning on the target ([mergeDecisions]).
+AccountDecision acceptedDuplicateDecision({
+  required core.LinkedAccountId accountId,
+  required String mail,
+  required Iterable<String> uids,
+  required String decidedBy,
+  required DateTime decidedAt,
+}) {
+  final normalized = normalizeDuplicateMail(mail);
+  return AccountDecision(
+    accountId: accountId,
+    kind: DecisionKind.acceptedDuplicate,
+    targetKind: normalized,
+    payload: {
+      acceptedDuplicateMailKey: normalized,
+      acceptedDuplicateUidsKey: sortedDuplicateUids(uids),
+    },
+    decidedBy: decidedBy,
+    decidedAt: decidedAt,
+  );
+}
+
+/// Reads the colliding uids an [acceptedDuplicate] decision covers, sorted.
+/// Empty for a decision of any other kind or a malformed payload.
+List<String> acceptedUidsOf(AccountDecision decision) {
+  if (decision.kind != DecisionKind.acceptedDuplicate) return const [];
+  final raw = decision.payload[acceptedDuplicateUidsKey];
+  if (raw is! List) return const [];
+  return sortedDuplicateUids([for (final u in raw) u as String]);
+}
+
+/// The persisted acceptance covering the collision on [mail] over exactly
+/// [uids], or `null` when none matches.
+///
+/// A match requires both the normalized mail **and** the exact colliding set to
+/// agree: a changed set (a new colliding account) yields no match, so the
+/// warning re-surfaces (#109).
+AccountDecision? findAcceptedDuplicate(
+  Iterable<AccountDecision> decisions, {
+  required String mail,
+  required Iterable<String> uids,
+}) {
+  final wantMail = normalizeDuplicateMail(mail);
+  final wantUids = sortedDuplicateUids(uids);
+  for (final d in decisions) {
+    if (d.kind != DecisionKind.acceptedDuplicate) continue;
+    if ((d.payload[acceptedDuplicateMailKey] as String?) != wantMail) continue;
+    final have = acceptedUidsOf(d);
+    if (have.length == wantUids.length &&
+        List.generate(have.length, (i) => have[i] == wantUids[i])
+            .every((e) => e)) {
+      return d;
+    }
+  }
+  return null;
+}
+
+/// Whether the collision on [mail] over exactly [uids] has been accepted.
+bool duplicateAccepted(
+  Iterable<AccountDecision> decisions, {
+  required String mail,
+  required Iterable<String> uids,
+}) =>
+    findAcceptedDuplicate(decisions, mail: mail, uids: uids) != null;

--- a/packages/account_state/lib/src/materialize/linked_store.dart
+++ b/packages/account_state/lib/src/materialize/linked_store.dart
@@ -57,6 +57,11 @@ abstract interface class LinkedStore {
   /// through it.
   Future<void> putDecision(AccountDecision decision);
 
+  /// Deletes one operator decision (matched by its [decisionDocId]). The revoke
+  /// path #109 uses to un-accept a duplicate: a no-op when the decision is not
+  /// present (already revoked, or swept by a merge).
+  Future<void> deleteDecision(AccountDecision decision);
+
   /// Merges [systemSyncs] into the stored per-system last-sync metadata
   /// **without** rewriting the view or bumping the generation (#108) — the light
   /// write the smart-sync "WISA unchanged" path uses to still stamp who/when it
@@ -172,6 +177,11 @@ class InMemoryLinkedStore implements LinkedStore {
   @override
   Future<void> putDecision(AccountDecision decision) async {
     _decisions[decisionDocId(decision)] = decision;
+  }
+
+  @override
+  Future<void> deleteDecision(AccountDecision decision) async {
+    _decisions.remove(decisionDocId(decision));
   }
 
   @override

--- a/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
@@ -250,6 +250,24 @@ void main() {
       expect(await store.readDecisions(), isEmpty);
     });
 
+    test('deleteDecision removes the decision doc (revoke, #109)', () async {
+      final client = _FakeClient();
+      final store = CosmosLinkedStore(client);
+      final decision = acceptedDuplicateDecision(
+        accountId: const core.LinkedAccountId('p0'),
+        mail: 'shared@school.example',
+        uids: const ['admin', 'user'],
+        decidedBy: 'op@school.example',
+        decidedAt: _d,
+      );
+
+      await store.putDecision(decision);
+      expect(await store.readDecisions(), hasLength(1));
+
+      await store.deleteDecision(decision);
+      expect(await store.readDecisions(), isEmpty);
+    });
+
     test('reading before any sync yields the initial generation', () async {
       final store = CosmosLinkedStore(_FakeClient());
       expect((await store.readSyncState()).generation, 0);

--- a/packages/account_state/test/materialize/accepted_duplicates_test.dart
+++ b/packages/account_state/test/materialize/accepted_duplicates_test.dart
@@ -1,0 +1,124 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+
+/// Unit coverage for the accepted duplicate-mail decisions (#109): building and
+/// matching the decision, the exact-set semantics that make a *changed* colliding
+/// set re-warn, and the store round-trip (put / read / delete) through the
+/// [InMemoryLinkedStore] seam. The Cosmos wire shape is covered separately by
+/// `cosmos_linked_store_test`.
+void main() {
+  final t0 = DateTime.utc(2026, 7, 4, 9, 0);
+  const id = core.LinkedAccountId('acc-1');
+
+  AccountDecision accept({
+    String mail = 'Dup@School.Example',
+    List<String> uids = const ['user', 'admin'],
+  }) =>
+      acceptedDuplicateDecision(
+        accountId: id,
+        mail: mail,
+        uids: uids,
+        decidedBy: 'jan@school',
+        decidedAt: t0,
+      );
+
+  group('acceptedDuplicateDecision', () {
+    test('normalizes the mail and sorts+dedups the uids into the payload', () {
+      final d = accept(
+          mail: '  Dup@School.Example ', uids: ['user', 'admin', 'user']);
+      expect(d.kind, DecisionKind.acceptedDuplicate);
+      expect(d.targetKind, 'dup@school.example');
+      expect(d.payload[acceptedDuplicateMailKey], 'dup@school.example');
+      expect(d.payload[acceptedDuplicateUidsKey], ['admin', 'user']);
+      expect(acceptedUidsOf(d), ['admin', 'user']);
+    });
+
+    test('round-trips through JSON', () {
+      final d = accept();
+      final back = AccountDecision.fromJson(d.toJson());
+      expect(back.kind, DecisionKind.acceptedDuplicate);
+      expect(back.accountId.value, 'acc-1');
+      expect(acceptedUidsOf(back), ['admin', 'user']);
+    });
+  });
+
+  group('matching', () {
+    test('accepts the exact colliding set, case/space/order-insensitive', () {
+      final decisions = [
+        accept(uids: ['user', 'admin'])
+      ];
+      expect(
+        duplicateAccepted(decisions,
+            mail: 'dup@school.example ', uids: ['admin', 'user']),
+        isTrue,
+      );
+      expect(
+        findAcceptedDuplicate(decisions,
+            mail: 'DUP@school.example', uids: ['user', 'admin']),
+        isNotNull,
+      );
+    });
+
+    test('a changed colliding set re-warns (not accepted)', () {
+      final decisions = [
+        accept(uids: ['user', 'admin'])
+      ];
+      // A third account joins the same mail — the stored set no longer matches.
+      expect(
+        duplicateAccepted(decisions,
+            mail: 'dup@school.example', uids: ['admin', 'user', 'intruder']),
+        isFalse,
+      );
+    });
+
+    test('a different mail is not accepted', () {
+      final decisions = [accept()];
+      expect(
+        duplicateAccepted(decisions,
+            mail: 'other@school.example', uids: ['admin', 'user']),
+        isFalse,
+      );
+    });
+
+    test('a non-duplicate decision never matches', () {
+      final other = AccountDecision(
+        accountId: id,
+        kind: DecisionKind.chosenAlternative,
+        targetKind: 'SomeAction',
+        decidedBy: 'jan@school',
+        decidedAt: t0,
+      );
+      expect(
+        duplicateAccepted([other], mail: 'x@y', uids: ['a', 'b']),
+        isFalse,
+      );
+    });
+  });
+
+  group('store round-trip', () {
+    test('put → read → delete through the LinkedStore seam', () async {
+      final store = InMemoryLinkedStore();
+      final d = accept();
+
+      await store.putDecision(d);
+      var read = await store.readDecisions();
+      expect(read, hasLength(1));
+      expect(
+        duplicateAccepted(read,
+            mail: 'dup@school.example', uids: ['admin', 'user']),
+        isTrue,
+      );
+
+      await store.deleteDecision(d);
+      read = await store.readDecisions();
+      expect(read, isEmpty);
+    });
+
+    test('deleting an absent decision is a no-op', () async {
+      final store = InMemoryLinkedStore();
+      await store.deleteDecision(accept());
+      expect(await store.readDecisions(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The reconcile screen surfaced the linker's `ResolveDuplicateMail` warnings
(INV-23) as a single line — "Duplicate mail x on N Smartschool accounts" — with
no way to see *which* accounts collided or to act. In practice every current
collision is deliberate (someone who needs both an admin and a normal user
account), so the operator now gets a drill-down and can mark a collision
**accepted**, after which it stops warning.

Per the issue's folding into the centralized-state model (#112), acceptance is
persisted as an `acceptedDuplicate` **decision** in the shared `decisions`
container (not a bespoke table), keyed to a colliding account so the decisions
merge re-attaches it across re-syncs. Acceptance covers the *exact* colliding
set (mail + sorted uids); when the set changes — a third account appears — the
stored set no longer matches and the warning re-surfaces.

## Linked issue

Closes #109

## Changes

- **account_state**
  - `accepted_duplicates.dart`: pure helpers to build and match an
    `acceptedDuplicate` decision, with the exact-set semantics that make a
    changed collision re-warn.
  - `LinkedStore.deleteDecision` seam (+ `InMemoryLinkedStore` and
    `CosmosLinkedStore` implementations) for revoke.
- **reconcile controller**: a `duplicateWarnings` view (colliding accounts
  flattened for display, tagged accepted/not), `acceptDuplicate` /
  `revokeDuplicate`, and persisted decisions loaded on every overview read and
  kept in sync after a persist.
- **reconcile screen**: the single warning line becomes an expandable tile
  listing each colliding account (uid, name, account type, role) with an
  "accept" / "revoke" action; accepted collisions are demoted, not hidden.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed` clean (packages + app)
- [x] `flutter analyze` clean (account_state, account_manager)
- [x] Unit tests pass: `dart test packages/account_state` — 255 tests
  (new `accepted_duplicates_test`: build/match/round-trip + changed-set re-warn;
  new Cosmos `deleteDecision` revoke test)
- [x] Widget/unit tests pass: `flutter test` (account_manager) — 112 tests
  (4 new controller #109 tests: surface / accept+revoke / survive-resync /
  changed-set re-warn; 1 new widget drill-down test)
- [x] Integration/e2e tests pass: `flutter test integration_test -d windows` —
  13 tests, incl. a new end-to-end #109 run (sync → drill down → accept →
  demoted, decision persisted) in the real app/engine