### PR TITLE
Add the Settings view: edit AppSettings + write secrets (#106)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -10,12 +10,15 @@ import 'package:account_manager/src/auth/auth.dart';
 import 'package:account_manager/src/screens/home_screen.dart';
 import 'package:account_manager/src/screens/passwords_screen.dart';
 import 'package:account_manager/src/screens/reconcile_screen.dart';
+import 'package:account_manager/src/screens/settings_screen.dart';
 import 'package:account_manager/src/shell/app_shell.dart';
 import 'package:account_state/account_state.dart'
     show
+        AppSettings,
         ChangeSignal,
         InMemoryLinkedStore,
         InMemorySignalHub,
+        SecretRef,
         SignalRConfig,
         SignalRRequest,
         SignalRResponse,
@@ -24,6 +27,7 @@ import 'package:account_state/account_state.dart'
         SignalRSubscriber,
         SignalRTransport,
         StaticSignalRTokenProvider,
+        WisaConnection,
         signalRRecordSeparator;
 import 'package:azure_api/azure_api.dart' show AzureCredentials;
 import 'package:flutter/material.dart';
@@ -32,6 +36,7 @@ import 'package:integration_test/integration_test.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
 import '../test/reconcile/reconcile_fakes.dart';
+import '../test/screens/settings_fakes.dart';
 
 /// End-to-end runs of the *real* app in the real engine, with the Plink fonts
 /// bundled by the design-system package. This is the layer that catches
@@ -706,6 +711,65 @@ void main() {
     expect(find.text('Jane Doe'), findsNothing);
     expect(find.byKey(const ValueKey('passwords-empty')), findsOneWidget);
     expect(await harness.passwordQueue.load(), isEmpty);
+  });
+
+  testWidgets(
+      'the Settings view edits a profile field and a secret, saving both '
+      'against the fakes — the secret through the provider, never into the blob '
+      '(#106)', (WidgetTester tester) async {
+    // The real app composition over the in-memory settings seams. The store
+    // already holds a partial config (the #99 seed) with a stale prefix.
+    useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    final settings = SettingsHarness(
+      initial: const AppSettings(
+        schoolPrefix: 'OLD',
+        wisa: WisaConnection(server: 'old.host'),
+      ),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    expect(find.byType(AppShell), findsOneWidget);
+
+    // Open Settings; the stored document is read into the real, laid-out form.
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+    expect(find.text('OLD'), findsOneWidget);
+    expect(find.text('old.host'), findsOneWidget);
+
+    // Edit a profile field and enter a write-only secret, then save.
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-school-prefix')),
+      'GBS-KA',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-wisa-server')),
+      'wisa.new.host',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-wisa-password')),
+      'typed-secret',
+    );
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    // The profile edits landed in the store…
+    final saved = await settings.store.load();
+    expect(saved.schoolPrefix, 'GBS-KA');
+    expect(saved.wisa.server, 'wisa.new.host');
+    // …the secret went through the provider, not into the settings document…
+    expect(await settings.secrets.read(passwordRef), 'typed-secret');
+    expect(saved.toJson().toString(), isNot(contains('typed-secret')));
+    // …and the secret field was cleared, never echoing the value back.
+    final field = tester.widget<TextField>(
+      find.byKey(const ValueKey('settings-wisa-password')),
+    );
+    expect(field.controller!.text, isEmpty);
   });
 
   testWidgets('silent sign-in leads straight into the shell',

--- a/account_manager/lib/main.dart
+++ b/account_manager/lib/main.dart
@@ -18,6 +18,7 @@ import 'src/auth/loopback_aad_broker.dart';
 import 'src/auth/method_channel_aad_broker.dart';
 import 'src/auth/sign_in_session.dart';
 import 'src/reconcile/reconcile_bootstrap.dart';
+import 'src/settings/settings_bootstrap.dart';
 
 void main() {
   // Azure AD app-registration values come from --dart-define (see
@@ -65,6 +66,15 @@ void main() {
           ? _memoizeOnSuccess(
               () => bootstrapReconcile(session: session, aad: config),
             )
+          : null,
+      // The settings seams (Cosmos-backed store + Key Vault secrets) are
+      // assembled lazily the first time the Settings screen is opened, memoized
+      // so repeat visits reuse the one store/provider. Kept separate from the
+      // reconcile stack on purpose: the Settings view exists to fix an
+      // incomplete config, so it must not depend on the connectors bootstrapping
+      // successfully.
+      settingsBootstrap: config.isConfigured
+          ? _memoizeOnSuccess(() => bootstrapSettings(session: session))
           : null,
     ),
   );

--- a/account_manager/lib/src/app.dart
+++ b/account_manager/lib/src/app.dart
@@ -5,6 +5,7 @@ import 'auth/aad_resource.dart';
 import 'auth/sign_in_gate.dart';
 import 'auth/sign_in_session.dart';
 import 'reconcile/reconcile_bootstrap.dart';
+import 'settings/settings_bootstrap.dart';
 import 'shell/app_shell.dart';
 
 /// This app's per-product accent (Plink DS-5): one colour that is clearly
@@ -24,6 +25,7 @@ class AccountManagerApp extends StatelessWidget {
     required this.session,
     required this.graph,
     this.reconcileBootstrap,
+    this.settingsBootstrap,
   });
 
   /// The operator's Azure AD session, used by the sign-in gate and, later, by
