### PR TITLE
Rework WISA schools editor: 3-column grid, persist names, drop manual add (#171)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1296,17 +1296,16 @@ void main() {
     await tester.tap(find.text('Settings'));
     await tester.pumpAndSettle();
     expect(find.byType(SettingsScreen), findsOneWidget);
-    // The managed-school list lives under the Wisa tab now (#140); open it and
-    // bring the seeded school's switch into view before reading it.
+    // The known-school list lives under the Wisa tab now (#140); open it and
+    // bring the seeded school's checkbox into view before reading it.
     await openSettingsTab(tester, 'settings-tab-wisa');
-    final ourSwitch =
-        find.byKey(const ValueKey('settings-wisa-school-42-ours'));
-    await tester.ensureVisible(ourSwitch);
+    final ourBox = find.byKey(const ValueKey('settings-wisa-school-42-ours'));
+    await tester.ensureVisible(ourBox);
     await tester.pumpAndSettle();
-    expect(tester.widget<SwitchListTile>(ourSwitch).value, isFalse);
+    expect(tester.widget<CheckboxListTile>(ourBox).value, isFalse);
 
     // Mark it managed and save (the Save action sits in the shared header).
-    await tester.tap(ourSwitch);
+    await tester.tap(ourBox);
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('settings-save')));
     await tester.pumpAndSettle();
@@ -1353,9 +1352,10 @@ void main() {
     final button = find.byKey(const ValueKey('settings-wisa-fetch-schools'));
     await tester.ensureVisible(button);
     await tester.pumpAndSettle();
-    expect(tester.widget<FilledButton>(button).onPressed, isNotNull);
+    expect(tester.widget<OutlinedButton>(button).onPressed, isNotNull);
 
-    // Fetch: both schools render by name, the stored password was resolved.
+    // Fetch: both schools render by name in the grid, the stored password was
+    // resolved.
     await tester.tap(button);
     await tester.pumpAndSettle();
     expect(fetcher.calls, 1);
@@ -1363,9 +1363,9 @@ void main() {
     expect(find.text('Sint-Jan'), findsOneWidget);
     expect(find.text('Sint-Pieter'), findsOneWidget);
 
-    // Pick one returned school and save; the selection lands in the store with
-    // no id ever typed by hand.
-    final picked = find.byKey(const ValueKey('settings-wisa-fetched-school-7'));
+    // Mark one fetched school managed and save; it lands in the store with its
+    // name, no id ever typed by hand.
+    final picked = find.byKey(const ValueKey('settings-wisa-school-7-ours'));
     await tester.ensureVisible(picked);
     await tester.tap(picked);
     await tester.pumpAndSettle();
@@ -1374,8 +1374,9 @@ void main() {
     await tester.pumpAndSettle();
 
     final saved = await settings.store.load();
-    expect(saved.wisaSchools.single.schoolId, 7);
-    expect(saved.wisaSchools.single.ours, isTrue);
+    final managed = saved.wisaSchools.firstWhere((p) => p.schoolId == 7);
+    expect(managed.name, 'Sint-Pieter');
+    expect(managed.ours, isTrue);
   });
 
   testWidgets(

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -84,14 +84,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   final _azTenantId = TextEditingController();
   final _azDomain = TextEditingController();
 
-  // Per-WISA-school ownership (#113). Held as a mutable working copy edited in
-  // place; committed to the settings document on save.
+  // The complete known-WISA-school list (#171): id + name + managed flag. The
+  // shared credentials see every group school; "Scholen ophalen" fills this
+  // list (merging by id, preserving the `ours` marks) and it persists so the
+  // tab renders the full set — with the managed ones marked — without a re-fetch.
+  // Held as a mutable working copy edited in place; committed on save.
   List<WisaSchoolProfile> _wisaSchools = const <WisaSchoolProfile>[];
-  final _wisaSchoolToAdd = TextEditingController();
-
-  // The schools last fetched from the WISA API (#142). Null until the operator
-  // fetches; then the id+name list the operator ticks to build the selection.
-  List<WisaSchool>? _fetchedSchools;
   bool _fetchingSchools = false;
 
   @override
@@ -117,7 +115,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _azClientId,
       _azTenantId,
       _azDomain,
-      _wisaSchoolToAdd,
       ..._grades,
       ..._years,
     ]) {
@@ -210,7 +207,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _azDomain.text = s.azure.domain;
 
     _wisaSchools = List<WisaSchoolProfile>.of(s.wisaSchools);
-    _wisaSchoolToAdd.clear();
   }
 
   /// Flips the `ours` flag on the profile at [index] (the toggle the operator
