### PR TITLE
WISA: fetch school IDs after config and select which schools to use (#142)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -31,6 +31,7 @@ import 'package:account_state/account_state.dart'
         WisaSchoolProfile,
         signalRRecordSeparator;
 import 'package:azure_api/azure_api.dart' show AzureCredentials;
+import 'package:wisa_api/wisa_api.dart' show WisaSchool;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -877,6 +878,67 @@ void main() {
     // The ownership flag landed in the store.
     final saved = await settings.store.load();
     expect(saved.wisaSchools.single.schoolId, 42);
+    expect(saved.wisaSchools.single.ours, isTrue);
+  });
+
+  testWidgets(
+      'the Settings view fetches the WISA school list and persists the picked '
+      'selection end-to-end, no id typed by hand (#142)',
+      (WidgetTester tester) async {
+    // The real app composition over the in-memory settings seams. The store
+    // holds a valid WISA connection profile and the password sits in the vault,
+    // so the fetch action lights up. The fetcher is faked (offline) but wired
+    // exactly like production — real screen, real navigation, real layout.
+    useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
+      WisaSchool(id: 3, name: 'Sint-Jan', description: 'SJ'),
+      WisaSchool(id: 7, name: 'Sint-Pieter', description: 'SP'),
+    ]);
+    final settings = SettingsHarness(
+      initial: const AppSettings(
+        wisa: WisaConnection(server: 'db.school.example', port: '1433'),
+      ),
+      secrets: {passwordRef: 'stored-pw'},
+      fetchWisaSchools: fetcher.call,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // Open Settings → Wisa tab; the fetch action is available for a valid config.
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    final button = find.byKey(const ValueKey('settings-wisa-fetch-schools'));
+    await tester.ensureVisible(button);
+    await tester.pumpAndSettle();
+    expect(tester.widget<FilledButton>(button).onPressed, isNotNull);
+
+    // Fetch: both schools render by name, the stored password was resolved.
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+    expect(fetcher.calls, 1);
+    expect(fetcher.lastPassword, 'stored-pw');
+    expect(find.text('Sint-Jan'), findsOneWidget);
+    expect(find.text('Sint-Pieter'), findsOneWidget);
+
+    // Pick one returned school and save; the selection lands in the store with
+    // no id ever typed by hand.
+    final picked = find.byKey(const ValueKey('settings-wisa-fetched-school-7'));
+    await tester.ensureVisible(picked);
+    await tester.tap(picked);
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await settings.store.load();
+    expect(saved.wisaSchools.single.schoolId, 7);
     expect(saved.wisaSchools.single.ours, isTrue);
   });
 

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -89,6 +89,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
   List<WisaSchoolProfile> _wisaSchools = const <WisaSchoolProfile>[];
   final _wisaSchoolToAdd = TextEditingController();
 
