### PR TITLE
Make the Reconcile log panel resizable (#152)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -344,6 +344,39 @@ void main() {
   });
 
   testWidgets(
+      'the operator drags the log divider to grow the log panel end-to-end '
+      '(#152)', (WidgetTester tester) async {
+    // The real app composition — real fonts, real window, real Column layout —
+    // is where a resizable divider that "works" in a widget test can drift: the
+    // handle sits between a flexible scroll area and the fixed-height panel.
+    useTallWindow(tester);
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+
+    final panel = find.byKey(const ValueKey('reconcile-log-panel'));
+    final handle = find.byKey(const ValueKey('reconcile-log-resize'));
+    expect(panel, findsOneWidget);
+    expect(handle, findsOneWidget);
+
+    // Opens at the default height, then dragging the handle up enlarges it by
+    // the drag distance — the operator can read a multi-line Cosmos error.
+    final double initial = tester.getSize(panel).height;
+    expect(initial, 160);
+    await tester.drag(handle, const Offset(0, -200),
+        touchSlopX: 0, touchSlopY: 0);
+    await tester.pumpAndSettle();
+    expect(tester.getSize(panel).height, 360);
+  });
+
+  testWidgets(
       'a resumed session trusts the stored state: Synchronise pulls no '
       'Smartschool/Azure (#107)', (WidgetTester tester) async {
     // Session 1 (offline harness over a shared cold-snapshot store): a full

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -137,25 +137,24 @@ class _ReconcileBody extends StatelessWidget {
     return ListenableBuilder(
       listenable: controller,
       builder: (context, _) {
-        return Column(
-          children: <Widget>[
-            Expanded(
-              child: Center(
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 960),
-                  // A CustomScrollView with lazy SliverLists for the pending
-                  // actions and the results, so only the visible tiles are
-                  // built — the fixed header/overview/banner stay as adapters
-                  // (#111). Slivers sit directly under the scroll view (not in a
-                  // SliverMainAxisGroup) so the scroll cache extent reaches the
-                  // sections below the fold.
-                  child: CustomScrollView(slivers: _slivers()),
-                ),
-              ),
+        // The scrollable content sits over the log panel, separated by a
+        // draggable handle the operator can use to grow/shrink the log (#152).
+        // The handle + panel height live in [_ResizableLogSection] so they
+        // persist across these controller-driven rebuilds.
+        return _ResizableLogSection(
+          log: log,
+          content: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 960),
+              // A CustomScrollView with lazy SliverLists for the pending
+              // actions and the results, so only the visible tiles are
+              // built — the fixed header/overview/banner stay as adapters
+              // (#111). Slivers sit directly under the scroll view (not in a
+              // SliverMainAxisGroup) so the scroll cache extent reaches the
+              // sections below the fold.
+              child: CustomScrollView(slivers: _slivers()),
             ),
-            const Divider(height: 1, thickness: 1),
-            _LogPanel(log: log),
-          ],
+          ),
         );
       },
     );
@@ -1369,10 +1368,100 @@ class _ResultRow extends StatelessWidget {
   }
 }
 
