### PR TITLE
Add per-WISA-school "ours" flag + group-membership plumbing (#133)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -28,6 +28,7 @@ import 'package:account_state/account_state.dart'
         SignalRTransport,
         StaticSignalRTokenProvider,
         WisaConnection,
+        WisaSchoolProfile,
         signalRRecordSeparator;
 import 'package:azure_api/azure_api.dart' show AzureCredentials;
 import 'package:flutter/material.dart';
@@ -770,6 +771,57 @@ void main() {
       find.byKey(const ValueKey('settings-wisa-password')),
     );
     expect(field.controller!.text, isEmpty);
+  });
+
+  testWidgets(
+      'the Settings view marks a WISA school as "ours" end-to-end, persisting '
+      'the ownership flag to the store (#133)', (WidgetTester tester) async {
+    // The real app composition over the in-memory settings seams. The store
+    // already knows one group school (id 42), not yet managed.
+    useTallWindow(tester);
+    final settings = SettingsHarness(
+      initial: const AppSettings(
+        wisaSchools: [WisaSchoolProfile(schoolId: 42)],
+      ),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // Open Settings; the seeded school renders in the real, laid-out form with
+    // its managed switch off.
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+    // The WISA-schools section sits below the fold; the form is a lazy ListView,
+    // so scroll the switch into view (and build it) before reading it.
+    final ourSwitch =
+        find.byKey(const ValueKey('settings-wisa-school-42-ours'));
+    await tester.scrollUntilVisible(
+      ourSwitch,
+      400,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(tester.widget<SwitchListTile>(ourSwitch).value, isFalse);
+
+    // Mark it managed and save.
+    await tester.tap(ourSwitch);
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('settings-save')),
+      -400,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    // The ownership flag landed in the store.
+    final saved = await settings.store.load();
+    expect(saved.wisaSchools.single.schoolId, 42);
+    expect(saved.wisaSchools.single.ours, isTrue);
   });
 
   testWidgets('silent sign-in leads straight into the shell',

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -84,6 +84,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
   final _azTenantId = TextEditingController();
   final _azDomain = TextEditingController();
 
+  // Per-WISA-school ownership (#113). Held as a mutable working copy edited in
+  // place; committed to the settings document on save.
+  List<WisaSchoolProfile> _wisaSchools = const <WisaSchoolProfile>[];
+  final _wisaSchoolToAdd = TextEditingController();
+
   @override
   void initState() {
     super.initState();
@@ -107,6 +112,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _azClientId,
       _azTenantId,
       _azDomain,
+      _wisaSchoolToAdd,
       ..._grades,
       ..._years,
     ]) {
@@ -197,6 +203,41 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _azClientId.text = s.azure.clientId;
     _azTenantId.text = s.azure.tenantId;
     _azDomain.text = s.azure.domain;
+
+    _wisaSchools = List<WisaSchoolProfile>.of(s.wisaSchools);
+    _wisaSchoolToAdd.clear();
+  }
+
+  /// Flips the `ours` flag on the profile at [index] (the toggle the operator
+  /// uses to mark a managed school).
+  void _toggleSchoolOurs(int index, bool ours) {
+    toggle(
+        () => _wisaSchools[index] = _wisaSchools[index].copyWith(ours: ours));
+  }
+
+  /// Appends a managed-school entry for the id typed in the add field, ignoring
+  /// blanks, non-numbers, and ids already present.
+  void _addWisaSchool() {
+    final id = int.tryParse(_wisaSchoolToAdd.text.trim());
+    if (id == null) return;
+    if (_wisaSchools.any((p) => p.schoolId == id)) {
+      _wisaSchoolToAdd.clear();
+      return;
+    }
+    toggle(() {
+      _wisaSchools = <WisaSchoolProfile>[
+        ..._wisaSchools,
+        WisaSchoolProfile(schoolId: id, ours: true),
+      ];
+      _wisaSchoolToAdd.clear();
+    });
+  }
+
+  /// Drops the managed-school entry at [index].
+  void _removeWisaSchool(int index) {
+    toggle(() {
+      _wisaSchools = <WisaSchoolProfile>[..._wisaSchools]..removeAt(index);
+    });
   }
 
   /// Assembles an [AppSettings] from the form, preserving the loaded document's
@@ -231,6 +272,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         tenantId: _azTenantId.text.trim(),
         domain: _azDomain.text.trim(),
       ),
