### PR TITLE
Linker/action-engine: remove-Smartschool vs delete-both for group-wide leave (#134)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -238,6 +238,58 @@ void main() {
   });
 
   testWidgets(
+      'a student who left our school but stayed in the group shows the '
+      'Smartschool departure and keeps Azure end-to-end (#134)',
+      (WidgetTester tester) async {
+    // The student is still in our Smartschool + Azure, but their WISA record now
+    // sits only in a sibling group school we do not manage. The dispatcher must
+    // raise the Smartschool departure while keeping Azure — never a removal.
+    useTallWindow(tester);
+    final harness = movedToSiblingHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // The departed student is a pending entry carrying the unregister/delete
+    // choice — and no Azure removal anywhere in the pending set.
+    final entry = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student');
+    expect(entry.choices.single.isChoice, isTrue);
+    expect(find.byKey(ValueKey('entry-student-${entry.targetId}')),
+        findsOneWidget);
+    final allKinds = harness.controller.pendingEntries
+        .expand((e) => e.choices)
+        .expand((c) => c.alternatives)
+        .map((a) => a.kind);
+    expect(allKinds, isNot(contains('RemoveStudentFromAzure')),
+        reason: 'the account is still in the group ⇒ Azure is kept');
+
+    // Apply for real: the Smartschool departure writes against the recording
+    // SOAP transport; Azure (Graph) is never called.
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-apply')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-apply')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Apply result'), findsOneWidget);
+    expect(harness.soap.soapActions, isNotEmpty);
+    expect(harness.graph.requests, isEmpty, reason: 'Azure account is kept');
+    final summaries =
+        harness.controller.applyResults!.map((r) => r.changes.summary);
+    expect(summaries, contains('Schrijf de leerling uit in Smartschool'));
+    expect(summaries, isNot(contains('Verwijder Azure account')));
+  });
+
+  testWidgets(
       'a large pending set virtualizes in the real app: only a bounded number '
       'of entry tiles build, and scrolling loads more (#111)',
       (WidgetTester tester) async {

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -70,6 +70,7 @@ class RecordingGraph implements az.GraphTransport {
 wapi.WisaStudent wisaStudent({
   String wisaId = '1',
   String classGroup = '3C',
+  int schoolId = 1,
 }) =>
     wapi.WisaStudent(
       wisaId: core.WisaId(wisaId),
@@ -86,8 +87,13 @@ wapi.WisaStudent wisaStudent({
       nationality: '',
       address: _addr,
       classChange: kFixtureDate,
-      schoolId: 1,
+      schoolId: schoolId,
     );
+
+/// A WISA school, optionally flagged [ours] (the managed-school signal the
+/// linker joins student `schoolId` against, #133/#134).
+wapi.WisaSchool wisaSchool(int id, {bool ours = false}) =>
+    wapi.WisaSchool(id: id, name: 'School $id', description: '', isOurs: ours);
 
 ss.SmartschoolAccount ssAccount({
   String uid = 'jane',
@@ -151,13 +157,14 @@ ss.SmartschoolMembership member(String uid, String groupCode) =>
 wapi.WisaSnapshot wisaSnap({
   DateTime? fetchedAt,
   List<wapi.WisaStudent>? students,
+  List<wapi.WisaSchool> schools = const [],
 }) =>
     wapi.WisaSnapshot(
       fetchedAt: fetchedAt ?? kFixtureDate,
       students: students ?? [wisaStudent()],
       staff: const [],
       classGroups: const [],
-      schools: const [],
+      schools: schools,
     );
 
 ss.SmartschoolSnapshot ssSnap({
@@ -225,6 +232,24 @@ ReconcileHarness manyDepartedHarness({int count = 2000}) => ReconcileHarness(
         memberships: const [],
       ),
       azure: azSnap(users: const []),
+    );
+
+/// A reconcile harness for the group-wide-leave keep-Azure case (#134): one
+/// student still in *our* Smartschool and Azure, but whose WISA record now sits
+/// only in a sibling group school (id 2) we don't manage — school 1 is flagged
+/// ours. The dispatcher must raise the Smartschool departure (unregister/delete)
+/// while **keeping** Azure (no `RemoveStudentFromAzure`).
+ReconcileHarness movedToSiblingHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(schoolId: 2)],
+        schools: [wisaSchool(1, ours: true), wisaSchool(2)],
+      ),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: [ssAccount()],
+        memberships: const [],
+      ),
+      azure: azSnap(users: [azUser()]),
     );
 
 az.AzureSnapshot azSnap({DateTime? fetchedAt, List<az.AzureUser>? users}) =>

--- a/account_manager/test/reconcile/reconcile_keep_azure_test.dart
+++ b/account_manager/test/reconcile/reconcile_keep_azure_test.dart
@@ -1,0 +1,62 @@
+import 'package:account_actions/account_actions.dart' as actions;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'reconcile_fakes.dart';
+
+/// #134 — a student who left *our* school but is still in a sibling group
+/// school surfaces the Smartschool departure in the reconcile pending list yet
+/// **keeps** their Azure account (no `RemoveStudentFromAzure`), and applying the
+/// departure never touches Azure. Mirrors `reconcile_pending_choice_test`.
+void main() {
+  group('keep-Azure sibling-school departure (#134)', () {
+    test(
+        'the departed student raises the Smartschool unregister/delete choice, '
+        'never an Azure removal', () async {
+      final h = movedToSiblingHarness();
+      await h.controller.sync();
+
+      final entry =
+          h.controller.pendingEntries.firstWhere((e) => e.family == 'student');
+      final choice = entry.choices.single;
+      expect(choice.isChoice, isTrue);
+      expect(
+        choice.alternatives.map((a) => a.kind),
+        containsAll(<String>[
+          'UnregisterStudentFromSmartschool',
+          'DeleteStudentFromSmartschool',
+        ]),
+      );
+      expect(choice.selected.kind, 'UnregisterStudentFromSmartschool',
+          reason: 'unregister (keep the account) is the safe default');
+
+      // No Azure removal anywhere in the pending set — the account is kept.
+      final allKinds = h.controller.pendingEntries
+          .expand((e) => e.choices)
+          .expand((c) => c.alternatives)
+          .map((a) => a.kind);
+      expect(allKinds, isNot(contains('RemoveStudentFromAzure')));
+    });
+
+    test('applying the departure writes to Smartschool and never touches Azure',
+        () async {
+      final h = movedToSiblingHarness();
+      await h.controller.sync();
+      final entry =
+          h.controller.pendingEntries.firstWhere((e) => e.family == 'student');
+
+      await h.controller.applyEntry(entry);
+
+      final summaries =
+          h.controller.applyResults!.map((r) => r.changes.summary).toList();
+      expect(summaries, contains('Schrijf de leerling uit in Smartschool'));
+      expect(summaries, isNot(contains('Verwijder Azure account')));
+      expect(
+        h.controller.applyResults!.map((r) => r.outcome),
+        everyElement(actions.ActionOutcome.applied),
+      );
+      // The real Smartschool write ran; Azure (Graph) was never called.
+      expect(h.soap.soapActions, isNotEmpty);
+      expect(h.graph.requests, isEmpty, reason: 'Azure account is kept');
+    });
+  });
+}

--- a/packages/account_actions/lib/src/student_action.dart
+++ b/packages/account_actions/lib/src/student_action.dart
@@ -113,7 +113,7 @@ class AddStudentToAzure extends StudentAction {
   const AddStudentToAzure(super.account, super.config);
 
   @override
-  bool evaluate() => account.wisa != null && account.azure == null;
+  bool evaluate() => account.isInOurWisa && account.azure == null;
 
   @override
   ChangeSet describeChanges() {
@@ -215,7 +215,7 @@ class AddStudentToSmartschool extends StudentAction {
 
   @override
   bool evaluate() =>
-      account.wisa != null &&
+      account.isInOurWisa &&
       account.azure != null &&
       account.smartschool == null;
 
@@ -336,13 +336,15 @@ class AddStudentToSmartschool extends StudentAction {
 }
 
 /// Unregister (but keep) a still-active Smartschool account whose student has
-/// left WISA. Ported from `Action\StudentAccount\UnregisterSmartschool`.
+/// left *our* school — gone from WISA entirely, or moved to a sibling group
+/// school we don't manage (#134). Ported from
+/// `Action\StudentAccount\UnregisterSmartschool`.
 class UnregisterStudentFromSmartschool extends StudentAction {
   const UnregisterStudentFromSmartschool(super.account, super.config);
 
   @override
   bool evaluate() =>
-      account.wisa == null &&
+      account.hasLeftOurSchool &&
       account.smartschool != null &&
       _ss.status == 'actief';
 
@@ -403,13 +405,14 @@ class UnregisterStudentFromSmartschool extends StudentAction {
   }
 }
 
-/// Delete a Smartschool account whose student no longer exists in WISA. Ported
-/// from `Action\StudentAccount\DeleteFromSmartschool`.
+/// Delete a Smartschool account whose student has left *our* school — gone from
+/// WISA entirely, or moved to a sibling group school we don't manage (#134).
+/// Ported from `Action\StudentAccount\DeleteFromSmartschool`.
 class DeleteStudentFromSmartschool extends StudentAction {
   const DeleteStudentFromSmartschool(super.account, super.config);
 
   @override
-  bool evaluate() => account.wisa == null && account.smartschool != null;
+  bool evaluate() => account.hasLeftOurSchool && account.smartschool != null;
 
   /// Delete and [UnregisterStudentFromSmartschool] are the two mutually
   /// exclusive resolutions of a WISA-departed Smartschool account (#110). Delete
@@ -465,15 +468,20 @@ class DeleteStudentFromSmartschool extends StudentAction {
   }
 }
 
-/// Delete an Azure-only account for a former student (no WISA, no Smartschool)
-/// carrying the school's `companyName`. Ported from
-/// `Action\StudentAccount\RemoveFromAzure`.
+/// Delete an Azure-only account for a student gone from the **whole group** (no
+/// WISA anywhere, no Smartschool) carrying the school's `companyName`. Ported
+/// from `Action\StudentAccount\RemoveFromAzure`.
+///
+/// A student who merely left *our* school but is still present in a sibling
+/// group school keeps a non-null WISA record ([WisaPresence.groupOnly]), so
+/// [LinkedAccount.hasLeftGroup] is false and their Azure account is **kept**
+/// (#134) — only a genuine group-departure removes it.
 class RemoveStudentFromAzure extends StudentAction {
   const RemoveStudentFromAzure(super.account, super.config);
 
   @override
   bool evaluate() =>
-      account.wisa == null &&
+      account.hasLeftGroup &&
       account.smartschool == null &&
       account.azure != null &&
       _eq(_az.companyName, config.schoolPrefix);

--- a/packages/account_actions/lib/src/student_dispatch.dart
+++ b/packages/account_actions/lib/src/student_dispatch.dart
@@ -31,11 +31,15 @@ List<StudentAction> studentActionsFor(
   StudentActionConfig config, {
   ClassPlacement Function(LinkedAccount account)? placementFor,
 }) {
-  final complete = account.wisa != null &&
+  // "Complete" (modify branch) requires presence in *our* WISA, not merely
+  // anywhere in the group (#134): a student who moved to a sibling group school
+  // still carries a WISA record but must fall to the lifecycle branch so the
+  // Smartschool departure fires (while their Azure account is kept).
+  final complete = account.isInOurWisa &&
       account.smartschool != null &&
       account.azure != null;
 
-  final placement = (placementFor != null && account.wisa != null)
+  final placement = (placementFor != null && account.isInOurWisa)
       ? placementFor(account)
       : null;
 

--- a/packages/account_actions/test/student_apply_test.dart
+++ b/packages/account_actions/test/student_apply_test.dart
@@ -187,4 +187,58 @@ void main() {
       expect(smartschool.accountId, 'W9');
     });
   });
+
+  group('group-wide leave: applying the dispatched resolution (#134)', () {
+    test(
+        'keep-Azure — a sibling-school departure applies the Smartschool '
+        'unregister and leaves Azure untouched', () async {
+      final soap = RecordingSmartschoolTransport();
+      final graph = RecordingGraphTransport();
+      final connectors = Connectors(
+        smartschool: smartschoolConnector(soap),
+        azure: azureConnector(graph),
+      );
+      // The student moved to a sibling group school: all three systems present,
+      // but WISA only in a school we don't manage (groupOnly).
+      final account = linked(
+        wisa: wisaStudent(),
+        smartschool: ssAccount(status: 'actief'),
+        azure: azureUser(companyName: 'SSM'),
+        wisaPresence: WisaPresence.groupOnly,
+        wisaSchoolIds: const {2},
+      );
+      final dispatched = studentActionsFor(account, cfg);
+
+      // Apply the safe default (unregister) — never the Azure removal.
+      final unregister =
+          dispatched.whereType<UnregisterStudentFromSmartschool>().single;
+      final result = await unregister.apply(connectors, const ApplyOptions());
+
+      expect(result.outcome, ActionOutcome.applied);
+      expect(result.system, Origin.smartschool);
+      expect(soap.soapActions, isNotEmpty, reason: 'the unregister ran');
+      // Azure was never touched — the account is kept.
+      expect(graph.requests, isEmpty);
+      expect(dispatched.whereType<RemoveStudentFromAzure>(), isEmpty);
+    });
+
+    test(
+        'delete-both — a whole-group departure with only Azure left applies '
+        'the Azure removal', () async {
+      final graph = RecordingGraphTransport();
+      final connectors = Connectors(azure: azureConnector(graph));
+      // Absent from WISA everywhere, no Smartschool: the terminal delete-both
+      // stage the two-phase resolution reaches once Smartschool is gone.
+      final account =
+          linked(azure: azureUser(id: 'az-gone', companyName: 'SSM'));
+      final dispatched = studentActionsFor(account, cfg);
+
+      final remove = dispatched.whereType<RemoveStudentFromAzure>().single;
+      final result = await remove.apply(connectors, const ApplyOptions());
+
+      expect(result.outcome, ActionOutcome.applied);
+      expect(result.removed, isTrue);
+      expect(graph.sent('DELETE', pathContains: 'az-gone'), isTrue);
+    });
+  });
 }

--- a/packages/account_actions/test/student_dispatch_test.dart
+++ b/packages/account_actions/test/student_dispatch_test.dart
@@ -1,4 +1,5 @@
 import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
 import 'package:test/test.dart';
 
 import 'support/fixtures.dart';
@@ -147,6 +148,99 @@ void main() {
       );
       expect(actions.whereType<AddStudentToAzure>(), isEmpty);
       expect(actions.whereType<DeleteStudentFromSmartschool>(), isEmpty);
+    });
+  });
+
+  group('dispatch §6.3 — group-wide leave detection (#134)', () {
+    test(
+        'a student moved to a sibling group school → Smartschool departure, '
+        'NOT RemoveStudentFromAzure (Azure is kept)', () {
+      // All three systems carry the student, but their WISA record is only in a
+      // sibling school we do not manage (groupOnly). Pre-#134 this looked
+      // "complete" and yielded no departure at all.
+      final actions = studentActionsFor(
+        linked(
+          wisa: wisaStudent(),
+          smartschool: ssAccount(status: 'actief'),
+          azure: azureUser(companyName: 'SSM'),
+          wisaPresence: WisaPresence.groupOnly,
+          wisaSchoolIds: const {2},
+        ),
+        cfg,
+      );
+      expect(
+        types(actions),
+        [UnregisterStudentFromSmartschool, DeleteStudentFromSmartschool],
+      );
+      expect(actions.whereType<RemoveStudentFromAzure>(), isEmpty,
+          reason: 'still in the group ⇒ Azure removal is suppressed');
+      // Nor any modify action: a departure is never the modify branch.
+      expect(actions.whereType<ModifyAzureName>(), isEmpty);
+    });
+
+    test(
+        'a sibling-school student already removed from our Smartschool keeps '
+        'Azure: no action at all', () {
+      // The settled keep-Azure end state: gone from our Smartschool, WISA still
+      // in a sibling school, Azure retained. Nothing further must fire — in
+      // particular not AddStudentToSmartschool (never re-add a departed student)
+      // nor RemoveStudentFromAzure.
+      final actions = studentActionsFor(
+        linked(
+          wisa: wisaStudent(),
+          azure: azureUser(companyName: 'SSM'),
+          wisaPresence: WisaPresence.groupOnly,
+          wisaSchoolIds: const {2},
+        ),
+        cfg,
+      );
+      expect(actions, isEmpty);
+    });
+
+    test(
+        'a student gone from the whole group (still in our Smartschool) → '
+        'Smartschool departure, Azure removal deferred until SS is gone', () {
+      // No WISA anywhere (absent). Smartschool + Azure still present. Legacy
+      // gates Azure removal behind !Smartschool.Exists, so this pass yields only
+      // the Smartschool departure.
+      final actions = studentActionsFor(
+        linked(
+          smartschool: ssAccount(status: 'actief'),
+          azure: azureUser(companyName: 'SSM'),
+        ),
+        cfg,
+      );
+      expect(
+        types(actions),
+        [UnregisterStudentFromSmartschool, DeleteStudentFromSmartschool],
+      );
+      expect(actions.whereType<RemoveStudentFromAzure>(), isEmpty);
+    });
+
+    test(
+        'a student gone from the whole group with only Azure left → '
+        'RemoveStudentFromAzure (delete-both completes)', () {
+      final actions = studentActionsFor(
+        linked(azure: azureUser(companyName: 'SSM')),
+        cfg,
+      );
+      expect(types(actions), [RemoveStudentFromAzure]);
+    });
+
+    test(
+        'a WISA-only sibling-school student is never provisioned into our '
+        'systems (no AddStudentToAzure)', () {
+      // A student present only in a sibling group school, with nothing of ours
+      // yet. They are not ours, so we must not create Azure/Smartschool accounts.
+      final actions = studentActionsFor(
+        linked(
+          wisa: wisaStudent(),
+          wisaPresence: WisaPresence.groupOnly,
+          wisaSchoolIds: const {2},
+        ),
+        cfg,
+      );
+      expect(actions, isEmpty);
     });
   });
 }

