### PR TITLE
Phase C: Passwords view — capture generated passwords into the shared queue + distribution UI (#105)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -8,6 +8,7 @@ import 'package:account_manager/main.dart' as app;
 import 'package:account_manager/src/app.dart';
 import 'package:account_manager/src/auth/auth.dart';
 import 'package:account_manager/src/screens/home_screen.dart';
+import 'package:account_manager/src/screens/passwords_screen.dart';
 import 'package:account_manager/src/screens/reconcile_screen.dart';
 import 'package:account_manager/src/shell/app_shell.dart';
 import 'package:account_state/account_state.dart'
@@ -647,6 +648,64 @@ void main() {
     expect(decisions, hasLength(1));
     expect(harness.controller.duplicateWarnings.single.accepted, isTrue);
     expect(find.byKey(const ValueKey('dup-revoke-$mail')), findsOneWidget);
+  });
+
+  testWidgets(
+      'creating an account captures its password into the Passwords view, which '
+      'distributes it out of the shared queue (#105)',
+      (WidgetTester tester) async {
+    // A brand-new student: present in WISA and Azure but not yet in Smartschool,
+    // so the dispatcher yields exactly one AddStudentToSmartschool — an
+    // account-creating apply that mints (and must capture) a password.
+    useTallWindow(tester);
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(students: [wisaStudent()]),
+      azure: azSnap(users: [azUser()]),
+      smartschool: ssSnap(accounts: const [], memberships: const []),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // Reconcile → sync → the create is pending. The queue starts empty.
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(find.text('Maak een nieuw Smartschool account'), findsWidgets);
+    expect(await harness.passwordQueue.load(), isEmpty);
+
+    // Apply it for real (against the recording SOAP transport): the create runs
+    // and its minted password is captured into the shared queue.
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-apply')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-apply')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-apply-confirm')));
+    await tester.pumpAndSettle();
+    expect(find.text('Apply result'), findsOneWidget);
+    final queued = await harness.passwordQueue.load();
+    expect(queued, hasLength(1),
+        reason: 'the created account\'s password landed in the queue');
+    expect(queued.single.smartschoolPassword, isNotNull);
+
+    // Switch to the Passwords view: the freshly captured sheet is listed in the
+    // real, laid-out app.
+    await tester.tap(find.text('Passwords'));
+    await tester.pumpAndSettle();
+    expect(find.byType(PasswordsScreen), findsOneWidget);
+    expect(find.text('Jane Doe'), findsOneWidget);
+    expect(find.text('Smartschool:'), findsOneWidget);
+
+    // Mark it distributed → it drains from the shared queue (saved remainder is
+    // empty) and the view falls back to the all-distributed state.
+    await tester.tap(find.byIcon(Icons.done_all));
+    await tester.pumpAndSettle();
+    expect(find.text('Jane Doe'), findsNothing);
+    expect(find.byKey(const ValueKey('passwords-empty')), findsOneWidget);
+    expect(await harness.passwordQueue.load(), isEmpty);
   });
 
   testWidgets('silent sign-in leads straight into the shell',

--- a/account_manager/lib/main.dart
+++ b/account_manager/lib/main.dart
@@ -56,13 +56,38 @@ void main() {
       session: session,
       graph: config.isConfigured ? config.graph : null,
       // The reconcile stack (settings from Azure SQL, secrets from Key Vault,
-      // the three connectors) is assembled lazily, the first time the screen
-      // is opened — after the sign-in gate has a session to mint tokens from.
+      // the three connectors) is assembled lazily, the first time a screen that
+      // needs it is opened — after the sign-in gate has a session to mint tokens
+      // from. Memoized so the Reconcile and Passwords screens share **one** stack
+      // (and so one queue instance links an apply to the Passwords view); a
+      // failed attempt is not cached, so the reconcile screen's retry re-runs it.
       reconcileBootstrap: config.isConfigured
-          ? () => bootstrapReconcile(session: session, aad: config)
+          ? _memoizeOnSuccess(
+              () => bootstrapReconcile(session: session, aad: config),
+            )
           : null,
     ),
   );
+}
+
+/// Wraps [make] so all callers share the first successful `Future`, while a
+/// failed attempt clears the cache so the next call retries. Keeps the reconcile
+/// stack a singleton without breaking the reconcile screen's retry-on-error.
+Future<T> Function() _memoizeOnSuccess<T>(Future<T> Function() make) {
+  Future<T>? pending;
+  return () {
+    final existing = pending;
+    if (existing != null) return existing;
+    final started = make().then(
+      (value) => value,
+      onError: (Object error, StackTrace stack) {
+        pending = null;
+        Error.throwWithStackTrace(error, stack);
+      },
+    );
+    pending = started;
+    return started;
+  };
 }
 
 /// The persistent, encrypted token cache for one resource: ciphertext in

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -87,6 +87,7 @@ class ReconcileServices {
     required this.applier,
     required this.controller,
     required this.log,
+    required this.passwordQueue,
   });
 
   final AppSettings settings;
@@ -94,6 +95,12 @@ class ReconcileServices {
   final StateApplier applier;
   final ReconcileController controller;
   final LogBuffer log;
+
+  /// The shared password-distribution queue (#105) the [applier] appends to
+  /// when an apply creates an account, and the Passwords view reads and drains.
+  /// The same instance is wired into [applier], so an apply and the view see the
+  /// one queue.
+  final PasswordQueueStore passwordQueue;
 }
 
 /// A configuration problem the operator can act on (missing secret, malformed