@@ -237,12 +233,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
       !_fetchingSchools &&
       _services?.fetchWisaSchools != null;
 
-  /// Whether the school with [id] is in the current (working) selection.
-  bool _isSchoolSelected(int id) => _wisaSchools.any((p) => p.schoolId == id);
-
-  /// Fetches the available WISA schools (id + name) from the API so the operator
-  /// can pick which to use instead of typing ids (#142). Prefers a freshly typed
-  /// password; otherwise resolves the stored secret. Failures surface as a toast.
+  /// Refreshes the known-WISA-school list from the API (#171). "Scholen ophalen"
+  /// is a *refresh* now, not the primary way to build the list: it merges the
+  /// fetched id+name records into [_wisaSchools], updating each name, adding any
+  /// genuinely new school (unmanaged by default), and preserving the `ours` mark
+  /// on schools already known. Prefers a freshly typed password; otherwise
+  /// resolves the stored secret. Failures surface as a toast. The merged list is
+  /// dirty until saved, so the enriched names persist and no re-fetch is needed.
   Future<void> _fetchWisaSchools() async {
     final services = _services;
     final fetcher = services?.fetchWisaSchools;
@@ -263,7 +260,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       }
       final schools = await fetcher(loaded.wisa, password);
       if (!mounted) return;
-      setState(() => _fetchedSchools = schools);
+      toggle(() => _wisaSchools = _mergeFetchedSchools(schools));
       _toast('${schools.length} scholen opgehaald.');
     } on Object catch (e) {
       if (mounted) _toast('Kon scholen niet ophalen: $e');
@@ -272,49 +269,23 @@ class _SettingsScreenState extends State<SettingsScreen> {
     }
   }
 