+      wisaSchools: List<WisaSchoolProfile>.of(_wisaSchools),
     );
   }
 
@@ -462,6 +504,14 @@ class _SettingsForm extends StatelessWidget {
                       state.toggle(() => state._virtualWorkDateIsNow = v),
                   onPick: () => state._pickWorkDate(virtual: true),
                 ),
+              ],
+            ),
+
+            // WISA schools (managed/"ours" flag — #113).
+            _Section(
+              title: 'WISA-scholen (beheerd)',
+              children: <Widget>[
+                _WisaSchoolsEditor(state: state),
               ],
             ),
 
@@ -721,6 +771,7 @@ class _RulesList extends StatelessWidget {
         ReplaceInstitute(:final original, :final replacement) =>
           'Vervang instituut: $original → $replacement',
         MarkAsVirtual(:final schoolCode) => 'Markeer als virtueel: $schoolCode',
+        MarkAsOurs(:final schoolCode) => 'Markeer als beheerd: $schoolCode',
       };
 
   static String _describeSmartschool(SmartschoolImportRule rule) =>
@@ -755,6 +806,91 @@ class _RulesList extends StatelessWidget {
             padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
             child: Text('• ${_describeSmartschool(r)}', style: text.bodyMedium),
           ),
+      ],
+    );
+  }
+}
+
+/// Editor for the per-WISA-school ownership list (#113): one switch per known
+/// school toggling its `ours`/managed flag, plus an add-by-id affordance. The
+/// shared credentials pull every group school; this is where the operator marks
+/// which ones we manage. Keyed by school id so a widget/integration test can
+/// seed a profile and flip it against the in-memory store.
+class _WisaSchoolsEditor extends StatelessWidget {
+  const _WisaSchoolsEditor({required this.state});
+
+  final _SettingsScreenState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final schools = state._wisaSchools;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          'Alle groepsscholen worden opgehaald; markeer hier welke we beheren.',
+          style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+        ),
+        const SizedBox(height: PlinkSpacing.s2),
+        if (schools.isEmpty)
+          Text(
+            'Nog geen scholen toegevoegd.',
+            key: const ValueKey('settings-wisa-schools-empty'),
+            style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+          ),
+        for (var i = 0; i < schools.length; i++)
+          Row(
+            key: ValueKey('settings-wisa-school-${schools[i].schoolId}'),
+            children: <Widget>[
+              Expanded(
+                child: SwitchListTile(
+                  key: ValueKey(
+                    'settings-wisa-school-${schools[i].schoolId}-ours',
+                  ),
+                  contentPadding: EdgeInsets.zero,
+                  title: Text('School ${schools[i].schoolId}'),
+                  subtitle: const Text('Beheerd'),
+                  value: schools[i].ours,
+                  onChanged: (v) => state._toggleSchoolOurs(i, v),
+                ),
+              ),
+              IconButton(
+                key: ValueKey(
+                  'settings-wisa-school-${schools[i].schoolId}-remove',
+                ),
+                icon: const Icon(Icons.delete_outline),
+                tooltip: 'Verwijderen',
+                onPressed: () => state._removeWisaSchool(i),
+              ),
+            ],
+          ),
+        const SizedBox(height: PlinkSpacing.s3),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Expanded(
+              child: TextField(
+                key: const ValueKey('settings-wisa-school-add'),
+                controller: state._wisaSchoolToAdd,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(
+                  labelText: 'School-id toevoegen',
+                  border: OutlineInputBorder(),
+                ),
+                onSubmitted: (_) => state._addWisaSchool(),
+              ),
+            ),
+            const SizedBox(width: PlinkSpacing.s3),
+            OutlinedButton.icon(
+              key: const ValueKey('settings-wisa-school-add-btn'),
+              onPressed: state._addWisaSchool,
+              icon: const Icon(Icons.add),
+              label: const Text('Toevoegen'),
+            ),
+          ],
+        ),
       ],
     );
   }

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -203,6 +203,68 @@ void main() {
     expect(find.text('STORED'), findsOneWidget);
   });
 
