### PR TITLE
Fold Blob Storage provisioning into the reproducible script (#161)

### DIFF
--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -221,10 +221,17 @@ ports the three existing seams, retiring the SQL/ODBC layer:
 - **Provisioning.** The database and containers are stood up by the checked-in
   idempotent script [`tool/provision-cosmos.ps1`](../tool/provision-cosmos.ps1) —
   the source of truth for the full nine-container set (partition keys, the
-  `identity` `/naturalKey` unique key, and the `syncState` TTL). It runs the
-  control-plane `az cosmosdb sql database/container create` commands, each guarded
-  by an `exists` check so it is safe to re-run against an already-provisioned
-  account, because data-plane RBAC cannot create databases or containers. So the
+  `identity` `/naturalKey` unique key, and the `syncState` TTL). The same script
+  also provisions the **Blob Storage** side the cold-snapshot overflow store
+  needs (#161): the `Microsoft.Storage` provider registration, the AAD-only
+  (`--allow-shared-key-access false`, mirroring Cosmos `disableLocalAuth`)
+  `accountmanagerarcadia` account, the `snapshots` overflow container, and —
+  optionally, via `-OperatorObjectId` — the operator's *Storage Blob Data
+  Contributor* data role. It runs the control-plane `az cosmosdb sql
+  database/container create` and `az storage account/container create` commands,
+  each guarded by an `exists`/presence check so it is safe to re-run against an
+  already-provisioned account, because data-plane RBAC cannot create databases,
+  containers, or storage accounts. So the
   launch-time `CREATE TABLE` DDL is gone. Bootstrap runs an idempotent
   `ensureContainers` preflight over the
   materialized-view containers: on the provisioned account it is a cheap metadata
@@ -237,7 +244,9 @@ ports the three existing seams, retiring the SQL/ODBC layer:
   in the read-only CI set. Run via `/live-tests cosmos`.
 
 The cold containers (`snapshots` + Blob, `linkedAccounts`, `decisions`,
-`rollups`, `syncState`) are stood up by their own epic-#112 children.
+`rollups`, `syncState`) are stood up by their own epic-#112 children — the Blob
+storage account and its `snapshots` overflow container now by the same
+`provision-cosmos.ps1` script (#161).
 
 ### Phase C — Flutter Windows desktop app *(not started, epic #75)*
 

--- a/packages/account_state/test/cosmos/provision_script_test.dart
+++ b/packages/account_state/test/cosmos/provision_script_test.dart
@@ -102,4 +102,53 @@ void main() {
       expect(script, contains("'create'"));
     });
   });
+
+  // The Blob Storage side of the state backend (#161). The cold-snapshot store
+  // (#107) overflows to Blob; the storage account, its `snapshots` container,
+  // and the operator data role were provisioned by hand and never scripted —
+  // the same drift the Cosmos guards above close. These assertions fail loudly
+  // if the storage provisioning is dropped from the script.
+  group('provision-cosmos.ps1 — Blob Storage (#161)', () {
+    final script = locateScript().readAsStringSync();
+
+    test('registers the Microsoft.Storage resource provider', () {
+      // Storage ARM calls return SubscriptionNotFound until the provider is
+      // registered, so the script must register it.
+      expect(script, contains('Microsoft.Storage'));
+      expect(script, contains("'register'"));
+    });
+
+    test('provisions the storage account, AAD-only, via a presence guard', () {
+      expect(script, contains('accountmanagerarcadia'));
+      expect(
+        script,
+        contains("'storage', 'account', 'create'"),
+        reason: 'the storage account must be created by the script',
+      );
+      // AAD-only: shared-key access disabled, mirroring Cosmos disableLocalAuth.
+      expect(
+        script,
+        contains('--allow-shared-key-access'),
+        reason: 'the account must be AAD-only (shared-key access disabled)',
+      );
+      expect(script, contains('StorageV2'));
+    });
+
+    test('provisions the snapshots overflow container over AAD', () {
+      expect(
+        script,
+        contains("'storage', 'container', 'create'"),
+        reason: 'the overflow container must be created by the script',
+      );
+      // With shared-key access disabled, container ops must authenticate via AAD.
+      expect(script, contains('--auth-mode'));
+    });
+
+    test('grants the operator Storage Blob Data Contributor', () {
+      // The app reaches Blob as the signed-in operator, who needs this data
+      // role — the missing scope/role is what made Blob writes fail (#161).
+      expect(script, contains('Storage Blob Data Contributor'));
+      expect(script, contains("'role', 'assignment'"));
+    });
+  });
 }

