### PR TITLE
Provision the snapshots container so mid-sync snapshot saves don't 404 (#151)

### DIFF
--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -157,13 +157,16 @@ Future<ReconcileServices> bootstrapReconcile({
         tokens: CosmosSessionTokenProvider(session),
       );
 
-  // Ensure the materialized-view containers (per-account/group docs, rollups,
-  // the operator decisions container, and the sync-state container) exist before
-  // anything reads or writes them. On the correctly-provisioned shared account
-  // this is a cheap metadata read that creates nothing; it closes the gap where
-  // a never-provisioned `decisions` container made "accept duplicate mail" fail
-  // with a Cosmos 404 (#150).
-  await ensureContainers(client);
+  // Ensure the Cosmos containers a sync reads or writes exist before anything
+  // touches them: the materialized-view containers (per-account/group docs,
+  // rollups, the operator decisions container, and the sync-state container)
+  // plus the cold-snapshot container. On the correctly-provisioned shared
+  // account this is a cheap metadata read that creates nothing; it closes the
+  // gap where a never-provisioned container surfaced only as a first-write 404
+  // mid-session — `decisions` for "accept duplicate mail" (#150), and
+  // `syncState` / `snapshots` for the sync-lock renewal and snapshot save that
+  // 404'd between the Smartschool and Azure passes (#151).
+  await ensureContainers(client, specs: bootstrapContainers);
 
   final store = settingsStore ?? CosmosSettingsStore(client);
   final settings = await store.load();

--- a/account_manager/test/reconcile/reconcile_bootstrap_test.dart
+++ b/account_manager/test/reconcile/reconcile_bootstrap_test.dart
@@ -268,12 +268,15 @@ void main() {
       );
     });
 