+  testWidgets('toggling a WISA school\'s "ours" flag round-trips to the store',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisaSchools: [
+          WisaSchoolProfile(schoolId: 42),
+        ],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The seeded (unmanaged) school renders with its switch off.
+    final ourSwitch =
+        find.byKey(const ValueKey('settings-wisa-school-42-ours'));
+    expect(ourSwitch, findsOneWidget);
+    expect(tester.widget<SwitchListTile>(ourSwitch).value, isFalse);
+
+    // Flip it on and save.
+    await tester.tap(ourSwitch);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.wisaSchools.single.schoolId, 42);
+    expect(saved.wisaSchools.single.ours, isTrue);
+  });
+
+  testWidgets('adding a WISA school by id appends a managed entry',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // No schools yet — the empty note shows.
+    expect(find.byKey(const ValueKey('settings-wisa-schools-empty')),
+        findsOneWidget);
+
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-wisa-school-add')),
+      '7',
+    );
+    await tester
+        .tap(find.byKey(const ValueKey('settings-wisa-school-add-btn')));
+    await tester.pumpAndSettle();
+
+    // The new row appears, defaults to managed, and saves.
+    expect(find.byKey(const ValueKey('settings-wisa-school-7-ours')),
+        findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.wisaSchools.single.schoolId, 7);
+    expect(saved.wisaSchools.single.ours, isTrue);
+  });
+
   testWidgets('accumulated import rules render read-only',
       (WidgetTester tester) async {
     _useTallWindow(tester);

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -98,6 +98,7 @@ export 'src/settings/connection.dart';
 export 'src/settings/import_rule_codec.dart';
 export 'src/settings/secret_provider.dart';
 export 'src/settings/settings_store.dart';
+export 'src/settings/wisa_school_profile.dart';
 export 'src/settings/work_date.dart';
 export 'src/cosmos/cosmos_client.dart';
 export 'src/cosmos/cosmos_config.dart';

--- a/packages/account_state/lib/src/apply/wisa_import_rules.dart
+++ b/packages/account_state/lib/src/apply/wisa_import_rules.dart
@@ -63,5 +63,6 @@ class WisaImportRules {
         DontImportUserFromWisa(:final userCode) => 'user:$userCode',
         ReplaceInstitute(:final original) => 'institute:$original',
         MarkAsVirtual(:final schoolCode) => 'virtual:$schoolCode',
+        MarkAsOurs(:final schoolCode) => 'ours:$schoolCode',
       };
 }

--- a/packages/account_state/lib/src/settings/app_settings.dart
+++ b/packages/account_state/lib/src/settings/app_settings.dart
@@ -3,6 +3,7 @@ import 'package:wisa_api/wisa_api.dart';
 
 import 'connection.dart';
 import 'import_rule_codec.dart';
+import 'wisa_school_profile.dart';
 
 /// The persisted configuration model for the Arcadia Account Manager.
 ///
@@ -35,6 +36,7 @@ class AppSettings {
     SmartschoolConnection? smartschool,
     this.wisaRules = const [],
     this.smartschoolRules = const [],
+    this.wisaSchools = const [],
   }) : _smartschool = smartschool;
 
   /// The school prefix used by the linker to scope Azure users to this school