+  // The schools last fetched from the WISA API (#142). Null until the operator
+  // fetches; then the id+name list the operator ticks to build the selection.
+  List<WisaSchool>? _fetchedSchools;
+  bool _fetchingSchools = false;
+
   @override
   void initState() {
     super.initState();
@@ -213,6 +218,78 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void _toggleSchoolOurs(int index, bool ours) {
     toggle(
         () => _wisaSchools[index] = _wisaSchools[index].copyWith(ours: ours));
+  }
+
+  /// Whether the persisted WISA connection is complete enough to fetch the
+  /// school list (#142): a non-empty server and a numeric port. Gated on the
+  /// *loaded* document — "config is valid" means a saved, valid profile — so the
+  /// operator saves a good profile before the fetch action lights up.
+  bool get _wisaConfigValid {
+    final w = _loaded?.wisa;
+    if (w == null) return false;
+    return w.server.trim().isNotEmpty && int.tryParse(w.port.trim()) != null;
+  }
+
+  /// Whether the "fetch schools" action can run right now: a valid config, a
+  /// wired fetcher, and no fetch already in flight.
+  bool get _canFetchSchools =>
+      _wisaConfigValid &&
+      !_fetchingSchools &&
+      _services?.fetchWisaSchools != null;
+
+  /// Whether the school with [id] is in the current (working) selection.
+  bool _isSchoolSelected(int id) => _wisaSchools.any((p) => p.schoolId == id);
+
+  /// Fetches the available WISA schools (id + name) from the API so the operator
+  /// can pick which to use instead of typing ids (#142). Prefers a freshly typed
+  /// password; otherwise resolves the stored secret. Failures surface as a toast.
+  Future<void> _fetchWisaSchools() async {
+    final services = _services;
+    final fetcher = services?.fetchWisaSchools;
+    final loaded = _loaded;
+    if (services == null || fetcher == null || loaded == null) return;
+    setState(() => _fetchingSchools = true);
+    try {
+      var password = _wisaPassword.text;
+      if (password.isEmpty) {
+        password = await services.secrets.read(loaded.wisa.passwordRef) ?? '';
+      }
+      if (password.isEmpty) {
+        if (mounted) {
+          _toast('Geen WISA-wachtwoord beschikbaar. Vul het wachtwoord in en '
+              'bewaar eerst.');
+        }
+        return;
+      }
+      final schools = await fetcher(loaded.wisa, password);
+      if (!mounted) return;
+      setState(() => _fetchedSchools = schools);
+      _toast('${schools.length} scholen opgehaald.');
+    } on Object catch (e) {
+      if (mounted) _toast('Kon scholen niet ophalen: $e');
+    } finally {
+      if (mounted) setState(() => _fetchingSchools = false);
+    }
+  }
+
+  /// Ticks or unticks a fetched school in the selection (#142): a tick appends a
+  /// managed [WisaSchoolProfile] for its id, an untick drops it. This replaces
+  /// the by-hand id entry as the normal way to build the school selection.
+  void _toggleFetchedSchool(int schoolId, bool selected) {
+    toggle(() {
+      if (selected) {
+        if (_wisaSchools.any((p) => p.schoolId == schoolId)) return;
+        _wisaSchools = <WisaSchoolProfile>[
+          ..._wisaSchools,
+          WisaSchoolProfile(schoolId: schoolId, ours: true),
+        ];
+      } else {
+        _wisaSchools = <WisaSchoolProfile>[
+          for (final p in _wisaSchools)
+            if (p.schoolId != schoolId) p,
+        ];
+      }
+    });
   }
 
   /// Appends a managed-school entry for the id typed in the add field, ignoring
@@ -923,11 +1000,70 @@ class _WisaSchoolsEditor extends StatelessWidget {
     final TextTheme text = Theme.of(context).textTheme;
     final ColorScheme colors = Theme.of(context).colorScheme;
     final schools = state._wisaSchools;
+    final fetched = state._fetchedSchools;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
+        // Fetch-from-WISA affordance (#142): pull the available schools (id +
+        // name) and tick which to use, instead of typing ids by hand.
         Text(
-          'Alle groepsscholen worden opgehaald; markeer hier welke we beheren.',
+          'Haal de beschikbare scholen op uit WISA en kies welke je gebruikt.',
+          style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+        ),
+        const SizedBox(height: PlinkSpacing.s2),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            FilledButton.icon(
+              key: const ValueKey('settings-wisa-fetch-schools'),
+              onPressed:
+                  state._canFetchSchools ? state._fetchWisaSchools : null,
+              icon: const Icon(Icons.cloud_download_outlined),
+              label: const Text('Scholen ophalen'),
+            ),
+            if (state._fetchingSchools) ...<Widget>[
+              const SizedBox(width: PlinkSpacing.s3),
+              const SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            ],
+          ],
+        ),
+        if (!state._wisaConfigValid)
+          Padding(
+            padding: const EdgeInsets.only(top: PlinkSpacing.s2),
+            child: Text(
+              'Bewaar eerst een geldige WISA-configuratie (server en poort) om '
+              'scholen te kunnen ophalen.',
+              key: const ValueKey('settings-wisa-fetch-hint'),
+              style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+            ),
+          ),
+        if (fetched != null) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s3),
+          if (fetched.isEmpty)
+            Text(
+              'Geen scholen gevonden.',
+              key: const ValueKey('settings-wisa-fetched-empty'),
+              style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+            )
+          else
+            for (final s in fetched)
+              CheckboxListTile(
+                key: ValueKey('settings-wisa-fetched-school-${s.id}'),
+                contentPadding: EdgeInsets.zero,
+                controlAffinity: ListTileControlAffinity.leading,
+                title: Text(s.name.isEmpty ? 'School ${s.id}' : s.name),
+                subtitle: Text('id: ${s.id}'),
+                value: state._isSchoolSelected(s.id),
+                onChanged: (v) => state._toggleFetchedSchool(s.id, v ?? false),
+              ),
+        ],
+        const Divider(height: PlinkSpacing.s6),
+        Text(
+          'Geselecteerde scholen — markeer welke we beheren.',
           style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
         ),
         const SizedBox(height: PlinkSpacing.s2),