-  /// Ticks or unticks a fetched school in the selection (#142): a tick appends a
-  /// managed [WisaSchoolProfile] for its id, an untick drops it. This replaces
-  /// the by-hand id entry as the normal way to build the school selection.
-  void _toggleFetchedSchool(int schoolId, bool selected) {
-    toggle(() {
-      if (selected) {
-        if (_wisaSchools.any((p) => p.schoolId == schoolId)) return;
-        _wisaSchools = <WisaSchoolProfile>[
-          ..._wisaSchools,
-          WisaSchoolProfile(schoolId: schoolId, ours: true),
-        ];
-      } else {
-        _wisaSchools = <WisaSchoolProfile>[
-          for (final p in _wisaSchools)
-            if (p.schoolId != schoolId) p,
-        ];
-      }
-    });
-  }
-
-  /// Appends a managed-school entry for the id typed in the add field, ignoring
-  /// blanks, non-numbers, and ids already present.
-  void _addWisaSchool() {
-    final id = int.tryParse(_wisaSchoolToAdd.text.trim());
-    if (id == null) return;
-    if (_wisaSchools.any((p) => p.schoolId == id)) {
-      _wisaSchoolToAdd.clear();
-      return;
+  /// Merges the [fetched] WISA schools (id + name) into the current known list:
+  /// keeps every already-known school (preserving its `ours`/`prefix`, refreshing
+  /// its name when the fetch supplies one) and appends any fetched school not yet
+  /// known as unmanaged. Order is stable by school id so the grid does not jump.
+  List<WisaSchoolProfile> _mergeFetchedSchools(List<WisaSchool> fetched) {
+    final byId = <int, WisaSchoolProfile>{
+      for (final p in _wisaSchools) p.schoolId: p,
+    };
+    for (final s in fetched) {
+      final existing = byId[s.id];
+      byId[s.id] = existing == null
+          ? WisaSchoolProfile(schoolId: s.id, name: s.name)
+          : existing.copyWith(name: s.name.isEmpty ? existing.name : s.name);
     }
-    toggle(() {
-      _wisaSchools = <WisaSchoolProfile>[
-        ..._wisaSchools,
-        WisaSchoolProfile(schoolId: id, ours: true),
-      ];
-      _wisaSchoolToAdd.clear();
-    });
-  }
-
-  /// Drops the managed-school entry at [index].
-  void _removeWisaSchool(int index) {
-    toggle(() {
-      _wisaSchools = <WisaSchoolProfile>[..._wisaSchools]..removeAt(index);
-    });
+    final merged = byId.values.toList()
+      ..sort((a, b) => a.schoolId.compareTo(b.schoolId));
+    return merged;
   }
 
   /// Assembles an [AppSettings] from the form, preserving the loaded document's
@@ -985,13 +956,18 @@ class _RulesList extends StatelessWidget {
   }
 }
 
-/// Editor for the per-WISA-school ownership list (#113): one switch per known
-/// school toggling its `ours`/managed flag, plus an add-by-id affordance. The
-/// shared credentials pull every group school; this is where the operator marks
-/// which ones we manage. Keyed by school id so a widget/integration test can
-/// seed a profile and flip it against the in-memory store.
+/// Editor for the complete known-WISA-school list (#171): the full set of group
+/// schools (id + name), persisted in the settings document, rendered as a
+/// 3-column grid where the operator marks inline which ones we manage (`ours`).
+/// The shared credentials see every group school; **Scholen ophalen** is a
+/// refresh that fills/updates this list (rarely needed once built). Keyed by
+/// school id so a widget/integration test can seed a profile and flip it against
+/// the in-memory store.
 class _WisaSchoolsEditor extends StatelessWidget {
   const _WisaSchoolsEditor({required this.state});
+
+  /// How many schools sit side by side in the grid.
+  static const int _columns = 3;
 
   final _SettingsScreenState state;
 
@@ -1000,25 +976,37 @@ class _WisaSchoolsEditor extends StatelessWidget {
     final TextTheme text = Theme.of(context).textTheme;
     final ColorScheme colors = Theme.of(context).colorScheme;
     final schools = state._wisaSchools;
-    final fetched = state._fetchedSchools;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        // Fetch-from-WISA affordance (#142): pull the available schools (id +
-        // name) and tick which to use, instead of typing ids by hand.
+        // The known-school list is the primary surface; the fetch is a refresh
+        // (#171): mark which schools we manage inline, and only re-fetch when a
+        // genuinely new school appears.
         Text(
-          'Haal de beschikbare scholen op uit WISA en kies welke je gebruikt.',
+          'De bekende WISA-scholen. Markeer welke we beheren. Gebruik '
+          '"Scholen ophalen" om de lijst te vernieuwen als er een nieuwe '
+          'school bijkomt.',
           style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
         ),
-        const SizedBox(height: PlinkSpacing.s2),
+        const SizedBox(height: PlinkSpacing.s3),
+        if (schools.isEmpty)
+          Text(
+            'Nog geen scholen bekend. Gebruik "Scholen ophalen" om de lijst op '
+            'te halen.',
+            key: const ValueKey('settings-wisa-schools-empty'),
+            style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+          )
+        else
+          ..._schoolRows(schools),
+        const SizedBox(height: PlinkSpacing.s4),
         Row(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
-            FilledButton.icon(
+            OutlinedButton.icon(
               key: const ValueKey('settings-wisa-fetch-schools'),
               onPressed:
                   state._canFetchSchools ? state._fetchWisaSchools : null,
-              icon: const Icon(Icons.cloud_download_outlined),
+              icon: const Icon(Icons.refresh),
               label: const Text('Scholen ophalen'),
             ),
             if (state._fetchingSchools) ...<Widget>[
@@ -1041,95 +1029,64 @@ class _WisaSchoolsEditor extends StatelessWidget {
               style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
             ),
           ),
-        if (fetched != null) ...<Widget>[
-          const SizedBox(height: PlinkSpacing.s3),
-          if (fetched.isEmpty)
-            Text(
-              'Geen scholen gevonden.',
-              key: const ValueKey('settings-wisa-fetched-empty'),
-              style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
-            )
-          else
-            for (final s in fetched)
-              CheckboxListTile(
-                key: ValueKey('settings-wisa-fetched-school-${s.id}'),
-                contentPadding: EdgeInsets.zero,
-                controlAffinity: ListTileControlAffinity.leading,
-                title: Text(s.name.isEmpty ? 'School ${s.id}' : s.name),
-                subtitle: Text('id: ${s.id}'),
-                value: state._isSchoolSelected(s.id),
-                onChanged: (v) => state._toggleFetchedSchool(s.id, v ?? false),
-              ),
-        ],
-        const Divider(height: PlinkSpacing.s6),
-        Text(
-          'Geselecteerde scholen — markeer welke we beheren.',
-          style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
-        ),
-        const SizedBox(height: PlinkSpacing.s2),
-        if (schools.isEmpty)
-          Text(
-            'Nog geen scholen toegevoegd.',
-            key: const ValueKey('settings-wisa-schools-empty'),
-            style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
-          ),
-        for (var i = 0; i < schools.length; i++)
-          Row(
-            key: ValueKey('settings-wisa-school-${schools[i].schoolId}'),
-            children: <Widget>[
-              Expanded(
-                child: SwitchListTile(
-                  key: ValueKey(
-                    'settings-wisa-school-${schools[i].schoolId}-ours',
-                  ),
-                  contentPadding: EdgeInsets.zero,
-                  title: Text('School ${schools[i].schoolId}'),
-                  subtitle: const Text('Beheerd'),
-                  value: schools[i].ours,
-                  onChanged: (v) => state._toggleSchoolOurs(i, v),
-                ),
-              ),
-              IconButton(
-                key: ValueKey(
-                  'settings-wisa-school-${schools[i].schoolId}-remove',
-                ),
-                icon: const Icon(Icons.delete_outline),
-                tooltip: 'Verwijderen',
-                onPressed: () => state._removeWisaSchool(i),
-              ),
-            ],
-          ),
-        const SizedBox(height: PlinkSpacing.s3),
-        Text(
-          'Optioneel: voeg een school handmatig toe via id.',
-          style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
-        ),
-        const SizedBox(height: PlinkSpacing.s2),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Expanded(
-              child: TextField(
-                key: const ValueKey('settings-wisa-school-add'),
-                controller: state._wisaSchoolToAdd,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(
-                  labelText: 'School-id toevoegen',
-                  border: OutlineInputBorder(),
-                ),
-                onSubmitted: (_) => state._addWisaSchool(),
-              ),
-            ),
-            const SizedBox(width: PlinkSpacing.s3),
-            OutlinedButton.icon(
-              key: const ValueKey('settings-wisa-school-add-btn'),
-              onPressed: state._addWisaSchool,
-              icon: const Icon(Icons.add),
-              label: const Text('Toevoegen'),
-            ),
-          ],
-        ),
       ],
+    );
+  }
+
+  /// Lays the known schools out as rows of [_columns] cells, padding the final
+  /// row with empty slots so the grid columns stay aligned. Each cell toggles
+  /// its school's managed (`ours`) flag inline.
+  List<Widget> _schoolRows(List<WisaSchoolProfile> schools) {
+    final rows = <Widget>[];
+    for (var start = 0; start < schools.length; start += _columns) {
+      final cells = <Widget>[];
+      for (var col = 0; col < _columns; col++) {
+        final i = start + col;
+        cells.add(Expanded(
+          child: i < schools.length
+              ? _SchoolCell(state: state, index: i, profile: schools[i])
+              : const SizedBox.shrink(),
+        ));
+      }
+      rows.add(Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: cells,
+      ));
+    }
+    return rows;
+  }
+}
+
+/// A single cell in the known-WISA-school grid (#171): the school name (falling
+/// back to `School <id>` for a profile stored before the name was persisted),
+/// its id, and an inline checkbox marking whether we manage it. Keyed by school
+/// id so a test can flip a specific school's managed flag.
+class _SchoolCell extends StatelessWidget {
+  const _SchoolCell({
+    required this.state,
+    required this.index,
+    required this.profile,
+  });
+
+  final _SettingsScreenState state;
+  final int index;
+  final WisaSchoolProfile profile;
+
+  @override
+  Widget build(BuildContext context) {
+    return CheckboxListTile(
+      key: ValueKey('settings-wisa-school-${profile.schoolId}-ours'),
+      contentPadding: EdgeInsets.zero,
+      controlAffinity: ListTileControlAffinity.leading,
+      dense: true,
+      title: Text(
+        profile.name.isEmpty ? 'School ${profile.schoolId}' : profile.name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text('id: ${profile.schoolId}'),
+      value: profile.ours,
+      onChanged: (v) => state._toggleSchoolOurs(index, v ?? false),
     );
   }
 }

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -242,13 +242,17 @@ void main() {
     expect(find.text('STORED'), findsOneWidget);
   });
 