@@ -128,6 +135,7 @@ Future<ReconcileServices> bootstrapReconcile({
   BlobStore? blobStore,
   SnapshotStore? snapshotStore,
   LinkedStore? linkedStore,
+  PasswordQueueStore? passwordQueueStore,
   SignalPublisher? publisher,
   SignalSubscriber? subscriber,
   LogBuffer? log,
@@ -167,6 +175,13 @@ Future<ReconcileServices> bootstrapReconcile({
   // docs + rollups here, and every passive session reads the overview back with
   // no pull and no link().
   final linked = linkedStore ?? CosmosLinkedStore(client);
+
+  // The shared password-distribution queue (#105): the whole team's pending
+  // password sheets in one Cosmos document, so one operator can generate and
+  // another print. The same instance is wired into the applier (which appends on
+  // every account-creating apply) and handed to the Passwords view (which reads
+  // and drains it).
+  final passwordQueue = passwordQueueStore ?? CosmosPasswordQueueStore(client);
 
   // The realtime seam (#116 publish, #124 subscribe): a sync/apply broadcasts a
   // small change signal so other operators refetch just the changed shard, and
@@ -354,6 +369,7 @@ Future<ReconcileServices> bootstrapReconcile({
       azureDomain: azureDomain,
     ),
     classTree: classTreeFrom(settings.smartschool),
+    passwordQueue: passwordQueue,
   );
 
   // The live SignalR subscriber (#124): on every (re)connect it re-reads the
@@ -390,6 +406,7 @@ Future<ReconcileServices> bootstrapReconcile({
     applier: applier,
     controller: controller,
     log: logBuffer,
+    passwordQueue: passwordQueue,
   );
 }
 

--- a/account_manager/lib/src/screens/passwords_screen.dart
+++ b/account_manager/lib/src/screens/passwords_screen.dart
@@ -1,0 +1,492 @@
+import 'package:account_state/account_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:plink_design_system/plink_design_system.dart';
+
+import '../reconcile/reconcile_bootstrap.dart';
+
+/// The Passwords view (#105): the shared distribution queue of passwords minted
+/// when an apply creates an account.
+///
+/// The whole point of the shared queue is the one-generates/one-prints flow —
+/// one operator runs the reconcile applies that fill the queue, another opens
+/// this view to read the sheets and mark them distributed. So this screen reads
+/// and drains the **same** [PasswordQueueStore] the [StateApplier] appends to
+/// (both come from the one memoized [ReconcileServices]).
+///
+/// Deliberately minimal per the Phase C rethink (#75): list pending entries,
+/// copy a password, and mark an entry distributed (which drains it by saving the
+/// remainder). Ticket-printer output is a later slice.
+class PasswordsScreen extends StatefulWidget {
+  const PasswordsScreen({super.key, required this.bootstrap});
+
+  /// Assembles (or returns the already-assembled) reconcile stack, or `null`
+  /// when Azure AD is not configured for this build. The same memoized closure
+  /// the reconcile screen uses, so both share one queue instance.
+  final Future<ReconcileServices> Function()? bootstrap;
+
+  @override
+  State<PasswordsScreen> createState() => _PasswordsScreenState();
+}
+
+class _PasswordsScreenState extends State<PasswordsScreen> {
+  ReconcileServices? _services;
+  List<PasswordEntry>? _entries;
+  Object? _error;
+  bool _busy = false;
+  int _attempts = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  /// Bootstraps the stack (once, memoized) if needed, then (re)reads the queue.
+  Future<void> _load() async {
+    final make = widget.bootstrap;
+    if (make == null) return;
+    setState(() {
+      _attempts++;
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final services = _services ?? await make();
+      final entries = await services.passwordQueue.load();
+      if (!mounted) return;
+      setState(() {
+        _services = services;
+        _entries = entries;
+      });
+    } on Object catch (e) {
+      if (mounted) setState(() => _error = e);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  /// Marks [entry] distributed: drops it from the queue and persists the
+  /// remainder (the queue store replaces the whole list on save). Optimistic —
+  /// the row disappears immediately; a failed save restores it and surfaces the
+  /// error.
+  Future<void> _distribute(PasswordEntry entry) async {
+    final services = _services;
+    final current = _entries;
+    if (services == null || current == null) return;
+
+    final remainder = <PasswordEntry>[
+      for (final e in current)
+        if (e.personId.value != entry.personId.value) e,
+    ];
+    setState(() => _entries = remainder);
+    try {
+      await services.passwordQueue.save(remainder);
+      if (mounted) _toast('Gemarkeerd als verdeeld — ${entry.displayName}.');
+    } on Object catch (e) {
+      if (!mounted) return;
+      // Restore the row so the operator can retry; the store rejected the drain.
+      setState(() => _entries = current);
+      _toast('Kon niet opslaan: $e');
+    }
+  }
+
+  Future<void> _copy(String label, String password) async {
+    await Clipboard.setData(ClipboardData(text: password));
+    if (mounted) _toast('$label gekopieerd.');
+  }
+
+  void _toast(String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.bootstrap == null) {
+      return const _MessagePanel(
+        eyebrow: 'Arcadia · wachtwoorden',
+        title: 'Not configured',
+        message: 'Azure AD is not configured for this build, so the shared '
+            'password queue cannot be reached. Provide the AAD --dart-define '
+            'values and restart.',
+      );
+    }
+    final error = _error;
+    if (error != null && _entries == null) {
+      final retryNote = _attempts > 1 ? '\n\n(Attempt $_attempts failed.)' : '';
+      return _MessagePanel(
+        eyebrow: 'Arcadia · wachtwoorden',
+        title: 'Kon de wachtwoordenlijst niet laden',
+        message: '$error$retryNote',
+        action: FilledButton(
+          key: const ValueKey('passwords-retry'),
+          onPressed: _load,
+          child: const Text('Opnieuw proberen'),
+        ),
+      );
+    }
+    final entries = _entries;
+    if (entries == null) {
+      return const _MessagePanel(
+        eyebrow: 'Arcadia · wachtwoorden',
+        title: 'Laden…',
+        message: 'De gedeelde wachtwoordenlijst wordt opgehaald.',
+        progress: true,
+      );
+    }
+    return _PasswordsBody(
+      entries: entries,
+      busy: _busy,
+      onRefresh: _load,
+      onCopy: _copy,
+      onDistribute: _distribute,
+    );
+  }
+}
+
+class _PasswordsBody extends StatelessWidget {
+  const _PasswordsBody({
+    required this.entries,
+    required this.busy,
+    required this.onRefresh,
+    required this.onCopy,
+    required this.onDistribute,
+  });
+
+  final List<PasswordEntry> entries;
+  final bool busy;
+  final VoidCallback onRefresh;
+  final Future<void> Function(String label, String password) onCopy;
+  final Future<void> Function(PasswordEntry entry) onDistribute;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 960),
+        child: CustomScrollView(
+          slivers: <Widget>[
+            const SliverToBoxAdapter(child: SizedBox(height: PlinkSpacing.s6)),
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: PlinkSpacing.s6),
+              sliver: SliverToBoxAdapter(
+                child: _Header(
+                    count: entries.length, busy: busy, onRefresh: onRefresh),
+              ),
+            ),
+            const SliverToBoxAdapter(child: SizedBox(height: PlinkSpacing.s5)),
+            if (entries.isEmpty)
+              SliverPadding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: PlinkSpacing.s6),
+                sliver: const SliverToBoxAdapter(child: _EmptyState()),
+              )
+            else
+              SliverPadding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: PlinkSpacing.s6),
+                sliver: SliverList.builder(
+                  itemCount: entries.length,
+                  itemBuilder: (context, index) => _PasswordCard(
+                    entry: entries[index],
+                    onCopy: onCopy,
+                    onDistribute: onDistribute,
+                  ),
+                ),
+              ),
+            const SliverToBoxAdapter(child: SizedBox(height: PlinkSpacing.s6)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({
+    required this.count,
+    required this.busy,
+    required this.onRefresh,
+  });
+
+  final int count;
+  final bool busy;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final bool ink = Theme.of(context).brightness == Brightness.dark;
+    final String subtitle = count == 0
+        ? 'Geen wachtwoorden in de wachtrij.'
+        : count == 1
+            ? '1 wachtwoord wacht op verdeling.'
+            : '$count wachtwoorden wachten op verdeling.';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Eyebrow('Arcadia · wachtwoorden', onInk: ink),
+        const SizedBox(height: PlinkSpacing.s4),
+        Text('Wachtwoorden', style: text.headlineMedium),
+        const SizedBox(height: PlinkSpacing.s4),
+        Wrap(
+          spacing: PlinkSpacing.s3,
+          runSpacing: PlinkSpacing.s2,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: <Widget>[
+            OutlinedButton.icon(
+              key: const ValueKey('passwords-refresh'),
+              onPressed: busy ? null : onRefresh,
+              icon: const Icon(Icons.refresh),
+              label: const Text('Vernieuwen'),
+            ),
+            Text(subtitle, style: text.bodySmall),
+          ],
+        ),
+        if (busy) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s4),
+          const LinearProgressIndicator(),
+        ],
+      ],
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return Container(
+      key: const ValueKey('passwords-empty'),
+      padding: const EdgeInsets.all(PlinkSpacing.s5),
+      decoration: BoxDecoration(
+        border: Border.all(color: colors.outlineVariant),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Row(
+        children: <Widget>[
+          Icon(Icons.check_circle_outline, color: colors.primary),
+          const SizedBox(width: PlinkSpacing.s3),
+          Flexible(
+            child: Text(
+              'Alle wachtwoorden zijn verdeeld. Nieuwe accounts die je aanmaakt '
+              'bij het reconcilen verschijnen hier.',
+              style: text.bodyMedium,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PasswordCard extends StatelessWidget {
+  const _PasswordCard({
+    required this.entry,
+    required this.onCopy,
+    required this.onDistribute,
+  });
+
+  final PasswordEntry entry;
+  final Future<void> Function(String label, String password) onCopy;
+  final Future<void> Function(PasswordEntry entry) onDistribute;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final subtitleParts = <String>[
+      entry.accountName,
+      if (entry.classGroup != null && entry.classGroup!.isNotEmpty)
+        entry.classGroup!,
+      if (entry.mail != null && entry.mail!.isNotEmpty) entry.mail!,
+    ];
+
+    return Container(
+      key: ValueKey('password-entry-${entry.personId.value}'),
+      margin: const EdgeInsets.only(bottom: PlinkSpacing.s3),
+      padding: const EdgeInsets.all(PlinkSpacing.s4),
+      decoration: BoxDecoration(
+        border: Border.all(color: colors.outlineVariant),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      entry.displayName.isEmpty
+                          ? entry.accountName
+                          : entry.displayName,
+                      style: text.titleMedium,
+                    ),
+                    if (subtitleParts.isNotEmpty) ...<Widget>[
+                      const SizedBox(height: PlinkSpacing.s1),
+                      Text(
+                        subtitleParts.join(' · '),
+                        style: text.bodySmall
+                            ?.copyWith(color: colors.onSurfaceVariant),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              TextButton.icon(
+                key: ValueKey('password-distribute-${entry.personId.value}'),
+                onPressed: () => onDistribute(entry),
+                icon: const Icon(Icons.done_all, size: 18),
+                label: const Text('Verdeeld'),
+              ),
+            ],
+          ),
+          const SizedBox(height: PlinkSpacing.s3),
+          Wrap(
+            spacing: PlinkSpacing.s3,
+            runSpacing: PlinkSpacing.s2,
+            children: <Widget>[
+              if (entry.smartschoolPassword != null &&
+                  entry.smartschoolPassword!.isNotEmpty)
+                _PasswordChip(
+                  keyValue: 'password-copy-ss-${entry.personId.value}',
+                  label: 'Smartschool',
+                  password: entry.smartschoolPassword!,
+                  onCopy: () => onCopy(
+                    'Smartschool-wachtwoord',
+                    entry.smartschoolPassword!,
+                  ),
+                ),
+              if (entry.azurePassword != null &&
+                  entry.azurePassword!.isNotEmpty)
+                _PasswordChip(
+                  keyValue: 'password-copy-azure-${entry.personId.value}',
+                  label: 'Office 365',
+                  password: entry.azurePassword!,
+                  onCopy: () => onCopy(
+                    'Office 365-wachtwoord',
+                    entry.azurePassword!,
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PasswordChip extends StatelessWidget {
+  const _PasswordChip({
+    required this.keyValue,
+    required this.label,
+    required this.password,
+    required this.onCopy,
+  });
+
+  final String keyValue;
+  final String label;
+  final String password;
+  final VoidCallback onCopy;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(
+        PlinkSpacing.s3,
+        PlinkSpacing.s2,
+        PlinkSpacing.s2,
+        PlinkSpacing.s2,
+      ),
+      decoration: BoxDecoration(
+        color: colors.surfaceContainerHighest,
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Text('$label:', style: text.labelMedium),
+          const SizedBox(width: PlinkSpacing.s2),
+          SelectableText(
+            password,
+            style: text.bodyMedium?.copyWith(fontFeatures: const <FontFeature>[
+              FontFeature.tabularFigures(),
+            ]),
+          ),
+          const SizedBox(width: PlinkSpacing.s1),
+          IconButton(
+            key: ValueKey(keyValue),
+            visualDensity: VisualDensity.compact,
+            tooltip: 'Kopieer $label-wachtwoord',
+            icon: const Icon(Icons.copy, size: 18),
+            onPressed: onCopy,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Full-panel message (loading / not-configured / error), mirroring the
+/// reconcile screen's panel so the two views read as one app.
+class _MessagePanel extends StatelessWidget {
+  const _MessagePanel({
+    required this.eyebrow,
+    required this.title,
+    required this.message,
+    this.action,
+    this.progress = false,
+  });
+
+  final String eyebrow;
+  final String title;
+  final String message;
+  final Widget? action;
+  final bool progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final bool ink = Theme.of(context).brightness == Brightness.dark;
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: Padding(
+          padding: const EdgeInsets.all(PlinkSpacing.s6),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Eyebrow(eyebrow, onInk: ink),
+              const SizedBox(height: PlinkSpacing.s4),
+              Text(title, style: text.headlineSmall),
+              const SizedBox(height: PlinkSpacing.s4),
+              Text(message, style: text.bodyMedium),
+              if (progress) ...<Widget>[
+                const SizedBox(height: PlinkSpacing.s5),
+                const LinearProgressIndicator(),
+              ],
+              if (action != null) ...<Widget>[
+                const SizedBox(height: PlinkSpacing.s5),
+                action!,
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/account_manager/lib/src/shell/app_shell.dart
+++ b/account_manager/lib/src/shell/app_shell.dart
@@ -3,6 +3,7 @@ import 'package:plink_design_system/plink_design_system.dart';
 
 import '../reconcile/reconcile_bootstrap.dart';
 import '../screens/home_screen.dart';
+import '../screens/passwords_screen.dart';
 import '../screens/reconcile_screen.dart';
 
 /// One navigable destination in the [AppShell].
@@ -46,6 +47,11 @@ class _AppShellState extends State<AppShell> {
       label: 'Reconcile',
       icon: Icons.sync_alt_outlined,
       builder: (_) => ReconcileScreen(bootstrap: widget.reconcileBootstrap),
+    ),
+    ShellDestination(
+      label: 'Passwords',
+      icon: Icons.password_outlined,
+      builder: (_) => PasswordsScreen(bootstrap: widget.reconcileBootstrap),
     ),
   ];
 

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -394,6 +394,7 @@ class ReconcileHarness {
         schoolPrefix: 'GBS',
         azureDomain: 'school.example',
       ),
+      passwordQueue: passwordQueue,
     );
 
     final signalHub = hub;
@@ -488,6 +489,10 @@ class ReconcileHarness {
   late final StateApplier applier;
   late final ReconcileController controller;
 
+  /// The shared password-distribution queue (#105): the applier appends to it on
+  /// every account-creating apply, and the Passwords view reads and drains it.
+  final InMemoryPasswordQueueStore passwordQueue = InMemoryPasswordQueueStore();
+
   /// The bundle the screen's bootstrap seam expects.
   ReconcileServices get services => ReconcileServices(
         settings: const AppSettings(),
@@ -495,6 +500,7 @@ class ReconcileHarness {
         applier: applier,
         controller: controller,
         log: log,
+        passwordQueue: passwordQueue,
       );
 
   /// A ready-made bootstrap closure for [ReconcileScreen]/[AccountManagerApp].

--- a/account_manager/test/screens/passwords_screen_test.dart
+++ b/account_manager/test/screens/passwords_screen_test.dart
@@ -1,0 +1,120 @@
+import 'package:account_manager/src/screens/passwords_screen.dart';
+import 'package:account_state/account_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../reconcile/reconcile_fakes.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+PasswordEntry _entry({
+  required String pid,
+  String name = 'Jane Doe',
+  String uid = 'jane.doe',
+  String? smartschool = 'SS-pw',
+  String? azure = 'AZ-pw',
+}) =>
+    PasswordEntry(
+      personId: PersonId(pid),
+      kind: PasswordAccountKind.account,
+      accountName: uid,
+      displayName: name,
+      mail: '$uid@student.school.example',
+      classGroup: '3C',
+      smartschoolPassword: smartschool,
+      azurePassword: azure,
+    );
+
+void main() {
+  testWidgets('shows the not-configured panel when AAD is absent',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_wrap(const PasswordsScreen(bootstrap: null)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Not configured'), findsOneWidget);
+    expect(find.byKey(const ValueKey('passwords-refresh')), findsNothing);
+  });
+
+  testWidgets('lists the pending entries the shared queue holds',
+      (WidgetTester tester) async {
+    final harness = ReconcileHarness();
+    await harness.passwordQueue.save([
+      _entry(pid: 'p1', name: 'Jane Doe', uid: 'jane.doe'),
+      _entry(pid: 'p2', name: 'Jan Peeters', uid: 'jan.peeters', azure: null),
+    ]);
+
+    await tester
+        .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Jane Doe'), findsOneWidget);
+    expect(find.text('Jan Peeters'), findsOneWidget);
+    // Jane has both backends; Jan only Smartschool.
+    expect(find.text('SS-pw'), findsWidgets);
+    expect(find.text('AZ-pw'), findsOneWidget);
+    expect(find.text('2 wachtwoorden wachten op verdeling.'), findsOneWidget);
+  });
+
+  testWidgets('copy puts the password on the clipboard',
+      (WidgetTester tester) async {
+    final copied = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (MethodCall call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied.add((call.arguments as Map)['text'] as String);
+        }
+        return null;
+      },
+    );
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null));
+
+    final harness = ReconcileHarness();
+    await harness.passwordQueue.save([_entry(pid: 'p1')]);
+    await tester
+        .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('password-copy-ss-p1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('password-copy-azure-p1')));
+    await tester.pumpAndSettle();
+
+    expect(copied, ['SS-pw', 'AZ-pw']);
+  });
+
+  testWidgets(
+      'marking an entry distributed drains it from the shared queue and shows '
+      'the empty state', (WidgetTester tester) async {
+    final harness = ReconcileHarness();
+    await harness.passwordQueue.save([_entry(pid: 'p1', name: 'Jane Doe')]);
+    await tester
+        .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Jane Doe'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('password-distribute-p1')));
+    await tester.pumpAndSettle();
+
+    // The row is gone from the view and, crucially, from the persisted queue —
+    // draining means saving the remainder so the other operators no longer see
+    // it.
+    expect(find.text('Jane Doe'), findsNothing);
+    expect(find.byKey(const ValueKey('passwords-empty')), findsOneWidget);
+    expect(await harness.passwordQueue.load(), isEmpty);
+  });
+
+  testWidgets('an empty queue renders the all-distributed state',
+      (WidgetTester tester) async {
+    final harness = ReconcileHarness();
+    await tester
+        .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('passwords-empty')), findsOneWidget);
+    expect(find.text('Geen wachtwoorden in de wachtrij.'), findsOneWidget);
+  });
+}

--- a/packages/account_actions/lib/src/action_result.dart
+++ b/packages/account_actions/lib/src/action_result.dart
@@ -68,6 +68,16 @@ class ActionResult {
   /// non-WISA action.
   final WisaImportRule? wisaRule;
 
+  /// The password minted for a **freshly created** account, so the State layer
+  /// can drop it into the shared password-distribution queue (#105) instead of
+  /// the account-creating action generating it and forgetting it.
+  ///
+  /// Set only by the account-creating actions on a real [ActionOutcome.applied]
+  /// write — the value they passed to the connector. Null for every modify or
+  /// delete action, and null on a dry run (no write, so no password is minted
+  /// and nothing must leak into the queue).
+  final String? generatedPassword;
+
   /// The failure cause; non-null only when [outcome] is [ActionOutcome.failed].
   final Object? error;
 
@@ -80,6 +90,7 @@ class ActionResult {
     this.group,
     this.removed = false,
     this.wisaRule,
+    this.generatedPassword,
     this.error,
   });
 

--- a/packages/account_actions/lib/src/staff_action.dart
+++ b/packages/account_actions/lib/src/staff_action.dart
@@ -154,10 +154,11 @@ class AddStaffToAzure extends StaffAction {
         config.azureDomain,
         isStudent: false,
       );
+      final password = config.newAccountPassword();
       final created = await users.createUser(
         userPrincipalName: upn,
         displayName: _displayName,
-        password: config.newAccountPassword(),
+        password: password,
         givenName: wisa.firstName,
         surname: wisa.lastName,
         employeeId: wisa.wisaId?.value,
@@ -169,6 +170,7 @@ class AddStaffToAzure extends StaffAction {
         changes: changes,
         system: Origin.azure,
         azure: created,
+        generatedPassword: password,
       );
     } on Object catch (e) {
       return _failed(changes, Origin.azure, e);
@@ -256,9 +258,10 @@ class AddStaffToSmartschool extends StaffAction {
     }
 
     try {
+      final password = config.newAccountPassword();
       final ok = await _requireSmartschool(connectors).saveAccount(
         built,
-        password: config.newAccountPassword(),
+        password: password,
       );
       if (!ok) {
         return _failed(
@@ -272,6 +275,7 @@ class AddStaffToSmartschool extends StaffAction {
         changes: changes,
         system: Origin.smartschool,
         smartschool: built,
+        generatedPassword: password,
       );
     } on Object catch (e) {
       return _failed(changes, Origin.smartschool, e);

--- a/packages/account_actions/lib/src/student_action.dart
+++ b/packages/account_actions/lib/src/student_action.dart
@@ -169,10 +169,11 @@ class AddStudentToAzure extends StudentAction {
         config.azureDomain,
         isStudent: true,
       );
+      final password = config.newAccountPassword();
       final created = await users.createUser(
         userPrincipalName: upn,
         displayName: wisa.fullName,
-        password: config.newAccountPassword(),
+        password: password,
         givenName: given,
         surname: wisa.name,
         employeeId: wisa.wisaId.value,
@@ -185,6 +186,7 @@ class AddStudentToAzure extends StudentAction {
         changes: changes,
         system: Origin.azure,
         azure: created,
+        generatedPassword: password,
       );
     } on Object catch (e) {
       return _failed(changes, Origin.azure, e);
@@ -276,9 +278,10 @@ class AddStudentToSmartschool extends StudentAction {
     }
 
     try {
+      final password = config.newAccountPassword();
       final ok = await _requireSmartschool(connectors).saveAccount(
         built,
-        password: config.newAccountPassword(),
+        password: password,
       );
       if (!ok) {
         return _failed(
@@ -293,6 +296,7 @@ class AddStudentToSmartschool extends StudentAction {
         changes: changes,
         system: Origin.smartschool,
         smartschool: built,
+        generatedPassword: password,
       );
     } on Object catch (e) {
       return _failed(changes, Origin.smartschool, e);

--- a/packages/account_state/lib/src/apply/state_applier.dart
+++ b/packages/account_state/lib/src/apply/state_applier.dart
@@ -2,9 +2,12 @@ import 'package:account_actions/account_actions.dart';
 import 'package:account_core/account_core.dart' as core;
 import 'package:azure_api/azure_api.dart' as az;
 import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:wisa_api/wisa_api.dart' as wapi;
 
 import '../link/linked_state.dart';
 import '../link/placement.dart';
+import '../passwords/password_entry.dart';
+import '../passwords/password_queue_store.dart';
 import '../sync/application_state.dart';
 import 'wisa_import_rules.dart';
 
@@ -62,6 +65,7 @@ class StateApplier {
     required StudentActionConfig studentConfig,
     required StaffActionConfig staffConfig,
     this.classTree = const SmartschoolClassTree(),
+    this.passwordQueue,
   })  : _studentConfig = _uniqueStudentConfig(studentConfig, _uidsFrom(app)),
         _staffConfig = _uniqueStaffConfig(staffConfig, _uidsFrom(app));
 
@@ -81,6 +85,16 @@ class StateApplier {
 
   /// Smartschool class-tree live-config the placement resolver needs.
   final SmartschoolClassTree classTree;
+
+  /// The shared password-distribution queue (#105). When wired, every apply that
+  /// **creates** an account drops the password it minted into this store, keyed
+  /// by [core.PersonId], so one operator can generate while another prints and
+  /// distributes. Azure-create and Smartschool-create for the same person merge
+  /// onto a single [PasswordEntry] (both backends on one sheet, matching legacy
+  /// `AccountPassword`). Left null when the caller does not centralize passwords
+  /// (e.g. headless linking-only paths), in which case the minted password is
+  /// still written to the target system but not queued.
+  final PasswordQueueStore? passwordQueue;
 
   final StudentActionConfig _studentConfig;
   final StaffActionConfig _staffConfig;
@@ -198,8 +212,165 @@ class StateApplier {
         );
     }
 
-    return ApplyResult(result, await link());
+    final linked = await link();
+    // A create action carries the password it minted; drop it in the shared
+    // queue keyed by person (#105), merging Azure- and Smartschool-create onto
+    // one sheet. Every other action leaves [generatedPassword] null.
+    if (result.generatedPassword != null) {
+      await _enqueuePassword(linked, result);
+    }
+    return ApplyResult(result, linked);
   }
+
+  /// Merges the freshly minted password from [result] into [passwordQueue],
+  /// keyed by the created person's [core.PersonId] (the `id` the linker built
+  /// from the resolver). A person's Azure and Smartschool creates land on **one**
+  /// [PasswordEntry] — the second create fills the empty backend field on the
+  /// entry the first create left — matching the legacy one-sheet-per-student
+  /// `AccountPassword`. A no-op when no queue is wired or the created record
+  /// cannot be matched in the fresh linked view.
+  Future<void> _enqueuePassword(LinkedState linked, ActionResult result) async {
+    final store = passwordQueue;
+    final password = result.generatedPassword;
+    if (store == null || password == null) return;
+
+    final target = _passwordTargetFor(linked, result);
+    if (target == null) return;
+
+    final toAzure = result.system == core.Origin.azure;
+    final queue = await store.load();
+    final index = queue.indexWhere(
+      (e) =>
+          e.personId.value == target.personId.value &&
+          e.kind == PasswordAccountKind.account,
+    );
+    final existing = index >= 0 ? queue[index] : null;
+
+    final merged = PasswordEntry(
+      personId: target.personId,
+      kind: PasswordAccountKind.account,
+      accountName: target.accountName,
+      displayName: target.displayName,
+      // Prefer the freshly linked view's fields (the second create sees a more
+      // complete record), falling back to whatever the first create recorded.
+      mail: target.mail ?? existing?.mail,
+      classGroup: target.classGroup ?? existing?.classGroup,
+      smartschoolPassword: toAzure ? existing?.smartschoolPassword : password,
+      azurePassword: toAzure ? password : existing?.azurePassword,
+    );
+
+    final updated = [...queue];
+    if (index >= 0) {
+      updated[index] = merged;
+    } else {
+      updated.add(merged);
+    }
+    await store.save(updated);
+  }
+
+  /// Locates the created record in the fresh linked view and reads the fields a
+  /// [PasswordEntry] prints, or null when it cannot be matched (which should not
+  /// happen right after a successful create). Matches on the connector identity
+  /// the write returned — Smartschool `uid` or Azure `id` — because the
+  /// [core.PersonId] is only known through the linked record.
+  _PasswordTarget? _passwordTargetFor(LinkedState linked, ActionResult result) {
+    final snapshot = linked.snapshot;
+    switch (result.system) {
+      case core.Origin.smartschool:
+        final uid = result.smartschool?.uid;
+        if (uid == null) return null;
+        for (final a in snapshot.accounts) {
+          if (a.smartschool?.uid == uid) return _targetFromAccount(a);
+        }
+        for (final s in snapshot.staff) {
+          if (s.smartschool?.uid == uid) return _targetFromStaff(s);
+        }
+        return null;
+      case core.Origin.azure:
+        final id = result.azure?.id;
+        if (id == null) return null;
+        for (final a in snapshot.accounts) {
+          if (a.azure?.id == id) return _targetFromAccount(a);
+        }
+        for (final s in snapshot.staff) {
+          if (s.azure?.id == id) return _targetFromStaff(s);
+        }
+        return null;
+      case core.Origin.wisa:
+      case core.Origin.all:
+      case core.Origin.other:
+        return null;
+    }
+  }
+
+  // The rich name/class/mail fields live on the concrete connector records, not
+  // the minimal `account_core` interfaces `LinkedAccount` exposes. The applier
+  // already downcasts these snapshot records elsewhere (see `_putAccount`), so
+  // the same casts are safe here.
+
+  _PasswordTarget _targetFromAccount(core.LinkedAccount a) {
+    final wisa = a.wisa as wapi.WisaStudent?;
+    final ssAccount = a.smartschool as ss.SmartschoolAccount?;
+    final azUser = a.azure as az.AzureUser?;
+    return _PasswordTarget(
+      personId: core.PersonId(a.id.value),
+      accountName: ssAccount?.uid ?? _localPart(azUser?.upn),
+      displayName:
+          wisa?.fullName ?? azUser?.displayName ?? _nameOf(ssAccount) ?? '',
+      mail: azUser?.upn ?? ssAccount?.mail,
+      classGroup: wisa?.classGroup ?? azUser?.department,
+    );
+  }
+
+  _PasswordTarget _targetFromStaff(core.LinkedStaff s) {
+    final wisa = s.wisa as wapi.WisaStaff?;
+    final ssAccount = s.smartschool as ss.SmartschoolAccount?;
+    final azUser = s.azure as az.AzureUser?;
+    return _PasswordTarget(
+      personId: core.PersonId(s.id.value),
+      accountName: ssAccount?.uid ?? _localPart(azUser?.upn),
+      displayName: azUser?.displayName ??
+          _nameOf(ssAccount) ??
+          [wisa?.firstName, wisa?.lastName]
+              .whereType<String>()
+              .join(' ')
+              .trim(),
+      mail: azUser?.upn ?? ssAccount?.mail,
+      classGroup: azUser?.department,
+    );
+  }
+}
+
+/// The fields a [PasswordEntry] needs, read from the freshly linked record the
+/// created account now belongs to.
+class _PasswordTarget {
+  const _PasswordTarget({
+    required this.personId,
+    required this.accountName,
+    required this.displayName,
+    this.mail,
+    this.classGroup,
+  });
+
+  final core.PersonId personId;
+  final String accountName;
+  final String displayName;
+  final String? mail;
+  final String? classGroup;
+}
+
+/// The local part of an email/UPN (`jane.doe` from `jane.doe@x.be`); '' when
+/// [mail] is null so the entry always has a non-null account name.
+String _localPart(String? mail) {
+  if (mail == null) return '';
+  return mail.contains('@') ? mail.split('@').first : mail;
+}
+
+/// A display name assembled from a Smartschool record's given + surname, or null
+/// when no record is present.
+String? _nameOf(ss.SmartschoolAccount? account) {
+  if (account == null) return null;
+  return '${account.givenName} ${account.surname}'.trim();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/account_state/test/password_queue_capture_test.dart
+++ b/packages/account_state/test/password_queue_capture_test.dart
@@ -1,0 +1,389 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+/// Covers #105: an apply that **creates** an account drops the password it
+/// minted into the shared [PasswordQueueStore], keyed by person, with Azure and
+/// Smartschool creates merging onto one [PasswordEntry] (legacy one sheet per
+/// student). Every other action leaves the queue untouched.
+
+final DateTime _d = DateTime.utc(2026);
+
+const core.Address _addr = core.Address(
+  street: '',
+  houseNumber: '',
+  postalCode: '',
+  city: '',
+  country: '',
+);
+
+// ---------------------------------------------------------------------------
+// Fakes: a SOAP transport whose every write succeeds, and a Graph transport
+// that answers the create path — 404 to the pre-create UPN-existence probe (so
+// `createPrincipalName` takes the first candidate) and 201 with an id echo to
+// the POST that creates the user.
+// ---------------------------------------------------------------------------
+
+class _OkSoap implements ss.SmartschoolSoapTransport {
+  @override
+  Future<String> send({
+    required Uri endpoint,
+    required String soapAction,
+    required String envelope,
+  }) async =>
+      '<?xml version="1.0" encoding="utf-8"?>'
+      '<soap:Envelope '
+      'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+      '<soap:Body><response><return>0</return></response>'
+      '</soap:Body></soap:Envelope>';
+}
+
+class _CreatingGraph implements az.GraphTransport {
+  int _created = 0;
+
+  @override
+  Future<az.GraphResponse> send(az.GraphRequest request) async {
+    if (request.method == 'POST') {
+      _created++;
+      return az.GraphResponse(
+        statusCode: 201,
+        body: '{"id":"az-created-$_created"}',
+      );
+    }
+    // The UPN-existence probe (GET) — report "not found" so the first
+    // candidate UPN is taken.
+    return const az.GraphResponse(statusCode: 404);
+  }
+}
+
+ss.SmartschoolConnector _ssConn() => ss.SmartschoolConnector.fromParts(
+      site: 'demo',
+      accessCode: 'secret',
+      transport: _OkSoap(),
+    );
+
+az.AzureConnector _azConn() => az.AzureConnector(
+      credentials: az.AzureCredentials(
+        clientId: 'c',
+        tenantId: 't',
+        azureDomain: 'school.example',
+        schoolPrefix: 'SSM',
+      ),
+      authProvider: const az.StaticAuthProvider('token'),
+      transport: _CreatingGraph(),
+    );
+
+// ---------------------------------------------------------------------------
+// Record + snapshot builders.
+// ---------------------------------------------------------------------------
+
+wapi.WisaStudent _wStudent({
+  String wisaId = 'W1',
+  String firstName = 'Jan',
+  String name = 'Peeters',
+  String classGroup = '3A',
+}) =>
+    wapi.WisaStudent(
+      wisaId: core.WisaId(wisaId),
+      classGroup: classGroup,
+      classSubGroup: '00',
+      name: name,
+      firstName: firstName,
+      preferredName: '',
+      birthDate: _d,
+      stemId: '',
+      gender: core.Gender.male,
+      nationalId: '',
+      birthPlace: '',
+      nationality: '',
+      address: _addr,
+      classChange: _d,
+      schoolId: 1,
+    );
+
+ss.SmartschoolAccount _ssAccount({
+  String uid = 'jan.peeters',
+  String accountId = 'W1',
+  String mail = 'jan.peeters@student.school.example',
+}) =>
+    ss.SmartschoolAccount(
+      uid: uid,
+      accountId: accountId,
+      mail: mail,
+      registerId: '',
+      stemId: 0,
+      role: core.PersonRole.student,
+      givenName: 'Jan',
+      surname: 'Peeters',
+      extraNames: '',
+      initials: '',
+      preferredName: '',
+      gender: core.Gender.male,
+      birthDate: null,
+      birthPlace: '',
+      birthCountry: '',
+      address: _addr,
+      mobilePhone: '',
+      homePhone: '',
+      fax: '',
+      untisId: '',
+      status: 'actief',
+    );
+
+az.AzureUser _azUser({
+  String id = 'az-1',
+  String upn = 'jan.peeters@student.school.example',
+  String employeeId = 'W1',
+}) =>
+    az.AzureUser(
+      id: id,
+      upn: upn,
+      employeeId: employeeId,
+      displayName: 'Jan Peeters',
+      givenName: 'Jan',
+      surname: 'Peeters',
+      companyName: 'SSM',
+      department: '3A',
+    );
+
+wapi.WisaSnapshot _wSnap({List<wapi.WisaStudent> students = const []}) =>
+    wapi.WisaSnapshot(
+      fetchedAt: _d,
+      students: students,
+      staff: const [],
+      classGroups: const [],
+      schools: const [],
+    );
+
+ss.SmartschoolSnapshot _sSnap(
+        {List<ss.SmartschoolAccount> accounts = const []}) =>
+    ss.SmartschoolSnapshot(
+      fetchedAt: _d,
+      groups: const [],
+      accounts: accounts,
+      memberships: const [],
+    );
+
+az.AzureSnapshot _aSnap({List<az.AzureUser> users = const []}) =>
+    az.AzureSnapshot(fetchedAt: _d, users: users, groups: const []);
+
+core.LinkedAccount _linkedStudent({
+  wapi.WisaStudent? wisa,
+  ss.SmartschoolAccount? smartschool,
+  az.AzureUser? azure,
+  String id = 'p0',
+}) =>
+    core.LinkedAccount(
+      id: core.LinkedAccountId(id),
+      role: core.PersonRole.student,
+      wisa: wisa,
+      smartschool: smartschool,
+      azure: azure,
+      confidence: core.LinkConfidence.high,
+    );
+
+/// Deterministic in-memory [core.PersonIdResolver] (mirrors the linker fixture):
+/// the same natural key always maps to the same id.
+class _SeqResolver implements core.PersonIdResolver {
+  final Map<String, String> _seen = {};
+
+  @override
+  core.PersonId resolve(String naturalKey) =>
+      core.PersonId(_seen.putIfAbsent(naturalKey, () => 'p${_seen.length}'));
+}
+
+/// One assembled State layer with the password queue wired, and a password
+/// generator that mints a distinct value per call so a test can tell the Azure
+/// password from the Smartschool one (the two systems deliberately differ).
+class _Harness {
+  _Harness({
+    wapi.WisaSnapshot? wisa,
+    ss.SmartschoolSnapshot? smartschool,
+    az.AzureSnapshot? azure,
+    this.wireQueue = true,
+  }) {
+    app = ApplicationState(
+      wisa: SystemState<wapi.WisaSnapshot>(
+        system: core.Origin.wisa,
+        initial: wisa ?? _wSnap(),
+        syncer: (_) async => wisa ?? _wSnap(),
+      ),
+      smartschool: SystemState<ss.SmartschoolSnapshot>(
+        system: core.Origin.smartschool,
+        initial: smartschool ?? _sSnap(),
+        syncer: (_) async => smartschool ?? _sSnap(),
+      ),
+      azure: SystemState<az.AzureSnapshot>(
+        system: core.Origin.azure,
+        initial: azure ?? _aSnap(),
+        syncer: (_) async => azure ?? _aSnap(),
+      ),
+    );
+    var n = 0;
+    String nextPassword() => 'pw${++n}';
+    applier = StateApplier(
+      app: app,
+      connectors: Connectors(smartschool: _ssConn(), azure: _azConn()),
+      resolver: _SeqResolver(),
+      wisaRules: WisaImportRules(),
+      studentConfig: StudentActionConfig(
+        schoolPrefix: 'SSM',
+        azureDomain: 'school.example',
+        newAccountPassword: nextPassword,
+      ),
+      staffConfig: StaffActionConfig(
+        schoolPrefix: 'SSM',
+        azureDomain: 'school.example',
+        newAccountPassword: nextPassword,
+      ),
+      passwordQueue: wireQueue ? queue : null,
+    );
+  }
+
+  final bool wireQueue;
+  final InMemoryPasswordQueueStore queue = InMemoryPasswordQueueStore();
+  late final ApplicationState app;
+  late final StateApplier applier;
+}
+
+void main() {
+  group('an account-creating apply captures its password', () {
+    test('a Smartschool create enqueues the Smartschool password only',
+        () async {
+      // WISA + Azure present, Smartschool missing → AddStudentToSmartschool.
+      final harness = _Harness(
+        wisa: _wSnap(students: [_wStudent()]),
+        azure: _aSnap(users: [_azUser()]),
+      );
+      final target = _linkedStudent(wisa: _wStudent(), azure: _azUser());
+
+      await harness.applier.applyStudent(
+        AddStudentToSmartschool(target, harness.applier.studentConfig),
+      );
+
+      final entries = await harness.queue.load();
+      expect(entries, hasLength(1));
+      final entry = entries.single;
+      expect(entry.kind, PasswordAccountKind.account);
+      expect(entry.smartschoolPassword, 'pw1');
+      expect(entry.azurePassword, isNull);
+      expect(entry.accountName, 'jan.peeters');
+      expect(entry.displayName, 'Jan Peeters');
+      expect(entry.classGroup, '3A');
+      expect(entry.mail, 'jan.peeters@student.school.example');
+    });
+
+    test('an Azure create enqueues the Azure password only', () async {
+      // WISA present, Azure missing → AddStudentToAzure.
+      final harness = _Harness(wisa: _wSnap(students: [_wStudent()]));
+      final target = _linkedStudent(wisa: _wStudent());
+
+      await harness.applier.applyStudent(
+        AddStudentToAzure(target, harness.applier.studentConfig),
+      );
+
+      final entries = await harness.queue.load();
+      expect(entries, hasLength(1));
+      final entry = entries.single;
+      expect(entry.azurePassword, 'pw1');
+      expect(entry.smartschoolPassword, isNull);
+      expect(entry.displayName, 'Jan Peeters');
+    });
+
+    test(
+        'Azure then Smartschool creates merge onto one entry with both passwords',
+        () async {
+      // The realistic two-pass flow: Azure is created first (Smartschool-create
+      // requires Azure to exist), then Smartschool. Both are the same WISA
+      // student, so they must land on one sheet — not two rows.
+      final harness = _Harness(wisa: _wSnap(students: [_wStudent()]));
+
+      final azApplied = await harness.applier.applyStudent(
+        AddStudentToAzure(
+          _linkedStudent(wisa: _wStudent()),
+          harness.applier.studentConfig,
+        ),
+      );
+      // After the Azure create the queue holds one entry with only the Azure
+      // password.
+      final afterAzure = await harness.queue.load();
+      expect(afterAzure, hasLength(1));
+      expect(afterAzure.single.azurePassword, 'pw1');
+      expect(afterAzure.single.smartschoolPassword, isNull);
+
+      // Now Smartschool, targeting the account with the freshly created Azure
+      // record (as the dispatcher would after the incremental relink).
+      final createdAzure = azApplied.result.azure! as az.AzureUser;
+      await harness.applier.applyStudent(
+        AddStudentToSmartschool(
+          _linkedStudent(wisa: _wStudent(), azure: createdAzure),
+          harness.applier.studentConfig,
+        ),
+      );
+
+      final merged = await harness.queue.load();
+      expect(merged, hasLength(1), reason: 'one sheet per student, not two');
+      final entry = merged.single;
+      expect(entry.azurePassword, 'pw1', reason: 'kept from the Azure create');
+      expect(entry.smartschoolPassword, 'pw2',
+          reason: 'filled by the Smartschool create — a distinct password');
+      expect(entry.accountName, 'jan.peeters',
+          reason: 'the now-known Smartschool uid');
+    });
+
+    test('a dry-run create enqueues nothing (no write, no password)', () async {
+      final harness = _Harness(wisa: _wSnap(students: [_wStudent()]));
+
+      await harness.applier.applyStudent(
+        AddStudentToAzure(
+          _linkedStudent(wisa: _wStudent()),
+          harness.applier.studentConfig,
+        ),
+        options: ApplyOptions.dry,
+      );
+
+      expect(await harness.queue.load(), isEmpty);
+    });
+
+    test('a non-creating modify apply enqueues nothing', () async {
+      final account = _linkedStudent(
+        wisa: _wStudent(),
+        smartschool: _ssAccount(accountId: 'OLD'),
+        azure: _azUser(),
+      );
+      final harness = _Harness(
+        wisa: _wSnap(students: [_wStudent()]),
+        smartschool: _sSnap(accounts: [_ssAccount(accountId: 'OLD')]),
+        azure: _aSnap(users: [_azUser()]),
+      );
+
+      await harness.applier.applyStudent(
+        ModifyAccountId(account, harness.applier.studentConfig),
+      );
+
+      expect(await harness.queue.load(), isEmpty);
+    });
+
+    test('a create applies cleanly when no queue is wired', () async {
+      final harness = _Harness(
+        wisa: _wSnap(students: [_wStudent()]),
+        wireQueue: false,
+      );
+
+      final applied = await harness.applier.applyStudent(
+        AddStudentToAzure(
+          _linkedStudent(wisa: _wStudent()),
+          harness.applier.studentConfig,
+        ),
+      );
+
+      expect(applied.result.wrote, isTrue);
+      // The unwired queue is untouched — no throw, nothing enqueued.
+      expect(await harness.queue.load(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes the password-distribution half deferred out of #99: when an apply **creates** an account, the password it mints now lands in the shared password queue (`PasswordQueueStore`, #86) so one operator can generate and another can print/distribute — the point of centralizing the queue. Today that password was generated at the connector-write site and forgotten.

Adds a minimal **Passwords** view per the Phase C rethink (#75): list the pending queue, copy a password, and mark entries distributed (drain). Printing (ticket printer) stays a later slice.

## Linked issue

Closes #105

## Changes

**`account_actions`**
- `ActionResult` gains `generatedPassword`, set only on a real `applied` create (null on dry runs / modifies / deletes).
- The four account-creating actions (`AddStudentToAzure`, `AddStudentToSmartschool`, `AddStaffToAzure`, `AddStaffToSmartschool`) capture the value they pass to the connector and surface it.

**`account_state`**
- `StateApplier` takes an optional `PasswordQueueStore`. On a successful create it locates the created record in the fresh relinked view, keys the entry off its `PersonId`, and merges the password in.
- **One sheet per person:** Azure-create and Smartschool-create (which happen on different reconcile passes) merge onto a single `PasswordEntry` carrying both — deliberately *distinct* — backend passwords, matching the legacy `AccountPassword` (Smartschool forces a first-login reset, so the two differ on purpose).

**`account_manager`**
- New **Passwords** shell destination: list pending entries, copy to clipboard, mark distributed (drains by saving the remainder).
- Bootstrap wires a `CosmosPasswordQueueStore` into both the applier and the view; the bootstrap closure is memoized so Reconcile and Passwords share one stack and one queue instance.

## Out of scope

- Ticket-printer output (future desktop-printing slice).

## Test plan

- [x] `dart format --output=none --set-exit-if-changed` clean (4 files reformatted and committed)
- [x] `flutter analyze` + `dart analyze packages/*` clean
- [x] Unit/widget tests pass: **366** package tests (6 new in `password_queue_capture_test.dart`, incl. the Azure→Smartschool merge and the no-queue/dry-run/modify negatives) + **121** app widget tests (5 new in `passwords_screen_test.dart`: list, copy-to-clipboard, drain, empty state, not-configured)
- [x] Integration/e2e pass: `flutter test integration_test -d windows` — **15** tests, including the new #105 end-to-end run (real app: create an account → password captured → Passwords view shows the sheet → distribute drains the shared queue). Verified the new e2e asserts the queue is empty before apply and populated after, so it fails on the unpatched capture path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)