-    test('provisions the materialized-view containers, incl. decisions (#150)',
-        () async {
+    test(
+        'provisions every sync container: view docs, decisions (#150), '
+        'syncState + snapshots (#151)', () async {
       // Drive the real bootstrap assembly with a recording client to prove the
-      // ensure-containers preflight is wired: the operator `decisions` container
-      // (whose absence made "accept duplicate mail" 404) is provisioned before
-      // the reconcile controller can write a decision to it.
+      // ensure-containers preflight is wired for every container a sync writes:
+      // the operator `decisions` container (whose absence made "accept
+      // duplicate mail" 404, #150), and the `syncState` / `snapshots`
+      // containers whose absence 404'd the sync-lock renewal and the snapshot
+      // save between the Smartschool and Azure passes (#151).
       final client = _RecordingCosmosClient();
       await bootstrapReconcile(
         session: SignInSession(FakeBroker()),
@@ -289,6 +292,8 @@ void main() {
         containsAll(['linkedAccounts', 'linkedGroups', 'rollups', 'decisions']),
       );
       expect(client.ensured['syncState'], '/id');
+      // The snapshot store's container — the missing piece #151 adds.
+      expect(client.ensured['snapshots'], '/id');
     });
 
     test('the real Cosmos path reads settings from the container', () async {

--- a/packages/account_state/lib/src/cosmos/cosmos_containers.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_containers.dart
@@ -34,6 +34,33 @@ const List<CosmosContainerSpec> linkedStoreContainers = [
   CosmosContainerSpec(syncStateContainer, '/id'),
 ];
 
+/// The cold-snapshot containers [CosmosSnapshotStore] reads and writes (#107):
+/// the [snapshotsContainer], one metadata document per system, each its own
+/// logical partition keyed by `/id`.
+///
+/// A separate seam from the materialized-view [linkedStoreContainers], but it
+/// shared their 404-on-first-write gap: a never-provisioned snapshots container
+/// surfaced only when the sync tried to persist a fresh snapshot mid-run —
+/// `[smartschool] Snapshot store: CosmosException(404 NotFound)` (#151), the
+/// same failure #150 hit on the operator `decisions` container.
+const List<CosmosContainerSpec> snapshotStoreContainers = [
+  CosmosContainerSpec(snapshotsContainer, '/id'),
+];
+
+/// Every container the reconcile bootstrap preflight ensures: the
+/// materialized-view [linkedStoreContainers] plus the cold-snapshot
+/// [snapshotStoreContainers].
+///
+/// This is the set [ensureContainers] provisions at startup so no store path a
+/// sync exercises — lease renewal and the `generation` write ([syncStateContainer]),
+/// a decision write ([decisionsContainer]), or a snapshot save
+/// ([snapshotsContainer]) — can surface a first-write 404 mid-session
+/// (#150, #151).
+const List<CosmosContainerSpec> bootstrapContainers = [
+  ...linkedStoreContainers,
+  ...snapshotStoreContainers,
+];
+
 /// Ensures every container in [specs] exists, creating any that are missing.
 ///
 /// The materialized-view containers are provisioned out of band on the shared

--- a/packages/account_state/test/cosmos/cosmos_containers_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_containers_test.dart
@@ -43,5 +43,37 @@ void main() {
       );
       expect(client.ensuredContainers, {decisionsContainer: '/pk'});
     });
+
+    test(
+        'the bootstrap set provisions the snapshots container the snapshot '
+        'store needs (#151)', () async {
+      final client = FakeCosmosClient();
+
+      await ensureContainers(client, specs: bootstrapContainers);
+
+      // The snapshot-store write path (CosmosSnapshotStore -> snapshots)
+      // 404'd mid-sync because the container was never ensured; the bootstrap
+      // set now provisions it, keyed by /id like its singleton documents.
+      expect(client.ensuredContainers[snapshotsContainer], '/id');
+      // Still covers the sync-lock renewal container (already ensured by #150's
+      // linked-store set) so a regression can't silently drop it.
+      expect(client.ensuredContainers[syncStateContainer], '/id');
+    });
+
+    test('the bootstrap set is the linked-store set plus the snapshot set',
+        () async {
+      final client = FakeCosmosClient();
+
+      await ensureContainers(client, specs: bootstrapContainers);
+
+      expect(client.ensuredContainers, {
+        linkedAccountsContainer: '/pk',
+        linkedGroupsContainer: '/pk',
+        rollupsContainer: '/pk',
+        decisionsContainer: '/pk',
+        syncStateContainer: '/id',
+        snapshotsContainer: '/id',
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary
During a sync, between the Smartschool and Azure passes, the log filled with `CosmosException(404 NotFound)` for two operations (#151): the sync-lock renewal and the snapshot store. Both are the same class of failure as #150 — a Cosmos container that was never provisioned surfaces only as a **first-write 404** mid-session.

Investigating against the #155 bootstrap preflight (`ensureContainers`, just merged for #150):

- **Sync-lock renewal** (`_renewLock()` → `store.renewLease()` → `syncState` container): **already fixed** by #155 — `syncStateContainer` is in `linkedStoreContainers`, so the preflight already ensures it.
- **Snapshot store** (`CosmosSnapshotStore` → `snapshots` container): **not covered** — `snapshotsContainer` was absent from the ensured set, so its first snapshot save still 404'd. This is the remaining fix.

## Linked issue
Closes #151

## Changes
- `packages/account_state/.../cosmos_containers.dart`: add a `snapshotStoreContainers` spec (`snapshots`, keyed by `/id` like its singleton documents) and a `bootstrapContainers` union of the linked-store + snapshot sets. `linkedStoreContainers` stays semantically the materialized-view set.
- `account_manager/.../reconcile_bootstrap.dart`: `ensureContainers(client, specs: bootstrapContainers)` so the preflight provisions the snapshot container too.
- Tests below.

## Test plan
- [x] `dart format --set-exit-if-changed` clean on changed files
- [x] `dart analyze` (full workspace) — No issues found
- [x] unit tests pass — `account_state`: 273 pass / 6 live-skipped, incl. new `bootstrapContainers` provisions `snapshots` (/id) + full set
- [x] integration/e2e — `account_manager`: `flutter test` 145 pass. The app-level `reconcile_bootstrap_test.dart` drives the **real** `bootstrapReconcile` assembly with a recording client and now asserts `snapshots` (/id) is ensured; **confirmed it fails on the unpatched wiring**. A full end-to-end reproduction (the log filling during a live sync) needs a live Cosmos account, which is un-fakeable and manual/read-only per this repo's live-testing policy — so that layer is exercised by the real-assembly bootstrap test, not a live run.