### PR TITLE
Make the reconcile progress bar advance through the pass (#176)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -215,6 +215,53 @@ void main() {
   });
 
   testWidgets(
+      'while a sync runs the reconcile header shows a determinate progress bar '
+      'that has advanced past the start end-to-end (#176)',
+      (WidgetTester tester) async {
+    // The real app over the offline harness, but the Azure pull parks on a gate
+    // so the pass is frozen mid-flight — the moment the operator stares at the
+    // busy bar during a long pull. It must read as a determinate bar that has
+    // already stepped forward through the earlier stages, not a motionless
+    // sweep that looks like a hung app.
+    useTallWindow(tester);
+    final gate = Completer<void>();
+    final harness = ReconcileHarness(azureGate: gate);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+
+    // Idle: no progress bar at all.
+    expect(find.byKey(const ValueKey('reconcile-progress')), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    // WISA + Smartschool resolve on the microtask queue; the Azure pull parks
+    // on the gate, freezing the pass with the busy bar on screen.
+    await tester.pump();
+    await tester.pump();
+
+    final bar = tester.widget<LinearProgressIndicator>(
+      find.byKey(const ValueKey('reconcile-progress')),
+    );
+    expect(bar.value, isNotNull, reason: 'determinate, not a static sweep');
+    expect(bar.value, greaterThan(0.0),
+        reason: 'already advanced through the earlier stages');
+    expect(bar.value, lessThan(1.0));
+    expect(harness.controller.busy, isTrue);
+
+    // Releasing the pull lets the pass finish; the bar disappears with busy.
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('reconcile-progress')), findsNothing);
+    expect(harness.controller.busy, isFalse);
+  });
+
+  testWidgets(
       'a completed sync logs a terminal "Sync complete … Ready." line and the '
       'prominent last-sync freshness row renders end-to-end (#162)',
       (WidgetTester tester) async {

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -324,6 +324,7 @@ class ReconcileController extends ChangeNotifier {
   StreamSubscription<ChangeSignal>? _signalSub;
 
   ReconcilePhase _phase = ReconcilePhase.idle;
+  double _progress = 0.0;
   LinkedState? _linked;
   bool _noChangesNeeded = false;
   String? _error;
@@ -373,6 +374,24 @@ class ReconcileController extends ChangeNotifier {
       _phase == ReconcilePhase.syncing ||
       _phase == ReconcilePhase.linking ||
       _phase == ReconcilePhase.applying;
+
+  /// How far the running pass has advanced, `0.0`–`1.0` — the value the busy
+  /// bar renders (#176). It steps forward at every stage of a sync/drift pass
+  /// (each system pulled, linking, persisting) and once per action during an
+  /// apply/dry-run, so the bar visibly *advances* rather than sitting as a
+  /// motionless sweep that reads as a hung app. Reset to `0.0` when a pass
+  /// begins; meaningless (and unread) while not [busy].
+  double get progress => _progress;
+
+  /// Steps the pass indicator to [value] (clamped) and repaints. A pass only
+  /// ever moves forward, so a lower [value] than the current one is ignored —
+  /// the shared [_relink] can't drag a further-along drift pass backwards.
+  void _setProgress(double value) {
+    final next = value.clamp(0.0, 1.0);
+    if (next <= _progress) return;
+    _progress = next;
+    notifyListeners();
+  }
 
   /// The current derived view, or `null` before the first successful sync.
   LinkedState? get linked => _linked;
@@ -919,6 +938,7 @@ class ReconcileController extends ChangeNotifier {
       log.addMessage(core.Origin.wisa, 'Syncing WISA…');
       final fresh = await app.sync(core.Origin.wisa) as wapi.WisaSnapshot;
       _recordPull(core.Origin.wisa, fresh);
+      _setProgress(0.25);
       log.addMessage(
         core.Origin.wisa,
         'WISA sync done: ${fresh.students.length} students, '
@@ -947,11 +967,13 @@ class ReconcileController extends ChangeNotifier {
         _recordPull(
             core.Origin.smartschool, await app.sync(core.Origin.smartschool));
       }
+      _setProgress(0.45);
       if (app.azure.snapshot == null) {
         await _renewLock();
         log.addMessage(core.Origin.azure, 'Syncing Azure AD…');
         _recordPull(core.Origin.azure, await app.sync(core.Origin.azure));
       }
+      _setProgress(0.65);
 
       await _relink();
       _logSyncComplete();
@@ -990,9 +1012,11 @@ class ReconcileController extends ChangeNotifier {
       );
       _recordPull(
           core.Origin.smartschool, await app.sync(core.Origin.smartschool));
+      _setProgress(0.35);
       await _renewLock();
       log.addMessage(core.Origin.azure, 'Checking Azure AD for drift…');
       _recordPull(core.Origin.azure, await app.sync(core.Origin.azure));
+      _setProgress(0.6);
 
       if (app.wisa.snapshot == null) {
         await _renewLock();
@@ -1200,12 +1224,15 @@ class ReconcileController extends ChangeNotifier {
     );
 
     try {
-      for (final option in selected) {
+      for (final (index, option) in selected.indexed) {
         results.add(await _applyOne(
           () => _applyAny(option.action, options),
           option.target,
           option.changes,
         ));
+        // Advance once per action so a long apply/dry-run pass reads as busy
+        // and visibly progressing rather than a motionless bar (#176).
+        _setProgress((index + 1) / selected.length);
       }
 
       final failed =
@@ -1283,6 +1310,7 @@ class ReconcileController extends ChangeNotifier {
 
   Future<void> _relink() async {
     _phase = ReconcilePhase.linking;
+    _setProgress(0.75);
     notifyListeners();
     _linked = await applier.link();
     final s = _linked!.snapshot;
@@ -1292,6 +1320,7 @@ class ReconcileController extends ChangeNotifier {
       '${s.groups.length} groups; ${pendingActions.length} pending '
       'action(s), ${s.warnings.length} warning(s).',
     );
+    _setProgress(0.9);
     await _persist(_linked!);
   }
 
@@ -1376,6 +1405,7 @@ class ReconcileController extends ChangeNotifier {
 
   void _begin(ReconcilePhase phase) {
     _phase = phase;
+    _progress = 0.0;
     _error = null;
     _noChangesNeeded = false;
     _dryRunResults = null;

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -294,7 +294,14 @@ class _Header extends StatelessWidget {
         ],
         if (controller.busy) ...<Widget>[
           const SizedBox(height: PlinkSpacing.s4),
-          const LinearProgressIndicator(),
+          // A determinate bar that steps forward through the pass (#176): each
+          // system pulled, linking, persisting, and every applied action nudges
+          // [ReconcileController.progress], so the operator sees the reconcile
+          // advancing instead of a motionless sweep that reads as a hung app.
+          LinearProgressIndicator(
+            key: const ValueKey('reconcile-progress'),
+            value: controller.progress,
+          ),
         ],
       ],
     );

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -377,6 +377,84 @@ void main() {
     });
   });
 
+  group('busy-pass progress (#176)', () {
+    /// Records [ReconcileController.progress] on every notification, so a test
+    /// can assert the pass stepped the bar forward through its stages even
+    /// though the whole pass resolves within a single microtask flush.
+    List<double> recordProgress(ReconcileController controller) {
+      final seen = <double>[];
+      controller.addListener(() => seen.add(controller.progress));
+      return seen;
+    }
+
+    void expectMonotonic(List<double> values) {
+      for (var i = 1; i < values.length; i++) {
+        expect(values[i], greaterThanOrEqualTo(values[i - 1]),
+            reason: 'progress must never move backwards: $values');
+      }
+    }
+
+    test('a sync steps the bar forward through every stage', () async {
+      final h = ReconcileHarness();
+      final seen = recordProgress(h.controller);
+
+      await h.controller.sync();
+
+      expect(seen, isNotEmpty);
+      expect(seen.first, 0.0, reason: 'a pass resets the bar to the start');
+      expectMonotonic(seen);
+      // The bar visited intermediate stages (systems pulled, linking,
+      // persisting) rather than jumping straight to done — the "advances"
+      // the issue asks for.
+      expect(seen.where((v) => v > 0.0 && v < 1.0).length,
+          greaterThanOrEqualTo(3));
+      expect(h.controller.progress, greaterThanOrEqualTo(0.9));
+    });
+
+    test('an unchanged re-sync still advances past the start', () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+      h.wisaResult =
+          wisaSnap(fetchedAt: kFixtureDate.add(const Duration(hours: 1)));
+
+      final seen = recordProgress(h.controller);
+      await h.controller.sync();
+
+      expect(h.controller.noChangesNeeded, isTrue);
+      expect(seen.first, 0.0);
+      expectMonotonic(seen);
+      expect(seen.any((v) => v > 0.0), isTrue,
+          reason: 'even the short no-changes path moves the bar off zero');
+    });
+
+    test('a drift check steps the bar forward through its stages', () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+
+      final seen = recordProgress(h.controller);
+      await h.controller.checkDrift();
+
+      expect(seen.first, 0.0);
+      expectMonotonic(seen);
+      expect(seen.where((v) => v > 0.0 && v < 1.0), isNotEmpty);
+    });
+
+    test('an apply advances once per action, reaching 1.0', () async {
+      final h = manyDepartedHarness(count: 4);
+      await h.controller.sync();
+      expect(h.controller.applyableCount, 4);
+
+      final seen = recordProgress(h.controller);
+      await h.controller.applyAll();
+
+      expect(seen.first, 0.0);
+      expectMonotonic(seen);
+      // One step per applied action: 0.25, 0.5, 0.75, 1.0.
+      expect(seen, containsAllInOrder(<double>[0.25, 0.5, 0.75, 1.0]));
+      expect(h.controller.progress, 1.0);
+    });
+  });
+
   group('materialized view (#115)', () {
     test('a sync writes per-account docs + rollups + bumps the generation',
         () async {

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -399,6 +399,7 @@ class ReconcileHarness {
     wapi.WisaSnapshot? wisaInitial,
     ss.SmartschoolSnapshot? ssInitial,
     az.AzureSnapshot? azureInitial,
+    this.azureGate,
     this.syncedBy = 'operator@school.example',
   })  : wisaResult = (wisa ?? wisaSnap()),
         ssResult = (smartschool ?? ssSnap()),
@@ -422,6 +423,11 @@ class ReconcileHarness {
     };
     Syncer<az.AzureSnapshot> azSync = (_) async {
       azSyncs++;
+      // When a test wires a gate, the Azure pull parks here until released, so
+      // a widget test can hold a sync mid-flight and observe the busy progress
+      // bar the earlier stages have already advanced (#176).
+      final gate = azureGate;
+      if (gate != null) await gate.future;
       return azResult;
     };
 
@@ -543,6 +549,11 @@ class ReconcileHarness {
   /// per-system sync-metadata author (#108). Vary it to model a second operator
   /// sharing the same [linkedStore].
   final String syncedBy;
+
+  /// When set, the Azure syncer parks on this completer until a test releases
+  /// it — a seam to freeze a sync mid-pass (WISA + Smartschool already pulled)
+  /// so a widget test can observe the busy progress bar (#176).
+  final Completer<void>? azureGate;
 
   /// Builds a "second session" seeded from [store] — a fresh controller over
   /// the state another harness already persisted, the way bootstrap seeds each

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
 import 'package:account_manager/src/screens/reconcile_screen.dart';
 import 'package:account_state/account_state.dart';
@@ -126,6 +128,40 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining('no account changes needed'), findsWidgets);
+  });
+
+  testWidgets(
+      'while a sync runs the header shows a determinate progress bar that has '
+      'advanced past the start (#176)', (WidgetTester tester) async {
+    final gate = Completer<void>();
+    final harness = ReconcileHarness(azureGate: gate);
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    // Idle: no progress bar.
+    expect(find.byKey(const ValueKey('reconcile-progress')), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    // WISA + Smartschool resolve on the microtask queue; the Azure pull parks
+    // on the gate, freezing the pass mid-flight so the busy bar is observable.
+    await tester.pump();
+    await tester.pump();
+
+    final barFinder = find.byKey(const ValueKey('reconcile-progress'));
+    expect(barFinder, findsOneWidget);
+    final bar = tester.widget<LinearProgressIndicator>(barFinder);
+    // Determinate — not the old motionless indeterminate sweep — and already
+    // stepped forward through the earlier stages (#176).
+    expect(bar.value, isNotNull);
+    expect(bar.value, greaterThan(0.0));
+    expect(bar.value, lessThan(1.0));
+
+    // Releasing the pull lets the pass finish; the bar disappears with busy.
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('reconcile-progress')), findsNothing);
   });
 
   testWidgets(


### PR DESCRIPTION
## Summary
The Reconcile busy indicator was an indeterminate `LinearProgressIndicator`. Its marching sweep stalls whenever the pass hits a synchronous CPU burst (the linker `recompute` and the `materialize` step run on the UI isolate), so on a long pass the bar looks frozen and the app reads as hung.

This drives the busy indicator as a **determinate bar that advances**: a new `ReconcileController.progress` (0.0–1.0) steps forward at each stage of a sync/drift pass — every system pulled, linking, persisting — and once per action during an apply/dry-run. The operator now sees the reconcile visibly progressing. The value only ever moves forward and resets when a pass begins. (The issue's Expected behavior explicitly sanctions "a determinate bar that advances.")

## Linked issue
Closes #176

## Changes
- `reconcile_controller.dart`: add `progress` getter + `_setProgress` helper; step it through `sync()`, `checkDrift()`, `_relink()`, and per-action in `_run()`; reset in `_begin`.
- `reconcile_screen.dart`: render the header busy bar as `LinearProgressIndicator(value: controller.progress)` with a `reconcile-progress` key. The brief bootstrap "Preparing…" bar stays indeterminate.
- Tests: unit progress-advance tests; a widget test and an end-to-end integration test that gate the Azure pull mid-pass and assert the header shows a determinate, advanced bar (both fail on the pre-fix indeterminate bar). Added an optional `azureGate` seam to `ReconcileHarness`.

## Test plan
- [x] `dart format --set-exit-if-changed` clean (6 files)
- [x] `flutter analyze` clean (no issues)
- [x] unit/widget tests pass — `flutter test` (179 tests, incl. 4 new controller + 1 new screen)
- [x] integration/e2e tests pass — `flutter test integration_test -d windows` (29 tests, incl. the new #176 case)
- [x] Regression confirmed: the widget/integration test fails on the pre-fix indeterminate bar, and the unit tests fail without the new `progress` API