### PR TITLE
Add reproducible Cosmos container provisioning script (#160)

### DIFF
--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -124,7 +124,7 @@ file/in-memory resolver is not preparable and keeps minting lazily, so the sync
 | Resource | Name | Notes |
 |---|---|---|
 | Cosmos DB account | `accountmanager-cosmos-arcadia` (`https://accountmanager-cosmos-arcadia.documents.azure.com/`) | SQL API, **serverless**, AAD-only (`disableLocalAuth`); operator holds *Cosmos DB Built-in Data Contributor*. Replaced the SQL server below (#114). |
-| Cosmos database | `accountmanager` | Containers: `identity` (pk `/pk` single logical partition, unique key `/naturalKey`), `settings` (pk `/id`), `passwordQueue` (pk `/pk`), plus the materialized-view containers `linkedAccounts` (pk `/pk`), `linkedGroups` (pk `/pk`), `rollups` (pk `/pk`), `decisions` (pk `/pk`), `syncState` (pk `/id`, TTL enabled for the lease), and `snapshots` (pk `/id`). Provisioned out of band with `az` — data-plane RBAC cannot create containers. Bootstrap runs an idempotent `ensureContainers` preflight (a metadata read, no create on the provisioned account) over the materialized-view set so a never-stood-up container surfaces at startup rather than as a silent item-write 404 (#150). |
+| Cosmos database | `accountmanager` | Containers: `identity` (pk `/pk` single logical partition, unique key `/naturalKey`), `settings` (pk `/id`), `passwordQueue` (pk `/pk`), plus the materialized-view containers `linkedAccounts` (pk `/pk`), `linkedGroups` (pk `/pk`), `rollups` (pk `/pk`), `decisions` (pk `/pk`), `syncState` (pk `/id`, TTL enabled for the lease), and `snapshots` (pk `/id`). Provisioned by the checked-in idempotent script [`tool/provision-cosmos.ps1`](../tool/provision-cosmos.ps1) (control-plane `az cosmosdb sql …`) — data-plane RBAC cannot create containers. Bootstrap runs an idempotent `ensureContainers` preflight (a metadata read, no create on the provisioned account) over the materialized-view set so a never-stood-up container surfaces at startup rather than as a silent item-write 404 (#150). |
 | Key Vault | `accountmanager-kv` (`https://accountmanager-kv.vault.azure.net/`) | RBAC-authorized; operator holds *Key Vault Secrets Officer*. |
 | ~~SQL server / database~~ | ~~`accountmanager-sql-arcadia`~~ | **Retired (#114).** Deleted; the ODBC/FFI path is gone. |
 
@@ -218,9 +218,15 @@ ports the three existing seams, retiring the SQL/ODBC layer:
   **single JSON document** (the config; the whole queue), reusing the existing
   `toJson`/`fromJson` codecs — a single-document upsert is atomic, so the
   whole-replace semantics carry over with no transaction.
-- **Provisioning.** The database and containers are created out of band with `az`
-  (data-plane RBAC cannot create them), so the launch-time `CREATE TABLE` DDL is
-  gone. Bootstrap runs an idempotent `ensureContainers` preflight over the
+- **Provisioning.** The database and containers are stood up by the checked-in
+  idempotent script [`tool/provision-cosmos.ps1`](../tool/provision-cosmos.ps1) —
+  the source of truth for the full nine-container set (partition keys, the
+  `identity` `/naturalKey` unique key, and the `syncState` TTL). It runs the
+  control-plane `az cosmosdb sql database/container create` commands, each guarded
+  by an `exists` check so it is safe to re-run against an already-provisioned
+  account, because data-plane RBAC cannot create databases or containers. So the
+  launch-time `CREATE TABLE` DDL is gone. Bootstrap runs an idempotent
+  `ensureContainers` preflight over the
   materialized-view containers: on the provisioned account it is a cheap metadata
   read that creates nothing, but a genuinely un-provisioned container (or a fresh
   dev/emulator account) is created where the identity may, and otherwise surfaces

--- a/packages/account_state/test/cosmos/provision_script_test.dart
+++ b/packages/account_state/test/cosmos/provision_script_test.dart
@@ -1,0 +1,105 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+
+/// Guards the checked-in provisioning script (`tool/provision-cosmos.ps1`,
+/// #160) against drifting from the Cosmos container definitions that are the
+/// Dart source of truth (`cosmos_config.dart`).
+///
+/// The whole point of the script is reproducibility: a fresh account must get
+/// *exactly* the container set the app expects. A silent gap between the script
+/// and the constants below is the same class of drift the issue was filed to
+/// close (the six epic-#112 containers that were never stood up), so this test
+/// fails loudly if a container is added to the model but not to the script, or
+/// if the two special cases (the `identity` unique key, the `syncState` TTL)
+/// are dropped.
+void main() {
+  // Walk up from the test's CWD until the repo-root script is found, so the
+  // test passes whether `dart test` is invoked from the repo root
+  // (`dart test packages/*/test`) or from the package directory.
+  File locateScript() {
+    var dir = Directory.current;
+    for (var i = 0; i < 8; i++) {
+      final candidate = File('${dir.path}/tool/provision-cosmos.ps1');
+      if (candidate.existsSync()) return candidate;
+      final parent = dir.parent;
+      if (parent.path == dir.path) break;
+      dir = parent;
+    }
+    fail(
+      'Could not locate tool/provision-cosmos.ps1 by walking up from '
+      '${Directory.current.path}',
+    );
+  }
+
+  group('provision-cosmos.ps1', () {
+    final script = locateScript().readAsStringSync();
+
+    // Every container the model defines, with the partition-key path the store
+    // writes it under. Kept in lockstep with cosmos_config.dart.
+    const expectedContainers = <String, String>{
+      identityContainer: '/pk',
+      passwordQueueContainer: '/pk',
+      linkedAccountsContainer: '/pk',
+      linkedGroupsContainer: '/pk',
+      rollupsContainer: '/pk',
+      decisionsContainer: '/pk',
+      settingsContainer: '/id',
+      snapshotsContainer: '/id',
+      syncStateContainer: '/id',
+    };
+
+    test('provisions every documented container with its partition key', () {
+      for (final entry in expectedContainers.entries) {
+        // The script builds each row as `Name = '<container>'; PartitionKey =
+        // '<path>'`, so both the name and its key path must appear.
+        expect(
+          script,
+          contains("'${entry.key}'"),
+          reason: 'container ${entry.key} missing from provisioning script',
+        );
+      }
+      // Guard the count too, so a container removed from the model but left in
+      // the script (or vice versa) is caught.
+      final nameMatches = RegExp(r"@\{\s*Name\s*=\s*'([^']+)'")
+          .allMatches(script)
+          .map((m) => m.group(1))
+          .toSet();
+      expect(nameMatches, equals(expectedContainers.keys.toSet()));
+    });
+
+    test('the identity container carries the /naturalKey unique-key policy',
+        () {
+      expect(script, contains(identityNaturalKeyPath));
+      expect(
+        script,
+        contains('--unique-key-policy'),
+        reason: 'identity unique-key policy must be applied at create time',
+      );
+    });
+
+    test('the syncState container enables TTL for the lease sweep', () {
+      // -1 = default-TTL on (items honor a per-item ttl); the lease document
+      // relies on it (#108).
+      expect(script, contains('--ttl'));
+      expect(
+          script,
+          matches(RegExp(
+              r"'syncState';\s*PartitionKey\s*=\s*'/id';\s*Ttl\s*=\s*-1")));
+    });
+
+    test(
+        'creates the database and every container idempotently via an '
+        'exists guard', () {
+      // Each create is gated on an `exists` check, so a re-run is a no-op.
+      expect(script, contains('cosmosdb'));
+      expect(script, contains('database'));
+      expect(script, contains("'exists'"));
+      expect(script, contains("'create'"));
+    });
+  });
+}

--- a/tool/provision-cosmos.ps1
+++ b/tool/provision-cosmos.ps1
@@ -1,0 +1,184 @@
+<#
+.SYNOPSIS
+  Idempotently provision the Cosmos DB database and container set the
+  centralized state layer (epic #112) requires.
+
+.DESCRIPTION
+  Stands up — reproducibly and safely to re-run — the full container set
+  documented in docs/port-plan.md on the shared Cosmos account. Data-plane
+  RBAC (Cosmos DB Built-in Data Contributor) cannot create databases or
+  containers, so provisioning is a control-plane job that runs through the
+  Azure CLI (az cosmosdb sql ...) under an identity with a management role on
+  the account. This replaces the prose "created out of band with az": the
+  script IS the source of truth for what must exist.
+
+  Every step is guarded by an `exists` check, so the script is idempotent: on
+  an already-provisioned account it creates nothing and reports each resource
+  as present; on a fresh (or partially provisioned) account it creates only
+  what is missing. That closes the reproducibility gap in #160 — the drift
+  where the six epic-#112 containers were never stood up on the shared account
+  and surfaced only as a 403/404 at reconcile time.
+
+  The nine containers, matching the table in docs/port-plan.md:
+
+    Partition key /pk                 Partition key /id
+    -----------------                 -----------------
+    identity  (+ /naturalKey          settings
+               unique-key policy)     snapshots
+    passwordQueue                     syncState (TTL enabled, --ttl -1,
+    linkedAccounts                               for the lease sweep)
+    linkedGroups
+    rollups
+    decisions
+
+  The identity container's /naturalKey unique-key policy is the convergence
+  mechanism CosmosPersonIdResolver relies on (a second create for the same key
+  is rejected 409). syncState has default-TTL enabled (--ttl -1: items don't
+  expire by default, but a per-item `ttl` IS honored) so the sync/drift lease
+  document is physically swept when its holder crashes (#108).
+
+.PARAMETER AccountName
+  The Cosmos DB account name. Default: accountmanager-cosmos-arcadia.
+
+.PARAMETER ResourceGroup
+  The resource group the account lives in. Default: accountmanager-rg.
+
+.PARAMETER Database
+  The SQL-API database name. Default: accountmanager.
+
+.PARAMETER DryRun
+  Print the provisioning plan (every az command that WOULD run) without
+  touching Azure — no `exists` checks, no creates. Useful to review the exact
+  container set / partition keys / TTL / unique-key policy before running for
+  real, and to verify the script offline.
+
+.EXAMPLE
+  ./tool/provision-cosmos.ps1
+  ./tool/provision-cosmos.ps1 -DryRun
+  ./tool/provision-cosmos.ps1 -AccountName my-cosmos -ResourceGroup my-rg -Database mydb
+
+.NOTES
+  Requires the Azure CLI, authenticated (`az login`) as an identity holding a
+  management role (e.g. DocumentDB Account Contributor) on the account — NOT
+  the data-plane-only Cosmos DB Built-in Data Contributor role, which cannot
+  create containers.
+#>
+[CmdletBinding()]
+param(
+  [string]$AccountName = 'accountmanager-cosmos-arcadia',
+  [string]$ResourceGroup = 'accountmanager-rg',
+  [string]$Database = 'accountmanager',
+  [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+# The unique-key policy applied to the `identity` container: /naturalKey is
+# globally unique because every identity document lives in one logical
+# partition (see cosmos_config.dart / identityPartitionKeyValue).
+$identityUniqueKeyPolicy = '{"uniqueKeys":[{"paths":["/naturalKey"]}]}'
+
+# The nine containers docs/port-plan.md documents. `ttl` and `uniqueKeyPolicy`
+# are optional per-container extras; when absent the container is created with
+# just its partition key.
+$containers = @(
+  @{ Name = 'identity';       PartitionKey = '/pk'; UniqueKeyPolicy = $identityUniqueKeyPolicy }
+  @{ Name = 'passwordQueue';  PartitionKey = '/pk' }
+  @{ Name = 'linkedAccounts'; PartitionKey = '/pk' }
+  @{ Name = 'linkedGroups';   PartitionKey = '/pk' }
+  @{ Name = 'rollups';        PartitionKey = '/pk' }
+  @{ Name = 'decisions';      PartitionKey = '/pk' }
+  @{ Name = 'settings';       PartitionKey = '/id' }
+  @{ Name = 'snapshots';      PartitionKey = '/id' }
+  @{ Name = 'syncState';      PartitionKey = '/id'; Ttl = -1 }
+)
+
+function Invoke-Az {
+  # Runs an az command, or — in -DryRun — just prints it and returns without
+  # invoking az. Args are passed as an array so no shell re-quoting happens.
+  param([string[]]$AzArgs)
+  Write-Host "  az $($AzArgs -join ' ')"
+  if ($DryRun) { return }
+  $output = & az @AzArgs
+  if ($LASTEXITCODE -ne 0) {
+    throw "az $($AzArgs -join ' ') failed (exit $LASTEXITCODE): $output"
+  }
+  return $output
+}
+
+function Test-AzResource {
+  # `az ... exists` prints `true`/`false`. In -DryRun we always report the
+  # resource as missing so the plan shows the create it would perform.
+  param([string[]]$AzArgs)
+  if ($DryRun) {
+    Write-Host "  az $($AzArgs -join ' ')  (dry-run: assume missing)"
+    return $false
+  }
+  $result = & az @AzArgs
+  if ($LASTEXITCODE -ne 0) {
+    throw "az $($AzArgs -join ' ') failed (exit $LASTEXITCODE): $result"
+  }
+  return "$result".Trim() -eq 'true'
+}
+
+Write-Host "Provisioning Cosmos DB '$Database' on account '$AccountName' (rg '$ResourceGroup')"
+if ($DryRun) { Write-Host "  [DRY RUN] no changes will be made" }
+Write-Host ""
+
+# 1. Database — create if missing so a fresh account provisions cleanly too.
+Write-Host "Database '$Database':"
+$dbExists = Test-AzResource @(
+  'cosmosdb', 'sql', 'database', 'exists',
+  '--account-name', $AccountName,
+  '--resource-group', $ResourceGroup,
+  '--name', $Database
+)
+if ($dbExists) {
+  Write-Host "  present — skipping"
+} else {
+  Write-Host "  missing — creating"
+  Invoke-Az @(
+    'cosmosdb', 'sql', 'database', 'create',
+    '--account-name', $AccountName,
+    '--resource-group', $ResourceGroup,
+    '--name', $Database
+  ) | Out-Null
+}
+Write-Host ""
+
+# 2. Containers — each guarded, created only when missing.
+foreach ($c in $containers) {
+  Write-Host "Container '$($c.Name)' (pk $($c.PartitionKey)):"
+  $exists = Test-AzResource @(
+    'cosmosdb', 'sql', 'container', 'exists',
+    '--account-name', $AccountName,
+    '--resource-group', $ResourceGroup,
+    '--database-name', $Database,
+    '--name', $c.Name
+  )
+  if ($exists) {
+    Write-Host "  present — skipping"
+    Write-Host ""
+    continue
+  }
+
+  Write-Host "  missing — creating"
+  $createArgs = @(
+    'cosmosdb', 'sql', 'container', 'create',
+    '--account-name', $AccountName,
+    '--resource-group', $ResourceGroup,
+    '--database-name', $Database,
+    '--name', $c.Name,
+    '--partition-key-path', $c.PartitionKey
+  )
+  if ($c.ContainsKey('Ttl')) {
+    $createArgs += @('--ttl', "$($c.Ttl)")
+  }
+  if ($c.ContainsKey('UniqueKeyPolicy')) {
+    $createArgs += @('--unique-key-policy', $c.UniqueKeyPolicy)
+  }
+  Invoke-Az $createArgs | Out-Null
+  Write-Host ""
+}
+
+Write-Host "Done."


### PR DESCRIPTION
## Summary

Replaces the "created out of band with `az`" prose in `docs/port-plan.md` with a checked-in, idempotent provisioning script that is the source of truth for the full nine-container Cosmos set. Closes the reproducibility gap in #160: the six epic-#112 containers that were never stood up on the shared account (and surfaced only as a 403/404 at reconcile time) can now be provisioned reproducibly on a fresh or partially-provisioned account.

## Linked issue

Closes #160

## Changes

- **`tool/provision-cosmos.ps1`** — stands up the database and all nine containers via the control-plane `az cosmosdb sql database/container create` commands (data-plane RBAC cannot create them). Data-driven, each step guarded by an `exists` check so a re-run is a no-op. Matches `docs/port-plan.md`:
  - `/pk`: `identity` (+ `/naturalKey` unique-key policy), `passwordQueue`, `linkedAccounts`, `linkedGroups`, `rollups`, `decisions`
  - `/id`: `settings`, `snapshots`, `syncState` (`--ttl -1` for the lease sweep)
  - `-DryRun` switch prints the exact plan without touching Azure; parameterized `-AccountName` / `-ResourceGroup` / `-Database` (defaults from the port plan).
- **`docs/port-plan.md`** — the infra table and the Cosmos-migration provisioning bullet now point at the script instead of describing hand-run `az`.
- **`provision_script_test.dart`** — drift-guard unit test asserting the script covers exactly the container set defined in `cosmos_config.dart`, with the `identity` unique key and the `syncState` TTL, so model/script drift fails CI.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` clean (273 files)
- [x] `dart analyze --fatal-infos --fatal-warnings` clean (whole workspace)
- [x] unit tests pass — full workspace suite `dart test packages/*/test`: **825 passed, 11 skipped** (live tests); new drift-guard test: 4/4 pass
- [x] Script driven end-to-end manually (see below)

### On the integration/e2e test

No CI integration test: the change is an ops **provisioning script** with no app runtime surface (not a Flutter/user-visible flow), and driving it for real *creates containers* against live Azure — a write-capable operation that is manual/opt-in only, never in CI, per the project's live-testing policy. This is the "infeasible — un-fakeable third-party system" exception.

It was nonetheless verified end-to-end manually:
- **`-DryRun`** emits the correct plan: database + 9 containers, right partition keys, `identity --unique-key-policy {"uniqueKeys":[{"paths":["/naturalKey"]}]}`, `syncState --ttl -1`.
- **Real run against the provisioned shared account** is a clean no-op — database + all 9 containers reported present and skipped (only `exists` reads executed, zero writes), proving idempotency.
- **Cross-checked live config** matches the script: `identity` pk `/pk` + `/naturalKey` unique key; `syncState` pk `/id` + `defaultTtl -1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)