@@ -37,6 +39,11 @@ class AccountManagerApp extends StatelessWidget {
   /// when AAD is not configured. Injectable so tests can bind the screen to
   /// fakes; the real closure is built in `main()`.
   final Future<ReconcileServices> Function()? reconcileBootstrap;
+
+  /// Assembles the settings seams (store + secret provider) when the Settings
+  /// screen is first opened, or `null` when AAD is not configured. Injectable so
+  /// tests can bind the screen to fakes; the real closure is built in `main()`.
+  final Future<SettingsServices> Function()? settingsBootstrap;
 
   ThemeData _themed(ThemeData base) => base.copyWith(
         extensions: const <ThemeExtension<dynamic>>[
@@ -54,7 +61,10 @@ class AccountManagerApp extends StatelessWidget {
       home: SignInGate(
         session: session,
         graph: graph,
-        child: AppShell(reconcileBootstrap: reconcileBootstrap),
+        child: AppShell(
+          reconcileBootstrap: reconcileBootstrap,
+          settingsBootstrap: settingsBootstrap,
+        ),
       ),
     );
   }

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -1,0 +1,813 @@
+import 'package:account_state/account_state.dart';
+import 'package:flutter/material.dart';
+import 'package:plink_design_system/plink_design_system.dart';
+import 'package:smartschool_api/smartschool_api.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+import '../settings/settings_bootstrap.dart';
+
+/// The Settings view (#106): edit the full [AppSettings] config document and
+/// write the two credentials (WISA password, Smartschool passphrase) through the
+/// [SecretProvider] seam.
+///
+/// The operator had no way to change any of this from the app — the #99 live
+/// bring-up seeded the settings document and the vault secrets with a one-off
+/// script, and the Smartschool group paths / grade-year vocabulary stayed at
+/// empty defaults, so placement-dependent actions could not resolve a parent
+/// group. This view closes that gap.
+///
+/// Two disciplines the seam enforces are honoured in the UI:
+///
+/// - **Secrets are write-only.** The WISA password and Smartschool passphrase
+///   fields start empty and are never populated from the provider — the value
+///   is never echoed back. Leaving a field blank on save keeps the stored
+///   secret; typing one replaces it via [SecretProvider.write].
+/// - **No restart needed.** A reload affordance re-reads the document from the
+///   store into the form, so a settings change another operator made (or the
+///   operator's own save) can be pulled back without relaunching.
+///
+/// Import rules are shown read-only for now (accumulated by `DontImportFromWisa`
+/// applies during reconcile); editing them is a later slice.
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key, required this.bootstrap});
+
+  /// Assembles (or returns the already-assembled) settings seams, or `null` when
+  /// Azure AD is not configured for this build (no session to mint the Cosmos /
+  /// Key Vault tokens the stores need).
+  final Future<SettingsServices> Function()? bootstrap;
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  SettingsServices? _services;
+  AppSettings? _loaded;
+  Object? _error;
+  bool _busy = false;
+  int _attempts = 0;
+
+  // Global.
+  final _schoolPrefix = TextEditingController();
+  bool _debugMode = false;
+
+  // WISA profile.
+  final _wisaServer = TextEditingController();
+  final _wisaPort = TextEditingController();
+  final _wisaDatabase = TextEditingController();
+  final _wisaUsername = TextEditingController();
+  final _wisaPassword = TextEditingController(); // write-only secret
+  bool _workDateIsNow = true;
+  DateTime? _workDate;
+  bool _virtualWorkDateIsNow = true;
+  DateTime? _virtualWorkDate;
+
+  // Smartschool profile.
+  final _ssUri = TextEditingController();
+  final _ssTestUser = TextEditingController();
+  final _ssStudentGroup = TextEditingController();
+  final _ssStaffGroup = TextEditingController();
+  final _ssPassphrase = TextEditingController(); // write-only secret
+  bool _ssUseGrades = false;
+  bool _ssUseYears = false;
+  late final List<TextEditingController> _grades = List.generate(
+    SmartschoolConnection.gradeCount,
+    (_) => TextEditingController(),
+  );
+  late final List<TextEditingController> _years = List.generate(
+    SmartschoolConnection.yearCount,
+    (_) => TextEditingController(),
+  );
+
+  // Azure profile.
+  final _azClientId = TextEditingController();
+  final _azTenantId = TextEditingController();
+  final _azDomain = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    for (final c in <TextEditingController>[
+      _schoolPrefix,
+      _wisaServer,
+      _wisaPort,
+      _wisaDatabase,
+      _wisaUsername,
+      _wisaPassword,
+      _ssUri,
+      _ssTestUser,
+      _ssStudentGroup,
+      _ssStaffGroup,
+      _ssPassphrase,
+      _azClientId,
+      _azTenantId,
+      _azDomain,
+      ..._grades,
+      ..._years,
+    ]) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  /// Bootstraps the seams (once, memoized) if needed, then reads the document
+  /// into the form.
+  Future<void> _load() async {
+    final make = widget.bootstrap;
+    if (make == null) return;
+    setState(() {
+      _attempts++;
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final services = _services ?? await make();
+      final settings = await services.store.load();
+      if (!mounted) return;
+      setState(() {
+        _services = services;
+        _loaded = settings;
+      });
+      _populate(settings);
+    } on Object catch (e) {
+      if (mounted) setState(() => _error = e);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  /// Re-reads the stored document into the form, discarding unsaved edits — the
+  /// reload affordance that spares a restart. Clears the write-only secret
+  /// fields too (they are never repopulated from the vault).
+  Future<void> _reload() async {
+    final services = _services;
+    if (services == null) return;
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final settings = await services.store.load();
+      if (!mounted) return;
+      setState(() => _loaded = settings);
+      _populate(settings);
+      _toast('Instellingen herladen.');
+    } on Object catch (e) {
+      if (mounted) _toast('Kon niet herladen: $e');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  void _populate(AppSettings s) {
+    _schoolPrefix.text = s.schoolPrefix;
+    _debugMode = s.debugMode;
+
+    _wisaServer.text = s.wisa.server;
+    _wisaPort.text = s.wisa.port;
+    _wisaDatabase.text = s.wisa.database;
+    _wisaUsername.text = s.wisa.username;
+    _wisaPassword.clear();
+    _workDateIsNow = s.wisa.workDate.isNow;
+    _workDate = s.wisa.workDate.date;
+    _virtualWorkDateIsNow = s.wisa.virtualWorkDate.isNow;
+    _virtualWorkDate = s.wisa.virtualWorkDate.date;
+
+    _ssUri.text = s.smartschool.uri;
+    _ssTestUser.text = s.smartschool.testUser;
+    _ssStudentGroup.text = s.smartschool.studentGroup;
+    _ssStaffGroup.text = s.smartschool.staffGroup;
+    _ssPassphrase.clear();
+    _ssUseGrades = s.smartschool.useGrades;
+    _ssUseYears = s.smartschool.useYears;
+    for (var i = 0; i < _grades.length; i++) {
+      _grades[i].text =
+          i < s.smartschool.grades.length ? s.smartschool.grades[i] : '';
+    }
+    for (var i = 0; i < _years.length; i++) {
+      _years[i].text =
+          i < s.smartschool.years.length ? s.smartschool.years[i] : '';
+    }
+
+    _azClientId.text = s.azure.clientId;
+    _azTenantId.text = s.azure.tenantId;
+    _azDomain.text = s.azure.domain;
+  }
+
+  /// Assembles an [AppSettings] from the form, preserving the loaded document's
+  /// secret refs and (read-only) import rules.
+  AppSettings _collect(AppSettings base) {
+    return base.copyWith(
+      schoolPrefix: _schoolPrefix.text.trim(),
+      debugMode: _debugMode,
+      wisa: base.wisa.copyWith(
+        server: _wisaServer.text.trim(),
+        port: _wisaPort.text.trim(),
+        database: _wisaDatabase.text.trim(),
+        username: _wisaUsername.text.trim(),
+        workDate: WorkDateSetting(isNow: _workDateIsNow, date: _workDate),
+        virtualWorkDate: WorkDateSetting(
+          isNow: _virtualWorkDateIsNow,
+          date: _virtualWorkDate,
+        ),
+      ),
+      smartschool: base.smartschool.copyWith(
+        uri: _ssUri.text.trim(),
+        testUser: _ssTestUser.text.trim(),
+        studentGroup: _ssStudentGroup.text.trim(),
+        staffGroup: _ssStaffGroup.text.trim(),
+        useGrades: _ssUseGrades,
+        useYears: _ssUseYears,
+        grades: <String>[for (final c in _grades) c.text.trim()],
+        years: <String>[for (final c in _years) c.text.trim()],
+      ),
+      azure: base.azure.copyWith(
+        clientId: _azClientId.text.trim(),
+        tenantId: _azTenantId.text.trim(),
+        domain: _azDomain.text.trim(),
+      ),
+    );
+  }
+
+  Future<void> _save() async {
+    final services = _services;
+    final base = _loaded;
+    if (services == null || base == null) return;
+
+    setState(() => _busy = true);
+    try {
+      final next = _collect(base);
+      await services.store.save(next);
+
+      // Secrets are write-only: a non-empty field replaces the stored value; a
+      // blank one leaves it untouched. The value is never read back into the UI.
+      final wisaPassword = _wisaPassword.text;
+      if (wisaPassword.isNotEmpty) {
+        await services.secrets.write(next.wisa.passwordRef, wisaPassword);
+      }
+      final passphrase = _ssPassphrase.text;
+      if (passphrase.isNotEmpty) {
+        await services.secrets
+            .write(next.smartschool.passphraseRef, passphrase);
+      }
+
+      if (!mounted) return;
+      setState(() => _loaded = next);
+      _wisaPassword.clear();
+      _ssPassphrase.clear();
+      _toast('Instellingen opgeslagen.');
+    } on Object catch (e) {
+      if (mounted) _toast('Kon niet opslaan: $e');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _pickWorkDate({required bool virtual}) async {
+    final current = virtual ? _virtualWorkDate : _workDate;
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: current ?? DateTime.now(),
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+    if (picked == null || !mounted) return;
+    setState(() {
+      if (virtual) {
+        _virtualWorkDate = picked;
+      } else {
+        _workDate = picked;
+      }
+    });
+  }
+
+  /// Applies [mutate] inside `setState` — the seam the form widget flips its
+  /// switches through, so no `setState` call leaks outside this State subclass.
+  void toggle(VoidCallback mutate) => setState(mutate);
+
+  void _toast(String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.bootstrap == null) {
+      return const _MessagePanel(
+        eyebrow: 'Arcadia · instellingen',
+        title: 'Not configured',
+        message: 'Azure AD is not configured for this build, so the settings '
+            'store cannot be reached. Provide the AAD --dart-define values and '
+            'restart.',
+      );
+    }
+    final error = _error;
+    if (error != null && _loaded == null) {
+      final retryNote = _attempts > 1 ? '\n\n(Attempt $_attempts failed.)' : '';
+      return _MessagePanel(
+        eyebrow: 'Arcadia · instellingen',
+        title: 'Kon de instellingen niet laden',
+        message: '$error$retryNote',
+        action: FilledButton(
+          key: const ValueKey('settings-retry'),
+          onPressed: _load,
+          child: const Text('Opnieuw proberen'),
+        ),
+      );
+    }
+    final loaded = _loaded;
+    if (loaded == null) {
+      return const _MessagePanel(
+        eyebrow: 'Arcadia · instellingen',
+        title: 'Laden…',
+        message: 'De instellingen worden opgehaald.',
+        progress: true,
+      );
+    }
+    return _SettingsForm(
+      state: this,
+      settings: loaded,
+    );
+  }
+}
+
+/// The scrolling settings form. A thin view over [_SettingsScreenState]'s
+/// controllers so all mutation stays in one place.
+class _SettingsForm extends StatelessWidget {
+  const _SettingsForm({required this.state, required this.settings});
+
+  final _SettingsScreenState state;
+  final AppSettings settings;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final bool ink = Theme.of(context).brightness == Brightness.dark;
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 760),
+        child: ListView(
+          padding: const EdgeInsets.symmetric(
+            horizontal: PlinkSpacing.s6,
+            vertical: PlinkSpacing.s6,
+          ),
+          children: <Widget>[
+            Eyebrow('Arcadia · instellingen', onInk: ink),
+            const SizedBox(height: PlinkSpacing.s4),
+            Text('Instellingen', style: text.headlineMedium),
+            const SizedBox(height: PlinkSpacing.s3),
+            Text(
+              'Bewerk de configuratie en bewaar. Wachtwoorden worden alleen '
+              'geschreven — laat een veld leeg om de bestaande waarde te '
+              'behouden.',
+              style: text.bodyMedium,
+            ),
+            const SizedBox(height: PlinkSpacing.s4),
+            Wrap(
+              spacing: PlinkSpacing.s3,
+              runSpacing: PlinkSpacing.s2,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: <Widget>[
+                FilledButton.icon(
+                  key: const ValueKey('settings-save'),
+                  onPressed: state._busy ? null : state._save,
+                  icon: const Icon(Icons.save_outlined),
+                  label: const Text('Opslaan'),
+                ),
+                OutlinedButton.icon(
+                  key: const ValueKey('settings-reload'),
+                  onPressed: state._busy ? null : state._reload,
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('Herladen'),
+                ),
+              ],
+            ),
+            if (state._busy) ...<Widget>[
+              const SizedBox(height: PlinkSpacing.s4),
+              const LinearProgressIndicator(),
+            ],
+            const SizedBox(height: PlinkSpacing.s5),
+
+            // Global.
+            _Section(
+              title: 'Algemeen',
+              children: <Widget>[
+                _Field(
+                  keyValue: 'settings-school-prefix',
+                  label: 'Schoolprefix',
+                  controller: state._schoolPrefix,
+                ),
+                SwitchListTile(
+                  key: const ValueKey('settings-debug-mode'),
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Debugmodus'),
+                  value: state._debugMode,
+                  onChanged: (v) => state.toggle(() => state._debugMode = v),
+                ),
+              ],
+            ),
+
+            // WISA.
+            _Section(
+              title: 'WISA',
+              children: <Widget>[
+                _Field(
+                  keyValue: 'settings-wisa-server',
+                  label: 'Server',
+                  controller: state._wisaServer,
+                ),
+                _Field(
+                  keyValue: 'settings-wisa-port',
+                  label: 'Poort',
+                  controller: state._wisaPort,
+                  keyboardType: TextInputType.number,
+                ),
+                _Field(
+                  keyValue: 'settings-wisa-database',
+                  label: 'Database',
+                  controller: state._wisaDatabase,
+                ),
+                _Field(
+                  keyValue: 'settings-wisa-username',
+                  label: 'Gebruikersnaam',
+                  controller: state._wisaUsername,
+                ),
+                _SecretField(
+                  keyValue: 'settings-wisa-password',
+                  label: 'Wachtwoord (schrijf-alleen)',
+                  controller: state._wisaPassword,
+                ),
+                _WorkDateField(
+                  keyValue: 'settings-wisa-workdate',
+                  label: 'Werkdatum',
+                  isNow: state._workDateIsNow,
+                  date: state._workDate,
+                  onIsNowChanged: (v) =>
+                      state.toggle(() => state._workDateIsNow = v),
+                  onPick: () => state._pickWorkDate(virtual: false),
+                ),
+                _WorkDateField(
+                  keyValue: 'settings-wisa-virtual-workdate',
+                  label: 'Virtuele werkdatum',
+                  isNow: state._virtualWorkDateIsNow,
+                  date: state._virtualWorkDate,
+                  onIsNowChanged: (v) =>
+                      state.toggle(() => state._virtualWorkDateIsNow = v),
+                  onPick: () => state._pickWorkDate(virtual: true),
+                ),
+              ],
+            ),
+
+            // Smartschool.
+            _Section(
+              title: 'Smartschool',
+              children: <Widget>[
+                _Field(
+                  keyValue: 'settings-ss-uri',
+                  label: 'URI',
+                  controller: state._ssUri,
+                ),
+                _Field(
+                  keyValue: 'settings-ss-test-user',
+                  label: 'Testgebruiker',
+                  controller: state._ssTestUser,
+                ),
+                _Field(
+                  keyValue: 'settings-ss-student-group',
+                  label: 'Pad leerlingengroep',
+                  controller: state._ssStudentGroup,
+                ),
+                _Field(
+                  keyValue: 'settings-ss-staff-group',
+                  label: 'Pad personeelsgroep',
+                  controller: state._ssStaffGroup,
+                ),
+                _SecretField(
+                  keyValue: 'settings-ss-passphrase',
+                  label: 'Passphrase (schrijf-alleen)',
+                  controller: state._ssPassphrase,
+                ),
+                SwitchListTile(
+                  key: const ValueKey('settings-ss-use-grades'),
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Gebruik graden'),
+                  value: state._ssUseGrades,
+                  onChanged: (v) => state.toggle(() => state._ssUseGrades = v),
+                ),
+                for (var i = 0; i < state._grades.length; i++)
+                  _Field(
+                    keyValue: 'settings-ss-grade-$i',
+                    label: 'Graad ${i + 1}',
+                    controller: state._grades[i],
+                  ),
+                SwitchListTile(
+                  key: const ValueKey('settings-ss-use-years'),
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Gebruik jaren'),
+                  value: state._ssUseYears,
+                  onChanged: (v) => state.toggle(() => state._ssUseYears = v),
+                ),
+                for (var i = 0; i < state._years.length; i++)
+                  _Field(
+                    keyValue: 'settings-ss-year-$i',
+                    label: 'Jaar ${i + 1}',
+                    controller: state._years[i],
+                  ),
+              ],
+            ),
+
+            // Azure.
+            _Section(
+              title: 'Azure AD / Office 365',
+              children: <Widget>[
+                _Field(
+                  keyValue: 'settings-az-client-id',
+                  label: 'Client ID',
+                  controller: state._azClientId,
+                ),
+                _Field(
+                  keyValue: 'settings-az-tenant-id',
+                  label: 'Tenant ID',
+                  controller: state._azTenantId,
+                ),
+                _Field(
+                  keyValue: 'settings-az-domain',
+                  label: 'Domein',
+                  controller: state._azDomain,
+                ),
+              ],
+            ),
+
+            // Import rules (read-only).
+            _Section(
+              title: 'Importregels (alleen-lezen)',
+              children: <Widget>[
+                _RulesList(
+                  wisaRules: settings.wisaRules,
+                  smartschoolRules: settings.smartschoolRules,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Section extends StatelessWidget {
+  const _Section({required this.title, required this.children});
+
+  final String title;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return Container(
+      margin: const EdgeInsets.only(bottom: PlinkSpacing.s4),
+      padding: const EdgeInsets.all(PlinkSpacing.s5),
+      decoration: BoxDecoration(
+        border: Border.all(color: colors.outlineVariant),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(title, style: text.titleMedium),
+          const SizedBox(height: PlinkSpacing.s3),
+          ...children,
+        ],
+      ),
+    );
+  }
+}
+
+class _Field extends StatelessWidget {
+  const _Field({
+    required this.keyValue,
+    required this.label,
+    required this.controller,
+    this.keyboardType,
+  });
+
+  final String keyValue;
+  final String label;
+  final TextEditingController controller;
+  final TextInputType? keyboardType;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: PlinkSpacing.s3),
+      child: TextField(
+        key: ValueKey(keyValue),
+        controller: controller,
+        keyboardType: keyboardType,
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+        ),
+      ),
+    );
+  }
+}
+
+/// A write-only credential field: obscured, never populated from the provider,
+/// with a hint that a blank field keeps the stored value.
+class _SecretField extends StatelessWidget {
+  const _SecretField({
+    required this.keyValue,
+    required this.label,
+    required this.controller,
+  });
+
+  final String keyValue;
+  final String label;
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: PlinkSpacing.s3),
+      child: TextField(
+        key: ValueKey(keyValue),
+        controller: controller,
+        obscureText: true,
+        autofillHints: const <String>[],
+        decoration: InputDecoration(
+          labelText: label,
+          hintText: 'Laat leeg om de bestaande waarde te behouden',
+          border: const OutlineInputBorder(),
+        ),
+      ),
+    );
+  }
+}
+
+class _WorkDateField extends StatelessWidget {
+  const _WorkDateField({
+    required this.keyValue,
+    required this.label,
+    required this.isNow,
+    required this.date,
+    required this.onIsNowChanged,
+    required this.onPick,
+  });
+
+  final String keyValue;
+  final String label;
+  final bool isNow;
+  final DateTime? date;
+  final ValueChanged<bool> onIsNowChanged;
+  final VoidCallback onPick;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final String pinned = date == null
+        ? 'geen datum gekozen'
+        : '${date!.year}-${date!.month.toString().padLeft(2, '0')}-'
+            '${date!.day.toString().padLeft(2, '0')}';
+    return Padding(
+      padding: const EdgeInsets.only(bottom: PlinkSpacing.s3),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          SwitchListTile(
+            key: ValueKey('$keyValue-is-now'),
+            contentPadding: EdgeInsets.zero,
+            title: Text('$label — volg de huidige datum'),
+            value: isNow,
+            onChanged: onIsNowChanged,
+          ),
+          if (!isNow)
+            Row(
+              children: <Widget>[
+                Text(pinned, style: text.bodyMedium),
+                const SizedBox(width: PlinkSpacing.s3),
+                OutlinedButton(
+                  key: ValueKey('$keyValue-pick'),
+                  onPressed: onPick,
+                  child: const Text('Kies datum'),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RulesList extends StatelessWidget {
+  const _RulesList({required this.wisaRules, required this.smartschoolRules});
+
+  final List<WisaImportRule> wisaRules;
+  final List<SmartschoolImportRule> smartschoolRules;
+
+  static String _describeWisa(WisaImportRule rule) => switch (rule) {
+        DontImportClass(:final className) =>
+          'Klas niet importeren uit WISA: $className',
+        DontImportUserFromWisa(:final userCode) =>
+          'Gebruiker niet importeren uit WISA: $userCode',
+        ReplaceInstitute(:final original, :final replacement) =>
+          'Vervang instituut: $original → $replacement',
+        MarkAsVirtual(:final schoolCode) => 'Markeer als virtueel: $schoolCode',
+      };
+
+  static String _describeSmartschool(SmartschoolImportRule rule) =>
+      switch (rule) {
+        DiscardSmartschoolGroup(:final groupName) =>
+          'Smartschool-groep negeren: $groupName',
+        NoSmartschoolSubgroups(:final groupName) =>
+          'Geen subgroepen: $groupName',
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    if (wisaRules.isEmpty && smartschoolRules.isEmpty) {
+      return Text(
+        'Nog geen importregels verzameld.',
+        key: const ValueKey('settings-rules-empty'),
+        style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        for (final r in wisaRules)
+          Padding(
+            padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
+            child: Text('• ${_describeWisa(r)}', style: text.bodyMedium),
+          ),
+        for (final r in smartschoolRules)
+          Padding(
+            padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
+            child: Text('• ${_describeSmartschool(r)}', style: text.bodyMedium),
+          ),
+      ],
+    );
+  }
+}
+
+/// Full-panel message (loading / not-configured / error), mirroring the
+/// passwords and reconcile screens so the views read as one app.
+class _MessagePanel extends StatelessWidget {
+  const _MessagePanel({
+    required this.eyebrow,
+    required this.title,
+    required this.message,
+    this.action,
+    this.progress = false,
+  });
+
+  final String eyebrow;
+  final String title;
+  final String message;
+  final Widget? action;
+  final bool progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final bool ink = Theme.of(context).brightness == Brightness.dark;
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: Padding(
+          padding: const EdgeInsets.all(PlinkSpacing.s6),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Eyebrow(eyebrow, onInk: ink),
+              const SizedBox(height: PlinkSpacing.s4),
+              Text(title, style: text.headlineSmall),
+              const SizedBox(height: PlinkSpacing.s4),
+              Text(message, style: text.bodyMedium),
+              if (progress) ...<Widget>[
+                const SizedBox(height: PlinkSpacing.s5),
+                const LinearProgressIndicator(),
+              ],
+              if (action != null) ...<Widget>[
+                const SizedBox(height: PlinkSpacing.s5),
+                action!,
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/account_manager/lib/src/settings/settings_bootstrap.dart
+++ b/account_manager/lib/src/settings/settings_bootstrap.dart
@@ -1,0 +1,59 @@
+import 'package:account_state/account_state.dart';
+
+import '../auth/sign_in_session.dart';
+import '../reconcile/reconcile_bootstrap.dart' show StoreEndpoints;
+
+/// The two seams the Settings view edits against: the [SettingsStore] holding
+/// the [AppSettings] config document and the [SecretProvider] the WISA password
+/// and Smartschool passphrase are written through.
+///
+/// Deliberately much lighter than [ReconcileServices]: the Settings view exists
+/// to *fix* an incomplete config, so it must reach the store and the vault
+/// without first standing up the connectors — which [bootstrapReconcile] refuses
+/// to do (it throws [ReconcileConfigException]) precisely when a secret or a
+/// profile field is still missing.
+class SettingsServices {
+  const SettingsServices({required this.store, required this.secrets});
+
+  /// The persistence seam for the [AppSettings] document (#114: Cosmos-backed).
+  final SettingsStore store;
+
+  /// The write-only secret seam (Key Vault in production) the Settings view
+  /// persists an operator-typed credential through — never read back into the UI.
+  final SecretProvider secrets;
+}
+
+/// Wires the Settings view's two seams for one signed-in session: a
+/// [CosmosSettingsStore] over the operator's Cosmos data-plane token and a
+/// [KeyVaultSecretProvider] over their Key Vault token (#114). Both default to
+/// the provisioned infrastructure in [StoreEndpoints] and can be overridden per
+/// environment with `--dart-define`.
+///
+/// The optional parameters are test seams; production callers pass only
+/// [session]. This never *loads* the settings — the screen does that itself, so
+/// a reload affordance can re-read without re-bootstrapping.
+Future<SettingsServices> bootstrapSettings({
+  required SignInSession session,
+  StoreEndpoints? endpoints,
+  SettingsStore? settingsStore,
+  SecretProvider? secretProvider,
+  CosmosClient? cosmosClient,
+}) async {
+  final ends = endpoints ?? StoreEndpoints.fromEnvironment();
+  final client = cosmosClient ??
+      HttpCosmosClient(
+        config: CosmosConfig(
+          endpoint: ends.cosmosEndpoint,
+          database: ends.cosmosDatabase,
+        ),
+        transport: HttpCosmosTransport(),
+        tokens: CosmosSessionTokenProvider(session),
+      );
+  final store = settingsStore ?? CosmosSettingsStore(client);
+  final secrets = secretProvider ??
+      KeyVaultSecretProvider(
+        config: KeyVaultConfig(vaultUri: ends.vaultUri),
+        tokens: VaultSessionTokenProvider(session),
+      );
+  return SettingsServices(store: store, secrets: secrets);
+}

--- a/account_manager/lib/src/shell/app_shell.dart
+++ b/account_manager/lib/src/shell/app_shell.dart
@@ -5,6 +5,8 @@ import '../reconcile/reconcile_bootstrap.dart';
 import '../screens/home_screen.dart';
 import '../screens/passwords_screen.dart';
 import '../screens/reconcile_screen.dart';
+import '../screens/settings_screen.dart';
+import '../settings/settings_bootstrap.dart';
 
 /// One navigable destination in the [AppShell].
 class ShellDestination {
@@ -26,11 +28,19 @@ class ShellDestination {
 /// the shell is built to grow, not to mirror the seven legacy WPF pages up
 /// front.
 class AppShell extends StatefulWidget {
-  const AppShell({super.key, this.reconcileBootstrap});
+  const AppShell({
+    super.key,
+    this.reconcileBootstrap,
+    this.settingsBootstrap,
+  });
 
   /// Assembles the reconcile stack on first use, or `null` when Azure AD is
   /// not configured for this build.
   final Future<ReconcileServices> Function()? reconcileBootstrap;
+
+  /// Assembles the settings seams (store + secret provider) on first use, or
+  /// `null` when Azure AD is not configured for this build.
+  final Future<SettingsServices> Function()? settingsBootstrap;
 
   @override
   State<AppShell> createState() => _AppShellState();
@@ -52,6 +62,11 @@ class _AppShellState extends State<AppShell> {
       label: 'Passwords',
       icon: Icons.password_outlined,
       builder: (_) => PasswordsScreen(bootstrap: widget.reconcileBootstrap),
+    ),
+    ShellDestination(
+      label: 'Settings',
+      icon: Icons.settings_outlined,
+      builder: (_) => SettingsScreen(bootstrap: widget.settingsBootstrap),
     ),
   ];
 

--- a/account_manager/test/screens/settings_fakes.dart
+++ b/account_manager/test/screens/settings_fakes.dart
@@ -1,0 +1,27 @@
+/// Shared fakes for the Settings view tests (#106): the in-memory store and
+/// secret provider the seam already ships, bundled behind the bootstrap closure
+/// the screen expects.
+library;
+
+import 'package:account_manager/src/settings/settings_bootstrap.dart';
+import 'package:account_state/account_state.dart';
+
+/// One assembled Settings stack over the in-memory seams — a headless stand-in
+/// for the Cosmos store + Key Vault provider, so a widget/integration test
+/// drives the real screen with zero infra.
+class SettingsHarness {
+  SettingsHarness({
+    AppSettings initial = const AppSettings(),
+    Map<SecretRef, String> secrets = const {},
+  })  : store = InMemorySettingsStore(initial),
+        secrets = InMemorySecretProvider(secrets);
+
+  final InMemorySettingsStore store;
+  final InMemorySecretProvider secrets;
+
+  SettingsServices get services =>
+      SettingsServices(store: store, secrets: secrets);
+
+  /// A ready-made bootstrap closure for [SettingsScreen]/[AccountManagerApp].
+  Future<SettingsServices> Function() get bootstrap => () async => services;
+}

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -1,0 +1,225 @@
+import 'package:account_manager/src/screens/settings_screen.dart';
+import 'package:account_state/account_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+import 'settings_fakes.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+/// A tall viewport so the long settings form lays out without needing to scroll
+/// every field into view before entering text.
+void _useTallWindow(WidgetTester tester) {
+  tester.view.physicalSize = const Size(1200, 4000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+void main() {
+  testWidgets('shows the not-configured panel when AAD is absent',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_wrap(const SettingsScreen(bootstrap: null)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Not configured'), findsOneWidget);
+    expect(find.byKey(const ValueKey('settings-save')), findsNothing);
+  });
+
+  testWidgets('populates the form from the stored document',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: AppSettings(
+        schoolPrefix: 'GBS',
+        wisa: const WisaConnection(server: 'db.school.example', port: '1433'),
+        smartschool: SmartschoolConnection(studentGroup: 'Leerlingen'),
+        azure: const AzureConnection(domain: 'school.onmicrosoft.com'),
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('GBS'), findsOneWidget);
+    expect(find.text('db.school.example'), findsOneWidget);
+    expect(find.text('Leerlingen'), findsOneWidget);
+    expect(find.text('school.onmicrosoft.com'), findsOneWidget);
+  });
+
+  testWidgets('edit → save round-trips a profile field to the store',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: const AppSettings(schoolPrefix: 'OLD'),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-school-prefix')),
+      'NEW',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-wisa-server')),
+      'wisa.host',
+    );
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.schoolPrefix, 'NEW');
+    expect(saved.wisa.server, 'wisa.host');
+  });
+
+  testWidgets('Smartschool group paths and useGrades round-trip',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-ss-student-group')),
+      'Leerlingen/2025',
+    );
+    await tester.tap(find.byKey(const ValueKey('settings-ss-use-grades')));
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-ss-grade-0')),
+      'Graad 1',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.smartschool.studentGroup, 'Leerlingen/2025');
+    expect(saved.smartschool.useGrades, isTrue);
+    expect(saved.smartschool.grades.first, 'Graad 1');
+  });
+
+  testWidgets('a stored secret is never echoed back into the UI',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    final harness = SettingsHarness(
+      secrets: {passwordRef: 'super-secret-value'},
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The value is nowhere in the rendered tree, and the field is empty.
+    expect(find.text('super-secret-value'), findsNothing);
+    final field = tester.widget<TextField>(
+      find.byKey(const ValueKey('settings-wisa-password')),
+    );
+    expect(field.controller!.text, isEmpty);
+    expect(field.obscureText, isTrue);
+  });
+
+  testWidgets(
+      'typing a secret writes it through the provider but not into the blob',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    const passphraseRef = SecretRef('smartschool.passphrase');
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-wisa-password')),
+      'new-wisa-pw',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-ss-passphrase')),
+      'new-passphrase',
+    );
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    // Written through the SecretProvider seam…
+    expect(await harness.secrets.read(passwordRef), 'new-wisa-pw');
+    expect(await harness.secrets.read(passphraseRef), 'new-passphrase');
+    // …and NOT serialized into the settings document.
+    final saved = await harness.store.load();
+    expect(saved.toJson().toString(), isNot(contains('new-wisa-pw')));
+    expect(saved.toJson().toString(), isNot(contains('new-passphrase')));
+
+    // The fields are cleared after a successful save (never re-shown).
+    final field = tester.widget<TextField>(
+      find.byKey(const ValueKey('settings-wisa-password')),
+    );
+    expect(field.controller!.text, isEmpty);
+  });
+
+  testWidgets('leaving the secret blank on save keeps the stored value',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    final harness = SettingsHarness(
+      secrets: {passwordRef: 'existing-pw'},
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-school-prefix')),
+      'GBS',
+    );
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    // The untouched secret survives the save.
+    expect(await harness.secrets.read(passwordRef), 'existing-pw');
+  });
+
+  testWidgets('reload discards unsaved edits and re-reads the store',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: const AppSettings(schoolPrefix: 'STORED'),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-school-prefix')),
+      'DIRTY',
+    );
+    await tester.pump();
+    expect(find.text('DIRTY'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('settings-reload')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('DIRTY'), findsNothing);
+    expect(find.text('STORED'), findsOneWidget);
+  });
+
+  testWidgets('accumulated import rules render read-only',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: AppSettings(
+        wisaRules: <WisaImportRule>[
+          const DontImportClass('OKAN'),
+          const MarkAsVirtual('VIRT'),
+        ],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('OKAN'), findsOneWidget);
+    expect(find.textContaining('VIRT'), findsOneWidget);
+    expect(find.byKey(const ValueKey('settings-rules-empty')), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Adds the **Settings** view deferred out of #99: a new shell destination that edits the full `AppSettings` config document and provisions the two credentials the connectors need, so the operator can change any of it from the app instead of re-running the #99 one-off seed script. It also fills the gap that left the Smartschool group paths / grade-year vocabulary at empty defaults (placement-dependent actions could not resolve a parent group).

## Linked issue

Closes #106

## Note on persistence (issue text is stale)

The issue says "backed by the Azure SQL `SettingsStore`" and "write secrets to Key Vault". #114 has since **migrated persistence off Azure SQL/ODBC onto Cosmos DB + Blob** and retired the SQL adapters. This PR builds against the *current* seam: `CosmosSettingsStore` + `KeyVaultSecretProvider`, discovered via `InMemorySettingsStore`/`InMemorySecretProvider` fakes for tests. No retired SQL store is reintroduced. The settings-document shape edited here is the one that exists in code today (`AppSettings` + the three `*Connection` profiles).

## Changes

- `screens/settings_screen.dart` — the view: form over global flags, WISA/Smartschool/Azure profiles (incl. group paths, `useGrades`/`useYears`, grade[3]/year[7] labels, WISA work-date pair), write-only secret fields for the WISA password + Smartschool passphrase, read-only accumulated import rules, and a **reload** affordance (re-reads the store, no restart).
- `settings/settings_bootstrap.dart` — `SettingsServices` bundle + `bootstrapSettings()` (Cosmos store + Key Vault provider from the session token). Kept **separate** from `bootstrapReconcile` on purpose: the Settings view exists to fix an incomplete config, so it must not depend on the connectors bootstrapping successfully.
- Shell/app/main wiring: a `Settings` navigation destination and a memoized `settingsBootstrap` closure.
- Secret discipline honoured in the UI: secret fields start empty, are `obscureText`, are never populated from the provider, and are cleared after save; a blank field on save keeps the stored value; the value is never serialized into the settings blob.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed account_manager` clean
- [x] `flutter analyze lib test integration_test` clean (no issues)
- [x] unit/widget tests pass (`flutter test`) — 130 total, 9 new for the Settings view: form populates from the store, edit→save round-trips (global + WISA + Smartschool group paths/useGrades), stored secret never echoed back, typed secret written through the provider but not into the blob, blank secret keeps the stored value, reload discards edits, rules render read-only.
- [x] integration/e2e tests pass (`flutter test integration_test -d windows`) — 16 total, 1 new (#106): the real app opens Settings, edits a profile field, enters a write-only secret, saves, and asserts the profile landed in the store while the secret went through the provider and never into the settings document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)