@@ -65,6 +67,11 @@ class AppSettings {
   /// Smartschool import rules applied at snapshot construction (spec §3.11).
   final List<SmartschoolImportRule> smartschoolRules;
 
+  /// Per-WISA-school ownership entries (the `MarkAsOurs` counterpart persisted
+  /// by school id). Empty means no school has been marked managed yet — the
+  /// group-membership plumbing #113 slice 2 reads, but no action fires here.
+  final List<WisaSchoolProfile> wisaSchools;
+
   /// Returns a copy with the given fields replaced.
   AppSettings copyWith({
     String? schoolPrefix,
@@ -74,6 +81,7 @@ class AppSettings {
     SmartschoolConnection? smartschool,
     List<WisaImportRule>? wisaRules,
     List<SmartschoolImportRule>? smartschoolRules,
+    List<WisaSchoolProfile>? wisaSchools,
   }) {
     return AppSettings(
       schoolPrefix: schoolPrefix ?? this.schoolPrefix,
@@ -83,6 +91,7 @@ class AppSettings {
       smartschool: smartschool ?? this.smartschool,
       wisaRules: wisaRules ?? this.wisaRules,
       smartschoolRules: smartschoolRules ?? this.smartschoolRules,
+      wisaSchools: wisaSchools ?? this.wisaSchools,
     );
   }
 
@@ -97,6 +106,7 @@ class AppSettings {
       'azure': azure.toJson(),
       'wisaRules': wisaRules.map(encodeWisaRule).toList(),
       'smartschoolRules': smartschoolRules.map(encodeSmartschoolRule).toList(),
+      'wisaSchools': wisaSchools.map((p) => p.toJson()).toList(),
     };
   }
 
@@ -112,6 +122,7 @@ class AppSettings {
     final wisaConn = json['wisa'] as Map<String, dynamic>?;
     final smartschoolConn = json['smartschool'] as Map<String, dynamic>?;
     final azureConn = json['azure'] as Map<String, dynamic>?;
+    final wisaSchools = (json['wisaSchools'] as List<dynamic>?) ?? const [];
     return AppSettings(
       schoolPrefix: (json['schoolPrefix'] as String?) ?? '',
       debugMode: (json['debugMode'] as bool?) ?? false,
@@ -130,6 +141,10 @@ class AppSettings {
       smartschoolRules: [
         for (final r in smartschool)
           decodeSmartschoolRule(r as Map<String, dynamic>),
+      ],
+      wisaSchools: [
+        for (final p in wisaSchools)
+          WisaSchoolProfile.fromJson(p as Map<String, dynamic>),
       ],
     );
   }

--- a/packages/account_state/lib/src/settings/import_rule_codec.dart
+++ b/packages/account_state/lib/src/settings/import_rule_codec.dart
@@ -29,6 +29,8 @@ Map<String, dynamic> encodeWisaRule(WisaImportRule rule) {
       };
     case MarkAsVirtual():
       return {'type': 'markAsVirtual', 'schoolCode': rule.schoolCode};
+    case MarkAsOurs():
+      return {'type': 'markAsOurs', 'schoolCode': rule.schoolCode};
   }
 }
 
@@ -50,6 +52,8 @@ WisaImportRule decodeWisaRule(Map<String, dynamic> json) {
       );
     case 'markAsVirtual':
       return MarkAsVirtual(json['schoolCode'] as String);
+    case 'markAsOurs':
+      return MarkAsOurs(json['schoolCode'] as String);
     default:
       throw FormatException('Unknown WisaImportRule type: $type');
   }