+/// The vertical extent the log panel opens to before the operator drags it, and
+/// the bounds a drag is clamped to (#152). The maximum is computed per layout so
+/// the content above always keeps at least [_ResizableLogSection._minContent].
+const double _kDefaultLogHeight = 160;
+const double _kMinLogHeight = 64;
+
+/// Wraps the reconcile [content] over a [_LogPanel] whose height the operator
+/// can change by dragging the [_LogResizeHandle] that replaces the old static
+/// divider (#152). The height is in-memory only — the app has no settings/prefs
+/// store yet, so a resized panel resets to [_kDefaultLogHeight] on restart.
+class _ResizableLogSection extends StatefulWidget {
+  const _ResizableLogSection({required this.content, required this.log});
+
+  final Widget content;
+  final LogBuffer log;
+
+  @override
+  State<_ResizableLogSection> createState() => _ResizableLogSectionState();
+}
+
+class _ResizableLogSectionState extends State<_ResizableLogSection> {
+  /// Kept for the content above the log so it never collapses to nothing.
+  static const double _minContent = 160;
+
+  double _logHeight = _kDefaultLogHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Grow the log as far as the viewport allows while leaving [_minContent]
+        // for the scroll area; clamp() keeps the stored height inside that band
+        // when the window (and so the available space) shrinks.
+        final double maxLog = (constraints.maxHeight - _minContent)
+            .clamp(_kMinLogHeight, double.infinity);
+        final double logHeight = _logHeight.clamp(_kMinLogHeight, maxLog);
+        return Column(
+          children: <Widget>[
+            Expanded(child: widget.content),
+            _LogResizeHandle(
+              onDrag: (double dy) => setState(() {
+                _logHeight = (logHeight - dy).clamp(_kMinLogHeight, maxLog);
+              }),
+            ),
+            _LogPanel(log: widget.log, height: logHeight),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// The draggable replacement for the static content/log divider: a thin rule
+/// with a centered grab bar. Dragging it vertically reports the delta up to
+/// [_ResizableLogSection], which owns the clamped height (#152).
+class _LogResizeHandle extends StatelessWidget {
+  const _LogResizeHandle({required this.onDrag});
+
+  final ValueChanged<double> onDrag;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeRow,
+      child: GestureDetector(
+        key: const ValueKey('reconcile-log-resize'),
+        behavior: HitTestBehavior.opaque,
+        onVerticalDragUpdate: (DragUpdateDetails d) => onDrag(d.delta.dy),
+        child: Container(
+          height: 14,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            border: Border(top: BorderSide(color: colors.outlineVariant)),
+          ),
+          child: Container(
+            width: 36,
+            height: 4,
+            decoration: BoxDecoration(
+              color: colors.outlineVariant,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _LogPanel extends StatelessWidget {
-  const _LogPanel({required this.log});
+  const _LogPanel({required this.log, required this.height});
 
   final LogBuffer log;
+  final double height;
 
   @override
   Widget build(BuildContext context) {
@@ -1380,7 +1469,8 @@ class _LogPanel extends StatelessWidget {
     final ColorScheme colors = Theme.of(context).colorScheme;
 
     return SizedBox(
-      height: 160,
+      key: const ValueKey('reconcile-log-panel'),
+      height: height,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -363,6 +363,11 @@ void main() {
     expect(find.text('Klasgroepen'), findsWidgets);
 
     // Opening it lists the orphan classes with their notice — no pull, no link.
+    // Bring it fully into view first: the draggable log divider (#152) is a
+    // touch larger than the old hairline, so this bottom-of-fold node can sit
+    // right on the panel boundary at the default window size.
+    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('rollup-groups')));
     await tester.pumpAndSettle();
 
@@ -572,6 +577,44 @@ void main() {
       findsNothing,
       reason: 'the first tile unloaded once scrolled far off-screen',
     );
+  });
+
+  testWidgets(
+      'dragging the divider handle grows the log panel and clamps to a min '
+      '(#152)', (WidgetTester tester) async {
+    // A fixed, comfortably tall window so the drag has room to grow the panel
+    // before hitting the "leave room for the content" cap.
+    tester.view.physicalSize = const Size(800, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    final panel = find.byKey(const ValueKey('reconcile-log-panel'));
+    final handle = find.byKey(const ValueKey('reconcile-log-resize'));
+    expect(panel, findsOneWidget);
+    expect(handle, findsOneWidget);
+
+    // Opens at the default height.
+    final double initial = tester.getSize(panel).height;
+    expect(initial, 160);
+
+    // Dragging the handle up grows the log area by the drag distance. Slop is
+    // zeroed so the whole offset lands as one reported delta.
+    await tester.drag(handle, const Offset(0, -120),
+        touchSlopX: 0, touchSlopY: 0);
+    await tester.pumpAndSettle();
+    expect(tester.getSize(panel).height, 280);
+
+    // Dragging far down clamps to the sensible minimum, never collapsing away.
+    await tester.drag(handle, const Offset(0, 2000),
+        touchSlopX: 0, touchSlopY: 0);
+    await tester.pumpAndSettle();
+    expect(tester.getSize(panel).height, 64);
   });
 
   testWidgets('the log panel clears on demand', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
The Reconcile screen's log panel was a fixed 160px tall, so multi-line Cosmos errors overflowed it and only one message was comfortably readable. This replaces the static content/log `Divider` with a draggable handle so the operator can grow or shrink the log area.

## Linked issue
Closes #152

## Changes
- Add `_ResizableLogSection` (StatefulWidget) that owns the log-panel height and renders the content over a new `_LogResizeHandle` (a thin rule with a centered grab bar, `resizeRow` cursor). Dragging it vertically adjusts the height.
- Clamp the height to a 64px minimum and a per-layout maximum (via `LayoutBuilder`) that always leaves 160px for the scroll content above, so it re-clamps when the window shrinks.
- `_LogPanel` now takes its `height` (keyed for tests); the handle is keyed too.
- The height is **in-memory only** — the app has no settings/prefs store to reuse yet (checked: no `shared_preferences`/Hive), so a resized panel resets to the 160px default on restart, as the issue allows.
- Adjust the #119 drill-down widget test to `ensureVisible()` its bottom-of-fold node, which the slightly taller handle (14px vs the old hairline) can push onto the panel boundary at the default window size.

## Test plan
- [x] `dart format --set-exit-if-changed .` clean (269 files)
- [x] `flutter analyze` clean (no issues)
- [x] unit/widget tests pass — `flutter test` 146/146, including a new #152 test that drags the handle to grow the panel and verifies it clamps to the 64px minimum
- [x] integration/e2e tests pass — `flutter test integration_test -d windows` 22/22, including a new #152 scenario driving the drag end-to-end in the real app (real fonts, window, and Column layout)