--- a/tool/provision-cosmos.ps1
+++ b/tool/provision-cosmos.ps1
@@ -1,16 +1,25 @@
 <#
 .SYNOPSIS
-  Idempotently provision the Cosmos DB database and container set the
-  centralized state layer (epic #112) requires.
+  Idempotently provision the Cosmos DB database/container set AND the Blob
+  Storage account the centralized state layer (epic #112) requires.
 
 .DESCRIPTION
   Stands up — reproducibly and safely to re-run — the full container set
-  documented in docs/port-plan.md on the shared Cosmos account. Data-plane
-  RBAC (Cosmos DB Built-in Data Contributor) cannot create databases or
-  containers, so provisioning is a control-plane job that runs through the
-  Azure CLI (az cosmosdb sql ...) under an identity with a management role on
-  the account. This replaces the prose "created out of band with az": the
-  script IS the source of truth for what must exist.
+  documented in docs/port-plan.md on the shared Cosmos account, plus the Blob
+  Storage account and container the cold-snapshot overflow store (#107) writes
+  to. Data-plane RBAC (Cosmos DB Built-in Data Contributor / Storage Blob Data
+  Contributor) cannot create databases, containers, or accounts, so
+  provisioning is a control-plane job that runs through the Azure CLI
+  (az cosmosdb sql ... / az storage ...) under an identity with a management
+  role. This replaces the prose "created out of band with az": the script IS
+  the source of truth for what must exist.
+
+  The Blob side (#161) closes the same drift as the Cosmos side: the storage
+  account, the `snapshots` overflow container, and the operator's data-plane
+  role were stood up by hand and never scripted, so a fresh environment could
+  not reproduce them — the missing storage scope/account is exactly what made
+  cold-snapshot Blob writes fail (AADSTS650057). It is folded in here so one
+  script provisions the whole state backend.
 
   Every step is guarded by an `exists` check, so the script is idempotent: on
   an already-provisioned account it creates nothing and reports each resource
@@ -46,6 +55,24 @@
 .PARAMETER Database
   The SQL-API database name. Default: accountmanager.
 
+.PARAMETER StorageAccount
+  The Blob Storage account for cold-snapshot overflow payloads. Default:
+  accountmanagerarcadia.
+
+.PARAMETER StorageContainer
+  The blob container holding the overflow snapshot payloads. Default: snapshots
+  (the BLOB_SNAPSHOTS_CONTAINER default).
+
+.PARAMETER Location
+  The Azure region for the storage account. Default: belgiumcentral (matching
+  the Cosmos account).
+
+.PARAMETER OperatorObjectId
+  Optional. The AAD object id of an operator principal to grant the *Storage
+  Blob Data Contributor* data-plane role on the storage account. When omitted,
+  the role assignment is skipped and the required role is reported as a
+  prerequisite (mirroring how the Cosmos data role is assumed, not assigned).
+
 .PARAMETER DryRun
   Print the provisioning plan (every az command that WOULD run) without
   touching Azure — no `exists` checks, no creates. Useful to review the exact
@@ -68,6 +95,10 @@ param(
   [string]$AccountName = 'accountmanager-cosmos-arcadia',
   [string]$ResourceGroup = 'accountmanager-rg',
   [string]$Database = 'accountmanager',
+  [string]$StorageAccount = 'accountmanagerarcadia',
+  [string]$StorageContainer = 'snapshots',
+  [string]$Location = 'belgiumcentral',
+  [string]$OperatorObjectId = '',
   [switch]$DryRun
 )
 
@@ -119,6 +150,22 @@ function Test-AzResource {
     throw "az $($AzArgs -join ' ') failed (exit $LASTEXITCODE): $result"
   }
   return "$result".Trim() -eq 'true'
+}
+
+function Get-AzOutput {
+  # Runs an az read that returns an arbitrary scalar (a state string, a resource
+  # id, a count), trimmed. In -DryRun it makes no call and returns '' so the
+  # caller takes its "missing/unset" branch and the create is shown in the plan.
+  param([string[]]$AzArgs)
+  if ($DryRun) {
+    Write-Host "  az $($AzArgs -join ' ')  (dry-run: assume missing/unset)"
+    return ''
+  }
+  $result = & az @AzArgs
+  if ($LASTEXITCODE -ne 0) {
+    throw "az $($AzArgs -join ' ') failed (exit $LASTEXITCODE): $result"
+  }
+  return "$result".Trim()
 }
 
 Write-Host "Provisioning Cosmos DB '$Database' on account '$AccountName' (rg '$ResourceGroup')"
@@ -180,5 +227,121 @@ foreach ($c in $containers) {
   Invoke-Az $createArgs | Out-Null
   Write-Host ""
 }
+
+# 3. Blob Storage account + overflow container (#161 / cold-snapshot store #107).
+#    The snapshot store writes payloads too large for a Cosmos document (>2 MB —
+#    a whole-school WISA/Azure snapshot overflows) to Blob Storage. The account,
+#    the `snapshots` container, and the operator's data-plane role were stood up
+#    by hand and never scripted; the missing Storage scope/account is what made
+#    those Blob writes fail with AADSTS650057. Folded in here, guarded the same
+#    idempotent way as the Cosmos side, so a fresh environment reproduces it.
+
+# 3a. Resource provider — Storage ARM calls fail (SubscriptionNotFound) until
+#     Microsoft.Storage is registered on the subscription.
+Write-Host "Resource provider 'Microsoft.Storage':"
+$rpState = Get-AzOutput @(
+  'provider', 'show',
+  '--namespace', 'Microsoft.Storage',
+  '--query', 'registrationState',
+  '-o', 'tsv'
+)
+if ($rpState -eq 'Registered') {
+  Write-Host "  registered — skipping"
+} else {
+  Write-Host "  '$rpState' — registering"
+  Invoke-Az @('provider', 'register', '--namespace', 'Microsoft.Storage', '--wait') |
+    Out-Null
+}
+Write-Host ""
+
+# 3b. Storage account — AAD-only (shared-key access disabled, mirroring the
+#     Cosmos account's disableLocalAuth), StorageV2, no public blob access.
+Write-Host "Storage account '$StorageAccount':"
+$saCount = Get-AzOutput @(
+  'storage', 'account', 'list',
+  '--resource-group', $ResourceGroup,
+  '--query', "length([?name=='$StorageAccount'])",
+  '-o', 'tsv'
+)
+if ($saCount -eq '1') {
+  Write-Host "  present — skipping"
+} else {
+  Write-Host "  missing — creating"
+  Invoke-Az @(
+    'storage', 'account', 'create',
+    '--name', $StorageAccount,
+    '--resource-group', $ResourceGroup,
+    '--location', $Location,
+    '--sku', 'Standard_LRS',
+    '--kind', 'StorageV2',
+    '--min-tls-version', 'TLS1_2',
+    '--allow-blob-public-access', 'false',
+    '--allow-shared-key-access', 'false'
+  ) | Out-Null
+}
+Write-Host ""
+
+# 3c. Overflow container — with shared-key access disabled, every container op
+#     must go through AAD (`--auth-mode login`).
+Write-Host "Blob container '$StorageContainer':"
+$containerExists = Get-AzOutput @(
+  'storage', 'container', 'exists',
+  '--account-name', $StorageAccount,
+  '--name', $StorageContainer,
+  '--auth-mode', 'login',
+  '--query', 'exists',
+  '-o', 'tsv'
+)
+if ($containerExists -eq 'true') {
+  Write-Host "  present — skipping"
+} else {
+  Write-Host "  missing — creating"
+  Invoke-Az @(
+    'storage', 'container', 'create',
+    '--account-name', $StorageAccount,
+    '--name', $StorageContainer,
+    '--auth-mode', 'login'
+  ) | Out-Null
+}
+Write-Host ""
+
+# 3d. Data-plane role — the app reaches Blob as the signed-in operator, who needs
+#     Storage Blob Data Contributor on the account. Assigned only when an operator
+#     object id is supplied; otherwise reported as a prerequisite, exactly as the
+#     Cosmos data role is assumed rather than assigned.
+Write-Host "Role 'Storage Blob Data Contributor' on '$StorageAccount':"
+if ($OperatorObjectId) {
+  $scope = Get-AzOutput @(
+    'storage', 'account', 'show',
+    '--name', $StorageAccount,
+    '--resource-group', $ResourceGroup,
+    '--query', 'id',
+    '-o', 'tsv'
+  )
+  $assignments = Get-AzOutput @(
+    'role', 'assignment', 'list',
+    '--assignee', $OperatorObjectId,
+    '--role', 'Storage Blob Data Contributor',
+    '--scope', $scope,
+    '--query', 'length(@)',
+    '-o', 'tsv'
+  )
+  if ($assignments -ne '' -and $assignments -ne '0') {
+    Write-Host "  already granted to $OperatorObjectId — skipping"
+  } else {
+    Write-Host "  missing — granting to $OperatorObjectId"
+    Invoke-Az @(
+      'role', 'assignment', 'create',
+      '--assignee', $OperatorObjectId,
+      '--role', 'Storage Blob Data Contributor',
+      '--scope', $scope
+    ) | Out-Null
+  }
+} else {
+  Write-Host "  no -OperatorObjectId given — skipping (each operator must hold"
+  Write-Host "  Storage Blob Data Contributor on the account, same as the Cosmos"
+  Write-Host "  Built-in Data Contributor data role)"
+}
+Write-Host ""
 
 Write-Host "Done."


### PR DESCRIPTION
## Summary

Issue #161 (Blob writes failing with `AADSTS650057`) was resolved on the Azure
side — the Desktop app registration's missing Storage scope was added and the
`accountmanagerarcadia` storage account + `snapshots` container + operator role
were stood up by hand. The issue comment promised that infra was "folded into
#160's scope so the reproducible provisioning script covers it too", but the
merged `tool/provision-cosmos.ps1` only covers Cosmos. The storage side was
never actually scripted — the exact "provisioned by hand, not reproducible"
drift the #160 effort exists to close.

This PR makes that promise real: one idempotent script now provisions the whole
state backend (Cosmos **and** Blob), so a fresh environment can reproduce the
storage side and this class of failure can't silently recur.

## Linked issue

Closes #161 (already closed on the infra side; this closes the reproducibility
gap its resolution left open).

## Changes

- `tool/provision-cosmos.ps1`: add a guarded Blob Storage section —
  `Microsoft.Storage` provider registration, the AAD-only `accountmanagerarcadia`
  account (`--allow-shared-key-access false`, StorageV2, no public blob), the
  `snapshots` overflow container (created over AAD, `--auth-mode login`), and an
  optional `-OperatorObjectId` step granting *Storage Blob Data Contributor*.
  Each step has a presence guard, so a re-run against the live account is a
  no-op. New `-DryRun`-safe `Get-AzOutput` helper for scalar reads.
- `packages/account_state/test/cosmos/provision_script_test.dart`: guard tests
  for the storage account, container, provider registration, and data role
  (mirroring the Cosmos guards).
- `docs/port-plan.md`: document that the script now provisions the Blob side.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` clean (273 files)
- [x] `dart analyze` clean (whole workspace)
- [x] unit tests pass — `dart test packages/account_state` (281 passed, 6 skipped);
      4 new guard tests confirmed to fail on the unpatched script (the storage
      strings are absent from the pre-change script)
- [x] script validated: parses, and `-DryRun` (with and without
      `-OperatorObjectId`) prints the full plan making zero `az` calls
- [ ] integration/e2e — **not warranted**: this is a provisioning-script + docs
      change with no user-visible app behavior (the app's `AadResource.storage`
      and `BlobStore` are unchanged). Same posture as #160, which guards the
      script with a unit test and no integration test.