--- a/packages/account_state/lib/src/settings/wisa_school_profile.dart
+++ b/packages/account_state/lib/src/settings/wisa_school_profile.dart
@@ -1,0 +1,68 @@
+/// Per-WISA-school ownership entry persisted in the settings document.
+///
+/// The shared credentials pull *every* WISA school the group can see, but we
+/// only **manage** some of them. This profile records, per school id, whether
+/// it is [ours] (managed) and an optional per-school [prefix] override for the
+/// Azure-orphan scoping the linker does (INV-22). It is the persistent, keyed
+/// counterpart of the snapshot-time `MarkAsOurs` import rule: the rule flips
+/// `WisaSchool.isOurs` at pull time by school *name*, while this list is the
+/// operator-editable ownership record keyed by school *id* that survives in the
+/// settings blob.
+///
+/// The shape (`{ schoolId, ours, prefix }`) is the per-WISA-school ownership
+/// link #112/#113 called for, so the settings document is not reshaped twice.
+/// This slice only carries the data — no action reads it yet (#134 is slice 2).
+class WisaSchoolProfile {
+  const WisaSchoolProfile({
+    required this.schoolId,
+    this.ours = false,
+    this.prefix = '',
+  });
+
+  /// The WISA school id (`WisaSchool.id`) this ownership entry is keyed by.
+  final int schoolId;
+
+  /// Whether we manage this school. A student found only in schools where this
+  /// is `false` (group-visible siblings) has left *our* schools.
+  final bool ours;
+
+  /// Per-school Azure-orphan scoping prefix. Empty means "inherit the global
+  /// [AppSettings.schoolPrefix]" — a per-school override to grow into (#113),
+  /// not yet consulted by the linker.
+  final String prefix;
+
+  WisaSchoolProfile copyWith({int? schoolId, bool? ours, String? prefix}) =>
+      WisaSchoolProfile(
+        schoolId: schoolId ?? this.schoolId,
+        ours: ours ?? this.ours,
+        prefix: prefix ?? this.prefix,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'schoolId': schoolId,
+        'ours': ours,
+        'prefix': prefix,
+      };
+
+  factory WisaSchoolProfile.fromJson(Map<String, dynamic> json) =>
+      WisaSchoolProfile(
+        schoolId: json['schoolId'] as int,
+        ours: (json['ours'] as bool?) ?? false,
+        prefix: (json['prefix'] as String?) ?? '',
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WisaSchoolProfile &&
+          schoolId == other.schoolId &&
+          ours == other.ours &&
+          prefix == other.prefix;
+
+  @override
+  int get hashCode => Object.hash(schoolId, ours, prefix);
+
+  @override
+  String toString() =>
+      'WisaSchoolProfile(schoolId: $schoolId, ours: $ours, prefix: $prefix)';
+}

--- a/packages/account_state/test/settings_store_test.dart
+++ b/packages/account_state/test/settings_store_test.dart
@@ -41,10 +41,15 @@ AppSettings _sampleSettings() => AppSettings(
         DontImportUserFromWisa('U42'),
         ReplaceInstitute(original: '001', replacement: '002'),
         MarkAsVirtual('VIRT'),
+        MarkAsOurs('SMA'),
       ],
       smartschoolRules: const [
         DiscardSmartschoolGroup('Archief'),
         NoSmartschoolSubgroups('Klassen'),
+      ],
+      wisaSchools: const [
+        WisaSchoolProfile(schoolId: 1, ours: true, prefix: 'SMA'),
+        WisaSchoolProfile(schoolId: 2),
       ],
     );
 
@@ -58,6 +63,7 @@ void expectSameSettings(AppSettings a, AppSettings b) {
       equals(encodeRules(b.wisaRules, encodeWisaRule)));
   expect(encodeRules(a.smartschoolRules, encodeSmartschoolRule),
       equals(encodeRules(b.smartschoolRules, encodeSmartschoolRule)));