@@ -964,6 +1100,11 @@ class _WisaSchoolsEditor extends StatelessWidget {
             ],
           ),
         const SizedBox(height: PlinkSpacing.s3),
+        Text(
+          'Optioneel: voeg een school handmatig toe via id.',
+          style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+        ),
+        const SizedBox(height: PlinkSpacing.s2),
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[

--- a/account_manager/lib/src/settings/settings_bootstrap.dart
+++ b/account_manager/lib/src/settings/settings_bootstrap.dart
@@ -1,7 +1,58 @@
 import 'package:account_state/account_state.dart';
+import 'package:wisa_api/wisa_api.dart';
 
 import '../auth/sign_in_session.dart';
 import '../reconcile/reconcile_bootstrap.dart' show StoreEndpoints;
+
+/// Fetches the selectable WISA schools (id + name) for a connection profile,
+/// with the password resolved out of band (#142). The Settings view calls this
+/// once the WISA config is valid so the operator can pick schools from the live
+/// list instead of typing ids by hand.
+typedef WisaSchoolFetcher = Future<List<WisaSchool>> Function(
+  WisaConnection connection,
+  String password,
+);
+
+/// A WISA school-list fetch that could not even be attempted because the
+/// connection profile is incomplete — distinct from a transport/SOAP failure,
+/// which surfaces from the connector itself.
+class WisaSchoolFetchException implements Exception {
+  const WisaSchoolFetchException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// The production [WisaSchoolFetcher]: builds a one-shot [WisaConnector] from
+/// the connection profile plus the resolved [password] and pulls the school
+/// list via the `SMAGetInst` query (legacy `SchoolManager.Load`). This is a
+/// read against WISA, safe to run from the settings screen.
+///
+/// [transport] is a test seam; production callers omit it and get the real HTTP
+/// SOAP transport.
+Future<List<WisaSchool>> fetchWisaSchoolsLive(
+  WisaConnection connection,
+  String password, {
+  WisaSoapTransport? transport,
+}) async {
+  final port = int.tryParse(connection.port.trim());
+  if (connection.server.trim().isEmpty || port == null) {
+    throw const WisaSchoolFetchException(
+      'De WISA-verbinding is onvolledig: vul een geldige server en poort in.',
+    );
+  }
+  final connector = WisaConnector.fromParts(
+    server: connection.server.trim(),
+    port: port,
+    database: connection.database.trim(),
+    username: connection.username.trim(),
+    password: password,
+    transport: transport,
+  );
+  return connector.loadSchools();
+}
 
 /// The two seams the Settings view edits against: the [SettingsStore] holding
 /// the [AppSettings] config document and the [SecretProvider] the WISA password
@@ -13,7 +64,11 @@ import '../reconcile/reconcile_bootstrap.dart' show StoreEndpoints;
 /// to do (it throws [ReconcileConfigException]) precisely when a secret or a
 /// profile field is still missing.
 class SettingsServices {
-  const SettingsServices({required this.store, required this.secrets});
+  const SettingsServices({
+    required this.store,
+    required this.secrets,
+    this.fetchWisaSchools,
+  });
 
   /// The persistence seam for the [AppSettings] document (#114: Cosmos-backed).
   final SettingsStore store;
@@ -21,6 +76,12 @@ class SettingsServices {
   /// The write-only secret seam (Key Vault in production) the Settings view
   /// persists an operator-typed credential through — never read back into the UI.
   final SecretProvider secrets;
+
+  /// Pulls the selectable WISA schools (id + name) so the operator can pick
+  /// which schools to use instead of typing ids (#142). Null when the build
+  /// cannot fetch (no fetcher wired); the screen then keeps the manual-entry
+  /// path only.
+  final WisaSchoolFetcher? fetchWisaSchools;
 }
 
 /// Wires the Settings view's two seams for one signed-in session: a
@@ -38,6 +99,7 @@ Future<SettingsServices> bootstrapSettings({
   SettingsStore? settingsStore,
   SecretProvider? secretProvider,
   CosmosClient? cosmosClient,
+  WisaSchoolFetcher? fetchWisaSchools,
 }) async {
   final ends = endpoints ?? StoreEndpoints.fromEnvironment();
   final client = cosmosClient ??
@@ -55,5 +117,9 @@ Future<SettingsServices> bootstrapSettings({
         config: KeyVaultConfig(vaultUri: ends.vaultUri),
         tokens: VaultSessionTokenProvider(session),
       );
-  return SettingsServices(store: store, secrets: secrets);
+  return SettingsServices(
+    store: store,
+    secrets: secrets,
+    fetchWisaSchools: fetchWisaSchools ?? fetchWisaSchoolsLive,
+  );
 }

--- a/account_manager/test/screens/settings_fakes.dart
+++ b/account_manager/test/screens/settings_fakes.dart
@@ -5,6 +5,7 @@ library;
 
 import 'package:account_manager/src/settings/settings_bootstrap.dart';
 import 'package:account_state/account_state.dart';
+import 'package:wisa_api/wisa_api.dart';
 
 /// One assembled Settings stack over the in-memory seams — a headless stand-in
 /// for the Cosmos store + Key Vault provider, so a widget/integration test
@@ -13,15 +14,46 @@ class SettingsHarness {
   SettingsHarness({
     AppSettings initial = const AppSettings(),
     Map<SecretRef, String> secrets = const {},
+    this.fetchWisaSchools,
   })  : store = InMemorySettingsStore(initial),
         secrets = InMemorySecretProvider(secrets);
 
   final InMemorySettingsStore store;
   final InMemorySecretProvider secrets;
 
-  SettingsServices get services =>
-      SettingsServices(store: store, secrets: secrets);
+  /// Optional WISA school-list fetcher (#142). When null the screen shows the
+  /// fetch button disabled/without a wired fetcher; pass [FakeWisaSchoolFetcher]
+  /// to drive the fetch flow offline.
+  final WisaSchoolFetcher? fetchWisaSchools;
+
+  SettingsServices get services => SettingsServices(
+        store: store,
+        secrets: secrets,
+        fetchWisaSchools: fetchWisaSchools,
+      );
 
   /// A ready-made bootstrap closure for [SettingsScreen]/[AccountManagerApp].
   Future<SettingsServices> Function() get bootstrap => () async => services;
+}
+
+/// A scripted [WisaSchoolFetcher] for tests: returns a canned school list and
+/// records the connection + password it was called with, so a test can assert
+/// the fetch was wired through the real screen without touching a live WISA.
+class FakeWisaSchoolFetcher {
+  FakeWisaSchoolFetcher(this.schools);
+
+  final List<WisaSchool> schools;
+  int calls = 0;
+  WisaConnection? lastConnection;
+  String? lastPassword;
+
+  Future<List<WisaSchool>> call(
+    WisaConnection connection,
+    String password,
+  ) async {
+    calls++;
+    lastConnection = connection;
+    lastPassword = password;
+    return schools;
+  }
 }

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -306,6 +306,113 @@ void main() {
     expect(saved.wisaSchools.single.ours, isTrue);
   });
 
+  testWidgets(
+      'the fetch-schools action is disabled with a hint until the WISA config '
+      'is valid (#142)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // A blank WISA profile (no server/port) — config is not yet valid.
+    final harness = SettingsHarness(
+      fetchWisaSchools: FakeWisaSchoolFetcher(const []).call,
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    final button = find.byKey(const ValueKey('settings-wisa-fetch-schools'));
+    expect(button, findsOneWidget);
+    expect(tester.widget<FilledButton>(button).onPressed, isNull,
+        reason: 'no valid config yet ⇒ fetch disabled');
+    expect(
+        find.byKey(const ValueKey('settings-wisa-fetch-hint')), findsOneWidget);
+  });
+
+  testWidgets(
+      'fetch → tick a returned school → save persists the selection, no id '
+      'typed by hand (#142)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
+      WisaSchool(id: 3, name: 'Sint-Jan', description: 'SJ'),
+      WisaSchool(id: 7, name: 'Sint-Pieter', description: 'SP'),
+    ]);
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisa: WisaConnection(server: 'db.school.example', port: '1433'),
+      ),
+      secrets: {passwordRef: 'stored-pw'},
+      fetchWisaSchools: fetcher.call,
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    // A valid config lights the fetch button up.
+    final button = find.byKey(const ValueKey('settings-wisa-fetch-schools'));
+    expect(tester.widget<FilledButton>(button).onPressed, isNotNull);
+    expect(
+        find.byKey(const ValueKey('settings-wisa-fetch-hint')), findsNothing);
+
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+
+    // The fetcher ran (with the stored password resolved) and both schools
+    // render by name for selection.
+    expect(fetcher.calls, 1);
+    expect(fetcher.lastPassword, 'stored-pw');
+    expect(fetcher.lastConnection?.server, 'db.school.example');
+    expect(find.text('Sint-Jan'), findsOneWidget);
+    expect(find.text('Sint-Pieter'), findsOneWidget);
+
+    // Tick one returned school; it becomes a managed selection and saves.
+    await tester
+        .tap(find.byKey(const ValueKey('settings-wisa-fetched-school-7')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.wisaSchools.single.schoolId, 7);
+    expect(saved.wisaSchools.single.ours, isTrue);
+  });
+
+  testWidgets('unticking a fetched school removes it from the selection (#142)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
+      WisaSchool(id: 7, name: 'Sint-Pieter', description: 'SP'),
+    ]);
+    // Id 7 is already selected from a previous run.
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisa: WisaConnection(server: 'db.school.example', port: '1433'),
+        wisaSchools: [WisaSchoolProfile(schoolId: 7, ours: true)],
+      ),
+      secrets: {passwordRef: 'stored-pw'},
+      fetchWisaSchools: fetcher.call,
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-fetch-schools')));
+    await tester.pumpAndSettle();
+
+    // The already-selected school shows ticked; untick and save clears it.
+    final tile = find.byKey(const ValueKey('settings-wisa-fetched-school-7'));
+    expect(tester.widget<CheckboxListTile>(tile).value, isTrue);
+    await tester.tap(tile);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.wisaSchools, isEmpty);
+  });
+
   testWidgets('accumulated import rules render read-only',
       (WidgetTester tester) async {
     _useTallWindow(tester);

--- a/account_manager/test/settings/wisa_school_fetcher_test.dart
+++ b/account_manager/test/settings/wisa_school_fetcher_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:account_manager/src/settings/settings_bootstrap.dart';
+import 'package:account_state/account_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+/// In-memory WISA SOAP transport that answers any query with a fixed CSV blob,
+/// wrapped in the base64 `GetCSVDataResponse` envelope the connector decodes.
+/// Records the request envelopes it saw so a test can assert `SMAGetInst` was
+/// the query issued.
+class _FakeTransport implements WisaSoapTransport {
+  _FakeTransport(this.csv);
+
+  final String csv;
+  final List<String> envelopes = <String>[];
+
+  @override
+  Future<String> send({
+    required Uri endpoint,
+    required String soapAction,
+    required String envelope,
+  }) async {
+    envelopes.add(envelope);
+    final encoded = base64.encode(latin1.encode(csv));
+    return '''<?xml version="1.0" encoding="utf-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body>
+    <NS1:GetCSVDataResponse xmlns:NS1="urn:WisaAPIService-WisaAPIService">
+      <Result xsi:type="xsd:base64Binary" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">$encoded</Result>
+    </NS1:GetCSVDataResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>''';
+  }
+}
+
+void main() {
+  group('fetchWisaSchoolsLive', () {
+    test('issues SMAGetInst and returns the parsed id + name list', () async {
+      // ID,NAME,DESCRIPTION — the connector maps DESCRIPTION → name (legacy
+      // quirk preserved), so column 3 is the display name.
+      final transport = _FakeTransport(
+        'ID,NAME,DESCRIPTION\n'
+        '3,SJ,Sint-Jan\n'
+        '7,SP,Sint-Pieter\n',
+      );
+      final schools = await fetchWisaSchoolsLive(
+        const WisaConnection(server: 'db.school.example', port: '1433'),
+        'pw',
+        transport: transport,
+      );
+
+      expect(transport.envelopes, hasLength(1));
+      expect(transport.envelopes.single, contains(WisaQuery.getSchools));
+      expect(schools.map((s) => s.id), [3, 7]);
+      expect(schools.map((s) => s.name), ['Sint-Jan', 'Sint-Pieter']);
+    });
+
+    test('throws WisaSchoolFetchException when the server is missing',
+        () async {
+      await expectLater(
+        fetchWisaSchoolsLive(const WisaConnection(port: '1433'), 'pw'),
+        throwsA(isA<WisaSchoolFetchException>()),
+      );
+    });
+
+    test('throws WisaSchoolFetchException when the port is not numeric',
+        () async {
+      await expectLater(
+        fetchWisaSchoolsLive(
+          const WisaConnection(server: 'db.school.example', port: 'nope'),
+          'pw',
+        ),
+        throwsA(isA<WisaSchoolFetchException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Restores the legacy self-service WISA setup (#142): once the WISA connection profile is valid, the operator fetches the list of available schools (id + name) from the WISA API and ticks which to use, instead of having to know and type school ids by hand.

The school list is retrieved via the WISA SOAP `SMAGetInst` query — the same call the legacy `SchoolManager.Load` used — which the connector already implements as `WisaConnector.loadSchools()`. This slice adds the app-layer wiring, the UI, and persistence of the selection.

## Linked issue
Closes #142

## Changes
- **Fetcher seam** (`settings_bootstrap.dart`): new `WisaSchoolFetcher` typedef + `fetchWisaSchoolsLive`, which builds a one-shot `WisaConnector` from the connection profile plus the resolved password and pulls the school list (`SMAGetInst`). A read against WISA, safe from the settings screen (per the live-testing policy). Added to `SettingsServices` and `bootstrapSettings` (default = live fetcher).
- **Wisa settings tab**: a "Scholen ophalen" action, enabled only once the *saved* WISA config is valid (non-empty server + numeric port), with a hint until then. Fetched schools render as a checkbox list (name + id); ticking one appends a managed `WisaSchoolProfile` for its id, unticking drops it. The selection persists through the existing Save into `wisaSchools`. The password is resolved from a freshly typed value or the stored secret.
- Manual id entry is kept only as an explicit optional fallback — no longer required for the normal setup path.

## Notes
- Selection persistence reuses the existing `wisaSchools` (`WisaSchoolProfile`) model from #113/#133/#134, so the settings document is not reshaped. `MarkAsOurs` / group-membership plumbing is unchanged.
- No change to how WISA sync consumes the selected schools (out of scope).

## Test plan
- [x] `dart format --set-exit-if-changed` clean
- [x] `flutter analyze` clean (no issues)
- [x] unit tests pass — `fetchWisaSchoolsLive` issues `SMAGetInst` + parses id/name, and guards an incomplete connection (server/port). Connector `loadSchools` id+name parsing already covered in `wisa_api`.
- [x] widget tests pass — fetch disabled + hint until config valid; fetch → tick a returned school → save persists the pick (no id typed); untick removes it.
- [x] integration/e2e test pass — `flutter test integration_test -d windows`, 20/20: new #142 scenario drives fetch + select + persist through the real app (real fonts/window/navigation). Full app suite 143/143.