--- a/packages/account_actions/test/support/fixtures.dart
+++ b/packages/account_actions/test/support/fixtures.dart
@@ -125,11 +125,18 @@ az.AzureUser azureUser({
 
 /// Builds a [LinkedAccount] from optional per-system records. Omit a system to
 /// simulate it missing (drives the lifecycle-action branch).
+///
+/// [wisaPresence] controls the ours-vs-group classification (#134): the default
+/// [WisaPresence.ours] means a WISA-present student is one of ours (pre-#134
+/// behaviour), while [WisaPresence.groupOnly] models a student who moved to a
+/// sibling group school we don't manage.
 LinkedAccount linked({
   wapi.WisaStudent? wisa,
   ss.SmartschoolAccount? smartschool,
   az.AzureUser? azure,
   String id = 'p0',
+  WisaPresence wisaPresence = WisaPresence.ours,
+  Set<int> wisaSchoolIds = const <int>{},
 }) =>
     LinkedAccount(
       id: LinkedAccountId(id),
@@ -138,6 +145,8 @@ LinkedAccount linked({
       smartschool: smartschool,
       azure: azure,
       confidence: LinkConfidence.high,
+      wisaPresence: wisaPresence,
+      wisaSchoolIds: wisaSchoolIds,
     );
 
 /// A fully-synced student present in all three systems with matching fields —

--- a/packages/account_core/lib/src/linked.dart
+++ b/packages/account_core/lib/src/linked.dart
@@ -23,6 +23,35 @@ enum LinkConfidence {
   static LinkConfidence fromJson(String s) => values.byName(s);
 }
 
+/// Where a linked student sits in the *aggregated* WISA snapshot relative to
+/// the schools we actually manage (#113/#134).
+///
+/// The shared credentials pull **every** WISA school the group can see, so a
+/// student's [LinkedAccount.wisa] being non-null only means they are somewhere
+/// in the group — not necessarily in one of our schools. This enum makes the
+/// distinction the departure actions turn on:
+///
+/// - [ours]: present in WISA in at least one school we manage — the normal
+///   "still here" case. Also the backward-compatible default when no school is
+///   flagged as ours (ownership unconfigured ⇒ every WISA-present student is
+///   treated as ours), so a group that hasn't adopted the aggregated pull keeps
+///   its pre-#134 behaviour.
+/// - [groupOnly]: present in the aggregated snapshot but only in sibling group
+///   schools we do **not** manage. The student left *our* school yet is still in
+///   the group — remove them from *our* Smartschool but **keep** Azure.
+/// - [absent]: no WISA record at all — gone from the whole group. Remove from
+///   Smartschool *and* Azure (the "incomplete Azure-only record flagged for
+///   deletion", per the no-alumni rule).
+enum WisaPresence {
+  ours,
+  groupOnly,
+  absent,
+  ;
+
+  String toJson() => name;
+  static WisaPresence fromJson(String s) => values.byName(s);
+}
+
 /// Output of the linker: one record per identified person.
 ///
 /// Any of [wisa], [smartschool], [azure] may be null; when all three are
@@ -36,6 +65,19 @@ class LinkedAccount {
   final AzureUser? azure;
   final LinkConfidence confidence;
 
+  /// The WISA school ids this student's record was found in — the raw
+  /// per-school membership the linker joins against the managed-school set
+  /// (#133). Empty when [wisa] is null. Retained on the record so the ours-vs-
+  /// group distinction is auditable, not just its derived [wisaPresence].
+  final Set<int> wisaSchoolIds;
+
+  /// Where this student sits relative to the schools we manage — the signal the
+  /// departure actions turn on (#134). Defaults to [WisaPresence.ours]; the
+  /// convenience getters below always fold in [wisa] nullness, so a hand-built
+  /// record left on the default but carrying no WISA record still reads as
+  /// having left.
+  final WisaPresence wisaPresence;
+
   const LinkedAccount({
     required this.id,
     required this.role,
@@ -43,7 +85,25 @@ class LinkedAccount {
     this.smartschool,
     this.azure,
     required this.confidence,
+    this.wisaSchoolIds = const <int>{},
+    this.wisaPresence = WisaPresence.ours,
   });
+
+  /// Whether this student is present in WISA in a school we manage. False when
+  /// absent from WISA entirely or present only in sibling group schools.
+  bool get isInOurWisa => wisa != null && wisaPresence == WisaPresence.ours;
+
+  /// Whether this student has left the schools we manage — moved to a sibling
+  /// group school, or gone from the group entirely. Drives the Smartschool
+  /// departure actions (unregister / delete).
+  bool get hasLeftOurSchool => !isInOurWisa;
+
+  /// Whether this student is gone from the **entire** group — absent from the
+  /// aggregated WISA snapshot. Drives the delete-both vs keep-Azure split: only
+  /// a group-departure removes the Azure account. A student still present in a
+  /// sibling group school ([WisaPresence.groupOnly]) keeps a non-null [wisa],
+  /// so this is false and their Azure removal is suppressed.
+  bool get hasLeftGroup => wisa == null;
 }
 
 /// Output of the linker: one record per identified staff member.

--- a/packages/account_core/test/linked_test.dart
+++ b/packages/account_core/test/linked_test.dart
@@ -90,6 +90,76 @@ void main() {
     expect(alumni.azure, isNotNull);
   });
 
+  group('WisaPresence classification getters (#134)', () {
+    const wisa = _FakeWisaStudent(WisaId('w-1'));
+    const ss = _FakeSmartschoolAccount(
+      uid: 'a',
+      mail: 'a@s.be',
+      accountId: 'w-1',
+      accountType: AccountType.student,
+    );
+    const az = _FakeAzureUser(id: 'az-1', upn: 'a@s.be', employeeId: 'w-1');
+
+    test('present in our WISA → in our WISA, not left', () {
+      const acc = LinkedAccount(
+        id: LinkedAccountId('la-ours'),
+        role: PersonRole.student,
+        wisa: wisa,
+        smartschool: ss,
+        azure: az,
+        confidence: LinkConfidence.high,
+        wisaSchoolIds: {1},
+      );
+      expect(acc.isInOurWisa, isTrue);
+      expect(acc.hasLeftOurSchool, isFalse);
+      expect(acc.hasLeftGroup, isFalse);
+      expect(acc.wisaSchoolIds, {1});
+    });
+
+    test('moved to a sibling group school → left our school, still in group',
+        () {
+      const acc = LinkedAccount(
+        id: LinkedAccountId('la-group'),
+        role: PersonRole.student,
+        wisa: wisa,
+        smartschool: ss,
+        azure: az,
+        confidence: LinkConfidence.medium,
+        wisaSchoolIds: {2},
+        wisaPresence: WisaPresence.groupOnly,
+      );
+      expect(acc.isInOurWisa, isFalse);
+      expect(acc.hasLeftOurSchool, isTrue);
+      // Still somewhere in the group ⇒ not a group-departure (Azure is kept).
+      expect(acc.hasLeftGroup, isFalse);
+    });
+
+    test(
+        'no WISA record → gone from the whole group, regardless of the '
+        'default presence enum', () {
+      // The default WisaPresence.ours must not leak through when there is no
+      // WISA record: the getters fold in wisa-nullness.
+      const acc = LinkedAccount(
+        id: LinkedAccountId('la-absent'),
+        role: PersonRole.student,
+        azure: az,
+        confidence: LinkConfidence.medium,
+      );
+      expect(acc.wisaPresence, WisaPresence.ours,
+          reason: 'the field default, deliberately masked by the getters');
+      expect(acc.isInOurWisa, isFalse);
+      expect(acc.hasLeftOurSchool, isTrue);
+      expect(acc.hasLeftGroup, isTrue);
+      expect(acc.wisaSchoolIds, isEmpty);
+    });
+
+    test('WisaPresence round-trips through JSON', () {
+      for (final p in WisaPresence.values) {
+        expect(WisaPresence.fromJson(p.toJson()), p);
+      }
+    });
+  });
+
   test('LinkedStaff distinguishes from LinkedAccount via WisaStaff', () {
     const staff = LinkedStaff(
       id: LinkedAccountId('ls-1'),

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -46,13 +46,29 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 /// [schoolPrefix] is the Azure `companyName` value the school stamps on its
 /// own users; an Azure-only user carrying it is a former student kept as an
 /// incomplete record so the action engine can flag it for deletion (INV-22).
+/// [ourSchoolIds] is the set of WISA school ids we actually **manage** (#133).
+/// The shared credentials pull every group school, so this set is what tells a
+/// student who left *our* school (but is still in a sibling group school) from
+/// one who is genuinely present here. When null, it is derived from the
+/// snapshot's own `WisaSchool.isOurs` flags (the `MarkAsOurs` import rule). When
+/// that derived set is also empty — ownership unconfigured — every WISA-present
+/// student is treated as ours, preserving the pre-#134 behaviour. Membership
+/// never changes which records exist or their identity keys, only how each is
+/// classified ([WisaPresence]).
 LinkedSnapshot link(
   wapi.WisaSnapshot wisaSnapshot,
   ss.SmartschoolSnapshot smartschoolSnapshot,
   az.AzureSnapshot azureSnapshot,
   PersonIdResolver resolver, {
   required String schoolPrefix,
+  Set<int>? ourSchoolIds,
 }) {
+  final effectiveOurSchoolIds = ourSchoolIds ??
+      <int>{
+        for (final school in wisaSnapshot.schools)
+          if (school.isOurs) school.id,
+      };
+
   // Build the student and staff records first, in that order, so the two
   // populations' duplicate-mail warnings accumulate student-then-staff exactly
   // as before. Group linking carries no identity, so it stays separate.
@@ -84,6 +100,8 @@ LinkedSnapshot link(
         smartschool: rec.smartschool,
         azure: rec.azure,
         confidence: _confidence(rec),
+        wisaSchoolIds: rec.wisaSchoolIds,
+        wisaPresence: _presence(rec.wisaSchoolIds, effectiveOurSchoolIds),
       ),
   ];
   final staff = <LinkedStaff>[
@@ -203,8 +221,10 @@ List<_Record> _buildStudentRecords(
     final match = key == null ? null : byWisaId[key];
     if (match != null && match.wisa == null) {
       match.wisa = student;
+      match.wisaSchoolIds.add(student.schoolId);
     } else {
-      final placeholder = _Record(wisa: student);
+      final placeholder = _Record(wisa: student)
+        ..wisaSchoolIds.add(student.schoolId);
       records.add(placeholder);
       if (key != null) byWisaId.putIfAbsent(key, () => placeholder);
     }
@@ -495,6 +515,11 @@ class _Record {
   wapi.WisaStudent? wisa;
   az.AzureUser? azure;
 
+  /// The WISA school ids this record's student was found in — accumulated as
+  /// WISA rows attach (a single id in the common case; more only for a student
+  /// enrolled across group schools). Frozen onto [LinkedAccount.wisaSchoolIds].
+  final Set<int> wisaSchoolIds = <int>{};
+
   _Record({this.smartschool, this.wisa, this.azure});
 }
 
@@ -536,6 +561,22 @@ String? _norm(String? value) {
   if (value == null) return null;
   final trimmed = value.trim();
   return trimmed.isEmpty ? null : trimmed.toLowerCase();
+}
+
+/// Classifies a student's WISA presence (#134) from the [wisaSchoolIds] its
+/// record was found in and the set of schools we manage ([ourSchoolIds]).
+///
+/// No WISA record ⇒ [WisaPresence.absent] (gone from the whole group). When
+/// [ourSchoolIds] is empty the ownership link is unconfigured, so any WISA
+/// presence counts as [WisaPresence.ours] — the pre-#134 behaviour. Otherwise a
+/// record is [WisaPresence.ours] when it was found in at least one managed
+/// school, and [WisaPresence.groupOnly] when found only in sibling schools.
+WisaPresence _presence(Set<int> wisaSchoolIds, Set<int> ourSchoolIds) {
+  if (wisaSchoolIds.isEmpty) return WisaPresence.absent;
+  if (ourSchoolIds.isEmpty) return WisaPresence.ours;
+  return wisaSchoolIds.any(ourSchoolIds.contains)
+      ? WisaPresence.ours
+      : WisaPresence.groupOnly;
 }
 
 /// Whether an Azure user's [companyName] marks it as one of the school's own

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -1,6 +1,7 @@
 import 'package:account_core/account_core.dart';
 import 'package:account_linker/account_linker.dart';
 import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart' as wapi;
 
 import 'support/fixtures.dart';
 
@@ -634,6 +635,92 @@ void main() {
 
       expect(snapshot.accounts.single.smartschool?.uid, 'stagiair1');
       expect(snapshot.staff.single.smartschool?.uid, 'begeleider');
+    });
+  });
+
+  group('link — WISA-school membership + ours-vs-group (#134)', () {
+    /// A student fully linked across the three systems whose WISA row sits in
+    /// [schoolId]. [schools] carries the managed-school flags the linker derives
+    /// its ownership set from; [ourSchoolIds] overrides that derivation.
+    LinkedSnapshot linkStudentIn(
+      int schoolId, {
+      List<wapi.WisaSchool> schools = const [],
+      Set<int>? ourSchoolIds,
+    }) =>
+        link(
+          wisaSnap([wisaStudent('W1', schoolId: schoolId)], schools: schools),
+          ssSnap([ssAccount(uid: 'jane', accountId: 'W1', mail: 'jane@s.be')]),
+          azSnap([
+            azureUser(
+              id: 'az-1',
+              upn: 'jane@s.be',
+              employeeId: 'W1',
+              companyName: _prefix,
+            ),
+          ]),
+          SeqResolver(),
+          schoolPrefix: _prefix,
+          ourSchoolIds: ourSchoolIds,
+        );
+
+    test('the record retains the WISA school ids it was found in', () {
+      final a = linkStudentIn(7).accounts.single;
+      expect(a.wisaSchoolIds, {7});
+    });
+
+    test('ownership unconfigured → any WISA presence counts as ours', () {
+      // No managed-school flags anywhere: pre-#134 behaviour, every WISA-present
+      // student is ours.
+      final a = linkStudentIn(2).accounts.single;
+      expect(a.wisaPresence, WisaPresence.ours);
+      expect(a.isInOurWisa, isTrue);
+      expect(a.hasLeftOurSchool, isFalse);
+    });
+
+    test('present in a managed school (explicit set) → ours', () {
+      final a = linkStudentIn(1, ourSchoolIds: {1}).accounts.single;
+      expect(a.wisaPresence, WisaPresence.ours);
+      expect(a.isInOurWisa, isTrue);
+    });
+
+    test('present only in a sibling group school → groupOnly, has left ours',
+        () {
+      final a = linkStudentIn(2, ourSchoolIds: {1}).accounts.single;
+      expect(a.wisaPresence, WisaPresence.groupOnly);
+      expect(a.isInOurWisa, isFalse);
+      expect(a.hasLeftOurSchool, isTrue);
+      // Still in the group ⇒ not a group-departure.
+      expect(a.hasLeftGroup, isFalse);
+    });
+
+    test('the managed-school set is derived from WisaSchool.isOurs by default',
+        () {
+      // No explicit ourSchoolIds: the snapshot's own isOurs flags decide.
+      final ours = linkStudentIn(
+        1,
+        schools: [wisaSchool(1, ours: true), wisaSchool(2)],
+      ).accounts.single;
+      expect(ours.wisaPresence, WisaPresence.ours);
+
+      final sibling = linkStudentIn(
+        2,
+        schools: [wisaSchool(1, ours: true), wisaSchool(2)],
+      ).accounts.single;
+      expect(sibling.wisaPresence, WisaPresence.groupOnly);
+    });
+
+    test('a WISA-absent (Azure-only) record is classified absent', () {
+      final snapshot = link(
+        wisaSnap(const [], schools: [wisaSchool(1, ours: true)]),
+        ssSnap(const []),
+        azSnap([azureUser(id: 'az-9', upn: 'gone@s.be', companyName: _prefix)]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+      final a = snapshot.accounts.single;
+      expect(a.wisaPresence, WisaPresence.absent);
+      expect(a.wisaSchoolIds, isEmpty);
+      expect(a.hasLeftGroup, isTrue);
     });
   });
 }

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -18,9 +18,11 @@ const Address _blankAddress = Address(
   country: '',
 );
 
-/// A WISA student carrying only the fields the linker reads (`wisaId`); the
-/// rest are inert defaults.
-wapi.WisaStudent wisaStudent(String wisaId) => wapi.WisaStudent(
+/// A WISA student carrying only the fields the linker reads (`wisaId`,
+/// `schoolId`); the rest are inert defaults. [schoolId] selects which group
+/// school the student sits in (the ours-vs-group join, #134).
+wapi.WisaStudent wisaStudent(String wisaId, {int schoolId = 1}) =>
+    wapi.WisaStudent(
       wisaId: WisaId(wisaId),
       classGroup: '',
       classSubGroup: '',
@@ -35,8 +37,13 @@ wapi.WisaStudent wisaStudent(String wisaId) => wapi.WisaStudent(
       nationality: '',
       address: _blankAddress,
       classChange: _fixedDate,
-      schoolId: 1,
+      schoolId: schoolId,
     );
+
+/// A WISA school, optionally flagged [ours] (the `MarkAsOurs` import-rule
+/// outcome the linker derives the managed-school set from, #133/#134).
+wapi.WisaSchool wisaSchool(int id, {bool ours = false}) =>
+    wapi.WisaSchool(id: id, name: 'S$id', description: '', isOurs: ours);
 
 /// A Smartschool **student** account. [accountId] holds the WISA id by
 /// convention; [mail] is the Azure-UPN bridge.
@@ -177,13 +184,14 @@ wapi.WisaSnapshot wisaSnap(
   List<wapi.WisaStudent> students, {
   List<wapi.WisaStaff> staff = const [],
   List<wapi.WisaClassGroup> classGroups = const [],
+  List<wapi.WisaSchool> schools = const [],
 }) =>
     wapi.WisaSnapshot(
       fetchedAt: _fixedDate,
       students: students,
       staff: staff,
       classGroups: classGroups,
-      schools: const [],
+      schools: schools,
     );
 
 ss.SmartschoolSnapshot ssSnap(


### PR DESCRIPTION
## Summary

Slice 2/3 of the group-wide leave detection epic (#113), on top of the
per-WISA-school "ours" plumbing merged in #133. Teaches the linker and the
Student action family to distinguish a student who **left our school but is
still in a sibling group school** (→ remove from *our* Smartschool, **keep**
Azure) from one who **left the whole group** (→ delete both).

The old departure signal was the single predicate `account.wisa == null`. Because
the WISA snapshot is aggregated across every group school, a student who moved to a
sibling school had `wisa != null` and got **no departure action at all**. This
slice threads the managed-school set through `link()` and keys the actions on
*where* the WISA record sits.

## Linked issue

Closes #134

## Changes

- **`account_core`** — `WisaPresence { ours, groupOnly, absent }` enum;
  `LinkedAccount` gains `wisaSchoolIds` (raw per-school membership) and
  `wisaPresence`, plus `isInOurWisa` / `hasLeftOurSchool` / `hasLeftGroup`
  getters (they fold in `wisa`-nullness, so the field default never leaks).
- **`account_linker`** — `link()` gains an optional `ourSchoolIds` set,
  defaulting to the snapshot's own `WisaSchool.isOurs` flags. Empty ⇒ ownership
  unconfigured ⇒ every WISA-present student is treated as ours (pre-#134
  behaviour preserved). Each student record retains the WISA school ids it was
  found in; membership never changes which records exist or their identity keys.
- **`account_actions`** — dispatch "complete" (modify branch) now requires
  presence in *our* WISA, so a sibling-moved student falls to the lifecycle
  branch and the Smartschool departure fires. `Add*`/`Unregister`/`Delete` key on
  `isInOurWisa`/`hasLeftOurSchool`; `RemoveStudentFromAzure` keys on
  `hasLeftGroup`, so a student still present in the group has their Azure removal
  suppressed. The legacy two-phase delete-both (Smartschool first, Azure once
  Smartschool is gone) is preserved.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `flutter analyze` clean — no issues
- [x] Unit/widget tests pass: `account_core` + `account_linker` + `account_actions`
  (**224**, incl. new `linked_test` presence getters, `link_test` per-school
  membership + ours-vs-group, `student_dispatch_test` sibling keep-Azure vs
  whole-group delete-both, `student_apply_test` keep-Azure vs delete-both apply),
  `account_state` (**486**), `account_manager` (**134**, incl. new
  `reconcile_keep_azure_test` controller test).
- [x] Integration/e2e pass: `flutter test integration_test -d windows` (**18**),
  including a new #134 case driving the keep-Azure flow through the real app
  (sync → departure choice shown, no Azure removal → apply → Smartschool write,
  Graph untouched).
- [x] Confirmed the new dispatch tests **fail on the pre-fix logic** before
  relying on them.
