### PR TITLE
Add a 'sync complete' log line and surface the last-synced-by/at freshness (#162)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -207,6 +207,53 @@ void main() {
   });
 
   testWidgets(
+      'a completed sync logs a terminal "Sync complete … Ready." line and the '
+      'prominent last-sync freshness row renders end-to-end (#162)',
+      (WidgetTester tester) async {
+    // The real app composition over the offline harness, driven the way the
+    // operator drives it. (Restart survival of the freshness line is covered by
+    // the passive-session freshness scenario below and the widget test.)
+    useTallWindow(tester);
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+
+    // Before syncing there is no freshness row yet.
+    expect(find.byKey(const ValueKey('reconcile-freshness')), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // The terminal ready line is logged (newest-first in the log panel) so the
+    // operator knows the pass finished, and it names the pending-action count.
+    expect(
+      find.textContaining('Sync complete — 4 pending action(s). Ready.'),
+      findsOneWidget,
+    );
+    // The last-sync freshness now renders in its own prominent row.
+    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
+    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
+    expect(find.textContaining('by operator@school.example'), findsOneWidget);
+
+    // A second, unchanged re-sync logs the no-change ready line too.
+    harness.wisaResult =
+        wisaSnap(fetchedAt: kFixtureDate.add(const Duration(hours: 1)));
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining('Sync complete — no account changes needed. Ready.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
       'the pending list groups one entry per account and applies the chosen '
       'alternative: choose delete → delete, not unregister (#110)',
       (WidgetTester tester) async {
@@ -669,8 +716,10 @@ void main() {
     await tester.tap(find.text('Reconcile'));
     await tester.pumpAndSettle();
 
-    // The shared per-system freshness line renders (who last synced each
-    // system, from the store — not this passive session).
+    // The shared per-system freshness line renders in its prominent row (#162)
+    // straight from the store (who last synced each system — not this passive
+    // session), proving it survives a restart.
+    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
     expect(find.textContaining('Last sync — WISA'), findsOneWidget);
     expect(find.textContaining('by operator@school.example'), findsOneWidget);
 

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -869,6 +869,7 @@ class ReconcileController extends ChangeNotifier {
           'no account changes needed.',
         );
         await _persistSystemMeta();
+        _logSyncComplete();
         _finish(ReconcilePhase.ready);
         return;
       }
@@ -887,12 +888,23 @@ class ReconcileController extends ChangeNotifier {
       }
 
       await _relink();
+      _logSyncComplete();
       _finish(ReconcilePhase.ready);
     } on Object catch (e) {
       _fail(e);
     } finally {
       await _releaseLock();
     }
+  }
+
+  /// Terminal "the pass is done, the screen is current" log line closing a
+  /// successful [sync] (#162). The [noChangesNeeded] path says so explicitly;
+  /// otherwise it names how many pending actions await the operator.
+  void _logSyncComplete() {
+    final message = _noChangesNeeded
+        ? 'Sync complete — no account changes needed. Ready.'
+        : 'Sync complete — ${pendingActions.length} pending action(s). Ready.';
+    log.addMessage(core.Origin.all, message);
   }
 
   /// Explicitly re-reads Smartschool and Azure (drift introduced by edits made

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -242,9 +242,27 @@ class _Header extends StatelessWidget {
               icon: const Icon(Icons.difference_outlined),
               label: const Text('Check for drift'),
             ),
-            if (freshness != null) Text(freshness, style: text.bodySmall),
           ],
         ),
+        if (freshness != null) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s3),
+          Row(
+            key: const ValueKey('reconcile-freshness'),
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(Icons.schedule_outlined, size: 16, color: colors.primary),
+              const SizedBox(width: PlinkSpacing.s2),
+              Flexible(
+                child: Text(
+                  freshness,
+                  style: text.bodyMedium?.copyWith(
+                    color: colors.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
         if (lockedByOther) ...<Widget>[
           const SizedBox(height: PlinkSpacing.s3),
           Row(

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -85,6 +85,43 @@ void main() {
     });
   });
 
+  group('sync-complete log line (#162)', () {
+    test('a completed sync logs a terminal ready line with the action count',
+        () async {
+      final h = ReconcileHarness();
+
+      await h.controller.sync();
+
+      // The count mirrors the relink summary's pendingActions.length (the
+      // fixture derives four pending actions across the families).
+      expect(
+        h.log.entries.map((e) => e.message),
+        contains('Sync complete — 4 pending action(s). Ready.'),
+      );
+      // It is the *last* line — the operator sees it closing the pass.
+      expect(h.log.entries.last.message,
+          'Sync complete — 4 pending action(s). Ready.');
+    });
+
+    test('the "no changes needed" path also logs a ready line', () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+      // A later, identical WISA pull: the early-return no-change path.
+      h.wisaResult =
+          wisaSnap(fetchedAt: kFixtureDate.add(const Duration(hours: 1)));
+
+      await h.controller.sync();
+
+      expect(h.controller.noChangesNeeded, isTrue);
+      expect(
+        h.log.entries.map((e) => e.message),
+        contains('Sync complete — no account changes needed. Ready.'),
+      );
+      expect(h.log.entries.last.message,
+          'Sync complete — no account changes needed. Ready.');
+    });
+  });
+
   group('check for drift', () {
     test('re-reads Smartschool and Azure and re-links', () async {
       final h = ReconcileHarness();

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -151,9 +151,37 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    // No sync yet → no freshness row.
+    expect(find.byKey(const ValueKey('reconcile-freshness')), findsNothing);
+
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
+    // The freshness now sits in its own prominent row (#162), not trailing the
+    // buttons.
+    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
+    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
+    expect(
+      find.textContaining('by operator@school.example'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('the last-sync line survives a restart / passive session (#162)',
+      (WidgetTester tester) async {
+    // Session 1 syncs and persists freshness to the shared store.
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(linkedStore: linkedStore).controller.sync();
+
+    // Session 2 opens fresh over the same store — no sync — and reads the
+    // overview back (loadOverview on bootstrap).
+    final passive = ReconcileHarness(linkedStore: linkedStore);
+    await tester
+        .pumpWidget(_wrap(ReconcileScreen(bootstrap: passive.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(passive.wisaSyncs, 0, reason: 'a passive session pulls nothing');
+    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
     expect(find.textContaining('Last sync — WISA'), findsOneWidget);
     expect(
       find.textContaining('by operator@school.example'),


### PR DESCRIPTION
## Summary

Closes #162.

Two operator-visibility fixes on the reconcile flow:

1. **Sync-complete log line.** `ReconcileController.sync()` now ends with a clear
   terminal line so the operator knows the pass is done and the screen is
   current. The normal path logs `Sync complete — N pending action(s). Ready.`
   (N mirrors the relink summary's `pendingActions.length`); the smart-diff
   `noChangesNeeded` early-return path logs `Sync complete — no account changes
   needed. Ready.`

2. **Prominent last-sync freshness.** The per-system "Last sync — WISA 09:12 by
   jan@… · Smartschool … · Azure …" line moves out of the trailing `bodySmall`
   slot in the button `Wrap` into its own icon row (keyed `reconcile-freshness`,
   `bodyMedium`), matching how the legacy app surfaced it. The write/read path
   (`writeMaterialized`/`recordSystemSync` → `readSyncState`, via `loadOverview`
   on a passive/restarted session) was already correct — it only failed while
   the `syncState` Cosmos container was missing, which was fixed by provisioning
   the container. No data-path change was needed; the restart-survival behaviour
   is now pinned by tests.

## Linked issue
Closes #162

## Changes
- `reconcile_controller.dart`: `_logSyncComplete()` helper, called on both the
  normal and `noChangesNeeded` sync completion paths.
- `reconcile_screen.dart`: freshness rendered as a dedicated, more prominent
  `reconcile-freshness` row below the buttons.
- Tests: controller unit tests for both log-line paths; widget tests for the
  prominent row + restart survival; integration coverage for the end-to-end
  sync-complete line + freshness row, and the existing passive-session freshness
  scenario now asserts the prominent row too.

## Test plan
- [x] `dart format --set-exit-if-changed .` clean (273 files)
- [x] `flutter analyze` clean (no issues)
- [x] unit/widget tests pass (`flutter test` — 153 passed)
- [x] integration/e2e tests pass (`flutter test integration_test -d windows` — 24 passed), including the new #162 end-to-end scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)