### PR TITLE
Surface Smartschool/Azure drift-check freshness beside WISA sync time (#170)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:account_core/account_core.dart' show Address;
+import 'package:account_core/account_core.dart' show Address, Origin;
 import 'package:account_manager/main.dart' as app;
 import 'package:account_manager/src/app.dart';
 import 'package:account_manager/src/auth/auth.dart';
@@ -259,6 +259,60 @@ void main() {
       find.textContaining('Sync complete — no account changes needed. Ready.'),
       findsOneWidget,
     );
+  });
+
+  testWidgets(
+      'the freshness line surfaces Smartschool and Azure as a drift check '
+      'alongside the WISA sync, and a Check for drift advances only those two '
+      '(#170)', (WidgetTester tester) async {
+    // The real app over the offline harness: a first full sync stamps all three
+    // systems, then Check for drift re-reads Smartschool/Azure at a later time
+    // while WISA keeps its earlier sync stamp. The freshness line must show both
+    // clauses throughout — the WISA sync time and the drift-checked pair.
+    useTallWindow(tester);
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // After the first full sync all three systems appear, split into the WISA
+    // "Last sync" clause and the Smartschool/Azure "drift check" clause.
+    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
+    Text freshnessText() => tester.widget<Text>(
+          find.descendant(
+            of: find.byKey(const ValueKey('reconcile-freshness')),
+            matching: find.byType(Text),
+          ),
+        );
+    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
+    expect(find.textContaining('drift check — Smartschool'), findsOneWidget);
+    expect(freshnessText().data, contains('Azure'));
+
+    // Check for drift re-pulls Smartschool and Azure at a later time; WISA is
+    // not re-pulled, so its sync stamp stays put while the drift pair advances.
+    final driftAt = kFixtureDate.add(const Duration(hours: 3));
+    harness.ssResult = ssSnap(fetchedAt: driftAt);
+    harness.azResult = azSnap(fetchedAt: driftAt);
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.pumpAndSettle();
+
+    // The line still carries both clauses, and the underlying state proves the
+    // drift pair advanced while WISA held its earlier sync time.
+    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
+    expect(find.textContaining('drift check — Smartschool'), findsOneWidget);
+    final systems = harness.controller.syncState.systems;
+    expect(systems[Origin.wisa]?.at, kFixtureDate);
+    expect(systems[Origin.smartschool]?.at, driftAt);
+    expect(systems[Origin.azure]?.at, driftAt);
   });
 
   testWidgets(

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -179,9 +179,12 @@ class _Header extends StatelessWidget {
 
   final ReconcileController controller;
 
-  /// The shared per-system freshness line ("Last sync — WISA 09:12 by jan@…"),
-  /// read from the materialized store so it names *whichever* operator last
-  /// synced each system — not just this session (#108). Null before any sync.
+  /// The shared per-system freshness line, e.g. "Last sync — WISA 09:12 by
+  /// jan@… · drift check — Smartschool 10:24 · Azure 10:25". Read from the
+  /// materialized store so it names *whichever* operator last synced each system
+  /// — not just this session (#108). WISA (the Synchronise target) and the
+  /// drift-checked pair (Smartschool, Azure) render as two clauses so their
+  /// differing times are self-explanatory (#170). Null before any sync.
   String? _freshness() {
     final systems = controller.syncState.systems;
     String? stamp(core.Origin system, String label) {
@@ -194,16 +197,26 @@ class _Header extends StatelessWidget {
       return '$label $hhmm$by';
     }
 
-    final parts = <String>[
+    // WISA is refreshed by Synchronise; Smartschool and Azure are refreshed by
+    // Check for drift. Present them as two labelled clauses so a later WISA-only
+    // smart-sync reads as "synced then, drift-checked earlier" rather than an
+    // unexplained gap between the timestamps (#170).
+    final segments = <String>[];
+    if (stamp(core.Origin.wisa, 'WISA') case final wisa?) {
+      segments.add('Last sync — $wisa');
+    }
+    final drift = <String>[
       for (final (system, label) in const [
-        (core.Origin.wisa, 'WISA'),
         (core.Origin.smartschool, 'Smartschool'),
         (core.Origin.azure, 'Azure'),
       ])
         if (stamp(system, label) case final s?) s,
     ];
-    if (parts.isEmpty) return null;
-    return 'Last sync — ${parts.join(' · ')}';
+    if (drift.isNotEmpty) {
+      segments.add('drift check — ${drift.join(' · ')}');
+    }
+    if (segments.isEmpty) return null;
+    return segments.join(' · ');
   }
 
   @override

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -639,6 +639,83 @@ void main() {
           reason: 'an unchanged sync does not bump the generation');
     });
 
+    test(
+        'a later WISA-only smart-sync keeps the Smartschool/Azure freshness '
+        '(#170)', () async {
+      final store = InMemoryLinkedStore();
+      final h = ReconcileHarness(linkedStore: store);
+      // First full sync: all three systems are pulled and stamped at the
+      // fixture time.
+      await h.controller.sync();
+      final first = (await store.readSyncState()).systems;
+      expect(
+        first.keys,
+        containsAll(<core.Origin>[
+          core.Origin.wisa,
+          core.Origin.smartschool,
+          core.Origin.azure,
+        ]),
+        reason: 'the first full sync records every system',
+      );
+
+      // A later smart-sync where only WISA changed: Smartschool and Azure are
+      // not re-pulled (their in-session snapshots are present).
+      final later = kFixtureDate.add(const Duration(hours: 1));
+      h.wisaResult = wisaSnap(
+        fetchedAt: later,
+        students: [wisaStudent(classGroup: '3D')],
+      );
+      await h.controller.sync();
+
+      expect(h.ssSyncs, 1,
+          reason: 'Smartschool is not re-pulled by smart-sync');
+      expect(h.azSyncs, 1, reason: 'Azure is not re-pulled by smart-sync');
+
+      // The store must still carry all three — WISA advanced, the drift-checked
+      // pair keeps its earlier stamp rather than being overwritten.
+      final stored = (await store.readSyncState()).systems;
+      expect(stored[core.Origin.wisa]?.at, later);
+      expect(stored[core.Origin.smartschool]?.at, kFixtureDate);
+      expect(stored[core.Origin.azure]?.at, kFixtureDate);
+      // …and the operator stamp from the earlier pull survives too (#169).
+      expect(
+          stored[core.Origin.smartschool]?.syncedBy, 'operator@school.example');
+      expect(stored[core.Origin.azure]?.syncedBy, 'operator@school.example');
+
+      // The controller mirrors the merged store for the header line.
+      final live = h.controller.syncState.systems;
+      expect(
+        live.keys,
+        containsAll(<core.Origin>[
+          core.Origin.wisa,
+          core.Origin.smartschool,
+          core.Origin.azure,
+        ]),
+      );
+      expect(live[core.Origin.wisa]?.at, later);
+      expect(live[core.Origin.smartschool]?.at, kFixtureDate);
+      expect(live[core.Origin.azure]?.at, kFixtureDate);
+    });
+
+    test('a Check for drift stamps Smartschool and Azure freshness (#170)',
+        () async {
+      final store = InMemoryLinkedStore();
+      final h = ReconcileHarness(linkedStore: store);
+      await h.controller.sync();
+
+      // Drift check re-pulls Smartschool and Azure at a later time.
+      final later = kFixtureDate.add(const Duration(hours: 2));
+      h.ssResult = ssSnap(fetchedAt: later);
+      h.azResult = azSnap(fetchedAt: later);
+      await h.controller.checkDrift();
+
+      final systems = (await store.readSyncState()).systems;
+      expect(systems[core.Origin.smartschool]?.at, later);
+      expect(systems[core.Origin.azure]?.at, later);
+      // WISA keeps its earlier sync stamp (drift does not re-pull it here).
+      expect(systems[core.Origin.wisa]?.at, kFixtureDate);
+    });
+
     test('a sync takes and releases the lease', () async {
       final h = ReconcileHarness();
 

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -177,6 +177,44 @@ void main() {
     );
   });
 
+  testWidgets(
+      'the freshness line surfaces Smartschool and Azure as a drift check next '
+      'to the WISA sync time (#170)', (WidgetTester tester) async {
+    // Distinct fetch times per system so the line shows the WISA sync time and
+    // the (later) Smartschool/Azure drift-check times side by side.
+    final wisaAt = kFixtureDate.add(const Duration(hours: 1));
+    final ssAt = kFixtureDate.add(const Duration(hours: 1, minutes: 3));
+    final azAt = kFixtureDate.add(const Duration(hours: 1, minutes: 4));
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(fetchedAt: wisaAt),
+      smartschool: ssSnap(fetchedAt: ssAt),
+      azure: azSnap(fetchedAt: azAt),
+    );
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // One row, three systems, split into a "Last sync" clause (WISA) and a
+    // "drift check" clause (Smartschool · Azure).
+    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
+    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
+    expect(find.textContaining('drift check — Smartschool'), findsOneWidget);
+    // Azure rides in the same (single) freshness Text.
+    final freshness = tester.widget<Text>(
+      find.descendant(
+        of: find.byKey(const ValueKey('reconcile-freshness')),
+        matching: find.byType(Text),
+      ),
+    );
+    expect(freshness.data, contains('Azure'));
+    expect(freshness.data, contains('Smartschool'));
+    expect(freshness.data, contains('WISA'));
+  });
+
   testWidgets('the last-sync line survives a restart / passive session (#162)',
       (WidgetTester tester) async {
     // Session 1 syncs and persists freshness to the shared store.


### PR DESCRIPTION
## Summary

The Reconcile **Last sync** line effectively read as WISA-only. The shared store already merges each pass's per-system pulls (#108), so Smartschool/Azure freshness *does* survive a later WISA-only smart-sync — but the three timestamps rendered as one flat list with no cue that **WISA** is the Synchronise target while **Smartschool/Azure** are what **Check for drift** refreshes. Differing times therefore read as an unexplained gap.

`_freshness()` now splits the line into two labelled clauses so the timestamps are self-explanatory, e.g.:

`Last sync — WISA 10:21 by jan@… · drift check — Smartschool 10:24 · Azure 10:25`

The per-operator "by …" stamping from #169 is preserved on each system, and the merge-not-overwrite behaviour of `syncState.systems` is now locked in by a regression test.

## Linked issue
Closes #170

## Changes
- `reconcile_screen.dart` — `_freshness()` renders a "Last sync — WISA …" clause and a "drift check — Smartschool … · Azure …" clause, joined only for the systems present; graceful when a system is missing. Doc comment updated.
- Controller tests — a first full sync records all three systems; a later WISA-only smart-sync keeps the Smartschool/Azure stamp (time **and** `syncedBy`) instead of overwriting; a Check for drift advances only the drift pair while WISA holds its sync time.
- Widget test — the freshness row shows the WISA sync clause and the Smartschool/Azure drift-check clause with distinct fetch times.
- Integration test (windows) — a real Synchronise then a real Check for drift keeps both clauses on the line and advances only Smartschool/Azure.

## Notes
Investigation confirmed the persistence layer already preserves all three systems (both the in-memory and Cosmos stores merge `systemSyncs` over the stored map); the user-visible gap was purely the presentation framing. The new controller test guards the preservation so a future refactor can't silently reintroduce an overwrite.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed` clean on all four touched files
- [x] `flutter analyze account_manager` — No issues found
- [x] unit/widget tests pass (`flutter test`) — 172 tests, all pass (includes the new controller + widget cases)
- [x] integration/e2e tests pass (`flutter test integration_test -d windows`) — 28 tests, all pass (includes the new #170 sync + drift e2e case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
