### PR TITLE
Name the operator who performed the last sync (#169)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3,6 +3,7 @@
 // ignore_for_file: use_build_context_synchronously
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:account_core/account_core.dart' show Address;
 import 'package:account_manager/main.dart' as app;
@@ -32,7 +33,8 @@ import 'package:account_state/account_state.dart'
         WisaConnection,
         WisaSchoolProfile,
         signalRRecordSeparator;
-import 'package:azure_api/azure_api.dart' show AzureCredentials;
+import 'package:azure_api/azure_api.dart'
+    show AzureCredentials, StaticAuthProvider;
 import 'package:wisa_api/wisa_api.dart' show WisaSchool;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -255,6 +257,53 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       find.textContaining('Sync complete — no account changes needed. Ready.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
+      'the operator decoded from the real loopback broker JWT names the last '
+      'sync in the freshness line end-to-end (#169)',
+      (WidgetTester tester) async {
+    // The production sign-in path on a machine without the native WAM broker:
+    // the *real* LoopbackAadBroker signs in and now decodes the operator UPN
+    // from the JWT access token — the piece that was empty, which left the
+    // freshness line without its "by …". Drive the real app with that broker
+    // and a JWT-bearing provider, sync, and read the line the operator sees.
+    useTallWindow(tester);
+    final jwt = _jwt({'upn': 'yvan@school.example'});
+    final session = SignInSession(
+      LoopbackAadBroker(providerFactory: (_) => StaticAuthProvider(jwt)),
+    );
+    // Sign in through the real broker → the UPN is decoded off the JWT. This is
+    // what production's bootstrap reads into syncedBy (`session.account ?? ''`,
+    // covered by the bootstrap unit test); the harness stands in for that one
+    // line so the render path can be exercised end-to-end.
+    await session.tokenFor(graph);
+    expect(session.account, 'yvan@school.example',
+        reason: 'the loopback broker now resolves the operator UPN');
+    final harness = ReconcileHarness(syncedBy: session.account ?? '');
+
+    await tester.pumpWidget(AccountManagerApp(
+      session: session,
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    expect(find.byType(AppShell), findsOneWidget);
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // The freshness line names the signed-in operator…
+    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
+    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
+    expect(find.textContaining('by yvan@school.example'), findsOneWidget);
+    // …and the terminal "Sync complete" line names them too (#169).
+    expect(
+      find.textContaining('Operator: yvan@school.example'),
       findsOneWidget,
     );
   });
@@ -1455,6 +1504,15 @@ BrokerToken _token(String v) => BrokerToken(
       expiresOn: DateTime.now().toUtc().add(const Duration(hours: 1)),
       account: 'operator@school.example',
     );
+
+/// An unsigned JWT (`header.payload.signature`) carrying [claims] — the real
+/// loopback broker decodes the operator UPN off its payload (#169). The
+/// signature is never verified, so a literal `sig` segment suffices.
+String _jwt(Map<String, Object?> claims) {
+  String seg(Map<String, Object?> m) =>
+      base64Url.encode(utf8.encode(jsonEncode(m))).replaceAll('=', '');
+  return '${seg({'alg': 'none', 'typ': 'JWT'})}.${seg(claims)}.sig';
+}
 
 /// A negotiate transport that hands back a scripted client URL + token, so the
 /// real [SignalRSubscriber] gets past negotiate with no network (#124).

--- a/account_manager/lib/src/auth/auth.dart
+++ b/account_manager/lib/src/auth/auth.dart
@@ -13,7 +13,8 @@ export 'aad_resource.dart' show AadResource;
 export 'composite_broker.dart' show CompositeBroker;
 export 'dpapi.dart' show Dpapi;
 export 'file_token_cache.dart' show FileTokenCache;
-export 'loopback_aad_broker.dart' show LoopbackAadBroker;
+export 'loopback_aad_broker.dart'
+    show LoopbackAadBroker, operatorAccountFromJwt;
 export 'method_channel_aad_broker.dart' show MethodChannelAadBroker;
 export 'sign_in_session.dart'
     show CosmosSessionTokenProvider, GraphSessionAuthProvider, SignInSession;

--- a/account_manager/lib/src/auth/loopback_aad_broker.dart
+++ b/account_manager/lib/src/auth/loopback_aad_broker.dart
@@ -1,9 +1,45 @@
+import 'dart:convert';
+
 import 'package:azure_api/azure_api.dart';
 import 'package:http/http.dart' as http;
 import 'package:oauth2/oauth2.dart' as oauth2;
 
 import 'aad_broker.dart';
 import 'aad_resource.dart';
+
+/// Best-effort extraction of the signed-in operator's UPN / e-mail from a JWT
+/// access token, so the session can name *who* signed in (#169): the value is
+/// stamped onto each per-system sync and shown in the reconcile freshness line
+/// ("Last sync — WISA 10:21 by yvan@…").
+///
+/// The loopback OAuth path only ever hands back a raw access-token string, so
+/// the identity has to be read off the token itself. This reads the standard
+/// identity claims in preference order (`upn` → `preferred_username` →
+/// `unique_name` → `email`) and returns `null` for an opaque or malformed
+/// token — an unknown operator then degrades gracefully (no dangling "by ").
+String? operatorAccountFromJwt(String token) {
+  final parts = token.split('.');
+  if (parts.length != 3) return null;
+  try {
+    final payload =
+        utf8.decode(base64Url.decode(base64Url.normalize(parts[1])));
+    final claims = jsonDecode(payload);
+    if (claims is! Map<String, dynamic>) return null;
+    for (final claim in const [
+      'upn',
+      'preferred_username',
+      'unique_name',
+      'email',
+    ]) {
+      final value = claims[claim];
+      if (value is String && value.isNotEmpty) return value;
+    }
+  } on FormatException {
+    // Not base64url, not JSON, or not UTF-8 — treat as an opaque token.
+    return null;
+  }
+  return null;
+}
 
 /// [AadBroker] backed by the interactive loopback OAuth flow — auth-code with
 /// PKCE through the system browser — reusing `azure_api`'s [OAuthAuthProvider]
@@ -84,6 +120,7 @@ class LoopbackAadBroker implements AadBroker {
           accessToken: credentials.accessToken,
           expiresOn: credentials.expiration?.toUtc() ??
               now().toUtc().add(assumedLifetime),
+          account: operatorAccountFromJwt(credentials.accessToken),
         );
 
     Future<BrokerToken?> silent(AadResource resource) async {
@@ -167,6 +204,7 @@ class LoopbackAadBroker implements AadBroker {
       return BrokerToken(
         accessToken: token,
         expiresOn: _clock().toUtc().add(_assumedLifetime),
+        account: operatorAccountFromJwt(token),
       );
     } on AzureAuthException catch (e) {
       throw AadBrokerException(e.message, cause: e);

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -967,9 +967,12 @@ class ReconcileController extends ChangeNotifier {
   /// successful [sync] (#162). The [noChangesNeeded] path says so explicitly;
   /// otherwise it names how many pending actions await the operator.
   void _logSyncComplete() {
+    // Name the operator who ran the pass when known (#169); an empty/unknown
+    // operator degrades gracefully (nothing appended, no dangling "by ").
+    final by = syncedBy.isEmpty ? '' : ' Operator: $syncedBy.';
     final message = _noChangesNeeded
-        ? 'Sync complete — no account changes needed. Ready.'
-        : 'Sync complete — ${pendingActions.length} pending action(s). Ready.';
+        ? 'Sync complete — no account changes needed. Ready.$by'
+        : 'Sync complete — ${pendingActions.length} pending action(s). Ready.$by';
     log.addMessage(core.Origin.all, message);
   }
 

--- a/account_manager/test/auth/loopback_aad_broker_test.dart
+++ b/account_manager/test/auth/loopback_aad_broker_test.dart
@@ -27,6 +27,14 @@ class _FakeProvider implements AzureAuthProvider {
   }
 }
 
+/// Builds an unsigned JWT (`header.payload.signature`) carrying [claims]. The
+/// decoder never verifies the signature, so a literal `sig` segment suffices.
+String _jwt(Map<String, Object?> claims) {
+  String seg(Map<String, Object?> m) =>
+      base64Url.encode(utf8.encode(jsonEncode(m))).replaceAll('=', '');
+  return '${seg({'alg': 'none', 'typ': 'JWT'})}.${seg(claims)}.sig';
+}
+
 void main() {
   final graph = AadResource.graph(AzureCredentials(
     clientId: 'c',
@@ -54,6 +62,64 @@ void main() {
     final token = await broker.acquireInteractive(graph);
     expect(token.accessToken, 'AT');
     expect(token.expiresOn, now.add(const Duration(minutes: 50)));
+  });
+
+  test('acquireInteractive stamps the operator UPN decoded from the JWT (#169)',
+      () async {
+    final broker = LoopbackAadBroker(
+      providerFactory: (_) =>
+          _FakeProvider(_jwt({'upn': 'yvan@school.example'})),
+    );
+
+    final token = await broker.acquireInteractive(graph);
+    expect(token.account, 'yvan@school.example',
+        reason: 'so session.account is populated and syncedBy is non-empty');
+  });
+
+  test('an opaque (non-JWT) token leaves the operator unknown, gracefully',
+      () async {
+    final broker = LoopbackAadBroker(
+      providerFactory: (_) => _FakeProvider('opaque-access-token'),
+    );
+
+    final token = await broker.acquireInteractive(graph);
+    expect(token.account, isNull);
+  });
+
+  group('operatorAccountFromJwt', () {
+    test('prefers upn over the other identity claims', () {
+      final token = _jwt({
+        'upn': 'yvan@school.example',
+        'preferred_username': 'other@school.example',
+        'unique_name': 'nope@school.example',
+        'email': 'nope2@school.example',
+      });
+      expect(operatorAccountFromJwt(token), 'yvan@school.example');
+    });
+
+    test('falls back to preferred_username, then unique_name, then email', () {
+      expect(
+        operatorAccountFromJwt(
+            _jwt({'preferred_username': 'a@school.example'})),
+        'a@school.example',
+      );
+      expect(
+        operatorAccountFromJwt(_jwt({'unique_name': 'b@school.example'})),
+        'b@school.example',
+      );
+      expect(
+        operatorAccountFromJwt(_jwt({'email': 'c@school.example'})),
+        'c@school.example',
+      );
+    });
+
+    test('returns null for an opaque, truncated, or claimless token', () {
+      expect(operatorAccountFromJwt('opaque'), isNull);
+      expect(operatorAccountFromJwt('only.two'), isNull);
+      expect(operatorAccountFromJwt('not.base64!.sig'), isNull);
+      expect(operatorAccountFromJwt(_jwt({'sub': 'no-upn-here'})), isNull);
+      expect(operatorAccountFromJwt(_jwt({'upn': ''})), isNull);
+    });
   });
 
   test('reuses one provider per resource so its cache survives calls',
@@ -181,6 +247,26 @@ void main() {
 
       expect(await broker.acquireSilent(AadResource.cosmos), isNull);
       expect(refreshRequests, isNotEmpty, reason: 'the redeem was attempted');
+    });
+
+    test('the silent leg stamps the operator UPN from the refreshed JWT (#169)',
+        () async {
+      // The refresh grant returns a JWT access token; the silently-minted
+      // resource token then carries the decoded operator (the real seed for
+      // syncedBy in a resumed session).
+      final jwt = _jwt({'upn': 'yvan@school.example'});
+      final broker = LoopbackAadBroker.oauth(
+        clientId: 'client-123',
+        tenantId: 'tenant-abc',
+        azureDomain: 'school.example',
+        schoolPrefix: 'GBS',
+        authorizer: (authUrl, redirect) async => {'code': 'auth-code-xyz'},
+        httpClient: MockClient((req) async => jsonResp(tokenBody(jwt))),
+      );
+
+      await broker.acquireInteractive(graph);
+      final cosmos = await broker.acquireSilent(AadResource.cosmos);
+      expect(cosmos!.account, 'yvan@school.example');
     });
 
     test('a persistent cache survives a "restart" — silent, no browser',

--- a/account_manager/test/reconcile/reconcile_bootstrap_test.dart
+++ b/account_manager/test/reconcile/reconcile_bootstrap_test.dart
@@ -1,4 +1,5 @@
 import 'package:account_manager/src/auth/aad_app_config.dart';
+import 'package:account_manager/src/auth/auth.dart' show AadResource;
 import 'package:account_manager/src/auth/sign_in_session.dart';
 import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
 import 'package:account_state/account_state.dart';
@@ -294,6 +295,39 @@ void main() {
       expect(client.ensured['syncState'], '/id');
       // The snapshot store's container — the missing piece #151 adds.
       expect(client.ensured['snapshots'], '/id');
+    });
+
+    test('threads the signed-in operator UPN into the sync author (#169)',
+        () async {
+      // The session is signed in as an operator whose broker token carries the
+      // UPN (the loopback broker now decodes it from the JWT). Warm it first —
+      // in production the Cosmos-container preflight acquires a token before
+      // bootstrap reads session.account; here the injected client skips that, so
+      // acquire once by hand to model a signed-in session.
+      final session = SignInSession(
+        FakeBroker(
+            silent: (_) => fakeToken('AT', account: 'yvan@school.example')),
+      );
+      await session.tokenFor(AadResource.cosmos);
+
+      final services = await bootstrapReconcile(
+        session: session,
+        aad: _aad,
+        settingsStore: InMemorySettingsStore(_settings()),
+        secretProvider: _secrets(),
+        cosmosClient: const _EmptyCosmosClient(),
+      );
+
+      expect(services.controller.syncedBy, 'yvan@school.example',
+          reason: 'so each pull is stamped and the freshness line names them');
+    });
+
+    test('an unsigned session leaves the sync author empty (graceful) (#169)',
+        () async {
+      // No token was ever acquired, so session.account is null and syncedBy
+      // degrades to '' — the freshness line then shows no dangling "by ".
+      final services = await _bootstrap();
+      expect(services.controller.syncedBy, '');
     });
 
     test('the real Cosmos path reads settings from the container', () async {

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -94,12 +94,26 @@ void main() {
       await h.controller.sync();
 
       // The count mirrors the relink summary's pendingActions.length (the
-      // fixture derives four pending actions across the families).
+      // fixture derives four pending actions across the families), and the line
+      // names the operator who ran the pass (#169).
       expect(
         h.log.entries.map((e) => e.message),
-        contains('Sync complete — 4 pending action(s). Ready.'),
+        contains('Sync complete — 4 pending action(s). Ready. '
+            'Operator: operator@school.example.'),
       );
       // It is the *last* line — the operator sees it closing the pass.
+      expect(
+          h.log.entries.last.message,
+          'Sync complete — 4 pending action(s). Ready. '
+          'Operator: operator@school.example.');
+    });
+
+    test('an empty operator degrades gracefully — no dangling "by" (#169)',
+        () async {
+      final h = ReconcileHarness(syncedBy: '');
+
+      await h.controller.sync();
+
       expect(h.log.entries.last.message,
           'Sync complete — 4 pending action(s). Ready.');
     });
@@ -116,10 +130,13 @@ void main() {
       expect(h.controller.noChangesNeeded, isTrue);
       expect(
         h.log.entries.map((e) => e.message),
-        contains('Sync complete — no account changes needed. Ready.'),
+        contains('Sync complete — no account changes needed. Ready. '
+            'Operator: operator@school.example.'),
       );
-      expect(h.log.entries.last.message,
-          'Sync complete — no account changes needed. Ready.');
+      expect(
+          h.log.entries.last.message,
+          'Sync complete — no account changes needed. Ready. '
+          'Operator: operator@school.example.');
     });
   });
 


### PR DESCRIPTION
## Summary

On the Reconcile tab the freshness line now names the operator who ran the last sync — `Last sync — WISA 10:21 by yvan@…` — and the terminal `Sync complete — …` log line names them too.

The rendering (`_freshness()`) and the `SystemSyncMeta.syncedBy` plumbing already supported this; the value was simply always empty. `syncedBy` comes from `session.account`, and the production `LoopbackAadBroker` (the fallback used when the native WAM broker is absent) built its `BrokerToken` **without** an `account`, so `session.account` was always null. The native `MethodChannelAadBroker` already sets it from the platform side.

## Linked issue
Closes #169

## Changes
- `loopback_aad_broker.dart`: new `operatorAccountFromJwt` helper decodes the operator UPN from the JWT access token (`upn` → `preferred_username` → `unique_name` → `email`; `null` for an opaque/malformed token). Both the interactive and silent legs now stamp it onto the `BrokerToken`. `session.account` then resolves, so bootstrap's `syncedBy = session.account ?? ''` populates each pull's `SystemSyncMeta` and the freshness line renders `by …`.
- `reconcile_controller.dart`: `_logSyncComplete` appends `Operator: <upn>.` when known (worded to avoid colliding with the freshness line's `by <upn>`), degrading to nothing when the operator is unknown.
- `auth.dart`: export `operatorAccountFromJwt` for direct unit testing.

## Graceful degradation
An empty/unknown operator yields no `by …` suffix on the freshness line and no `Operator:` suffix on the log line — no dangling `by`.

## Test plan
- [x] `dart format --set-exit-if-changed` clean on all changed files
- [x] `flutter analyze lib test integration_test` — No issues found
- [x] unit/widget tests pass (`flutter test`) — 169 tests green, including new coverage for `operatorAccountFromJwt` (claim preference + graceful null), both broker legs stamping the account, `bootstrapReconcile` threading `session.account` into `controller.syncedBy` (and empty → `''`), and the operator-named ready line
- [x] integration/e2e tests pass (`flutter test integration_test -d windows`) — 27 tests green, including a new #169 scenario that drives the **real** `LoopbackAadBroker` with a JWT-bearing sign-in so the decoded UPN renders in the freshness line and the `Sync complete` line end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)