### PR TITLE
Clarify Settings/Algemeen werkdatum controls (#141)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -880,6 +880,55 @@ void main() {
     expect(saved.wisaSchools.single.ours, isTrue);
   });
 
+  testWidgets(
+      'the Settings/Algemeen werkdatum controls read clearly end-to-end: '
+      'renamed virtual label + right-aligned switch instruction (#141)',
+      (WidgetTester tester) async {
+    // The real app composition over the in-memory settings seams — real fonts,
+    // real window, real ListTile layout, which is exactly where a right-align
+    // that "works" in a widget test can drift.
+    useTallWindow(tester);
+    final settings = SettingsHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // Open Settings; the werkdatum controls sit on the default Algemeen tab.
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+
+    // The virtual field carries the clearer label, and the old one is gone.
+    expect(find.text('Werkdatum Virtuele School'), findsOneWidget);
+    expect(find.text('Virtuele werkdatum'), findsNothing);
+
+    // The "volg de huidige datum" instruction is right-aligned against its
+    // switch, not merged into the field label on the left.
+    final tile = find.byKey(const ValueKey('settings-workdate-is-now'));
+    await tester.ensureVisible(tile);
+    await tester.pumpAndSettle();
+    final label = find.descendant(of: tile, matching: find.text('Werkdatum'));
+    final instruction =
+        find.descendant(of: tile, matching: find.text('volg de huidige datum'));
+    final switchWidget =
+        find.descendant(of: tile, matching: find.byType(Switch));
+    expect(label, findsOneWidget);
+    expect(instruction, findsOneWidget);
+    expect(switchWidget, findsOneWidget);
+    final tileLeft = tester.getTopLeft(tile).dx;
+    final tileCenter = tester.getCenter(tile).dx;
+    final instrCenter = tester.getCenter(instruction).dx;
+    expect(instrCenter, greaterThan(tileCenter),
+        reason: 'the instruction sits in the right portion, by the switch');
+    final switchLeft = tester.getTopLeft(switchWidget).dx;
+    final instrRight = tester.getTopRight(instruction).dx;
+    expect(switchLeft - instrRight, lessThan(instrCenter - tileLeft),
+        reason: 'the instruction hugs the switch, away from the field label');
+  });
+
   testWidgets('silent sign-in leads straight into the shell',
       (WidgetTester tester) async {
     final broker = _FakeBroker(silent: (_) => _token('AT'));

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -526,7 +526,7 @@ class _SettingsForm extends StatelessWidget {
           ),
           _WorkDateField(
             keyValue: 'settings-virtual-workdate',
-            label: 'Virtuele werkdatum',
+            label: 'Werkdatum Virtuele School',
             isNow: state._virtualWorkDateIsNow,
             date: state._virtualWorkDate,
             onIsNowChanged: (v) =>
@@ -813,7 +813,19 @@ class _WorkDateField extends StatelessWidget {
           SwitchListTile(
             key: ValueKey('$keyValue-is-now'),
             contentPadding: EdgeInsets.zero,
-            title: Text('$label — volg de huidige datum'),
+            // The field's label sits on the left; the "volg de huidige datum"
+            // instruction is pushed to the right so it reads against the switch
+            // it controls (currently off ⇒ today's date is *not* followed) —
+            // not against the werkdatum field on the left (#141).
+            title: Row(
+              children: <Widget>[
+                Expanded(child: Text(label)),
+                const Text(
+                  'volg de huidige datum',
+                  textAlign: TextAlign.right,
+                ),
+              ],
+            ),
             value: isNow,
             onChanged: onIsNowChanged,
           ),

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -328,4 +328,57 @@ void main() {
     expect(
         find.byKey(const ValueKey('settings-wisa-rules-empty')), findsNothing);
   });
+
+  testWidgets(
+      'the virtual werkdatum field is labelled "Werkdatum Virtuele '
+      'School" (#141)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The werkdatum controls live on the default Algemeen tab (#140).
+    expect(find.text('Werkdatum Virtuele School'), findsOneWidget);
+    expect(find.text('Virtuele werkdatum'), findsNothing);
+  });
+
+  testWidgets(
+      'the werkdatum switch tile right-aligns "volg de huidige datum" next to '
+      'its switch, not the field label (#141)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // Scope everything to the primary werkdatum switch tile.
+    final tile = find.byKey(const ValueKey('settings-workdate-is-now'));
+    expect(tile, findsOneWidget);
+
+    final label = find.descendant(of: tile, matching: find.text('Werkdatum'));
+    final instruction =
+        find.descendant(of: tile, matching: find.text('volg de huidige datum'));
+    final switchWidget =
+        find.descendant(of: tile, matching: find.byType(Switch));
+    expect(label, findsOneWidget);
+    expect(instruction, findsOneWidget);
+    expect(switchWidget, findsOneWidget);
+
+    // The instruction is a separate widget (not merged into the field label),
+    // right-aligned into the right portion of the tile so it reads against the
+    // switch (currently off ⇒ today's date is *not* followed).
+    final tileLeft = tester.getTopLeft(tile).dx;
+    final tileCenter = tester.getCenter(tile).dx;
+    final instrCenter = tester.getCenter(instruction).dx;
+    expect(instrCenter, greaterThan(tileCenter),
+        reason: 'the instruction sits in the right portion, by the switch');
+
+    // And it hugs the trailing switch: nearer the switch than the tile's left
+    // edge where the field label lives.
+    final switchLeft = tester.getTopLeft(switchWidget).dx;
+    final instrRight = tester.getTopRight(instruction).dx;
+    expect(switchLeft - instrRight, lessThan(instrCenter - tileLeft),
+        reason: 'the instruction hugs the switch, away from the field label');
+  });
 }


### PR DESCRIPTION
## Summary
Two copy/layout fixes to the Settings → Algemeen werkdatum controls (added in #140), removing a genuine misreading where the app could look like it was following today's date when it was not.

## Linked issue
Closes #141

## Changes
- `_WorkDateField`: the SwitchListTile title now puts the field label in an `Expanded` and right-aligns the "volg de huidige datum" text so it reads against its switch (off ⇒ today's date is *not* followed), not against the werkdatum field.
- Renamed the second field's label "Virtuele werkdatum" → "Werkdatum Virtuele School".
- No change to how the werkdatum value is stored or used — copy/layout only.

## Test plan
- [x] `dart format --set-exit-if-changed` clean
- [x] `flutter analyze` clean — No issues found
- [x] Widget tests pass (`flutter test`) — 137 tests, incl. 2 new for #141 (label rename + right-aligned instruction geometry). Confirmed the geometry test fails on the pre-fix combined-string layout and passes with the fix.
- [x] Integration/e2e tests pass (`flutter test integration_test -d windows`) — 19 tests, incl. a new end-to-end #141 case driving the real app to Settings/Algemeen and asserting the renamed label + right-aligned instruction in real fonts/layout (a user-visible layout change, so an integration test is warranted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)