-  testWidgets('toggling a WISA school\'s "ours" flag round-trips to the store',
-      (WidgetTester tester) async {
+  testWidgets(
+      'the stored known-school list renders by name in a grid on open, no '
+      're-fetch (#171)', (WidgetTester tester) async {
     _useTallWindow(tester);
+    // Two schools already persisted (with names): one managed, one not. Opening
+    // the tab shows the complete list by name — no fetch needed.
     final harness = SettingsHarness(
       initial: const AppSettings(
         wisaSchools: [
-          WisaSchoolProfile(schoolId: 42),
+          WisaSchoolProfile(schoolId: 42, name: 'Sint-Jan', ours: true),
+          WisaSchoolProfile(schoolId: 43, name: 'Sint-Pieter'),
         ],
       ),
     );
@@ -257,14 +261,49 @@ void main() {
     await tester.pumpAndSettle();
 
     await _openTab(tester, 'settings-tab-wisa');
-    // The seeded (unmanaged) school renders with its switch off.
-    final ourSwitch =
-        find.byKey(const ValueKey('settings-wisa-school-42-ours'));
-    expect(ourSwitch, findsOneWidget);
-    expect(tester.widget<SwitchListTile>(ourSwitch).value, isFalse);
+    expect(find.text('Sint-Jan'), findsOneWidget);
+    expect(find.text('Sint-Pieter'), findsOneWidget);
+    expect(find.byKey(const ValueKey('settings-wisa-school-42-ours')),
+        findsOneWidget);
+    expect(find.byKey(const ValueKey('settings-wisa-school-43-ours')),
+        findsOneWidget);
+    // The managed one shows ticked, the other not.
+    expect(
+        tester
+            .widget<CheckboxListTile>(
+                find.byKey(const ValueKey('settings-wisa-school-42-ours')))
+            .value,
+        isTrue);
+    expect(
+        tester
+            .widget<CheckboxListTile>(
+                find.byKey(const ValueKey('settings-wisa-school-43-ours')))
+            .value,
+        isFalse);
+  });
+
+  testWidgets('toggling a WISA school\'s "ours" flag round-trips to the store',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisaSchools: [
+          WisaSchoolProfile(schoolId: 42, name: 'Sint-Jan'),
+        ],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    // The seeded (unmanaged) school renders with its checkbox off.
+    final ourBox = find.byKey(const ValueKey('settings-wisa-school-42-ours'));
+    expect(ourBox, findsOneWidget);
+    expect(tester.widget<CheckboxListTile>(ourBox).value, isFalse);
 
     // Flip it on and save.
-    await tester.tap(ourSwitch);
+    await tester.tap(ourBox);
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('settings-save')));
     await tester.pumpAndSettle();
@@ -274,7 +313,26 @@ void main() {
     expect(saved.wisaSchools.single.ours, isTrue);
   });
 
-  testWidgets('adding a WISA school by id appends a managed entry',
+  testWidgets('a profile stored without a name falls back to "School <id>"',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // A profile predating the persisted name (#171): the row still renders.
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisaSchools: [WisaSchoolProfile(schoolId: 9)],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    expect(find.text('School 9'), findsOneWidget);
+    expect(find.byKey(const ValueKey('settings-wisa-school-9-ours')),
+        findsOneWidget);
+  });
+
+  testWidgets('no manual add-by-id UI remains (#171)',
       (WidgetTester tester) async {
     _useTallWindow(tester);
     final harness = SettingsHarness();
@@ -286,24 +344,12 @@ void main() {
     // No schools yet — the empty note shows.
     expect(find.byKey(const ValueKey('settings-wisa-schools-empty')),
         findsOneWidget);
-
-    await tester.enterText(
-      find.byKey(const ValueKey('settings-wisa-school-add')),
-      '7',
-    );
-    await tester
-        .tap(find.byKey(const ValueKey('settings-wisa-school-add-btn')));
-    await tester.pumpAndSettle();
-
-    // The new row appears, defaults to managed, and saves.
-    expect(find.byKey(const ValueKey('settings-wisa-school-7-ours')),
-        findsOneWidget);
-    await tester.tap(find.byKey(const ValueKey('settings-save')));
-    await tester.pumpAndSettle();
-
-    final saved = await harness.store.load();
-    expect(saved.wisaSchools.single.schoolId, 7);
-    expect(saved.wisaSchools.single.ours, isTrue);
+    // The add-by-id field/button are gone.
+    expect(
+        find.byKey(const ValueKey('settings-wisa-school-add')), findsNothing);
+    expect(find.byKey(const ValueKey('settings-wisa-school-add-btn')),
+        findsNothing);
+    expect(find.text('Toevoegen'), findsNothing);
   });
 
   testWidgets(
@@ -321,15 +367,15 @@ void main() {
     await _openTab(tester, 'settings-tab-wisa');
     final button = find.byKey(const ValueKey('settings-wisa-fetch-schools'));
     expect(button, findsOneWidget);
-    expect(tester.widget<FilledButton>(button).onPressed, isNull,
+    expect(tester.widget<OutlinedButton>(button).onPressed, isNull,
         reason: 'no valid config yet ⇒ fetch disabled');
     expect(
         find.byKey(const ValueKey('settings-wisa-fetch-hint')), findsOneWidget);
   });
 
   testWidgets(
-      'fetch → tick a returned school → save persists the selection, no id '
-      'typed by hand (#142)', (WidgetTester tester) async {
+      'fetch merges the school list by name, mark one → save persists name + '
+      'ours, new schools unmanaged (#171)', (WidgetTester tester) async {
     _useTallWindow(tester);
     const passwordRef = SecretRef('wisa.password');
     final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
@@ -350,41 +396,53 @@ void main() {
     await _openTab(tester, 'settings-tab-wisa');
     // A valid config lights the fetch button up.
     final button = find.byKey(const ValueKey('settings-wisa-fetch-schools'));
-    expect(tester.widget<FilledButton>(button).onPressed, isNotNull);
+    expect(tester.widget<OutlinedButton>(button).onPressed, isNotNull);
     expect(
         find.byKey(const ValueKey('settings-wisa-fetch-hint')), findsNothing);
 
     await tester.tap(button);
     await tester.pumpAndSettle();
 
-    // The fetcher ran (with the stored password resolved) and both schools
-    // render by name for selection.
+    // The fetcher ran (with the stored password resolved) and both schools now
+    // render by name in the grid, unmanaged by default.
     expect(fetcher.calls, 1);
     expect(fetcher.lastPassword, 'stored-pw');
     expect(fetcher.lastConnection?.server, 'db.school.example');
     expect(find.text('Sint-Jan'), findsOneWidget);
     expect(find.text('Sint-Pieter'), findsOneWidget);
+    expect(
+        tester
+            .widget<CheckboxListTile>(
+                find.byKey(const ValueKey('settings-wisa-school-7-ours')))
+            .value,
+        isFalse,
+        reason: 'a freshly fetched school is unmanaged until marked');
 
-    // Tick one returned school; it becomes a managed selection and saves.
-    await tester
-        .tap(find.byKey(const ValueKey('settings-wisa-fetched-school-7')));
+    // Mark one managed; save persists both the name and the ours flag.
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-school-7-ours')));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('settings-save')));
     await tester.pumpAndSettle();
 
     final saved = await harness.store.load();
-    expect(saved.wisaSchools.single.schoolId, 7);
-    expect(saved.wisaSchools.single.ours, isTrue);
+    expect(saved.wisaSchools.length, 2);
+    final managed = saved.wisaSchools.firstWhere((p) => p.schoolId == 7);
+    expect(managed.name, 'Sint-Pieter');
+    expect(managed.ours, isTrue);
+    final other = saved.wisaSchools.firstWhere((p) => p.schoolId == 3);
+    expect(other.name, 'Sint-Jan');
+    expect(other.ours, isFalse);
   });
 
-  testWidgets('unticking a fetched school removes it from the selection (#142)',
+  testWidgets(
+      'refetch preserves the existing ours mark and fills in the name (#171)',
       (WidgetTester tester) async {
     _useTallWindow(tester);
     const passwordRef = SecretRef('wisa.password');
     final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
       WisaSchool(id: 7, name: 'Sint-Pieter', description: 'SP'),
     ]);
-    // Id 7 is already selected from a previous run.
+    // Id 7 is already managed from a previous run, but stored without a name.
     final harness = SettingsHarness(
       initial: const AppSettings(
         wisa: WisaConnection(server: 'db.school.example', port: '1433'),
@@ -398,19 +456,26 @@ void main() {
     await tester.pumpAndSettle();
 
     await _openTab(tester, 'settings-tab-wisa');
+    // Before the refetch it renders by id (no stored name) and stays ticked.
+    expect(find.text('School 7'), findsOneWidget);
     await tester.tap(find.byKey(const ValueKey('settings-wisa-fetch-schools')));
     await tester.pumpAndSettle();
 
-    // The already-selected school shows ticked; untick and save clears it.
-    final tile = find.byKey(const ValueKey('settings-wisa-fetched-school-7'));
-    expect(tester.widget<CheckboxListTile>(tile).value, isTrue);
-    await tester.tap(tile);
-    await tester.pumpAndSettle();
+    // The refetch fills in the name and keeps the managed mark.
+    expect(find.text('Sint-Pieter'), findsOneWidget);
+    expect(
+        tester
+            .widget<CheckboxListTile>(
+                find.byKey(const ValueKey('settings-wisa-school-7-ours')))
+            .value,
+        isTrue);
     await tester.tap(find.byKey(const ValueKey('settings-save')));
     await tester.pumpAndSettle();
 
     final saved = await harness.store.load();
-    expect(saved.wisaSchools, isEmpty);
+    expect(saved.wisaSchools.single.schoolId, 7);
+    expect(saved.wisaSchools.single.name, 'Sint-Pieter');
+    expect(saved.wisaSchools.single.ours, isTrue);
   });
 
   testWidgets('accumulated import rules render read-only',

--- a/packages/account_state/lib/src/settings/wisa_school_profile.dart
+++ b/packages/account_state/lib/src/settings/wisa_school_profile.dart
@@ -9,18 +9,25 @@
 /// operator-editable ownership record keyed by school *id* that survives in the
 /// settings blob.
 ///
-/// The shape (`{ schoolId, ours, prefix }`) is the per-WISA-school ownership
+/// The shape (`{ schoolId, name, ours, prefix }`) is the per-WISA-school ownership
 /// link #112/#113 called for, so the settings document is not reshaped twice.
 /// This slice only carries the data — no action reads it yet (#134 is slice 2).
 class WisaSchoolProfile {
   const WisaSchoolProfile({
     required this.schoolId,
+    this.name = '',
     this.ours = false,
     this.prefix = '',
   });
 
   /// The WISA school id (`WisaSchool.id`) this ownership entry is keyed by.
   final int schoolId;
+
+  /// The WISA school name (`WisaSchool.name`), persisted so the settings editor
+  /// can render the full known-school list by name without re-fetching. Empty
+  /// for profiles stored before the name was persisted (#171) — the editor
+  /// falls back to `School <id>` and a later fetch fills the name in.
+  final String name;
 
   /// Whether we manage this school. A student found only in schools where this
   /// is `false` (group-visible siblings) has left *our* schools.
@@ -31,15 +38,22 @@ class WisaSchoolProfile {
   /// not yet consulted by the linker.
   final String prefix;
 
-  WisaSchoolProfile copyWith({int? schoolId, bool? ours, String? prefix}) =>
+  WisaSchoolProfile copyWith({
+    int? schoolId,
+    String? name,
+    bool? ours,
+    String? prefix,
+  }) =>
       WisaSchoolProfile(
         schoolId: schoolId ?? this.schoolId,
+        name: name ?? this.name,
         ours: ours ?? this.ours,
         prefix: prefix ?? this.prefix,
       );
 
   Map<String, dynamic> toJson() => {
         'schoolId': schoolId,
+        'name': name,
         'ours': ours,
         'prefix': prefix,
       };
@@ -47,6 +61,7 @@ class WisaSchoolProfile {
   factory WisaSchoolProfile.fromJson(Map<String, dynamic> json) =>
       WisaSchoolProfile(
         schoolId: json['schoolId'] as int,
+        name: (json['name'] as String?) ?? '',
         ours: (json['ours'] as bool?) ?? false,
         prefix: (json['prefix'] as String?) ?? '',
       );
@@ -56,13 +71,15 @@ class WisaSchoolProfile {
       identical(this, other) ||
       other is WisaSchoolProfile &&
           schoolId == other.schoolId &&
+          name == other.name &&
           ours == other.ours &&
           prefix == other.prefix;
 
   @override
-  int get hashCode => Object.hash(schoolId, ours, prefix);
+  int get hashCode => Object.hash(schoolId, name, ours, prefix);
 
   @override
   String toString() =>
-      'WisaSchoolProfile(schoolId: $schoolId, ours: $ours, prefix: $prefix)';
+      'WisaSchoolProfile(schoolId: $schoolId, name: $name, ours: $ours, '
+      'prefix: $prefix)';
 }

--- a/packages/account_state/test/settings_store_test.dart
+++ b/packages/account_state/test/settings_store_test.dart
@@ -108,15 +108,31 @@ void main() {
     test('per-WISA-school ownership list round-trips through JSON', () {
       const original = AppSettings(
         wisaSchools: [
-          WisaSchoolProfile(schoolId: 10, ours: true, prefix: 'KA'),
-          WisaSchoolProfile(schoolId: 20),
+          WisaSchoolProfile(
+              schoolId: 10, name: 'Sint-Jan', ours: true, prefix: 'KA'),
+          WisaSchoolProfile(schoolId: 20, name: 'Sint-Pieter'),
         ],
       );
       final restored = AppSettings.fromJson(original.toJson());
       expect(restored.wisaSchools, original.wisaSchools);
+      expect(restored.wisaSchools.first.name, 'Sint-Jan');
       expect(restored.wisaSchools.first.ours, isTrue);
       expect(restored.wisaSchools.first.prefix, 'KA');
+      expect(restored.wisaSchools.last.name, 'Sint-Pieter');
       expect(restored.wisaSchools.last.ours, isFalse);
+    });
+
+    test(
+        'a school profile predating the persisted name loads with an empty '
+        'name (#171)', () {
+      final settings = AppSettings.fromJson({
+        'wisaSchools': [
+          {'schoolId': 42, 'ours': true, 'prefix': ''},
+        ],
+      });
+      expect(settings.wisaSchools.single.schoolId, 42);
+      expect(settings.wisaSchools.single.name, isEmpty);
+      expect(settings.wisaSchools.single.ours, isTrue);
     });
 
     test('a config predating wisaSchools loads with an empty list', () {


### PR DESCRIPTION
## Summary

Reworks the WISA schools editor (`_WisaSchoolsEditor`) from three stacked
sections into a single, complete known-school list rendered as a 3-column grid.
Previously the tab showed a long checkbox list of fetched schools, a repeated
"Geselecteerde scholen" section that could only render `School <id>` (the stored
profile had no name), and a manual add-by-id field.

## Linked issue

Closes #171

## Changes

- **Persist the school name.** Added a `name` field to `WisaSchoolProfile`
  (`packages/account_state`). Backward-compatible: `fromJson` tolerates a missing
  `name` and the editor falls back to `School <id>`. The tab now renders the full
  known set by name on open, with managed schools marked, without re-fetching.
- **3-column grid.** The known schools render as a grid (manual rows of 3 with
  `Expanded` cells to avoid font-dependent overflow); each cell is an inline
  checkbox toggling the school's managed (`ours`) flag. This removes the separate
  "Geselecteerde scholen" section — marking happens inline on the single list.
- **Dropped the manual add-by-id UI** (text field + Toevoegen button) plus the
  now-dead `_wisaSchoolToAdd` controller and `_addWisaSchool()`.
- **Demoted "Scholen ophalen" to a refresh.** It now merges fetched id+name
  records into the known list — updating names, appending genuinely new
  (unmanaged) schools, and preserving existing `ours` marks — instead of building
  a separate fetched list.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed` clean
- [x] `flutter analyze` clean (account_manager + account_state)
- [x] Unit/widget tests pass — `flutter test` (account_manager: 174) and
      `dart test` (account_state: 283, incl. new name round-trip + missing-name
      backward-compat cases). Added widget tests: stored list renders by name in
      the grid on open (no re-fetch), toggle round-trips, missing-name fallback,
      no add-by-id UI remains, fetch merges by name with new schools unmanaged,
      refetch preserves `ours` and fills the name.
- [x] Integration/e2e tests pass — `flutter test integration_test -d windows`
      (28 tests). Updated the two WISA-schools e2e cases (#133 ownership toggle,
      #142 fetch flow) to the new grid/merge model; user-visible change, so the
      real-app run is included.
