### PR TITLE
Split the Settings view into connector tabs (Algemeen, Wisa, Smartschool, Azure) (#140)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -69,6 +69,13 @@ void main() {
     addTearDown(tester.view.reset);
   }
 
+  /// Switches the Settings view to the tab with [tabKey] (#140: config is split
+  /// across Algemeen / Wisa / Smartschool / Azure tabs).
+  Future<void> openSettingsTab(WidgetTester tester, String tabKey) async {
+    await tester.tap(find.byKey(ValueKey(tabKey)));
+    await tester.pumpAndSettle();
+  }
+
   testWidgets('the app launches into the Plink-themed Home shell',
       (WidgetTester tester) async {
     // The real main(): with no --dart-define config, AAD is not configured, so
@@ -792,14 +799,17 @@ void main() {
     await tester.tap(find.text('Settings'));
     await tester.pumpAndSettle();
     expect(find.byType(SettingsScreen), findsOneWidget);
+    // The app-wide prefix shows on the default Algemeen tab.
     expect(find.text('OLD'), findsOneWidget);
-    expect(find.text('old.host'), findsOneWidget);
 
-    // Edit a profile field and enter a write-only secret, then save.
+    // Edit the app-wide prefix on Algemeen…
     await tester.enterText(
       find.byKey(const ValueKey('settings-school-prefix')),
       'GBS-KA',
     );
+    // …then the WISA connection + secret on the Wisa tab (#140).
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    expect(find.text('old.host'), findsOneWidget);
     await tester.enterText(
       find.byKey(const ValueKey('settings-wisa-server')),
       'wisa.new.host',
@@ -818,7 +828,8 @@ void main() {
     // …the secret went through the provider, not into the settings document…
     expect(await settings.secrets.read(passwordRef), 'typed-secret');
     expect(saved.toJson().toString(), isNot(contains('typed-secret')));
-    // …and the secret field was cleared, never echoing the value back.
+    // …and the secret field (still on the Wisa tab) was cleared, never echoing
+    // the value back.
     final field = tester.widget<TextField>(
       find.byKey(const ValueKey('settings-wisa-password')),
     );
@@ -848,25 +859,18 @@ void main() {
     await tester.tap(find.text('Settings'));
     await tester.pumpAndSettle();
     expect(find.byType(SettingsScreen), findsOneWidget);
-    // The WISA-schools section sits below the fold; the form is a lazy ListView,
-    // so scroll the switch into view (and build it) before reading it.
+    // The managed-school list lives under the Wisa tab now (#140); open it and
+    // bring the seeded school's switch into view before reading it.
+    await openSettingsTab(tester, 'settings-tab-wisa');
     final ourSwitch =
         find.byKey(const ValueKey('settings-wisa-school-42-ours'));
-    await tester.scrollUntilVisible(
-      ourSwitch,
-      400,
-      scrollable: find.byType(Scrollable).first,
-    );
+    await tester.ensureVisible(ourSwitch);
+    await tester.pumpAndSettle();
     expect(tester.widget<SwitchListTile>(ourSwitch).value, isFalse);
 
-    // Mark it managed and save.
+    // Mark it managed and save (the Save action sits in the shared header).
     await tester.tap(ourSwitch);
     await tester.pumpAndSettle();
-    await tester.scrollUntilVisible(
-      find.byKey(const ValueKey('settings-save')),
-      -400,
-      scrollable: find.byType(Scrollable).first,
-    );
     await tester.tap(find.byKey(const ValueKey('settings-save')));
     await tester.pumpAndSettle();
 

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -395,220 +395,298 @@ class _SettingsForm extends StatelessWidget {
     return Center(
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 760),
-        child: ListView(
-          padding: const EdgeInsets.symmetric(
-            horizontal: PlinkSpacing.s6,
-            vertical: PlinkSpacing.s6,
-          ),
-          children: <Widget>[
-            Eyebrow('Arcadia · instellingen', onInk: ink),
-            const SizedBox(height: PlinkSpacing.s4),
-            Text('Instellingen', style: text.headlineMedium),
-            const SizedBox(height: PlinkSpacing.s3),
-            Text(
-              'Bewerk de configuratie en bewaar. Wachtwoorden worden alleen '
-              'geschreven — laat een veld leeg om de bestaande waarde te '
-              'behouden.',
-              style: text.bodyMedium,
-            ),
-            const SizedBox(height: PlinkSpacing.s4),
-            Wrap(
-              spacing: PlinkSpacing.s3,
-              runSpacing: PlinkSpacing.s2,
-              crossAxisAlignment: WrapCrossAlignment.center,
-              children: <Widget>[
-                FilledButton.icon(
-                  key: const ValueKey('settings-save'),
-                  onPressed: state._busy ? null : state._save,
-                  icon: const Icon(Icons.save_outlined),
-                  label: const Text('Opslaan'),
+        child: DefaultTabController(
+          length: 4,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              // Shared header + actions: kept above the tabs so Save/Herladen
+              // act on the whole document regardless of the active tab.
+              Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  PlinkSpacing.s6,
+                  PlinkSpacing.s6,
+                  PlinkSpacing.s6,
+                  PlinkSpacing.s4,
                 ),
-                OutlinedButton.icon(
-                  key: const ValueKey('settings-reload'),
-                  onPressed: state._busy ? null : state._reload,
-                  icon: const Icon(Icons.refresh),
-                  label: const Text('Herladen'),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Eyebrow('Arcadia · instellingen', onInk: ink),
+                    const SizedBox(height: PlinkSpacing.s4),
+                    Text('Instellingen', style: text.headlineMedium),
+                    const SizedBox(height: PlinkSpacing.s3),
+                    Text(
+                      'Bewerk de configuratie en bewaar. Wachtwoorden worden '
+                      'alleen geschreven — laat een veld leeg om de bestaande '
+                      'waarde te behouden.',
+                      style: text.bodyMedium,
+                    ),
+                    const SizedBox(height: PlinkSpacing.s4),
+                    Wrap(
+                      spacing: PlinkSpacing.s3,
+                      runSpacing: PlinkSpacing.s2,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: <Widget>[
+                        FilledButton.icon(
+                          key: const ValueKey('settings-save'),
+                          onPressed: state._busy ? null : state._save,
+                          icon: const Icon(Icons.save_outlined),
+                          label: const Text('Opslaan'),
+                        ),
+                        OutlinedButton.icon(
+                          key: const ValueKey('settings-reload'),
+                          onPressed: state._busy ? null : state._reload,
+                          icon: const Icon(Icons.refresh),
+                          label: const Text('Herladen'),
+                        ),
+                      ],
+                    ),
+                    if (state._busy) ...<Widget>[
+                      const SizedBox(height: PlinkSpacing.s4),
+                      const LinearProgressIndicator(),
+                    ],
+                  ],
                 ),
-              ],
-            ),
-            if (state._busy) ...<Widget>[
-              const SizedBox(height: PlinkSpacing.s4),
-              const LinearProgressIndicator(),
+              ),
+              const TabBar(
+                key: ValueKey('settings-tabs'),
+                isScrollable: true,
+                tabAlignment: TabAlignment.start,
+                tabs: <Widget>[
+                  Tab(key: ValueKey('settings-tab-algemeen'), text: 'Algemeen'),
+                  Tab(key: ValueKey('settings-tab-wisa'), text: 'Wisa'),
+                  Tab(
+                    key: ValueKey('settings-tab-smartschool'),
+                    text: 'Smartschool',
+                  ),
+                  Tab(key: ValueKey('settings-tab-azure'), text: 'Azure'),
+                ],
+              ),
+              Expanded(
+                child: TabBarView(
+                  children: <Widget>[
+                    _algemeenTab(),
+                    _wisaTab(),
+                    _smartschoolTab(),
+                    _azureTab(),
+                  ],
+                ),
+              ),
             ],
-            const SizedBox(height: PlinkSpacing.s5),
-
-            // Global.
-            _Section(
-              title: 'Algemeen',
-              children: <Widget>[
-                _Field(
-                  keyValue: 'settings-school-prefix',
-                  label: 'Schoolprefix',
-                  controller: state._schoolPrefix,
-                ),
-                SwitchListTile(
-                  key: const ValueKey('settings-debug-mode'),
-                  contentPadding: EdgeInsets.zero,
-                  title: const Text('Debugmodus'),
-                  value: state._debugMode,
-                  onChanged: (v) => state.toggle(() => state._debugMode = v),
-                ),
-              ],
-            ),
-
-            // WISA.
-            _Section(
-              title: 'WISA',
-              children: <Widget>[
-                _Field(
-                  keyValue: 'settings-wisa-server',
-                  label: 'Server',
-                  controller: state._wisaServer,
-                ),
-                _Field(
-                  keyValue: 'settings-wisa-port',
-                  label: 'Poort',
-                  controller: state._wisaPort,
-                  keyboardType: TextInputType.number,
-                ),
-                _Field(
-                  keyValue: 'settings-wisa-database',
-                  label: 'Database',
-                  controller: state._wisaDatabase,
-                ),
-                _Field(
-                  keyValue: 'settings-wisa-username',
-                  label: 'Gebruikersnaam',
-                  controller: state._wisaUsername,
-                ),
-                _SecretField(
-                  keyValue: 'settings-wisa-password',
-                  label: 'Wachtwoord (schrijf-alleen)',
-                  controller: state._wisaPassword,
-                ),
-                _WorkDateField(
-                  keyValue: 'settings-wisa-workdate',
-                  label: 'Werkdatum',
-                  isNow: state._workDateIsNow,
-                  date: state._workDate,
-                  onIsNowChanged: (v) =>
-                      state.toggle(() => state._workDateIsNow = v),
-                  onPick: () => state._pickWorkDate(virtual: false),
-                ),
-                _WorkDateField(
-                  keyValue: 'settings-wisa-virtual-workdate',
-                  label: 'Virtuele werkdatum',
-                  isNow: state._virtualWorkDateIsNow,
-                  date: state._virtualWorkDate,
-                  onIsNowChanged: (v) =>
-                      state.toggle(() => state._virtualWorkDateIsNow = v),
-                  onPick: () => state._pickWorkDate(virtual: true),
-                ),
-              ],
-            ),
-
-            // WISA schools (managed/"ours" flag — #113).
-            _Section(
-              title: 'WISA-scholen (beheerd)',
-              children: <Widget>[
-                _WisaSchoolsEditor(state: state),
-              ],
-            ),
-
-            // Smartschool.
-            _Section(
-              title: 'Smartschool',
-              children: <Widget>[
-                _Field(
-                  keyValue: 'settings-ss-uri',
-                  label: 'URI',
-                  controller: state._ssUri,
-                ),
-                _Field(
-                  keyValue: 'settings-ss-test-user',
-                  label: 'Testgebruiker',
-                  controller: state._ssTestUser,
-                ),
-                _Field(
-                  keyValue: 'settings-ss-student-group',
-                  label: 'Pad leerlingengroep',
-                  controller: state._ssStudentGroup,
-                ),
-                _Field(
-                  keyValue: 'settings-ss-staff-group',
-                  label: 'Pad personeelsgroep',
-                  controller: state._ssStaffGroup,
-                ),
-                _SecretField(
-                  keyValue: 'settings-ss-passphrase',
-                  label: 'Passphrase (schrijf-alleen)',
-                  controller: state._ssPassphrase,
-                ),
-                SwitchListTile(
-                  key: const ValueKey('settings-ss-use-grades'),
-                  contentPadding: EdgeInsets.zero,
-                  title: const Text('Gebruik graden'),
-                  value: state._ssUseGrades,
-                  onChanged: (v) => state.toggle(() => state._ssUseGrades = v),
-                ),
-                for (var i = 0; i < state._grades.length; i++)
-                  _Field(
-                    keyValue: 'settings-ss-grade-$i',
-                    label: 'Graad ${i + 1}',
-                    controller: state._grades[i],
-                  ),
-                SwitchListTile(
-                  key: const ValueKey('settings-ss-use-years'),
-                  contentPadding: EdgeInsets.zero,
-                  title: const Text('Gebruik jaren'),
-                  value: state._ssUseYears,
-                  onChanged: (v) => state.toggle(() => state._ssUseYears = v),
-                ),
-                for (var i = 0; i < state._years.length; i++)
-                  _Field(
-                    keyValue: 'settings-ss-year-$i',
-                    label: 'Jaar ${i + 1}',
-                    controller: state._years[i],
-                  ),
-              ],
-            ),
-
-            // Azure.
-            _Section(
-              title: 'Azure AD / Office 365',
-              children: <Widget>[
-                _Field(
-                  keyValue: 'settings-az-client-id',
-                  label: 'Client ID',
-                  controller: state._azClientId,
-                ),
-                _Field(
-                  keyValue: 'settings-az-tenant-id',
-                  label: 'Tenant ID',
-                  controller: state._azTenantId,
-                ),
-                _Field(
-                  keyValue: 'settings-az-domain',
-                  label: 'Domein',
-                  controller: state._azDomain,
-                ),
-              ],
-            ),
-
-            // Import rules (read-only).
-            _Section(
-              title: 'Importregels (alleen-lezen)',
-              children: <Widget>[
-                _RulesList(
-                  wisaRules: settings.wisaRules,
-                  smartschoolRules: settings.smartschoolRules,
-                ),
-              ],
-            ),
-          ],
+          ),
         ),
       ),
     );
+  }
+
+  /// A scrolling tab body with the shared page padding.
+  Widget _tab(String keyValue, List<Widget> children) {
+    return ListView(
+      key: ValueKey(keyValue),
+      padding: const EdgeInsets.symmetric(
+        horizontal: PlinkSpacing.s6,
+        vertical: PlinkSpacing.s5,
+      ),
+      children: children,
+    );
+  }
+
+  /// App-wide options: school prefix, debug mode, and the werkdatum controls
+  /// (app-wide, not connector-specific — #140).
+  Widget _algemeenTab() {
+    return _tab('settings-tab-algemeen-body', <Widget>[
+      _Section(
+        title: 'Algemeen',
+        children: <Widget>[
+          _Field(
+            keyValue: 'settings-school-prefix',
+            label: 'Schoolprefix',
+            controller: state._schoolPrefix,
+          ),
+          SwitchListTile(
+            key: const ValueKey('settings-debug-mode'),
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Debugmodus'),
+            value: state._debugMode,
+            onChanged: (v) => state.toggle(() => state._debugMode = v),
+          ),
+        ],
+      ),
+      _Section(
+        title: 'Werkdatum',
+        children: <Widget>[
+          _WorkDateField(
+            keyValue: 'settings-workdate',
+            label: 'Werkdatum',
+            isNow: state._workDateIsNow,
+            date: state._workDate,
+            onIsNowChanged: (v) => state.toggle(() => state._workDateIsNow = v),
+            onPick: () => state._pickWorkDate(virtual: false),
+          ),
+          _WorkDateField(
+            keyValue: 'settings-virtual-workdate',
+            label: 'Virtuele werkdatum',
+            isNow: state._virtualWorkDateIsNow,
+            date: state._virtualWorkDate,
+            onIsNowChanged: (v) =>
+                state.toggle(() => state._virtualWorkDateIsNow = v),
+            onPick: () => state._pickWorkDate(virtual: true),
+          ),
+        ],
+      ),
+    ]);
+  }
+
+  /// WISA connector config: connection, credentials, managed-school list, and
+  /// the WISA import rules (read-only).
+  Widget _wisaTab() {
+    return _tab('settings-tab-wisa-body', <Widget>[
+      _Section(
+        title: 'WISA',
+        children: <Widget>[
+          _Field(
+            keyValue: 'settings-wisa-server',
+            label: 'Server',
+            controller: state._wisaServer,
+          ),
+          _Field(
+            keyValue: 'settings-wisa-port',
+            label: 'Poort',
+            controller: state._wisaPort,
+            keyboardType: TextInputType.number,
+          ),
+          _Field(
+            keyValue: 'settings-wisa-database',
+            label: 'Database',
+            controller: state._wisaDatabase,
+          ),
+          _Field(
+            keyValue: 'settings-wisa-username',
+            label: 'Gebruikersnaam',
+            controller: state._wisaUsername,
+          ),
+          _SecretField(
+            keyValue: 'settings-wisa-password',
+            label: 'Wachtwoord (schrijf-alleen)',
+            controller: state._wisaPassword,
+          ),
+        ],
+      ),
+      _Section(
+        title: 'WISA-scholen (beheerd)',
+        children: <Widget>[
+          _WisaSchoolsEditor(state: state),
+        ],
+      ),
+      _Section(
+        title: 'Importregels (alleen-lezen)',
+        children: <Widget>[
+          _RulesList(
+            emptyKey: const ValueKey('settings-wisa-rules-empty'),
+            wisaRules: settings.wisaRules,
+          ),
+        ],
+      ),
+    ]);
+  }
+
+  /// Smartschool connector config: connection, credentials, grade/year
+  /// vocabulary, and the Smartschool import rules (read-only).
+  Widget _smartschoolTab() {
+    return _tab('settings-tab-smartschool-body', <Widget>[
+      _Section(
+        title: 'Smartschool',
+        children: <Widget>[
+          _Field(
+            keyValue: 'settings-ss-uri',
+            label: 'URI',
+            controller: state._ssUri,
+          ),
+          _Field(
+            keyValue: 'settings-ss-test-user',
+            label: 'Testgebruiker',
+            controller: state._ssTestUser,
+          ),
+          _Field(
+            keyValue: 'settings-ss-student-group',
+            label: 'Pad leerlingengroep',
+            controller: state._ssStudentGroup,
+          ),
+          _Field(
+            keyValue: 'settings-ss-staff-group',
+            label: 'Pad personeelsgroep',
+            controller: state._ssStaffGroup,
+          ),
+          _SecretField(
+            keyValue: 'settings-ss-passphrase',
+            label: 'Passphrase (schrijf-alleen)',
+            controller: state._ssPassphrase,
+          ),
+          SwitchListTile(
+            key: const ValueKey('settings-ss-use-grades'),
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Gebruik graden'),
+            value: state._ssUseGrades,
+            onChanged: (v) => state.toggle(() => state._ssUseGrades = v),
+          ),
+          for (var i = 0; i < state._grades.length; i++)
+            _Field(
+              keyValue: 'settings-ss-grade-$i',
+              label: 'Graad ${i + 1}',
+              controller: state._grades[i],
+            ),
+          SwitchListTile(
+            key: const ValueKey('settings-ss-use-years'),
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Gebruik jaren'),
+            value: state._ssUseYears,
+            onChanged: (v) => state.toggle(() => state._ssUseYears = v),
+          ),
+          for (var i = 0; i < state._years.length; i++)
+            _Field(
+              keyValue: 'settings-ss-year-$i',
+              label: 'Jaar ${i + 1}',
+              controller: state._years[i],
+            ),
+        ],
+      ),
+      _Section(
+        title: 'Importregels (alleen-lezen)',
+        children: <Widget>[
+          _RulesList(
+            emptyKey: const ValueKey('settings-ss-rules-empty'),
+            smartschoolRules: settings.smartschoolRules,
+          ),
+        ],
+      ),
+    ]);
+  }
+
+  /// Azure AD / Office 365 connector config.
+  Widget _azureTab() {
+    return _tab('settings-tab-azure-body', <Widget>[
+      _Section(
+        title: 'Azure AD / Office 365',
+        children: <Widget>[
+          _Field(
+            keyValue: 'settings-az-client-id',
+            label: 'Client ID',
+            controller: state._azClientId,
+          ),
+          _Field(
+            keyValue: 'settings-az-tenant-id',
+            label: 'Tenant ID',
+            controller: state._azTenantId,
+          ),
+          _Field(
+            keyValue: 'settings-az-domain',
+            label: 'Domein',
+            controller: state._azDomain,
+          ),
+        ],
+      ),
+    ]);
   }
 }
 
@@ -758,8 +836,15 @@ class _WorkDateField extends StatelessWidget {
 }
 
 class _RulesList extends StatelessWidget {
-  const _RulesList({required this.wisaRules, required this.smartschoolRules});
+  const _RulesList({
+    required this.emptyKey,
+    this.wisaRules = const <WisaImportRule>[],
+    this.smartschoolRules = const <SmartschoolImportRule>[],
+  });
 
+  /// Key stamped on the "no rules yet" placeholder, so each connector tab's
+  /// empty state is addressable on its own.
+  final Key emptyKey;
   final List<WisaImportRule> wisaRules;
   final List<SmartschoolImportRule> smartschoolRules;
 
@@ -789,7 +874,7 @@ class _RulesList extends StatelessWidget {
     if (wisaRules.isEmpty && smartschoolRules.isEmpty) {
       return Text(
         'Nog geen importregels verzameld.',
-        key: const ValueKey('settings-rules-empty'),
+        key: emptyKey,
         style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
       );
     }

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -16,6 +16,13 @@ void _useTallWindow(WidgetTester tester) {
   addTearDown(tester.view.reset);
 }
 
+/// Switches the settings view to the tab with [tabKey] (#140: the config is now
+/// split across Algemeen / Wisa / Smartschool / Azure tabs).
+Future<void> _openTab(WidgetTester tester, String tabKey) async {
+  await tester.tap(find.byKey(ValueKey(tabKey)));
+  await tester.pumpAndSettle();
+}
+
 void main() {
   testWidgets('shows the not-configured panel when AAD is absent',
       (WidgetTester tester) async {
@@ -41,10 +48,36 @@ void main() {
         .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
+    // Algemeen is the default tab.
     expect(find.text('GBS'), findsOneWidget);
+
+    // Each connector's config lives under its own tab now (#140).
+    await _openTab(tester, 'settings-tab-wisa');
     expect(find.text('db.school.example'), findsOneWidget);
+
+    await _openTab(tester, 'settings-tab-smartschool');
     expect(find.text('Leerlingen'), findsOneWidget);
+
+    await _openTab(tester, 'settings-tab-azure');
     expect(find.text('school.onmicrosoft.com'), findsOneWidget);
+  });
+
+  testWidgets('the settings view exposes the four config tabs',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    for (final key in const <String>[
+      'settings-tab-algemeen',
+      'settings-tab-wisa',
+      'settings-tab-smartschool',
+      'settings-tab-azure',
+    ]) {
+      expect(find.byKey(ValueKey(key)), findsOneWidget);
+    }
   });
 
   testWidgets('edit → save round-trips a profile field to the store',
@@ -61,6 +94,7 @@ void main() {
       find.byKey(const ValueKey('settings-school-prefix')),
       'NEW',
     );
+    await _openTab(tester, 'settings-tab-wisa');
     await tester.enterText(
       find.byKey(const ValueKey('settings-wisa-server')),
       'wisa.host',
@@ -81,6 +115,7 @@ void main() {
         .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
+    await _openTab(tester, 'settings-tab-smartschool');
     await tester.enterText(
       find.byKey(const ValueKey('settings-ss-student-group')),
       'Leerlingen/2025',
@@ -111,6 +146,7 @@ void main() {
         .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
+    await _openTab(tester, 'settings-tab-wisa');
     // The value is nowhere in the rendered tree, and the field is empty.
     expect(find.text('super-secret-value'), findsNothing);
     final field = tester.widget<TextField>(
@@ -131,10 +167,12 @@ void main() {
         .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
+    await _openTab(tester, 'settings-tab-wisa');
     await tester.enterText(
       find.byKey(const ValueKey('settings-wisa-password')),
       'new-wisa-pw',
     );
+    await _openTab(tester, 'settings-tab-smartschool');
     await tester.enterText(
       find.byKey(const ValueKey('settings-ss-passphrase')),
       'new-passphrase',
@@ -151,6 +189,7 @@ void main() {
     expect(saved.toJson().toString(), isNot(contains('new-passphrase')));
 
     // The fields are cleared after a successful save (never re-shown).
+    await _openTab(tester, 'settings-tab-wisa');
     final field = tester.widget<TextField>(
       find.byKey(const ValueKey('settings-wisa-password')),
     );
@@ -217,6 +256,7 @@ void main() {
         .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
+    await _openTab(tester, 'settings-tab-wisa');
     // The seeded (unmanaged) school renders with its switch off.
     final ourSwitch =
         find.byKey(const ValueKey('settings-wisa-school-42-ours'));
@@ -242,6 +282,7 @@ void main() {
         .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
+    await _openTab(tester, 'settings-tab-wisa');
     // No schools yet — the empty note shows.
     expect(find.byKey(const ValueKey('settings-wisa-schools-empty')),
         findsOneWidget);
@@ -280,8 +321,11 @@ void main() {
         .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
+    // WISA import rules live under the Wisa tab now (#140).
+    await _openTab(tester, 'settings-tab-wisa');
     expect(find.textContaining('OKAN'), findsOneWidget);
     expect(find.textContaining('VIRT'), findsOneWidget);
-    expect(find.byKey(const ValueKey('settings-rules-empty')), findsNothing);
+    expect(
+        find.byKey(const ValueKey('settings-wisa-rules-empty')), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary
Reorganizes the Settings view (`account_manager/`) from a single flat scrolling list into four tabs — **Algemeen**, **Wisa**, **Smartschool**, **Azure** — so each connector's configuration lives under its own tab. App-wide options stay under Algemeen.

## Linked issue
Closes #140

## Changes
- `settings_screen.dart`: `_SettingsForm` now uses a `DefaultTabController` + `TabBar` / `TabBarView`. The shared header (title, description, **Opslaan**/**Herladen** actions, busy indicator) sits above the tabs so save/reload act on the whole document regardless of the active tab.
  - **Algemeen**: school prefix, debug mode, and the werkdatum controls (app-wide, moved here from under WISA per the issue). The two werkdatum keys were renamed `settings-workdate` / `settings-virtual-workdate` (no test referenced the old names).
  - **Wisa**: connection, credentials, managed-school ("ours") list, and WISA import rules (read-only).
  - **Smartschool**: connection, credentials, grade/year vocabulary, and Smartschool import rules (read-only).
  - **Azure**: client id, tenant id, domain.
- Split the combined read-only `_RulesList` per connector, each with its own empty-state key (`settings-wisa-rules-empty` / `settings-ss-rules-empty`), so WISA rules render under Wisa and Smartschool rules under Smartschool.
- No settings lost or orphaned; all field keys preserved except the two werkdatum keys noted above.

## Test plan
- [x] `dart format --set-exit-if-changed` clean on changed files
- [x] `flutter analyze` clean (no issues)
- [x] Unit/widget tests pass — `flutter test` (135 tests). Updated the settings widget tests to open the relevant tab before interacting; added a new test asserting the four tabs render.
- [x] Integration/e2e tests pass — `flutter test integration_test -d windows` (18 tests). The two Settings scenarios (#106 profile+secret edit, #133 mark-school-"ours") were updated to drive the tabs in the real app; this exercises the real navigation/layout of the new TabBar composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
