### PR TITLE
Virtualize the reconcile pending-action and results lists (#111)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -52,6 +52,16 @@ void main() {
     schoolPrefix: 'GBS',
   ));
 
+  /// Gives the app a tall viewport so the reconcile screen's below-the-fold
+  /// sections lay out without scrolling. The body is a lazy [CustomScrollView]
+  /// (#111), so off-screen slivers are not built; a tall window keeps the
+  /// presence-only assertions honest. Reset after each test.
+  void useTallWindow(WidgetTester tester) {
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+  }
+
   testWidgets('the app launches into the Plink-themed Home shell',
       (WidgetTester tester) async {
     // The real main(): with no --dart-define config, AAD is not configured, so
@@ -99,6 +109,7 @@ void main() {
     // The real app composition — shell, navigation, theme — over the offline
     // reconcile harness (scripted syncers + recording transports), driven the
     // way the operator drives it.
+    useTallWindow(tester);
     final harness = ReconcileHarness();
     final broker = _FakeBroker(silent: (_) => _token('AT'));
     await tester.pumpWidget(AccountManagerApp(
@@ -160,6 +171,7 @@ void main() {
     // A WISA-departed student: a Smartschool-only active account (no WISA, no
     // Azure) whose dispatcher yields the mutually-exclusive unregister/delete
     // resolutions — the exact situation #110 fixes.
+    useTallWindow(tester);
     final harness = ReconcileHarness(
       wisa: wisaSnap(students: const []),
       smartschool: ssSnap(
@@ -216,6 +228,52 @@ void main() {
     expect(summaries, contains('Verwijder dit account uit Smartschool'));
     expect(summaries, isNot(contains('Schrijf de leerling uit in Smartschool')),
         reason: 'only the chosen resolution ran — never both');
+  });
+
+  testWidgets(
+      'a large pending set virtualizes in the real app: only a bounded number '
+      'of entry tiles build, and scrolling loads more (#111)',
+      (WidgetTester tester) async {
+    // A September-changeover-scale pending set (a thousand WISA-departed
+    // accounts) in the real, laid-out app. The old eager Column built every
+    // tile up front; the lazy CustomScrollView builds only the on-screen ones.
+    useTallWindow(tester);
+    final harness = manyDepartedHarness(count: 1000);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // All 1000 accounts are pending, but only a small window of tiles is built.
+    expect(harness.controller.pendingEntries, hasLength(1000));
+    final entryTiles = find.byWidgetPredicate(
+      (w) =>
+          w.key is ValueKey<String> &&
+          (w.key! as ValueKey<String>).value.startsWith('entry-'),
+    );
+    final builtInitially = entryTiles.evaluate().length;
+    expect(builtInitially, greaterThan(0));
+    expect(builtInitially, lessThan(200),
+        reason: 'virtualized: on-screen tiles only, not all 1000');
+
+    // A far-off entry is not built until scrolled to.
+    final entries = harness.controller.pendingEntries;
+    final lastKey = ValueKey('entry-student-${entries.last.targetId}');
+    expect(find.byKey(lastKey), findsNothing);
+    await tester.scrollUntilVisible(
+      find.byKey(lastKey),
+      5000,
+      scrollable: find.byType(Scrollable).first,
+      maxScrolls: 200,
+    );
+    expect(find.byKey(lastKey), findsOneWidget);
   });
 
   testWidgets(
@@ -554,6 +612,7 @@ void main() {
     // Two Smartschool accounts share one mail (INV-23) — the deliberate
     // admin+user collision the operator accepts. The whole run is offline over
     // the recording transports, driven the way the operator drives it.
+    useTallWindow(tester);
     final linkedStore = InMemoryLinkedStore();
     final harness = dupMailHarness(linkedStore: linkedStore);
     await tester.pumpWidget(AccountManagerApp(

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -321,6 +321,18 @@ class ReconcileController extends ChangeNotifier {
   /// means the situation still shows its default alternative.
   final Map<String, String> _choices = {};
 
+  /// Memoized [pendingEntries] (#111). Building the entries runs
+  /// `describeChanges()` for every pending action, and the screen reads
+  /// `pendingEntries` (directly and via `pendingSituations` / `applyableCount`)
+  /// several times per frame — recomputing it each time is what janks a large
+  /// pending set. The cache is keyed on the identity of the linked view (a fresh
+  /// `link()` / apply-refresh replaces it) and a version bumped on every
+  /// [chooseAlternative], so a stale entry can never be served.
+  List<PendingAccountEntry>? _pendingEntriesCache;
+  LinkedState? _pendingCacheKey;
+  int _choicesVersion = 0;
+  int _pendingCacheChoicesVersion = -1;
+
   /// The persisted operator decisions loaded from the shared store (#109/#110),
   /// used to tell which duplicate-mail collisions have been accepted. Refreshed
   /// on every overview read and after each accept/revoke.
@@ -394,6 +406,11 @@ class ReconcileController extends ChangeNotifier {
   List<PendingAccountEntry> get pendingEntries {
     final l = _linked;
     if (l == null) return const [];
+    if (identical(_pendingCacheKey, l) &&
+        _pendingCacheChoicesVersion == _choicesVersion &&
+        _pendingEntriesCache != null) {
+      return _pendingEntriesCache!;
+    }
     final entries = <PendingAccountEntry>[];
     entries.addAll(_entriesFor(
       family: 'student',
@@ -425,6 +442,9 @@ class ReconcileController extends ChangeNotifier {
       changes: (a) => a.describeChanges(),
       canApply: (a) => a.canApply,
     ));
+    _pendingCacheKey = l;
+    _pendingCacheChoicesVersion = _choicesVersion;
+    _pendingEntriesCache = entries;
     return entries;
   }
 
@@ -535,6 +555,7 @@ class ReconcileController extends ChangeNotifier {
     required String kind,
   }) {
     _choices['${entry.targetId}|$group'] = kind;
+    _choicesVersion++;
     notifyListeners();
   }
 

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -105,6 +105,27 @@ class _ReconcileScreenState extends State<ReconcileScreen> {
   }
 }
 
+/// One row of the flattened pending-actions list (#111): a same-situation
+/// bulk header or a single account entry. Flattening the situation → entries
+/// tree into a linear list lets a lazy [SliverList] build only the on-screen
+/// rows, so a September changeover's hundreds/thousands of tiles no longer all
+/// build, lay out, and paint every frame.
+sealed class _PendingRow {
+  const _PendingRow();
+}
+
+class _SituationHeaderRow extends _PendingRow {
+  const _SituationHeaderRow(this.entries);
+
+  final List<PendingAccountEntry> entries;
+}
+
+class _EntryRow extends _PendingRow {
+  const _EntryRow(this.entry);
+
+  final PendingAccountEntry entry;
+}
+
 class _ReconcileBody extends StatelessWidget {
   const _ReconcileBody({required this.controller, required this.log});
 
@@ -116,44 +137,19 @@ class _ReconcileBody extends StatelessWidget {
     return ListenableBuilder(
       listenable: controller,
       builder: (context, _) {
-        final linked = controller.linked;
         return Column(
           children: <Widget>[
             Expanded(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.all(PlinkSpacing.s6),
-                child: Center(
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 960),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        _Header(controller: controller),
-                        const SizedBox(height: PlinkSpacing.s5),
-                        _StatusBanner(controller: controller),
-                        if (controller.selectedClassroom != null) ...<Widget>[
-                          const SizedBox(height: PlinkSpacing.s5),
-                          _ClassroomDetail(controller: controller),
-                        ] else if (controller.showingGroups) ...<Widget>[
-                          const SizedBox(height: PlinkSpacing.s5),
-                          _GroupsDetail(controller: controller),
-                        ] else if (controller.hasOverview) ...<Widget>[
-                          const SizedBox(height: PlinkSpacing.s5),
-                          _DrillDownSection(controller: controller),
-                        ],
-                        if (linked != null) ...<Widget>[
-                          const SizedBox(height: PlinkSpacing.s5),
-                          _OverviewSection(
-                            linked: linked,
-                            controller: controller,
-                          ),
-                          const SizedBox(height: PlinkSpacing.s5),
-                          _ActionsSection(controller: controller),
-                        ],
-                        ..._results(context),
-                      ],
-                    ),
-                  ),
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 960),
+                  // A CustomScrollView with lazy SliverLists for the pending
+                  // actions and the results, so only the visible tiles are
+                  // built — the fixed header/overview/banner stay as adapters
+                  // (#111). Slivers sit directly under the scroll view (not in a
+                  // SliverMainAxisGroup) so the scroll cache extent reaches the
+                  // sections below the fold.
+                  child: CustomScrollView(slivers: _slivers()),
                 ),
               ),
             ),
@@ -165,28 +161,143 @@ class _ReconcileBody extends StatelessWidget {
     );
   }
 
-  List<Widget> _results(BuildContext context) {
+  /// The horizontal inset that stands in for the old body padding; vertical
+  /// insets are the leading/trailing gaps and the inter-section [_gap]s.
+  static const EdgeInsets _hPad =
+      EdgeInsets.symmetric(horizontal: PlinkSpacing.s6);
+
+  /// A fixed-size section: its child laid out once, inset to the body margin.
+  static Widget _section(Widget child) => SliverPadding(
+        padding: _hPad,
+        sliver: SliverToBoxAdapter(child: child),
+      );
+
+  /// A vertical spacer between sections (no horizontal inset needed).
+  static SliverToBoxAdapter _gap(double height) =>
+      SliverToBoxAdapter(child: SizedBox(height: height));
+
+  List<Widget> _slivers() {
+    final linked = controller.linked;
+    final slivers = <Widget>[
+      _gap(PlinkSpacing.s6),
+      _section(_Header(controller: controller)),
+      _gap(PlinkSpacing.s5),
+      _section(_StatusBanner(controller: controller)),
+    ];
+    if (controller.selectedClassroom != null) {
+      slivers
+        ..add(_gap(PlinkSpacing.s5))
+        ..add(_section(_ClassroomDetail(controller: controller)));
+    } else if (controller.showingGroups) {
+      slivers
+        ..add(_gap(PlinkSpacing.s5))
+        ..add(_section(_GroupsDetail(controller: controller)));
+    } else if (controller.hasOverview) {
+      slivers
+        ..add(_gap(PlinkSpacing.s5))
+        ..add(_section(_DrillDownSection(controller: controller)));
+    }
+    if (linked != null) {
+      slivers
+        ..add(_gap(PlinkSpacing.s5))
+        ..add(
+            _section(_OverviewSection(linked: linked, controller: controller)))
+        ..add(_gap(PlinkSpacing.s5))
+        ..addAll(_actionsSlivers());
+    }
+    slivers
+      ..addAll(_resultsSlivers())
+      ..add(_gap(PlinkSpacing.s6));
+    return slivers;
+  }
+
+  /// The pending-actions section (#110/#111): the title and dry-run/apply
+  /// buttons stay as adapters, but the situation headers and per-account entry
+  /// tiles render through a lazy [SliverList] so a huge pending set does not
+  /// build every tile up front.
+  List<Widget> _actionsSlivers() {
+    final entries = controller.pendingEntries;
+    if (entries.isEmpty) {
+      return <Widget>[_section(const _PendingActionsHeader(count: 0))];
+    }
+    final rows = _pendingRows(controller.pendingSituations);
+    return <Widget>[
+      _section(_PendingActionsHeader(count: entries.length)),
+      SliverPadding(
+        padding: _hPad,
+        sliver: SliverList.builder(
+          itemCount: rows.length,
+          itemBuilder: (context, index) {
+            final row = rows[index];
+            return switch (row) {
+              _SituationHeaderRow(:final entries) =>
+                _SituationHeader(controller: controller, entries: entries),
+              _EntryRow(:final entry) =>
+                _PendingEntryTile(controller: controller, entry: entry),
+            };
+          },
+        ),
+      ),
+      _section(_PendingActionsFooter(controller: controller)),
+    ];
+  }
+
+  static List<_PendingRow> _pendingRows(
+    List<List<PendingAccountEntry>> situations,
+  ) {
+    final rows = <_PendingRow>[];
+    for (final subset in situations) {
+      if (subset.length > 1) rows.add(_SituationHeaderRow(subset));
+      for (final entry in subset) {
+        rows.add(_EntryRow(entry));
+      }
+    }
+    return rows;
+  }
+
+  List<Widget> _resultsSlivers() {
     final dry = controller.dryRunResults;
     final applied = controller.applyResults;
-    return <Widget>[
-      if (dry != null) ...<Widget>[
-        const SizedBox(height: PlinkSpacing.s5),
-        _ResultsSection(
+    final slivers = <Widget>[];
+    if (dry != null) {
+      slivers
+        ..add(_gap(PlinkSpacing.s5))
+        ..addAll(_resultSectionSlivers(
           title: 'Dry-run result',
           subtitle: 'No changes were written. This is what an apply would do.',
           results: dry,
-        ),
-      ],
-      if (applied != null) ...<Widget>[
-        const SizedBox(height: PlinkSpacing.s5),
-        _ResultsSection(
+        ));
+    }
+    if (applied != null) {
+      slivers
+        ..add(_gap(PlinkSpacing.s5))
+        ..addAll(_resultSectionSlivers(
           title: 'Apply result',
           subtitle: 'Written to the target systems.',
           results: applied,
-        ),
-      ],
-    ];
+        ));
+    }
+    return slivers;
   }
+
+  /// One dry-run/apply result set (#111): its header is an adapter and its
+  /// outcome rows render through a lazy [SliverList] — an apply over thousands
+  /// of accounts yields thousands of rows.
+  List<Widget> _resultSectionSlivers({
+    required String title,
+    required String subtitle,
+    required List<ActionOutcomeEntry> results,
+  }) =>
+      <Widget>[
+        _section(_ResultsHeader(title: title, subtitle: subtitle)),
+        SliverPadding(
+          padding: _hPad,
+          sliver: SliverList.builder(
+            itemCount: results.length,
+            itemBuilder: (context, index) => _ResultRow(result: results[index]),
+          ),
+        ),
+      ];
 }
 
 class _Header extends StatelessWidget {
@@ -561,73 +672,81 @@ Future<void> _confirmAndApply(
   if (confirmed ?? false) await apply();
 }
 
-/// The pending-actions list (#110): **one entry per account**, mutually
-/// exclusive resolutions rendered as a choice, and per-entry / per-situation
-/// apply as the primary affordances. The global "apply all" is kept as a
-/// secondary escape hatch, not the headline.
-class _ActionsSection extends StatelessWidget {
-  const _ActionsSection({required this.controller});
+/// The pending-actions title (#110/#111): the "Pending actions (N)" heading,
+/// plus the "everything is in sync" line when there is nothing to do. Kept a
+/// fixed-size adapter above the lazy entry list.
+class _PendingActionsHeader extends StatelessWidget {
+  const _PendingActionsHeader({required this.count});
 
-  final ReconcileController controller;
+  final int count;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
-    final entries = controller.pendingEntries;
-    final situations = controller.pendingSituations;
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Pending actions (${entries.length})', style: text.titleMedium),
+        Text('Pending actions ($count)', style: text.titleMedium),
         const SizedBox(height: PlinkSpacing.s3),
-        if (entries.isEmpty)
+        if (count == 0)
           Text(
             'Everything is in sync — no pending actions.',
             style: text.bodyMedium,
-          )
-        else ...<Widget>[
-          for (final subset in situations)
-            _SituationSection(controller: controller, entries: subset),
-          const SizedBox(height: PlinkSpacing.s3),
-          Wrap(
-            spacing: PlinkSpacing.s3,
-            children: <Widget>[
-              OutlinedButton.icon(
-                key: const ValueKey('reconcile-dry-run'),
-                onPressed: controller.busy || controller.applyableCount == 0
-                    ? null
-                    : controller.dryRun,
-                icon: const Icon(Icons.visibility_outlined),
-                label: const Text('Dry-run all'),
-              ),
-              TextButton.icon(
-                key: const ValueKey('reconcile-apply'),
-                onPressed: controller.busy || controller.applyableCount == 0
-                    ? null
-                    : () => _confirmAndApply(
-                          context,
-                          title: 'Apply pending actions?',
-                          count: controller.applyableCount,
-                          apply: controller.applyAll,
-                        ),
-                icon: const Icon(Icons.play_arrow_outlined),
-                label: const Text('Apply all'),
-              ),
-            ],
           ),
-        ],
       ],
     );
   }
 }
 
-/// One "same situation" subset (#110): the entries whose situation matches, with
-/// a bulk "apply this resolution to all" affordance that honours each entry's
-/// own chosen alternative. The bulk header only appears when more than one
-/// account is in the situation — a lone entry is resolved from its own tile.
-class _SituationSection extends StatelessWidget {
-  const _SituationSection({required this.controller, required this.entries});
+/// The global dry-run/apply affordances (#110): the secondary escape hatch that
+/// acts on every pending entry's chosen resolution. Sits below the lazy entry
+/// list as a fixed-size adapter (#111).
+class _PendingActionsFooter extends StatelessWidget {
+  const _PendingActionsFooter({required this.controller});
+
+  final ReconcileController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: PlinkSpacing.s3),
+      child: Wrap(
+        spacing: PlinkSpacing.s3,
+        children: <Widget>[
+          OutlinedButton.icon(
+            key: const ValueKey('reconcile-dry-run'),
+            onPressed: controller.busy || controller.applyableCount == 0
+                ? null
+                : controller.dryRun,
+            icon: const Icon(Icons.visibility_outlined),
+            label: const Text('Dry-run all'),
+          ),
+          TextButton.icon(
+            key: const ValueKey('reconcile-apply'),
+            onPressed: controller.busy || controller.applyableCount == 0
+                ? null
+                : () => _confirmAndApply(
+                      context,
+                      title: 'Apply pending actions?',
+                      count: controller.applyableCount,
+                      apply: controller.applyAll,
+                    ),
+            icon: const Icon(Icons.play_arrow_outlined),
+            label: const Text('Apply all'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The bulk header of one "same situation" subset (#110): the "apply this
+/// resolution to all" affordance that honours each entry's own chosen
+/// alternative. Rendered as its own row in the lazy list (#111), only when more
+/// than one account shares the situation — a lone entry is resolved from its
+/// own tile.
+class _SituationHeader extends StatelessWidget {
+  const _SituationHeader({required this.controller, required this.entries});
 
   final ReconcileController controller;
   final List<PendingAccountEntry> entries;
@@ -638,52 +757,43 @@ class _SituationSection extends StatelessWidget {
     final key = entries.first.situationKey;
     final applyable = entries.where((e) => e.canApply).length;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        if (entries.length > 1) ...<Widget>[
-          Padding(
-            padding: const EdgeInsets.only(
-              top: PlinkSpacing.s2,
-              bottom: PlinkSpacing.s2,
-            ),
-            child: Row(
-              children: <Widget>[
-                Expanded(
-                  child: Text(
-                    '${entries.first.situationLabel} — ${entries.length} '
-                    'accounts in the same situation',
-                    style: text.titleSmall,
-                  ),
-                ),
-                const SizedBox(width: PlinkSpacing.s2),
-                OutlinedButton(
-                  key: ValueKey('situation-dry-run-$key'),
-                  onPressed: controller.busy || applyable == 0
-                      ? null
-                      : () => controller.dryRunSituation(key),
-                  child: const Text('Dry-run all'),
-                ),
-                const SizedBox(width: PlinkSpacing.s2),
-                FilledButton(
-                  key: ValueKey('situation-apply-$key'),
-                  onPressed: controller.busy || applyable == 0
-                      ? null
-                      : () => _confirmAndApply(
-                            context,
-                            title: 'Apply to ${entries.length} accounts?',
-                            count: applyable,
-                            apply: () => controller.applySituation(key),
-                          ),
-                  child: Text('Apply to all ($applyable)'),
-                ),
-              ],
+    return Padding(
+      padding: const EdgeInsets.only(
+        top: PlinkSpacing.s2,
+        bottom: PlinkSpacing.s2,
+      ),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Text(
+              '${entries.first.situationLabel} — ${entries.length} '
+              'accounts in the same situation',
+              style: text.titleSmall,
             ),
           ),
+          const SizedBox(width: PlinkSpacing.s2),
+          OutlinedButton(
+            key: ValueKey('situation-dry-run-$key'),
+            onPressed: controller.busy || applyable == 0
+                ? null
+                : () => controller.dryRunSituation(key),
+            child: const Text('Dry-run all'),
+          ),
+          const SizedBox(width: PlinkSpacing.s2),
+          FilledButton(
+            key: ValueKey('situation-apply-$key'),
+            onPressed: controller.busy || applyable == 0
+                ? null
+                : () => _confirmAndApply(
+                      context,
+                      title: 'Apply to ${entries.length} accounts?',
+                      count: applyable,
+                      apply: () => controller.applySituation(key),
+                    ),
+            child: Text('Apply to all ($applyable)'),
+          ),
         ],
-        for (final entry in entries)
-          _PendingEntryTile(controller: controller, entry: entry),
-      ],
+      ),
     );
   }
 }
@@ -1196,22 +1306,17 @@ class _AccountTile extends StatelessWidget {
   }
 }
 
-class _ResultsSection extends StatelessWidget {
-  const _ResultsSection({
-    required this.title,
-    required this.subtitle,
-    required this.results,
-  });
+/// The header of a dry-run/apply result set: its title and subtitle, above the
+/// lazy list of outcome rows (#111).
+class _ResultsHeader extends StatelessWidget {
+  const _ResultsHeader({required this.title, required this.subtitle});
 
   final String title;
   final String subtitle;
-  final List<ActionOutcomeEntry> results;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
-    final ColorScheme colors = Theme.of(context).colorScheme;
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
@@ -1219,34 +1324,47 @@ class _ResultsSection extends StatelessWidget {
         const SizedBox(height: PlinkSpacing.s1),
         Text(subtitle, style: text.bodySmall),
         const SizedBox(height: PlinkSpacing.s3),
-        for (final r in results)
-          Padding(
-            padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Icon(
-                  r.outcome == actions.ActionOutcome.failed
-                      ? Icons.close
-                      : Icons.check,
-                  size: 16,
-                  color: r.outcome == actions.ActionOutcome.failed
-                      ? colors.error
-                      : colors.primary,
-                ),
-                const SizedBox(width: PlinkSpacing.s2),
-                Expanded(
-                  child: Text(
-                    r.outcome == actions.ActionOutcome.failed
-                        ? '${r.target} — ${r.changes.summary}: ${r.error}'
-                        : '${r.target} — ${r.changes.summary}',
-                    style: text.bodySmall,
-                  ),
-                ),
-              ],
+      ],
+    );
+  }
+}
+
+/// One outcome row of a dry-run/apply pass (#111): the check/cross plus the
+/// target and its change summary (or the failure cause). Built lazily by the
+/// results [SliverList].
+class _ResultRow extends StatelessWidget {
+  const _ResultRow({required this.result});
+
+  final ActionOutcomeEntry result;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final failed = result.outcome == actions.ActionOutcome.failed;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(
+            failed ? Icons.close : Icons.check,
+            size: 16,
+            color: failed ? colors.error : colors.primary,
+          ),
+          const SizedBox(width: PlinkSpacing.s2),
+          Expanded(
+            child: Text(
+              failed
+                  ? '${result.target} — ${result.changes.summary}: '
+                      '${result.error}'
+                  : '${result.target} — ${result.changes.summary}',
+              style: text.bodySmall,
             ),
           ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -205,6 +205,28 @@ ReconcileHarness dupMailHarness({
       syncedBy: syncedBy,
     );
 
+/// A reconcile harness over [count] WISA-departed, Smartschool-only active
+/// accounts (no WISA, no Azure): each raises the mutually-exclusive
+/// unregister/delete choice (#110), so the pending list holds [count] entries in
+/// one "same situation" subset — a large set to exercise list virtualization
+/// (#111).
+ReconcileHarness manyDepartedHarness({int count = 2000}) => ReconcileHarness(
+      wisa: wisaSnap(students: const []),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: [
+          for (var i = 0; i < count; i++)
+            ssAccount(
+              uid: 'user$i',
+              accountId: '$i',
+              mail: 'user$i@student.school.example',
+            ),
+        ],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+    );
+
 az.AzureSnapshot azSnap({DateTime? fetchedAt, List<az.AzureUser>? users}) =>
     az.AzureSnapshot(
       fetchedAt: fetchedAt ?? kFixtureDate,

--- a/account_manager/test/reconcile/reconcile_pending_choice_test.dart
+++ b/account_manager/test/reconcile/reconcile_pending_choice_test.dart
@@ -154,4 +154,49 @@ void main() {
       expect(h.controller.applyableCount, 2);
     });
   });
+
+  group('pendingEntries memoization (#111)', () {
+    test('repeated reads return the identical cached list', () async {
+      final h = departedHarness();
+      await h.controller.sync();
+
+      final first = h.controller.pendingEntries;
+      final second = h.controller.pendingEntries;
+      expect(identical(first, second), isTrue,
+          reason: 'the entries are built once and cached, not per read');
+    });
+
+    test('choosing an alternative invalidates the cache', () async {
+      final h = departedHarness();
+      await h.controller.sync();
+
+      final before = h.controller.pendingEntries;
+      h.controller.chooseAlternative(
+        entry: before.firstWhere((e) => e.family == 'student'),
+        group: actions.smartschoolDepartureAlternative,
+        kind: 'DeleteStudentFromSmartschool',
+      );
+      final after = h.controller.pendingEntries;
+
+      expect(identical(before, after), isFalse,
+          reason: 'a new pick must rebuild the entries so the choice shows');
+      // …and the pick is reflected in the freshly built entry.
+      final entry = after.firstWhere((e) => e.family == 'student');
+      expect(
+          entry.choices.single.selected.kind, 'DeleteStudentFromSmartschool');
+    });
+
+    test('a re-link rebuilds the cache from the fresh view', () async {
+      final h = departedHarness();
+      await h.controller.sync();
+      final before = h.controller.pendingEntries;
+
+      // A drift re-read re-links, replacing the linked view.
+      await h.controller.checkDrift();
+      final after = h.controller.pendingEntries;
+
+      expect(identical(before, after), isFalse,
+          reason: 'a fresh linked view must not serve a stale cached list');
+    });
+  });
 }

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -8,6 +8,18 @@ import 'reconcile_fakes.dart';
 
 Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
 
+/// Gives the reconcile screen a tall viewport so the below-the-fold sections
+/// (overview, pending actions, results) are laid out without scrolling. The
+/// body is now a lazy [CustomScrollView] (#111), so — unlike the old eager
+/// `SingleChildScrollView` — off-screen slivers are not built; a tall window
+/// keeps these presence-only assertions honest without a scroll on every one.
+/// Width is left at the default 800 so horizontal layout is unchanged.
+void _useTallWindow(WidgetTester tester) {
+  tester.view.physicalSize = const Size(800, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
 void main() {
   testWidgets('shows the not-configured panel when AAD is absent',
       (WidgetTester tester) async {
@@ -70,6 +82,7 @@ void main() {
   testWidgets(
       'sync → overview → pending actions → dry-run → apply → unchanged banner',
       (WidgetTester tester) async {
+    _useTallWindow(tester);
     final harness = ReconcileHarness();
     await tester.pumpWidget(
       _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
@@ -131,6 +144,7 @@ void main() {
 
   testWidgets('cancelling the apply dialog writes nothing',
       (WidgetTester tester) async {
+    _useTallWindow(tester);
     final harness = ReconcileHarness();
     await tester.pumpWidget(
       _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
@@ -388,6 +402,7 @@ void main() {
       'a departed student renders one entry with a unregister/delete choice; '
       'picking delete applies delete, not unregister (#110)',
       (WidgetTester tester) async {
+    _useTallWindow(tester);
     final harness = departedHarness();
     await tester
         .pumpWidget(_wrap(ReconcileScreen(bootstrap: harness.bootstrap)));
@@ -437,6 +452,7 @@ void main() {
   testWidgets(
       'a same-situation subset offers a bulk apply that respects each row\'s '
       'choice (#110)', (WidgetTester tester) async {
+    _useTallWindow(tester);
     final harness = departedHarness(count: 2);
     await tester
         .pumpWidget(_wrap(ReconcileScreen(bootstrap: harness.bootstrap)));
@@ -469,6 +485,7 @@ void main() {
   testWidgets(
       'a duplicate-mail warning drills down to its accounts; accepting demotes '
       'it and revoking restores it (#109)', (WidgetTester tester) async {
+    _useTallWindow(tester);
     final linkedStore = InMemoryLinkedStore();
     final harness = dupMailHarness(linkedStore: linkedStore);
     await tester
@@ -504,6 +521,57 @@ void main() {
     await tester.pumpAndSettle();
     expect(await linkedStore.readDecisions(), isEmpty);
     expect(find.byKey(const ValueKey('dup-accept-$mail')), findsOneWidget);
+  });
+
+  testWidgets(
+      'a large pending set virtualizes: only a bounded number of entry tiles '
+      'build, and scrolling builds/unloads them (#111)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = manyDepartedHarness(count: 2000);
+    await tester
+        .pumpWidget(_wrap(ReconcileScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // All 2000 accounts are one pending entry each (one situation subset).
+    expect(harness.controller.pendingEntries, hasLength(2000));
+
+    // The lazy SliverList builds only the on-screen tiles — nowhere near 2000.
+    final entryTiles = find.byWidgetPredicate(
+      (w) =>
+          w.key is ValueKey<String> &&
+          (w.key! as ValueKey<String>).value.startsWith('entry-'),
+    );
+    final builtInitially = entryTiles.evaluate().length;
+    expect(builtInitially, greaterThan(0));
+    expect(
+      builtInitially,
+      lessThan(200),
+      reason: 'virtualized: on-screen tiles only, not all 2000',
+    );
+
+    // A far-off entry is not built yet…
+    final entries = harness.controller.pendingEntries;
+    final firstKey = ValueKey('entry-student-${entries.first.targetId}');
+    final lastKey = ValueKey('entry-student-${entries.last.targetId}');
+    expect(find.byKey(lastKey), findsNothing);
+
+    // …scrolling to it builds it on demand (and unloads the top of the list).
+    await tester.scrollUntilVisible(
+      find.byKey(lastKey),
+      5000,
+      scrollable: find.byType(Scrollable).first,
+      maxScrolls: 200,
+    );
+    expect(find.byKey(lastKey), findsOneWidget);
+    expect(
+      find.byKey(firstKey),
+      findsNothing,
+      reason: 'the first tile unloaded once scrolled far off-screen',
+    );
   });
 
   testWidgets('the log panel clears on demand', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary

With a real-school pending set (thousands of entries during a September changeover), the reconcile screen janked: the body was one `SingleChildScrollView` + `Column`, so every pending-action tile (an `ExpansionTile` each) and every dry-run/apply result row was built, laid out, and painted on every frame — visible or not — and `ReconcileController.pendingEntries` re-ran `describeChanges()` for every action several times per frame.

## Linked issue

Closes #111

## Changes

- **Lazy scroll body.** `_ReconcileBody` is now a `CustomScrollView`. The header, status banner, drill-down/classroom/groups detail, linked overview, and the section titles/footers stay as fixed `SliverToBoxAdapter`s; the pending entries (flattened to situation-header + per-account rows) and the dry-run/apply result rows render through lazy `SliverList.builder`s, so only on-screen tiles are built and off-screen ones are unloaded. Slivers sit directly under the scroll view (not a `SliverMainAxisGroup`, which swallows the scroll cache extent), each with the body's horizontal inset.
- **Memoized `pendingEntries` (#111).** Cached and keyed on the linked-view identity plus a version bumped on every `chooseAlternative`, so a re-link or a new pick always rebuilds but a per-frame read is free. `pendingSituations` / `applyableCount` ride on the cache.
- #110's per-entry / per-situation apply + choice grouping and #109's duplicate-mail warnings are preserved unchanged.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `dart analyze --fatal-infos --fatal-warnings` clean (repo root)
- [x] Unit/widget tests pass — `flutter test` (116 tests). New: a widget test drives a 2000-entry pending set and asserts only a bounded number of entry tiles build (<200) and that scrolling builds/unloads them; controller unit tests cover the cache identity + invalidation (repeated read is identical, `chooseAlternative` and a re-link invalidate).
- [x] Integration/e2e tests pass — `flutter test integration_test -d windows` (14 tests). New: a real-app scenario drives a 1000-entry pending set and asserts bounded tile building + scroll-loads-more, with real fonts/window/navigation — exactly the composition a widget test can't cover.

Note on the existing reconcile tests: the body is now a lazy `CustomScrollView`, so unlike the old eager `SingleChildScrollView` its off-screen slivers are not built. The existing reconcile widget/integration tests that assert below-the-fold content now run in a tall viewport (`tester.view.physicalSize`) so those presence-only assertions stay honest without a scroll on every one; width is left unchanged.