### PR TITLE
Restore the category overview to the Reconcile tab (#163)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -151,7 +151,13 @@ void main() {
     expect(harness.wisaSyncs, 1);
     expect(harness.ssSyncs, 1);
     expect(harness.azSyncs, 1);
-    expect(find.text('Linked overview'), findsOneWidget);
+    // The per-category overview renders on Reconcile from the rollups (#163):
+    // students / staff / class-groups, the one fixture student summed with a
+    // pending indicator.
+    expect(find.text('Overview'), findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-category-students')),
+        findsOneWidget);
+    expect(find.text('2 openstaande acties'), findsOneWidget);
     expect(find.textContaining('Pending actions'), findsNothing);
     expect(
       find.byWidgetPredicate((w) =>
@@ -585,7 +591,7 @@ void main() {
     expect(resumed.wisaSyncs, 1);
     expect(resumed.ssSyncs, 0, reason: 'Smartschool seeded from the store');
     expect(resumed.azSyncs, 0, reason: 'Azure seeded from the store');
-    expect(find.text('Linked overview'), findsOneWidget);
+    expect(find.text('Overview'), findsOneWidget);
   });
 
   testWidgets(
@@ -636,6 +642,52 @@ void main() {
     expect(find.text('Jane Doe'), findsOneWidget);
     expect(
         find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+    expect(resumed.wisaSyncs, 0);
+    expect(resumed.ssSyncs, 0);
+    expect(resumed.azSyncs, 0);
+  });
+
+  testWidgets(
+      'a passive session renders the category overview on Reconcile from the '
+      'stored rollups, with no pull and no link() (#163)',
+      (WidgetTester tester) async {
+    // Session 1 (offline harness) syncs and materializes the shared view — the
+    // rollups the passive overview reads — into stores both sessions share.
+    useTallWindow(tester);
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+        .controller
+        .sync();
+
+    // Session 2 is the real app over the same stores. It never syncs.
+    final resumed = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: resumed.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+
+    // The per-category overview renders straight from the stored rollups — no
+    // Synchronise tapped, and link() is never called in a passive session.
+    expect(find.text('Overview'), findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-category-students')),
+        findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('reconcile-category-staff')), findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-category-groups')),
+        findsOneWidget);
+    // The one fixture student is summed from the rollup with a pending indicator.
+    expect(find.text('2 openstaande acties'), findsOneWidget);
+    expect(resumed.controller.linked, isNull,
+        reason: 'link() is never called in a passive session');
     expect(resumed.wisaSyncs, 0);
     expect(resumed.ssSyncs, 0);
     expect(resumed.azSyncs, 0);

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -237,6 +237,24 @@ class DuplicateMailWarning {
   List<String> get uids => sortedDuplicateUids(accounts.map((a) => a.uid));
 }
 
+/// A per-category summary for the Reconcile overview (#163): how many accounts
+/// (or class groups) the category holds, and how many of them carry an applyable
+/// pending action. Derived from the stored [Rollup]s, so it is readable in a
+/// passive session that never linked — the whole point of the materialized view.
+class CategorySummary {
+  const CategorySummary({required this.total, required this.pending});
+
+  /// The total accounts (students / staff) or class groups in this category.
+  final int total;
+
+  /// How many of them carry at least one applyable pending action (the
+  /// informational group notices, which never write, are excluded).
+  final int pending;
+
+  /// The zero state before any sync has materialized a rollup.
+  static const CategorySummary empty = CategorySummary(total: 0, pending: 0);
+}
+
 /// Drives the reconcile loop over the State layer (#99): **sync → linked
 /// overview → pending actions → dry-run → apply**, with progress and failures
 /// reported through the shared [LogBuffer].
@@ -804,6 +822,44 @@ class ReconcileController extends ChangeNotifier {
 
   /// Whether a classroom drill-down read is in flight.
   bool get loadingClassroom => _loadingClassroom;
+
+  /// The three category summaries the Reconcile overview renders (#163), summed
+  /// from the stored rollups so they read in a passive session too: students are
+  /// every school rollup *except* the synthetic staff bucket, staff is that
+  /// bucket, and class groups is the single "Klasgroepen" node. Each is zero
+  /// before any operator has synced.
+  CategorySummary get studentSummary {
+    var total = 0;
+    var pending = 0;
+    for (final r in _rollups) {
+      if (r.level == RollupLevel.school && r.school != staffPartition) {
+        total += r.accountCount;
+        pending += r.pendingCount;
+      }
+    }
+    return CategorySummary(total: total, pending: pending);
+  }
+
+  /// The staff category summary (#163): the single school rollup living in the
+  /// synthetic [staffPartition] bucket, or [CategorySummary.empty] when no staff
+  /// account has been materialized.
+  CategorySummary get staffSummary {
+    for (final r in _rollups) {
+      if (r.level == RollupLevel.school && r.school == staffPartition) {
+        return CategorySummary(total: r.accountCount, pending: r.pendingCount);
+      }
+    }
+    return CategorySummary.empty;
+  }
+
+  /// The class-groups category summary (#163): the single "Klasgroepen" rollup
+  /// node, or [CategorySummary.empty] when no group carries an action to surface.
+  CategorySummary get groupSummary {
+    final r = groupRollup;
+    return r == null
+        ? CategorySummary.empty
+        : CategorySummary(total: r.accountCount, pending: r.pendingCount);
+  }
 
   /// The single "Klasgroepen" rollup node (#119), or `null` when no group has a
   /// pending action to drill into.

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:account_core/account_core.dart' as core;
-import 'package:account_state/account_state.dart' show LinkedState;
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
@@ -153,22 +152,22 @@ class _ReconcileBody extends StatelessWidget {
       SliverToBoxAdapter(child: SizedBox(height: height));
 
   /// Reconcile is now short and responsive (#154): the sync/drift header, the
-  /// status banner, and — once a sync has linked this session — the linked
-  /// overview counts with the duplicate-mail warnings. The pending actions and
-  /// their per-year/per-class drill-down live on the Actions tab.
+  /// status banner, and — as soon as *any* operator has synced — the per-category
+  /// overview (students / staff / class groups with their pending indicators)
+  /// with the duplicate-mail warnings. The overview reads from the stored rollups
+  /// (#163), so it renders in a passive session that never linked; the pending
+  /// actions and their per-year/per-class drill-down live on the Actions tab.
   List<Widget> _slivers() {
-    final linked = controller.linked;
     final slivers = <Widget>[
       _gap(PlinkSpacing.s6),
       _section(_Header(controller: controller)),
       _gap(PlinkSpacing.s5),
       _section(_StatusBanner(controller: controller)),
     ];
-    if (linked != null) {
+    if (controller.hasOverview || controller.duplicateWarnings.isNotEmpty) {
       slivers
         ..add(_gap(PlinkSpacing.s5))
-        ..add(
-            _section(_OverviewSection(linked: linked, controller: controller)));
+        ..add(_section(_OverviewSection(controller: controller)));
     }
     slivers.add(_gap(PlinkSpacing.s6));
     return slivers;
@@ -364,32 +363,59 @@ class _StatusBanner extends StatelessWidget {
       );
 }
 
+/// The at-a-glance category overview restored to the Reconcile tab (#163): the
+/// students / staff / class-groups totals with a per-category pending indicator,
+/// summed from the stored rollups so it renders even in a passive session that
+/// never linked. The duplicate-mail warnings stay here beneath it; they come
+/// from the live linked view, so they only appear in an active session.
 class _OverviewSection extends StatelessWidget {
-  const _OverviewSection({required this.linked, required this.controller});
+  const _OverviewSection({required this.controller});
 
-  final LinkedState linked;
   final ReconcileController controller;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
-    final snapshot = linked.snapshot;
+    final ColorScheme colors = Theme.of(context).colorScheme;
     final duplicates = controller.duplicateWarnings;
+    final students = controller.studentSummary;
+    final staff = controller.staffSummary;
+    final groups = controller.groupSummary;
+    final pending = students.pending + staff.pending + groups.pending;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Linked overview', style: text.titleMedium),
+        Text('Overview', style: text.titleMedium),
         const SizedBox(height: PlinkSpacing.s3),
         Wrap(
           spacing: PlinkSpacing.s4,
           runSpacing: PlinkSpacing.s4,
           children: <Widget>[
-            _CountTile(system: 'WISA', counts: snapshot.wisa),
-            _CountTile(system: 'Smartschool', counts: snapshot.smartschool),
-            _CountTile(system: 'Azure AD', counts: snapshot.azure),
+            _CategoryTile(
+              key: const ValueKey('reconcile-category-students'),
+              category: 'Leerlingen',
+              summary: students,
+            ),
+            _CategoryTile(
+              key: const ValueKey('reconcile-category-staff'),
+              category: 'Personeel',
+              summary: staff,
+            ),
+            _CategoryTile(
+              key: const ValueKey('reconcile-category-groups'),
+              category: 'Klasgroepen',
+              summary: groups,
+            ),
           ],
         ),
+        if (pending > 0) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s3),
+          Text(
+            'Bekijk en pas de openstaande acties toe op het tabblad Acties.',
+            style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+          ),
+        ],
         if (duplicates.isNotEmpty) ...<Widget>[
           const SizedBox(height: PlinkSpacing.s3),
           for (final w in duplicates)
@@ -400,16 +426,27 @@ class _OverviewSection extends StatelessWidget {
   }
 }
 
-class _CountTile extends StatelessWidget {
-  const _CountTile({required this.system, required this.counts});
+/// One category card in the Reconcile overview (#163): its name, the total count
+/// of accounts/groups it holds, and a pending indicator — a check when nothing
+/// is outstanding, otherwise the count of applyable actions (which the Actions
+/// tab drills into).
+class _CategoryTile extends StatelessWidget {
+  const _CategoryTile({
+    super.key,
+    required this.category,
+    required this.summary,
+  });
 
-  final String system;
-  final core.LinkCounts counts;
+  final String category;
+  final CategorySummary summary;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
     final Color hairline = Theme.of(context).dividerColor;
+    final int pending = summary.pending;
+    final bool clear = pending == 0;
 
     return Container(
       width: 200,
@@ -421,18 +458,29 @@ class _CountTile extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          PlinkBadge(system),
+          PlinkBadge(category),
           const SizedBox(height: PlinkSpacing.s3),
-          Text(
-            '${counts.linked} / ${counts.total}',
-            style: text.headlineSmall,
-          ),
-          const SizedBox(height: PlinkSpacing.s1),
-          Text(
-            counts.unlinked == 0
-                ? 'fully linked'
-                : '${counts.unlinked} not in every system',
-            style: text.bodySmall,
+          Text('${summary.total}', style: text.headlineSmall),
+          const SizedBox(height: PlinkSpacing.s2),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(
+                clear ? Icons.check_circle_outline : Icons.pending_actions,
+                size: 16,
+                color: clear ? colors.primary : colors.error,
+              ),
+              const SizedBox(width: PlinkSpacing.s2),
+              Flexible(
+                child: Text(
+                  clear
+                      ? 'geen openstaande acties'
+                      : '$pending openstaande '
+                          '${pending == 1 ? 'actie' : 'acties'}',
+                  style: text.bodySmall,
+                ),
+              ),
+            ],
           ),
         ],
       ),

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:account_actions/account_actions.dart' as actions;
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_manager/src/reconcile/log_buffer.dart';
+import 'package:account_manager/src/reconcile/reconcile_controller.dart';
 import 'package:account_state/account_state.dart';
 import 'package:azure_api/azure_api.dart' as az;
 import 'package:flutter_test/flutter_test.dart';
@@ -376,6 +377,67 @@ void main() {
           await h.linkedStore.readClassroom(school: '1', classroom: '3D');
       expect(classroom.single.decisions, hasLength(1),
           reason: 'the surviving decision is re-attached to the account doc');
+    });
+  });
+
+  group('category overview summaries (#163)', () {
+    void expectSummary(CategorySummary s,
+        {required int total, required int pending}) {
+      expect(s.total, total);
+      expect(s.pending, pending);
+    }
+
+    test('are empty before any sync', () {
+      final h = ReconcileHarness();
+      expectSummary(h.controller.studentSummary, total: 0, pending: 0);
+      expectSummary(h.controller.staffSummary, total: 0, pending: 0);
+      expectSummary(h.controller.groupSummary, total: 0, pending: 0);
+    });
+
+    test('sum the rollups per category after a sync', () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+
+      // One fixture student (School 1); the rollup pendingCount sums her
+      // applyable candidate actions (as the Actions drill-down badges do).
+      expectSummary(h.controller.studentSummary, total: 1, pending: 2);
+      // No staff in the fixture ⇒ the staff bucket is absent.
+      expectSummary(h.controller.staffSummary, total: 0, pending: 0);
+      // Two Smartschool-only classes (2B, 3C) are informational group notices,
+      // so they count toward the total but carry no applyable pending action.
+      expectSummary(h.controller.groupSummary, total: 2, pending: 0);
+    });
+
+    test('departed students sum across the unassigned bucket, not staff',
+        () async {
+      // Three WISA-departed, Smartschool-only accounts, all in the synthetic
+      // "unassigned" school — never the staff bucket. Each carries two applyable
+      // candidates (the unregister + delete alternatives), so the rollup
+      // pendingCount is 3 × 2.
+      final h = manyDepartedHarness(count: 3);
+      await h.controller.sync();
+
+      expectSummary(h.controller.studentSummary, total: 3, pending: 6);
+      expectSummary(h.controller.staffSummary, total: 0, pending: 0);
+    });
+
+    test('a passive session derives the summaries from the stored rollups',
+        () async {
+      final snapshots = InMemorySnapshotStore();
+      final linkedStore = InMemoryLinkedStore();
+      await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+          .controller
+          .sync();
+
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      await s2.controller.loadOverview();
+
+      expect(s2.controller.linked, isNull);
+      expectSummary(s2.controller.studentSummary, total: 1, pending: 2);
+      expectSummary(s2.controller.groupSummary, total: 2, pending: 0);
     });
   });
 

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -76,8 +76,8 @@ void main() {
   });
 
   testWidgets(
-      'sync renders the linked overview and keeps the pending actions off '
-      'Reconcile; an unchanged re-sync shows the no-changes banner (#154)',
+      'sync renders the category overview and keeps the pending actions off '
+      'Reconcile; an unchanged re-sync shows the no-changes banner (#154/#163)',
       (WidgetTester tester) async {
     _useTallWindow(tester);
     final harness = ReconcileHarness();
@@ -87,15 +87,25 @@ void main() {
     await tester.pumpAndSettle();
 
     // Idle: the explainer is shown, no overview yet.
-    expect(find.text('Linked overview'), findsNothing);
+    expect(find.text('Overview'), findsNothing);
+    expect(find.byKey(const ValueKey('reconcile-category-students')),
+        findsNothing);
 
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    // The linked overview counts render on Reconcile…
-    expect(find.text('Linked overview'), findsOneWidget);
-    expect(find.text('WISA'), findsOneWidget);
-    expect(find.text('SMARTSCHOOL'), findsOneWidget); // PlinkBadge uppercases
+    // The per-category overview renders on Reconcile from the rollups (#163):
+    // students / staff / class-groups, each with a pending indicator.
+    expect(find.text('Overview'), findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-category-students')),
+        findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('reconcile-category-staff')), findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-category-groups')),
+        findsOneWidget);
+    expect(find.text('LEERLINGEN'), findsOneWidget); // PlinkBadge uppercases
+    // The one fixture student's applyable actions surface as a pending indicator.
+    expect(find.text('2 openstaande acties'), findsOneWidget);
 
     // …but the pending actions moved to the Actions tab: neither the title, the
     // global apply, nor any entry tile is on the Reconcile screen (#154).
@@ -187,6 +197,36 @@ void main() {
       find.textContaining('by operator@school.example'),
       findsOneWidget,
     );
+  });
+
+  testWidgets(
+      'a passive session renders the category overview from the stored rollups '
+      'with no live linked view (#163)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // Session 1 syncs and materializes the rollups into the shared store.
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(linkedStore: linkedStore).controller.sync();
+
+    // Session 2 opens fresh over the same store — no sync — and reads the
+    // overview back (loadOverview on bootstrap).
+    final passive = ReconcileHarness(linkedStore: linkedStore);
+    await tester
+        .pumpWidget(_wrap(ReconcileScreen(bootstrap: passive.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The overview renders from the rollups alone — link() was never called.
+    expect(passive.controller.linked, isNull,
+        reason: 'a passive session never links');
+    expect(passive.wisaSyncs, 0, reason: 'a passive session pulls nothing');
+    expect(find.text('Overview'), findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-category-students')),
+        findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('reconcile-category-staff')), findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-category-groups')),
+        findsOneWidget);
+    // The one fixture student is summed from the rollup, with a pending indicator.
+    expect(find.text('2 openstaande acties'), findsOneWidget);
   });
 
   testWidgets(

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -204,7 +204,7 @@ List<Rollup> buildRollups(List<MaterializedAccount> accounts) {
 // Placement.
 // ---------------------------------------------------------------------------
 
-const String _staffSchool = 'staff';
+const String _staffSchool = staffPartition;
 const String _staffLabel = 'Personeel';
 const String _unassignedSchool = 'unassigned';
 const String _unassignedLabel = 'Niet toegewezen';

--- a/packages/account_state/lib/src/materialize/materialized_state.dart
+++ b/packages/account_state/lib/src/materialize/materialized_state.dart
@@ -314,6 +314,13 @@ class MaterializedAccount {
 /// mirror of the `staff` bucket accounts use.
 const String groupsPartition = 'groups';
 
+/// The synthetic partition (and rollup school) every staff [MaterializedAccount]
+/// shares. Staff have no WISA class the way a student does, so they land in one
+/// logical bucket of their own — the counterpart of [groupsPartition]. Exposed
+/// so the reconcile overview can tell the staff school [Rollup] apart from the
+/// student-school rollups when it sums the per-category totals (#163).
+const String staffPartition = 'staff';
+
 /// One linked **class group** as a stored document (#119).
 ///
 /// The group-family counterpart of [MaterializedAccount]: where a per-account


### PR DESCRIPTION
## Summary

Moving the pending actions to the Actions tab (#154) left the Reconcile tab without an at-a-glance overview. This restores it as a **per-category** summary — students / staff / class groups — each with a pending-action indicator, sourced from the **stored rollups** rather than a live linked view, so it renders in a passive session too (the point of the materialized view, #115).

## Linked issue

Closes #163

## Changes

- **`account_state`** — expose a public `staffPartition` constant (mirror of `groupsPartition`) so the overview can tell the staff school rollup apart from the student-school rollups.
- **`ReconcileController`** — add `CategorySummary` plus `studentSummary` / `staffSummary` / `groupSummary`, summed from the rollups (student = every school rollup except the staff bucket; staff = that bucket; groups = the "Klasgroepen" node). Each is zero before any sync, and derives from `_rollups`, so it works in a passive session that never linked.
- **`ReconcileScreen`** — render the three category tiles (each with a total count + a pending indicator, and a hint toward the Actions tab for the detail) whenever an overview exists, keeping the duplicate-mail warnings beneath them. The now-unused per-system tiles and the `LinkedState` import are dropped. The section title is `Overview` (matching the Reconcile screen's English chrome, and distinct from the Actions tab's `Overzicht`).

The per-category pending indicator uses the rollup `pendingCount` (applyable candidate actions), the same count the Actions drill-down badges already use, so the two stay consistent.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed` clean (273 files)
- [x] `flutter analyze` clean — No issues found
- [x] Unit/widget tests pass — `flutter test` in `account_manager` (158) and `packages/account_state` (281). New: controller summary tests (empty / after-sync / departed-only / passive), and reconcile widget tests for the rendered tiles (active + passive session).
- [x] Integration/e2e tests pass — `flutter test integration_test -d windows` (25). New passive-session Reconcile category-overview scenario end-to-end, and the existing #154/#107 flows updated to assert the category tiles. This is a user-visible UI change, so an integration test is included.