### PR TITLE
Fix full-sync hang: batch the persist and time it out (#168)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -260,6 +260,61 @@ void main() {
   });
 
   testWidgets(
+      'a sync whose shared-store persist stalls still finishes: Synchronise '
+      're-enables and the timeout is surfaced in the log (#168)',
+      (WidgetTester tester) async {
+    // The real app over the offline harness, but the LinkedStore write hangs
+    // (the ~9.6k-doc persist that wedged the pass). The controller must not stay
+    // stuck in `linking` with Synchronise disabled forever — it times out the
+    // persist, surfaces it, and returns to ready.
+    useTallWindow(tester);
+    final stalling = StallingLinkedStore();
+    final harness = ReconcileHarness(
+      controllerStore: stalling,
+      persistTimeout: const Duration(milliseconds: 300),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+
+    // Start the sync; while the persist hangs the pass is busy and Synchronise
+    // is disabled.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pump();
+    expect(harness.controller.busy, isTrue);
+    expect(
+      tester
+          .widget<FilledButton>(find.byKey(const ValueKey('reconcile-sync')))
+          .onPressed,
+      isNull,
+    );
+
+    // Let the persist timeout elapse (real wall-clock in the live binding), then
+    // settle the resulting frame.
+    await Future<void>.delayed(const Duration(milliseconds: 700));
+    await tester.pumpAndSettle();
+
+    // The persist was reached but hung; the pass recovered rather than wedging.
+    expect(stalling.writeAttempted, isTrue);
+    expect(harness.controller.busy, isFalse);
+    // Synchronise is live again.
+    expect(
+      tester
+          .widget<FilledButton>(find.byKey(const ValueKey('reconcile-sync')))
+          .onPressed,
+      isNotNull,
+    );
+    // The operator sees the timeout in the log panel, not silence.
+    expect(find.textContaining('timed out'), findsOneWidget);
+  });
+
+  testWidgets(
       'the pending list groups one entry per account and applies the chosen '
       'alternative: choose delete → delete, not unregister (#110)',
       (WidgetTester tester) async {

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -275,6 +275,7 @@ class ReconcileController extends ChangeNotifier {
     this.syncedBy = '',
     this.publisher,
     this.subscriber,
+    this.persistTimeout = const Duration(minutes: 10),
     DateTime Function()? clock,
   }) : _now = clock ?? DateTime.now {
     final sub = subscriber;
@@ -308,6 +309,15 @@ class ReconcileController extends ChangeNotifier {
   /// `viewChanged` refetches the changed shard, a `syncStarted` / `syncEnded`
   /// re-reads the lease to disable/enable Synchronise. Null when unwired (#116).
   final SignalSubscriber? subscriber;
+
+  /// How long [_persist] waits for the shared-store write before giving up and
+  /// returning the pass to `ready` (#168). A full materialized view is ~9.6k
+  /// account docs; if the write stalls (throttling loop, a wedged connection),
+  /// the operator must not be stuck with Synchronise disabled forever — the
+  /// in-memory linked view is still usable this session. The wait is generous
+  /// so a merely-slow (but progressing) write is never cut off in practice;
+  /// tests inject a tiny value.
+  final Duration persistTimeout;
 
   final DateTime Function() _now;
 
@@ -1311,13 +1321,21 @@ class ReconcileController extends ChangeNotifier {
         rollups: view.rollups,
       );
       final at = _now();
-      await store.writeMaterialized(
-        merged,
-        syncedBy: syncedBy,
-        at: at,
-        droppedDecisions: merge.dropped,
-        systemSyncs: _pulled,
-      );
+      // Guard the shared-store write with a timeout: a full view is ~9.6k
+      // account docs, and a stalled write must not leave the pass wedged in
+      // `linking` with Synchronise disabled forever — the in-memory view is
+      // usable this session regardless (#168). Progress lines from the store
+      // keep a long-but-healthy write visible in the log.
+      await store
+          .writeMaterialized(
+            merged,
+            syncedBy: syncedBy,
+            at: at,
+            droppedDecisions: merge.dropped,
+            systemSyncs: _pulled,
+            onProgress: (m) => log.addMessage(core.Origin.all, m),
+          )
+          .timeout(persistTimeout);
       _rollups = merged.rollups;
       _syncState = SyncState(
         generation: view.generation,
@@ -1334,6 +1352,13 @@ class ReconcileController extends ChangeNotifier {
       _classroomAccounts = null;
       _showingGroups = false;
       _groupDocs = null;
+    } on TimeoutException {
+      log.addError(
+        core.Origin.all,
+        'Persisting the linked view timed out after '
+        '${persistTimeout.inSeconds}s — the linked view is usable this session '
+        'but was not saved to the shared store.',
+      );
     } on Object catch (e) {
       log.addError(core.Origin.all, 'Could not persist the linked view: $e');
     }

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -123,6 +123,53 @@ void main() {
     });
   });
 
+  group('persist resilience (#168)', () {
+    test(
+        'a stalled writeMaterialized times out, logs it, and returns the pass '
+        'to ready so Synchronise re-enables', () async {
+      final stalling = StallingLinkedStore();
+      final h = ReconcileHarness(
+        controllerStore: stalling,
+        persistTimeout: const Duration(milliseconds: 50),
+      );
+
+      await h.controller.sync();
+
+      // The persist step was reached but hung — the controller did not wait
+      // forever: it timed out and finished the pass.
+      expect(stalling.writeAttempted, isTrue);
+      expect(h.controller.busy, isFalse,
+          reason: 'a stalled persist must not leave the pass wedged');
+      expect(h.controller.phase, ReconcilePhase.ready);
+      // The operator sees the timeout, not silence.
+      expect(
+        h.log.entries.where((e) => e.isError).map((e) => e.message),
+        contains(contains('timed out')),
+      );
+      // The in-memory linked view is still usable this session.
+      expect(h.controller.linked, isNotNull);
+    });
+
+    test(
+        'a failing writeMaterialized is caught, logged, and the pass still '
+        'reaches ready', () async {
+      final failing = StallingLinkedStore(
+        failWith: StateError('cosmos down'),
+      );
+      final h = ReconcileHarness(controllerStore: failing);
+
+      await h.controller.sync();
+
+      expect(h.controller.busy, isFalse);
+      expect(h.controller.phase, ReconcilePhase.ready);
+      expect(
+        h.log.entries.where((e) => e.isError).map((e) => e.message),
+        contains(contains('Could not persist the linked view')),
+      );
+      expect(h.controller.linked, isNotNull);
+    });
+  });
+
   group('check for drift', () {
     test('re-reads Smartschool and Azure and re-links', () async {
       final h = ReconcileHarness();

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -9,6 +9,8 @@
 /// exactly one deterministic pending action (`MoveToSmartschoolClassGroup`).
 library;
 
+import 'dart:async';
+
 import 'package:account_actions/account_actions.dart' as actions;
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_manager/src/reconcile/log_buffer.dart';
@@ -302,6 +304,79 @@ class InMemorySnapshotStore implements SnapshotStore {
   }
 }
 
+/// A [LinkedStore] whose [writeMaterialized] never completes (a hung Cosmos
+/// write) or throws, while every read delegates to an inner [InMemoryLinkedStore]
+/// — the persist-stall the reconcile controller must survive (#168).
+class StallingLinkedStore implements LinkedStore {
+  StallingLinkedStore({InMemoryLinkedStore? inner, this.failWith})
+      : _in = inner ?? InMemoryLinkedStore();
+
+  final InMemoryLinkedStore _in;
+
+  /// When set, [writeMaterialized] throws this instead of hanging.
+  final Object? failWith;
+
+  /// True once a write was attempted — proves the controller reached persist.
+  bool writeAttempted = false;
+
+  @override
+  Future<void> writeMaterialized(
+    MaterializedView view, {
+    required String syncedBy,
+    required DateTime at,
+    List<AccountDecision> droppedDecisions = const [],
+    Map<core.Origin, SystemSyncMeta> systemSyncs = const {},
+    void Function(String message)? onProgress,
+  }) {
+    writeAttempted = true;
+    final fail = failWith;
+    if (fail != null) return Future<void>.error(fail);
+    // Never completes: models a wedged store write the controller must time out.
+    return Completer<void>().future;
+  }
+
+  @override
+  Future<SyncState> readSyncState() => _in.readSyncState();
+  @override
+  Future<List<Rollup>> readRollups() => _in.readRollups();
+  @override
+  Future<List<MaterializedAccount>> readClassroom({
+    required String school,
+    required String classroom,
+  }) =>
+      _in.readClassroom(school: school, classroom: classroom);
+  @override
+  Future<List<MaterializedGroup>> readGroups() => _in.readGroups();
+  @override
+  Future<List<AccountDecision>> readDecisions() => _in.readDecisions();
+  @override
+  Future<void> putDecision(AccountDecision decision) =>
+      _in.putDecision(decision);
+  @override
+  Future<void> deleteDecision(AccountDecision decision) =>
+      _in.deleteDecision(decision);
+  @override
+  Future<void> recordSystemSync(Map<core.Origin, SystemSyncMeta> systemSyncs) =>
+      _in.recordSystemSync(systemSyncs);
+  @override
+  Future<SyncLease?> readLease(DateTime now) => _in.readLease(now);
+  @override
+  Future<LeaseOutcome> acquireLease({
+    required String owner,
+    required DateTime now,
+  }) =>
+      _in.acquireLease(owner: owner, now: now);
+  @override
+  Future<LeaseOutcome> renewLease({
+    required String owner,
+    required DateTime now,
+  }) =>
+      _in.renewLease(owner: owner, now: now);
+  @override
+  Future<void> releaseLease({required String owner}) =>
+      _in.releaseLease(owner: owner);
+}
+
 // ---------------------------------------------------------------------------
 // The harness: the real State layer over scripted syncers.
 // ---------------------------------------------------------------------------
@@ -316,6 +391,8 @@ class ReconcileHarness {
     az.AzureSnapshot? azure,
     this.store,
     InMemoryLinkedStore? linkedStore,
+    this.controllerStore,
+    this.persistTimeout,
     this.hub,
     SignalPublisher? publisher,
     SignalSubscriber? subscriber,
@@ -429,13 +506,24 @@ class ReconcileHarness {
       app: app,
       applier: applier,
       log: log,
-      store: this.linkedStore,
+      store: controllerStore ?? this.linkedStore,
       syncedBy: syncedBy,
       publisher: publisher ?? signalHub?.publisher(),
       subscriber: subscriber ?? signalHub?.subscriber(),
+      persistTimeout: persistTimeout ?? const Duration(minutes: 10),
       clock: () => kFixtureDate,
     );
   }
+
+  /// An alternate [LinkedStore] handed to the controller instead of the plain
+  /// [linkedStore] — used to inject a stalling/failing `writeMaterialized` for
+  /// the persist-resilience tests (#168). Reads still resolve through it, so it
+  /// normally wraps an [InMemoryLinkedStore].
+  final LinkedStore? controllerStore;
+
+  /// The controller's persist-step timeout (#168); defaults to 10 minutes when
+  /// unset, and the stall tests inject a tiny value.
+  final Duration? persistTimeout;
 
   /// The shared materialized-view store (#115): a sync writes the derived
   /// per-account docs + rollups here, and a resumed session reads the overview

--- a/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
@@ -26,6 +26,17 @@ class CosmosLinkedStore implements LinkedStore {
 
   final CosmosClient _client;
 
+  /// How many per-document upserts/deletes may be in flight at once during a
+  /// [writeMaterialized] container replace. A full account container is ~9.6k
+  /// docs; a bounded fan-out turns thousands of serial round-trips into a write
+  /// that finishes in a fraction of the wall-clock while staying well under the
+  /// throughput that would trip sustained throttling (#168).
+  static const int _writeConcurrency = 24;
+
+  /// Emit a progress line every this many upserts (plus one at the end), so a
+  /// long write ticks in the operator log rather than looking hung (#168).
+  static const int _progressEvery = 1000;
+
   @override
   Future<SyncState> readSyncState() async {
     final doc = await _client.readDocument(
@@ -89,6 +100,7 @@ class CosmosLinkedStore implements LinkedStore {
     required DateTime at,
     List<AccountDecision> droppedDecisions = const [],
     Map<core.Origin, SystemSyncMeta> systemSyncs = const {},
+    void Function(String message)? onProgress,
   }) async {
     // Merge the systems pulled this pass over whatever the last write recorded,
     // so a system this pass did not pull keeps its earlier stamp (#108).
@@ -97,7 +109,8 @@ class CosmosLinkedStore implements LinkedStore {
       ...systemSyncs,
     };
     // Per-account docs: upsert the fresh set, then delete the stragglers no
-    // longer present so a departed account's doc does not linger.
+    // longer present so a departed account's doc does not linger. This is the
+    // big one (~9.6k docs); its progress is what the operator sees ticking.
     await _replaceContainer(
       container: linkedAccountsContainer,
       freshIds: {for (final a in view.accounts) a.id.value},
@@ -105,6 +118,8 @@ class CosmosLinkedStore implements LinkedStore {
         for (final a in view.accounts)
           a.id.value: (pk: a.school, doc: a.toJson()),
       },
+      label: 'accounts',
+      onProgress: onProgress,
     );
     // Per-group docs: same wholesale replace, in the single groups partition
     // (#119).
@@ -115,6 +130,8 @@ class CosmosLinkedStore implements LinkedStore {
         for (final g in view.groups)
           g.id.value: (pk: g.school, doc: g.toJson()),
       },
+      label: 'groups',
+      onProgress: onProgress,
     );
     // Rollups: same replace, keyed by the rollup node key.
     await _replaceContainer(
@@ -123,16 +140,19 @@ class CosmosLinkedStore implements LinkedStore {
       docsById: {
         for (final r in view.rollups) r.key: (pk: r.school, doc: r.toJson()),
       },
+      label: 'rollups',
+      onProgress: onProgress,
     );
 
     // Drop the decisions the merge found no longer applicable.
-    for (final d in droppedDecisions) {
-      await _client.deleteDocument(
+    await _runBounded(
+      droppedDecisions,
+      (d) => _client.deleteDocument(
         container: decisionsContainer,
         id: decisionDocId(d),
         partitionKey: d.accountId.value,
-      );
-    }
+      ),
+    );
 
     // Bump the generation last, so a reader that sees the new generation also
     // sees the rewritten docs.
@@ -339,30 +359,84 @@ class CosmosLinkedStore implements LinkedStore {
   /// Upserts every document in [docsById], then deletes any document currently
   /// in [container] whose id is not in [freshIds] — the "replace the whole set"
   /// the derived containers need without a container-level truncate.
+  ///
+  /// The upserts and deletes run with bounded concurrency ([_writeConcurrency])
+  /// rather than strictly one at a time: a full account container is ~9.6k docs,
+  /// and issuing that many serial round-trips is what made a full sync look hung
+  /// (#168). A bounded fan-out keeps wall-clock low without stampeding the
+  /// account's provisioned throughput into a sustained 429 back-off. When
+  /// [onProgress] and [label] are given, a line is emitted every
+  /// [_progressEvery] upserts (and once at the end) so a long write is visible.
   Future<void> _replaceContainer({
     required String container,
     required Set<String> freshIds,
     required Map<String, ({String pk, Map<String, dynamic> doc})> docsById,
+    String? label,
+    void Function(String message)? onProgress,
   }) async {
-    for (final entry in docsById.entries) {
-      await _client.upsertDocument(
+    final total = docsById.length;
+    await _runBounded(
+      docsById.values,
+      (entry) => _client.upsertDocument(
         container: container,
-        partitionKey: entry.value.pk,
-        document: entry.value.doc,
-      );
-    }
+        partitionKey: entry.pk,
+        document: entry.doc,
+      ),
+      onDone: (label == null || onProgress == null)
+          ? null
+          : (done) {
+              if (done == total || done % _progressEvery == 0) {
+                onProgress('Persisting $label: $done/$total…');
+              }
+            },
+    );
     final existing = await _client.queryDocuments(
       container: container,
       query: 'SELECT c.id, c.pk FROM c',
     );
-    for (final doc in existing) {
-      final id = doc['id'] as String?;
-      if (id == null || freshIds.contains(id)) continue;
-      await _client.deleteDocument(
+    final stragglers = [
+      for (final doc in existing)
+        if (doc['id'] is String && !freshIds.contains(doc['id']))
+          (
+            id: doc['id'] as String,
+            pk: (doc['pk'] as String?) ?? doc['id'] as String,
+          ),
+    ];
+    await _runBounded(
+      stragglers,
+      (s) => _client.deleteDocument(
         container: container,
-        id: id,
-        partitionKey: (doc['pk'] as String?) ?? id,
-      );
+        id: s.id,
+        partitionKey: s.pk,
+      ),
+    );
+  }
+
+  /// Runs [action] over [items] with at most [_writeConcurrency] futures in
+  /// flight at once, calling [onDone] with the running completed count after
+  /// each. A worker-pool (not fixed chunks) keeps the pool full — the slowest
+  /// item in a chunk never idles the rest — and any failure surfaces from the
+  /// awaited [Future.wait] just as the old serial loop would have thrown.
+  Future<void> _runBounded<T>(
+    Iterable<T> items,
+    Future<void> Function(T) action, {
+    void Function(int done)? onDone,
+  }) async {
+    final list = items.toList(growable: false);
+    if (list.isEmpty) return;
+    var next = 0;
+    var done = 0;
+    Future<void> worker() async {
+      while (true) {
+        final i = next++;
+        if (i >= list.length) return;
+        await action(list[i]);
+        onDone?.call(++done);
+      }
     }
+
+    final pool =
+        list.length < _writeConcurrency ? list.length : _writeConcurrency;
+    await Future.wait([for (var w = 0; w < pool; w++) worker()]);
   }
 }

--- a/packages/account_state/lib/src/materialize/linked_store.dart
+++ b/packages/account_state/lib/src/materialize/linked_store.dart
@@ -44,12 +44,18 @@ abstract interface class LinkedStore {
   /// last-sync metadata in [systemSyncs] (the systems this pass pulled), merged
   /// into the stored map so a system not pulled this pass keeps its earlier
   /// stamp (#108). Only the sync/drift process calls this.
+  ///
+  /// A full view is ~9.6k account docs, so a real write can take a while.
+  /// [onProgress], when given, is called with human-readable progress lines
+  /// (e.g. `Persisting accounts: 2000/9600…`) so a long write is visible in the
+  /// operator log rather than looking hung (#168).
   Future<void> writeMaterialized(
     MaterializedView view, {
     required String syncedBy,
     required DateTime at,
     List<AccountDecision> droppedDecisions = const [],
     Map<core.Origin, SystemSyncMeta> systemSyncs = const {},
+    void Function(String message)? onProgress,
   });
 
   /// Creates or replaces one operator decision. The write seam #109/#110 use;
@@ -154,6 +160,7 @@ class InMemoryLinkedStore implements LinkedStore {
     required DateTime at,
     List<AccountDecision> droppedDecisions = const [],
     Map<core.Origin, SystemSyncMeta> systemSyncs = const {},
+    void Function(String message)? onProgress,
   }) async {
     _accounts
       ..clear()

--- a/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
@@ -186,6 +186,87 @@ class _EnforcingFakeClient implements CosmosClient {
       [for (final d in _c(container).values) Map<String, dynamic>.from(d)];
 }
 
+/// A [CosmosClient] that yields on every upsert (so writes can overlap) and
+/// records the peak number of concurrent upserts — to prove [writeMaterialized]
+/// fans out with *bounded* concurrency rather than one-at-a-time or unbounded
+/// (#168).
+class _ConcurrencyClient implements CosmosClient {
+  final Map<String, Map<String, Map<String, dynamic>>> _store = {};
+  int inFlight = 0;
+  int peakInFlight = 0;
+  int upserts = 0;
+
+  Map<String, Map<String, dynamic>> _c(String name) =>
+      _store.putIfAbsent(name, () => {});
+
+  @override
+  Future<WriteOutcome> upsertDocument({
+    required String container,
+    required Map<String, dynamic> document,
+    required String partitionKey,
+    String? ifMatch,
+  }) async {
+    inFlight++;
+    upserts++;
+    if (inFlight > peakInFlight) peakInFlight = inFlight;
+    // Yield twice so overlapping calls actually interleave before any completes.
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+    _c(container)[document['id'] as String] = Map.of(document);
+    inFlight--;
+    return const WriteOutcome.applied('etag');
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> queryDocuments({
+    required String container,
+    required String query,
+    Map<String, Object?> parameters = const {},
+    String? partitionKey,
+  }) async {
+    if (query.contains('SELECT c.id, c.pk')) {
+      return [
+        for (final d in _c(container).values) {'id': d['id'], 'pk': d['pk']},
+      ];
+    }
+    return [for (final d in _c(container).values) Map<String, dynamic>.from(d)];
+  }
+
+  @override
+  Future<Map<String, dynamic>?> readDocument({
+    required String container,
+    required String id,
+    required String partitionKey,
+  }) async =>
+      _c(container)[id];
+
+  @override
+  Future<bool> createDocument({
+    required String container,
+    required Map<String, dynamic> document,
+    required String partitionKey,
+  }) async {
+    _c(container)[document['id'] as String] = Map.of(document);
+    return true;
+  }
+
+  @override
+  Future<void> deleteDocument({
+    required String container,
+    required String id,
+    required String partitionKey,
+  }) async {
+    _c(container).remove(id);
+  }
+
+  @override
+  Future<bool> ensureContainer({
+    required String container,
+    required String partitionKeyPath,
+  }) async =>
+      true;
+}
+
 final DateTime _d = DateTime.utc(2026, 7, 1);
 
 MaterializedAccount _account(String id,
@@ -382,6 +463,46 @@ void main() {
 
       await store.deleteDecision(decision);
       expect(await store.readDecisions(), isEmpty);
+    });
+
+    test(
+        'a full-size view writes with bounded concurrency and reports progress '
+        '(#168)', () async {
+      final client = _ConcurrencyClient();
+      final store = CosmosLinkedStore(client);
+      final progress = <String>[];
+
+      // A large account set: enough to cross the progress-report interval and to
+      // exercise the bounded fan-out.
+      final accounts = [
+        for (var i = 0; i < 2500; i++) _account('p$i', classroom: 'c${i % 30}'),
+      ];
+
+      await store.writeMaterialized(
+        _view(accounts),
+        syncedBy: 'op@school.example',
+        at: _d,
+        onProgress: progress.add,
+      );
+
+      // Every account doc was upserted…
+      expect(client.upserts, greaterThanOrEqualTo(2500));
+      // …with overlap (not strictly serial), but bounded — never a stampede of
+      // thousands of simultaneous writes.
+      expect(client.peakInFlight, greaterThan(1),
+          reason: 'the write fans out rather than crawling one at a time');
+      expect(client.peakInFlight, lessThanOrEqualTo(24),
+          reason: 'concurrency is capped so it never stampedes throughput');
+      // The long write ticked visibly: interim lines plus a final full count for
+      // the big account container.
+      expect(progress, isNotEmpty);
+      expect(progress.where((m) => m.startsWith('Persisting accounts:')),
+          isNotEmpty);
+      expect(progress, contains('Persisting accounts: 1000/2500…'));
+      expect(progress, contains('Persisting accounts: 2500/2500…'));
+
+      // The whole set round-trips despite the batching.
+      expect((await store.readRollups()).isNotEmpty, isTrue);
     });
 
     test('reading before any sync yields the initial generation', () async {


### PR DESCRIPTION
## Summary

On the Reconcile tab, running **Synchronise** against the full dataset hung after the `Linked: …` log line: the pass never reached `ready`, so `busy` stayed true, **Synchronise** never re-enabled, and **Last sync** never updated.

Root cause: `CosmosLinkedStore.writeMaterialized` upserted the whole materialized view (~9.6k account docs + rollups) **strictly one document at a time**, and the controller's `_persist` awaited it with **no upper bound**. A slow or stalled write therefore looked like a hang, and the controller had no way out of `linking`.

## Linked issue
Closes #168

## Changes

**Store — make the write fast and visible** (`cosmos_linked_store.dart`, `linked_store.dart`)
- `writeMaterialized` now fans the per-container upserts and straggler-deletes out with **bounded concurrency** (a worker pool, cap 24) instead of a serial loop — thousands of round-trips no longer run back-to-back.
- New optional `onProgress` callback on the `LinkedStore.writeMaterialized` contract; the store emits `Persisting accounts: N/total…` lines every 1000 docs so a long write ticks in the operator log rather than looking wedged.

**UI — stay resilient regardless of the store** (`reconcile_controller.dart`)
- `_persist` guards the store write with a `persistTimeout` (default 10 min, injectable for tests). A stall now surfaces a distinct timeout line and still returns the pass to `ready`, re-enabling Synchronise; the in-memory linked view remains usable this session.
- Persist progress is wired to the log via `onProgress`.

## Test plan
- [x] `dart format --set-exit-if-changed` clean
- [x] `flutter analyze` clean (account_state + account_manager)
- [x] unit/widget tests pass — `account_state` 282 tests (incl. new bounded-concurrency + progress test), `account_manager` 160 tests (incl. new persist-timeout and persist-failure controller tests, both reaching `ready`)
- [x] integration/e2e tests pass — `flutter test integration_test -d windows`, 26 scenarios, including the new #168 case: a stalling persist driven through the real Reconcile screen re-enables Synchronise and surfaces the timeout in the log panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)