### PR TITLE
Fix Dutch wording "(schrijf-alleen)" -> "(alleen schrijven)" on Settings secret fields (#143)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -991,6 +991,37 @@ void main() {
         reason: 'the instruction hugs the switch, away from the field label');
   });
 
+  testWidgets(
+      'the Settings secret fields read "(alleen schrijven)" end-to-end, not '
+      'the ungrammatical "(schrijf-alleen)" (#143)',
+      (WidgetTester tester) async {
+    // The real app composition over the in-memory settings seams — real fonts,
+    // real window, real tab navigation, which is where the rendered label copy
+    // is exercised as the operator actually sees it.
+    useTallWindow(tester);
+    final settings = SettingsHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+
+    // WISA password label carries the corrected Dutch; the old calque is gone.
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    expect(find.text('Wachtwoord (alleen schrijven)'), findsOneWidget);
+    expect(find.text('Wachtwoord (schrijf-alleen)'), findsNothing);
+
+    // Same for the Smartschool passphrase label.
+    await openSettingsTab(tester, 'settings-tab-smartschool');
+    expect(find.text('Passphrase (alleen schrijven)'), findsOneWidget);
+    expect(find.text('Passphrase (schrijf-alleen)'), findsNothing);
+  });
+
   testWidgets('silent sign-in leads straight into the shell',
       (WidgetTester tester) async {
     final broker = _FakeBroker(silent: (_) => _token('AT'));

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -645,7 +645,7 @@ class _SettingsForm extends StatelessWidget {
           ),
           _SecretField(
             keyValue: 'settings-wisa-password',
-            label: 'Wachtwoord (schrijf-alleen)',
+            label: 'Wachtwoord (alleen schrijven)',
             controller: state._wisaPassword,
           ),
         ],
@@ -697,7 +697,7 @@ class _SettingsForm extends StatelessWidget {
           ),
           _SecretField(
             keyValue: 'settings-ss-passphrase',
-            label: 'Passphrase (schrijf-alleen)',
+            label: 'Passphrase (alleen schrijven)',
             controller: state._ssPassphrase,
           ),
           SwitchListTile(

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -437,6 +437,26 @@ void main() {
   });
 
   testWidgets(
+      'the secret fields read "(alleen schrijven)", not the ungrammatical '
+      '"(schrijf-alleen)" (#143)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // WISA password label (on the Wisa tab).
+    await _openTab(tester, 'settings-tab-wisa');
+    expect(find.text('Wachtwoord (alleen schrijven)'), findsOneWidget);
+    expect(find.text('Wachtwoord (schrijf-alleen)'), findsNothing);
+
+    // Smartschool passphrase label (on the Smartschool tab).
+    await _openTab(tester, 'settings-tab-smartschool');
+    expect(find.text('Passphrase (alleen schrijven)'), findsOneWidget);
+    expect(find.text('Passphrase (schrijf-alleen)'), findsNothing);
+  });
+
+  testWidgets(
       'the virtual werkdatum field is labelled "Werkdatum Virtuele '
       'School" (#141)', (WidgetTester tester) async {
     _useTallWindow(tester);


### PR DESCRIPTION
## Summary
The WISA password and Smartschool passphrase secret fields on the Settings view annotated their write-only note as "(schrijf-alleen)" — an ungrammatical calque of "write-only". Both now read the natural Dutch "(alleen schrijven)".

The issue framed this as the "Passwords view"; the only two occurrences of the string in the codebase are these password/passphrase secret-field labels on the Settings screen (Wisa + Smartschool tabs). A repo-wide search for `schrijf-alleen` confirms no other occurrences (widget code or tests).

## Linked issue
Closes #143

## Changes
- `account_manager/lib/src/screens/settings_screen.dart` — `Wachtwoord (schrijf-alleen)` → `Wachtwoord (alleen schrijven)`; `Passphrase (schrijf-alleen)` → `Passphrase (alleen schrijven)`.
- `account_manager/test/screens/settings_screen_test.dart` — widget test asserting both corrected labels render and the old string is absent.
- `account_manager/integration_test/app_launch_test.dart` — end-to-end test opening Settings → Wisa/Smartschool tabs in the real app, asserting the corrected labels and the absence of the old copy.

Pure copy change, no behavioral impact.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed` clean on changed files
- [x] `flutter analyze` clean (no issues found)
- [x] unit/widget tests pass (`flutter test` — 144 tests, all passing, including the new #143 widget test)
- [x] integration/e2e tests pass (`flutter test integration_test -d windows` — 21 tests, all passing, including the new #143 end-to-end label assertion). User-visible copy change, so an end-to-end assertion is included per the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