+  expect(a.wisaSchools, equals(b.wisaSchools));
 }
 
 List<Map<String, dynamic>> encodeRules<T>(
@@ -97,6 +103,25 @@ void main() {
       expect(smartschool['passphraseRef'], 'smartschool.passphrase');
       expect(wisa.containsKey('password'), isFalse);
       expect(smartschool.containsKey('passphrase'), isFalse);
+    });
+
+    test('per-WISA-school ownership list round-trips through JSON', () {
+      const original = AppSettings(
+        wisaSchools: [
+          WisaSchoolProfile(schoolId: 10, ours: true, prefix: 'KA'),
+          WisaSchoolProfile(schoolId: 20),
+        ],
+      );
+      final restored = AppSettings.fromJson(original.toJson());
+      expect(restored.wisaSchools, original.wisaSchools);
+      expect(restored.wisaSchools.first.ours, isTrue);
+      expect(restored.wisaSchools.first.prefix, 'KA');
+      expect(restored.wisaSchools.last.ours, isFalse);
+    });
+
+    test('a config predating wisaSchools loads with an empty list', () {
+      final settings = AppSettings.fromJson({'schoolPrefix': 'X'});
+      expect(settings.wisaSchools, isEmpty);
     });
 
     test('throws on an unknown rule type tag', () {

--- a/packages/wisa_api/lib/src/models/wisa_school.dart
+++ b/packages/wisa_api/lib/src/models/wisa_school.dart
@@ -8,17 +8,26 @@
 /// [isVirtual] is set at snapshot construction time by the
 /// `MarkAsVirtual` import rule; it tells the connector that this school
 /// should be synced using the virtual workdate instead of the real one.
+///
+/// [isOurs] marks a school we actually **manage** (as opposed to one that
+/// is merely group-visible through the shared credentials). It is set at
+/// snapshot construction time by the `MarkAsOurs` import rule, paralleling
+/// [isVirtual]. Group-wide leave detection (#113) needs it to tell a student
+/// who left *our* school but stayed in the group from one who left the group
+/// entirely; this slice only carries the flag — it changes no action yet.
 class WisaSchool {
   final int id;
   final String name;
   final String description;
   final bool isVirtual;
+  final bool isOurs;
 
   const WisaSchool({
     required this.id,
     required this.name,
     required this.description,
     this.isVirtual = false,
+    this.isOurs = false,
   });
 
   /// Serializes to the connector's own snapshot shape. Round-trips with
@@ -28,6 +37,7 @@ class WisaSchool {
         'name': name,
         'description': description,
         'isVirtual': isVirtual,
+        'isOurs': isOurs,
       };
 
   factory WisaSchool.fromJson(Map<String, dynamic> json) => WisaSchool(
@@ -35,13 +45,15 @@ class WisaSchool {
         name: json['name'] as String,
         description: json['description'] as String,
         isVirtual: (json['isVirtual'] as bool?) ?? false,
+        isOurs: (json['isOurs'] as bool?) ?? false,
       );
 
-  WisaSchool copyWith({bool? isVirtual}) => WisaSchool(
+  WisaSchool copyWith({bool? isVirtual, bool? isOurs}) => WisaSchool(
         id: id,
         name: name,
         description: description,
         isVirtual: isVirtual ?? this.isVirtual,
+        isOurs: isOurs ?? this.isOurs,
       );
 
   @override
@@ -51,12 +63,13 @@ class WisaSchool {
           id == other.id &&
           name == other.name &&
           description == other.description &&
-          isVirtual == other.isVirtual;
+          isVirtual == other.isVirtual &&
+          isOurs == other.isOurs;
 
   @override
-  int get hashCode => Object.hash(id, name, description, isVirtual);
+  int get hashCode => Object.hash(id, name, description, isVirtual, isOurs);
 
   @override
   String toString() =>
-      'WisaSchool(id: $id, name: $name, isVirtual: $isVirtual)';
+      'WisaSchool(id: $id, name: $name, isVirtual: $isVirtual, isOurs: $isOurs)';
 }

--- a/packages/wisa_api/lib/src/rules/import_rules.dart
+++ b/packages/wisa_api/lib/src/rules/import_rules.dart
@@ -63,6 +63,18 @@ class MarkAsVirtual extends WisaImportRule {
   bool matches(WisaSchool s) => s.name == schoolCode;
 }
 
+/// Flags schools whose [WisaSchool.name] equals [schoolCode] as *ours*
+/// (managed). Group-wide leave detection (#113) uses the flag to tell a
+/// student gone from *our* school but still in the group from one gone from
+/// the whole group. Mirrors [MarkAsVirtual] — a snapshot-time school marker
+/// keyed by the WISA school name.
+class MarkAsOurs extends WisaImportRule {
+  final String schoolCode;
+  const MarkAsOurs(this.schoolCode);
+
+  bool matches(WisaSchool s) => s.name == schoolCode;
+}
+
 /// Applies all rules in [rules] to [groups], in order. Returns a new list;
 /// the input is not mutated.
 ///
@@ -89,6 +101,7 @@ List<WisaClassGroup> applyRulesToClassGroups(
           g = r.apply(g);
         case DontImportUserFromWisa():
         case MarkAsVirtual():
+        case MarkAsOurs():
           break;
       }
     }
@@ -114,17 +127,20 @@ List<WisaStaff> applyRulesToStaff(
   return result;
 }
 
-/// Applies all [MarkAsVirtual] rules in [rules] to [schools]. Returns a
-/// new list with `isVirtual` flipped on matching schools; the input is
-/// not mutated.
+/// Applies the school-marking rules ([MarkAsVirtual], [MarkAsOurs]) in
+/// [rules] to [schools]. Returns a new list with `isVirtual` / `isOurs`
+/// flipped on matching schools; the input is not mutated. A school can be
+/// flagged by both rules independently.
 List<WisaSchool> applyRulesToSchools(
   Iterable<WisaSchool> schools,
   Iterable<WisaImportRule> rules,
 ) {
   return [
     for (final s in schools)
-      rules.any((r) => r is MarkAsVirtual && r.matches(s))
-          ? s.copyWith(isVirtual: true)
-          : s,
+      s.copyWith(
+        isVirtual:
+            s.isVirtual || rules.any((r) => r is MarkAsVirtual && r.matches(s)),
+        isOurs: s.isOurs || rules.any((r) => r is MarkAsOurs && r.matches(s)),
+      ),
   ];
 }

--- a/packages/wisa_api/test/models/models_equality_test.dart
+++ b/packages/wisa_api/test/models/models_equality_test.dart
@@ -121,6 +121,26 @@ void main() {
       expect(a.copyWith().isVirtual, isFalse);
     });
 
+    test('isOurs participates in equality and copyWith and round-trips', () {
+      const a = WisaSchool(id: 1, name: 'SMA', description: 'X');
+      const managed = WisaSchool(
+        id: 1,
+        name: 'SMA',
+        description: 'X',
+        isOurs: true,
+      );
+      expect(a, isNot(managed));
+      expect(a.copyWith(isOurs: true).isOurs, isTrue);
+      expect(a.copyWith().isOurs, isFalse);
+      expect(WisaSchool.fromJson(managed.toJson()), managed);
+      // Old snapshots without the key default to not-ours.
+      expect(
+        WisaSchool.fromJson(const {'id': 1, 'name': 'SMA', 'description': 'X'})
+            .isOurs,
+        isFalse,
+      );
+    });
+
     test('toString includes id, name, and virtual flag', () {
       const a = WisaSchool(id: 1, name: 'SMA', description: 'X');
       final s = a.toString();

--- a/packages/wisa_api/test/rules/import_rules_test.dart
+++ b/packages/wisa_api/test/rules/import_rules_test.dart
@@ -88,6 +88,38 @@ void main() {
     });
   });
 
+  group('MarkAsOurs', () {
+    test('flips isOurs on matching school name only', () {
+      const schools = [
+        WisaSchool(id: 1, name: 'SMA', description: 'Sint Maria'),
+        WisaSchool(id: 2, name: 'SDK', description: 'Sint Dimphna'),
+      ];
+      final out = applyRulesToSchools(schools, const [MarkAsOurs('SMA')]);
+      expect(out[0].isOurs, isTrue);
+      expect(out[1].isOurs, isFalse);
+      // No cross-contamination with the virtual marker.
+      expect(out[0].isVirtual, isFalse);
+    });
+
+    test('MarkAsVirtual and MarkAsOurs flag independently on one school', () {
+      const schools = [WisaSchool(id: 1, name: 'SMA', description: 'X')];
+      final out = applyRulesToSchools(
+        schools,
+        const [MarkAsVirtual('SMA'), MarkAsOurs('SMA')],
+      );
+      expect(out.single.isVirtual, isTrue);
+      expect(out.single.isOurs, isTrue);
+    });
+
+    test('is a no-op for class groups and staff', () {
+      final groups = [_g('1A')];
+      expect(
+          applyRulesToClassGroups(groups, const [MarkAsOurs('SMA')]), groups);
+      final staff = [_s('AAAAA')];
+      expect(applyRulesToStaff(staff, const [MarkAsOurs('SMA')]), staff);
+    });
+  });
+
   group('rule interactions', () {
     test('ReplaceInstitute then DontImportClass on same class group', () {
       // 1A gets its institute rewritten, then is filtered out.


### PR DESCRIPTION
## Summary

Foundation slice of #113. Marks **which** WISA schools we manage (`ours`) vs. merely group-visible, persists that in the settings document, and carries the marker through the sync pipeline — with **no change to action behaviour yet**. This is the data plumbing #113's leave-detection logic (slice 2/3, #134) needs.

## Linked issue

Closes #133

## Changes

- **`WisaSchool.isOurs`** — a new managed marker mirroring `isVirtual` (constructor, `toJson`/`fromJson`, `copyWith`, equality, `toString`), defaulting `false` so older cold snapshots keep loading.
- **`MarkAsOurs` import rule** paralleling `MarkAsVirtual`: `applyRulesToSchools` now flips `isVirtual`/`isOurs` independently; a school can carry both. Added the JSON codec tag (`markAsOurs`) and the `WisaImportRules` de-dupe key.
- **`WisaSchoolProfile` + `AppSettings.wisaSchools`** — a `List<WisaSchoolProfile>` of `{ schoolId, ours, prefix }`, the per-WISA-school ownership link shape #112/#113 called for, with `toJson`/`fromJson` round-trip (survives the in-memory / file / Cosmos stores unchanged, since they reuse `AppSettings.toJson`). Global `schoolPrefix` is untouched (INV-22 preserved); `prefix` is an override to grow into.
- **Settings view** — a new "WISA-scholen (beheerd)" section to toggle a school's managed flag and add/remove schools by id.

Per-school **student membership already flows** via `WisaStudent.schoolId` (each row is tagged with the school it was pulled from), so slice 2 can join `student.schoolId → school.isOurs` — no snapshot reshape needed. Azure is already pulled in full by the existing bootstrap.

## Explicitly out of scope

No change to `StudentAction` evaluation — behaviour-preserving for the existing dispatch/link suites (that is #134).

## Test plan

- [x] `dart format --set-exit-if-changed .` clean (265 files, 0 changed)
- [x] `dart analyze` clean across the whole workspace
- [x] Unit tests: `MarkAsOurs` rule (flips only matching school; independent of virtual; no-op for groups/staff) + `WisaSchool.isOurs` equality/copyWith/JSON default; `AppSettings`/store round-trip of the ownership list incl. an older-config-defaults-empty case. `wisa_api` 117 pass, `account_state` 262 pass.
- [x] Widget tests: Settings view toggles a seeded school's `ours` flag and adds one by id, both round-tripping to `InMemorySettingsStore`. `account_manager` 132 pass.
- [x] Integration test: `flutter test integration_test -d windows` — new "marks a WISA school as ours end-to-end" scenario drives the real app (scroll, toggle, save) and asserts the flag persists; full suite 17 pass.