### PR TITLE
Log Azure account/group pull progress during drift check (#177)

### DIFF
--- a/packages/azure_api/lib/src/graph/graph_client.dart
+++ b/packages/azure_api/lib/src/graph/graph_client.dart
@@ -67,15 +67,21 @@ class GraphClient {
   /// GET every page of a collection at [url], following `@odata.nextLink`.
   /// Returns the concatenated `value` arrays. [headers] (e.g. the advanced-
   /// query `ConsistencyLevel: eventual`) are sent on every page.
+  ///
+  /// [onPage], when supplied, is invoked after each page with the running
+  /// total of items gathered so far. Callers use it to emit progress while a
+  /// large multi-page pull is advancing (issue #177).
   Future<List<Map<String, dynamic>>> getCollection(
     Uri url, {
     Map<String, String>? headers,
+    void Function(int total)? onPage,
   }) async {
     final items = <Map<String, dynamic>>[];
     Uri? next = url;
     while (next != null) {
       final body = await getJson(next, headers: headers);
       items.addAll(_values(body));
+      onPage?.call(items.length);
       next = _nextLink(body);
     }
     return items;

--- a/packages/azure_api/lib/src/group_manager.dart
+++ b/packages/azure_api/lib/src/group_manager.dart
@@ -22,6 +22,9 @@ class GroupManager {
 
   static final String _select = AzureGroup.graphSelectFields.join(',');
 
+  /// Emit a progress log line for every this-many groups pulled (issue #177).
+  static const int _progressEvery = 20;
+
   static const Map<String, String> _advancedQueryHeaders = {
     'ConsistencyLevel': 'eventual',
   };
@@ -46,6 +49,12 @@ class GroupManager {
       final id = (row['id'] as String?) ?? '';
       final members = await loadMemberIds(id);
       groups.add(AzureGroup.fromGraphJson(row, members: members));
+      if (groups.length % _progressEvery == 0) {
+        _log?.addMessage(
+          core.Origin.azure,
+          'Azure: ${groups.length} groepen opgehaald…',
+        );
+      }
     }
     _log?.addMessage(
       core.Origin.azure,

--- a/packages/azure_api/lib/src/user_manager.dart
+++ b/packages/azure_api/lib/src/user_manager.dart
@@ -39,6 +39,9 @@ class UserManager {
 
   static final String _select = AzureUser.graphSelectFields.join(',');
 
+  /// Emit a progress log line for every this-many accounts pulled (issue #177).
+  static const int _progressEvery = 100;
+
   /// Headers required for advanced directory queries (`$count`,
   /// `startswith`, `$filter` with `or`). Graph rejects these without
   /// `ConsistencyLevel: eventual`.
@@ -71,8 +74,11 @@ class UserManager {
         r'$filter': filterFor(schoolPrefix),
       },
     );
-    final rows =
-        await _graph.getCollection(url, headers: _advancedQueryHeaders);
+    final rows = await _graph.getCollection(
+      url,
+      headers: _advancedQueryHeaders,
+      onPage: _accountProgress(),
+    );
     final users = rows.map(AzureUser.fromGraphJson).toList();
     _log?.addMessage(
       core.Origin.azure,
@@ -87,7 +93,7 @@ class UserManager {
   /// than [load]; use only when [load]'s server-side filter is insufficient.
   Future<List<AzureUser>> loadClientFiltered(String schoolPrefix) async {
     final url = _graph.uri('users', query: {r'$select': _select});
-    final rows = await _graph.getCollection(url);
+    final rows = await _graph.getCollection(url, onPage: _accountProgress());
     final users = rows
         .map(AzureUser.fromGraphJson)
         .where((u) => _belongsToSchool(u, schoolPrefix))
@@ -287,6 +293,25 @@ class UserManager {
       candidate = '$local$suffix@$domain';
     }
     return candidate;
+  }
+
+  /// Builds an `onPage` callback that logs one line each time another
+  /// [_progressEvery] accounts have been pulled (issue #177), so a long Azure
+  /// bulk read visibly advances in the Log panel. Returns `null` when no log
+  /// sink is attached, so paging stays allocation-free in that case.
+  void Function(int total)? _accountProgress() {
+    final log = _log;
+    if (log == null) return null;
+    var nextMilestone = _progressEvery;
+    return (total) {
+      while (total >= nextMilestone) {
+        log.addMessage(
+          core.Origin.azure,
+          'Azure: $nextMilestone accounts opgehaald…',
+        );
+        nextMilestone += _progressEvery;
+      }
+    };
   }
 
   bool _belongsToSchool(AzureUser u, String prefix) {

--- a/packages/azure_api/test/connector_test.dart
+++ b/packages/azure_api/test/connector_test.dart
@@ -69,6 +69,70 @@ void main() {
     });
   });
 
+  group('drift-check progress logging (#177)', () {
+    test('a full sync emits account and group progress while paging', () async {
+      // azure_api is a pure-Dart package with no UI, so the end-to-end surface
+      // for issue #177 is the connector driving the real managers + paging
+      // GraphClient against a fake transport, with the progress lines landing
+      // in the injected ILog exactly as they would in the app's Log panel.
+      const groupCount = 45;
+      GraphResponse pagedRoute(GraphRequest req) {
+        final path = req.url.path;
+        if (path.contains('/members')) {
+          return jsonOk({'value': const <Object>[]});
+        }
+        if (path.contains('groups')) {
+          return jsonOk({
+            'value': [
+              for (var i = 0; i < groupCount; i++)
+                {'id': 'g$i', 'displayName': 'GBS-$i', 'securityEnabled': true},
+            ],
+          });
+        }
+        if (path.contains('users/delta')) {
+          return jsonOk(readFixture('delta_latest.json'));
+        }
+        // Bulk /users read: 250 users across three pages (100 / 100 / 50).
+        switch (req.url.queryParameters[r'$skiptoken']) {
+          case 'P1':
+            return usersPage(startIndex: 100, count: 100, nextSkipToken: 'P2');
+          case 'P2':
+            return usersPage(startIndex: 200, count: 50);
+          default:
+            return usersPage(startIndex: 0, count: 100, nextSkipToken: 'P1');
+        }
+      }
+
+      final transport = FakeGraphTransport(pagedRoute);
+      final log = RecordingLog();
+      final connector = AzureConnector(
+        credentials: credentials,
+        authProvider: const StaticAuthProvider('T'),
+        transport: transport,
+        log: log,
+      );
+
+      final snapshot = await connector.sync();
+
+      expect(snapshot.users, hasLength(250));
+      expect(snapshot.groups, hasLength(groupCount));
+      expect(
+        log.messages,
+        containsAllInOrder(<String>[
+          'Azure: 20 groepen opgehaald…',
+          'Azure: 40 groepen opgehaald…',
+        ]),
+      );
+      expect(
+        log.messages,
+        containsAllInOrder(<String>[
+          'Azure: 100 accounts opgehaald…',
+          'Azure: 200 accounts opgehaald…',
+        ]),
+      );
+    });
+  });
+
   group('incremental sync', () {
     test('applies delta changes and removals on top of the previous snapshot',
         () async {

--- a/packages/azure_api/test/group_manager_test.dart
+++ b/packages/azure_api/test/group_manager_test.dart
@@ -50,6 +50,47 @@ void main() {
     });
   });
 
+  group('progress logging (#177)', () {
+    GraphResponse routeWithGroups(GraphRequest req, int total) {
+      if (req.url.path.contains('/members')) {
+        return jsonOk({'value': const <Object>[]});
+      }
+      return jsonOk({
+        'value': [
+          for (var i = 0; i < total; i++)
+            {'id': 'g$i', 'displayName': 'GBS-$i', 'securityEnabled': true},
+        ],
+      });
+    }
+
+    test('logs one line for every 20 groups pulled', () async {
+      final transport = FakeGraphTransport((req) => routeWithGroups(req, 45));
+      final log = RecordingLog();
+      final groups = GroupManager(clientWith(transport), log: log);
+
+      final result = await groups.listGroups('GBS');
+
+      expect(result, hasLength(45));
+      expect(
+        log.messages.where((m) => m.contains('groepen opgehaald')).toList(),
+        ['Azure: 20 groepen opgehaald…', 'Azure: 40 groepen opgehaald…'],
+      );
+    });
+
+    test('emits no progress line below the first 20 threshold', () async {
+      final transport = FakeGraphTransport((req) => routeWithGroups(req, 5));
+      final log = RecordingLog();
+      final groups = GroupManager(clientWith(transport), log: log);
+
+      await groups.listGroups('GBS');
+
+      expect(
+        log.messages.where((m) => m.contains('groepen opgehaald')),
+        isEmpty,
+      );
+    });
+  });
+
   group('membership writes', () {
     test('addMember POSTs an @odata.id directoryObjects ref', () async {
       final transport = FakeGraphTransport.constant(noContent());

--- a/packages/azure_api/test/support/fake_graph_transport.dart
+++ b/packages/azure_api/test/support/fake_graph_transport.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:account_core/account_core.dart' as core;
 import 'package:azure_api/azure_api.dart';
 
 /// A [GraphTransport] that records every outgoing [GraphRequest] and replays a
@@ -64,3 +65,39 @@ String readFixture(String name) {
 /// Reads and decodes a JSON fixture object.
 Map<String, dynamic> readJsonFixture(String name) =>
     jsonDecode(readFixture(name)) as Map<String, dynamic>;
+
+/// An [core.ILog] that records every message and error for assertions.
+class RecordingLog implements core.ILog {
+  final List<String> messages = [];
+  final List<String> errors = [];
+
+  @override
+  void addMessage(core.Origin origin, String message) => messages.add(message);
+
+  @override
+  void addError(core.Origin origin, String message) => errors.add(message);
+}
+
+/// Builds a `200 OK` Graph `/users` collection page carrying [count] synthetic
+/// users numbered from [startIndex]. When [nextSkipToken] is non-null the page
+/// includes an `@odata.nextLink` pointing at that skiptoken, so paging in
+/// [GraphClient.getCollection] continues to the next page. Lets tests exercise
+/// the multi-page progress logging (issue #177) without giant fixtures.
+GraphResponse usersPage({
+  required int startIndex,
+  required int count,
+  String? nextSkipToken,
+}) =>
+    jsonOk({
+      if (nextSkipToken != null)
+        '@odata.nextLink':
+            'https://graph.microsoft.com/v1.0/users?\$skiptoken=$nextSkipToken',
+      'value': [
+        for (var i = startIndex; i < startIndex + count; i++)
+          {
+            'id': 'id-$i',
+            'userPrincipalName': 'user$i@student.school.example',
+            'companyName': 'GBS',
+          },
+      ],
+    });

--- a/packages/azure_api/test/user_manager_test.dart
+++ b/packages/azure_api/test/user_manager_test.dart
@@ -67,6 +67,76 @@ void main() {
     });
   });
 
+  group('progress logging (#177)', () {
+    test('logs one line for every 100 accounts pulled while paging', () async {
+      // 250 users across three pages of 100 / 100 / 50.
+      final transport = FakeGraphTransport((req) {
+        switch (req.url.queryParameters[r'$skiptoken']) {
+          case 'P1':
+            return usersPage(startIndex: 100, count: 100, nextSkipToken: 'P2');
+          case 'P2':
+            return usersPage(startIndex: 200, count: 50);
+          default:
+            return usersPage(startIndex: 0, count: 100, nextSkipToken: 'P1');
+        }
+      });
+      final log = RecordingLog();
+      final users = UserManager(clientWith(transport), log: log);
+
+      final result = await users.load('GBS');
+
+      expect(result, hasLength(250));
+      // A line at each full hundred crossed (250 → 100 and 200), not the tail.
+      expect(
+        log.messages.where((m) => m.contains('accounts opgehaald')).toList(),
+        ['Azure: 100 accounts opgehaald…', 'Azure: 200 accounts opgehaald…'],
+      );
+    });
+
+    test('emits no progress line below the first 100 threshold', () async {
+      final transport =
+          FakeGraphTransport((_) => usersPage(startIndex: 0, count: 3));
+      final log = RecordingLog();
+      final users = UserManager(clientWith(transport), log: log);
+
+      await users.load('GBS');
+
+      expect(
+        log.messages.where((m) => m.contains('accounts opgehaald')),
+        isEmpty,
+      );
+    });
+
+    test('loadClientFiltered logs progress on the same cadence', () async {
+      final transport = FakeGraphTransport((req) {
+        switch (req.url.queryParameters[r'$skiptoken']) {
+          case 'P1':
+            return usersPage(startIndex: 100, count: 50);
+          default:
+            return usersPage(startIndex: 0, count: 100, nextSkipToken: 'P1');
+        }
+      });
+      final log = RecordingLog();
+      final users = UserManager(clientWith(transport), log: log);
+
+      await users.loadClientFiltered('GBS');
+
+      expect(
+        log.messages.where((m) => m.contains('accounts opgehaald')).toList(),
+        ['Azure: 100 accounts opgehaald…'],
+      );
+    });
+
+    test('no progress lines are emitted when no log sink is attached',
+        () async {
+      final transport =
+          FakeGraphTransport((_) => usersPage(startIndex: 0, count: 100));
+      final users = UserManager(clientWith(transport));
+      // Must not throw despite a page crossing the 100 threshold.
+      expect(await users.load('GBS'), hasLength(100));
+    });
+  });
+
   group('delta', () {
     test(
         'uses the supplied token, filters by prefix, captures removals + token',


### PR DESCRIPTION
## Summary
During a drift check the Azure connector pulls the full tenant (6000+ accounts, hundreds of groups) in one long step that previously logged nothing, so the operator could not tell whether the app was working or hung. This adds periodic progress lines via the existing `ILog` sink so the pull visibly advances in the Log panel.

## Linked issue
Closes #177

## Changes
- `GraphClient.getCollection` gains an optional `onPage(total)` callback, invoked after each page with the running item total. Returns `null`-free / allocation-free when unused.
- `UserManager.load` and `loadClientFiltered` log `Azure: N accounts opgehaald…` every 100 accounts, via an `onPage` closure that is only built when a log sink is attached.
- `GroupManager.listGroups` logs `Azure: N groepen opgehaald…` every 20 groups.
- Counters run against the already-paged results — no extra API cost, logging-only, no behavioral change to the sync itself.

The app already wires `log: logBuffer` into `AzureConnector` (`reconcile_bootstrap.dart`), which flows to both managers, so the lines reach the Log panel with no `account_manager` change.

## Test plan
- [x] `dart format --set-exit-if-changed` clean (32 files, 0 changed)
- [x] `dart analyze` clean (no issues)
- [x] unit tests pass (`dart test` — 76 tests): 4 new `user_manager` (100-cadence while paging, sub-threshold silence, `loadClientFiltered` cadence, no-sink safety), 2 new `group_manager` (20-cadence, sub-threshold silence)
- [x] end-to-end pass: new `connector_test` "drift-check progress logging (#177)" drives the real `connector.sync()` through the paging `GraphClient` + real managers against a fake transport (250 users over 3 pages, 45 groups), asserting the account and group progress lines land in the injected `ILog` in order — the full end-to-end surface for a pure-Dart connector package with no UI of its own.