### PR TITLE
Restrict the Actions view to schools we manage (#178)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -575,16 +575,20 @@ void main() {
     expect(allKinds, isNot(contains('RemoveStudentFromAzure')),
         reason: 'the account is still in the group ⇒ Azure is kept');
 
-    // Browse it on the Actions tab: it sits under its sibling school in the
-    // drill-down (WISA still places it, in School 2).
+    // Browse it on the Actions tab: because school 2 is one we do NOT manage,
+    // its node is kept out of the drill-down (#178). The departed student is
+    // re-bucketed to "Niet toegewezen" so its Smartschool cleanup stays
+    // actionable — never surfacing a non-managed school node.
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('School 2'));
+    expect(find.text('School 2'), findsNothing,
+        reason: 'a school we do not manage never appears in Actions (#178)');
+    await tester.tap(find.text('Niet toegewezen'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Jaar 3'));
+    await tester.tap(find.text('Jaar Overig'));
     await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('3C'));
-    await tester.tap(find.text('3C'));
+    await tester.ensureVisible(find.text('Zonder klas'));
+    await tester.tap(find.text('Zonder klas'));
     await tester.pumpAndSettle();
     expect(find.byKey(ValueKey('entry-student-${entry.targetId}')),
         findsOneWidget);
@@ -604,6 +608,70 @@ void main() {
         harness.controller.applyResults!.map((r) => r.changes.summary);
     expect(summaries, contains('Schrijf de leerling uit in Smartschool'));
     expect(summaries, isNot(contains('Verwijder Azure account')));
+  });
+
+  testWidgets(
+      'the Actions drill-down hides a school the operator does not manage in '
+      'Settings, re-bucketing its student to the leaver group (#178)',
+      (WidgetTester tester) async {
+    // A student enrolled in school 2, fully present in our Smartschool + Azure.
+    // The WISA schools carry no MarkAsOurs flag, so ownership comes solely from
+    // the Settings-derived managed set the applier is wired with — the exact
+    // "persisted but never consumed" wiring #178 closes. Here only school 1 is
+    // managed, so the school-2 student is groupOnly.
+    useTallWindow(tester);
+    final harness = managedSchoolsHarness(ourSchoolIds: const {1});
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(find.text('Overzicht'), findsOneWidget);
+    // The non-managed school is not a node in the drill-down…
+    expect(find.text('School 2'), findsNothing,
+        reason: 'school 2 is not managed → no node in Actions');
+    // …but the departed student's cleanup stays actionable under the leaver
+    // bucket rather than vanishing entirely.
+    expect(find.text('Niet toegewezen'), findsOneWidget);
+  });
+
+  testWidgets(
+      'marking that same school as managed in Settings surfaces it in the '
+      'Actions drill-down end-to-end (#178)', (WidgetTester tester) async {
+    // The very same school-2 student, but now school 2 is one of ours: it must
+    // appear as a school node and the student sits under it. Proves the managed
+    // set from Settings — not the snapshot MarkAsOurs flags — drives which
+    // schools show.
+    useTallWindow(tester);
+    final harness = managedSchoolsHarness(ourSchoolIds: const {1, 2});
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(find.text('School 2'), findsOneWidget,
+        reason: 'managing school 2 surfaces it in Actions (#178)');
+    await tester.tap(find.text('School 2'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    expect(find.text('3C'), findsWidgets);
   });
 
   testWidgets(

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -383,6 +383,13 @@ Future<ReconcileServices> bootstrapReconcile({
     ),
     classTree: classTreeFrom(settings.smartschool),
     passwordQueue: passwordQueue,
+    // Wire the operator's managed-school choice into the linker (#178): the
+    // `ours`-flagged WISA schools from Settings drive `wisaPresence`, so the
+    // Actions view only surfaces schools we manage. Null when no school is
+    // flagged, so a not-yet-configured group falls back to the snapshot's
+    // `MarkAsOurs` flags rather than treating an empty managed set as "none".
+    ourSchoolIds:
+        settings.wisaSchools.isEmpty ? null : settings.managedWisaSchoolIds,
   );
 
   // The live SignalR subscriber (#124): on every (re)connect it re-reads the

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -256,6 +256,27 @@ ReconcileHarness movedToSiblingHarness() => ReconcileHarness(
       azure: azSnap(users: [azUser()]),
     );
 
+/// A harness for the managed-schools-only Actions filter (#178). One student is
+/// enrolled in school 2 and fully present in *our* Smartschool + Azure. The WISA
+/// schools carry **no** `MarkAsOurs` flag, so the managed set comes solely from
+/// [ourSchoolIds] (the persisted Settings path). Managing only school 1 leaves
+/// the student `groupOnly` — kept out of the school tree (re-bucketed to "Niet
+/// toegewezen"); adding school 2 to the managed set surfaces it under School 2.
+ReconcileHarness managedSchoolsHarness({required Set<int> ourSchoolIds}) =>
+    ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(schoolId: 2)],
+        schools: [wisaSchool(1), wisaSchool(2)],
+      ),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: [ssAccount()],
+        memberships: const [],
+      ),
+      azure: azSnap(users: [azUser()]),
+      ourSchoolIds: ourSchoolIds,
+    );
+
 az.AzureSnapshot azSnap({DateTime? fetchedAt, List<az.AzureUser>? users}) =>
     az.AzureSnapshot(
       fetchedAt: fetchedAt ?? kFixtureDate,
@@ -401,6 +422,7 @@ class ReconcileHarness {
     az.AzureSnapshot? azureInitial,
     this.azureGate,
     this.syncedBy = 'operator@school.example',
+    Set<int>? ourSchoolIds,
   })  : wisaResult = (wisa ?? wisaSnap()),
         ssResult = (smartschool ?? ssSnap()),
         azResult = (azure ?? azSnap()),
@@ -505,6 +527,10 @@ class ReconcileHarness {
         azureDomain: 'school.example',
       ),
       passwordQueue: passwordQueue,
+      // The operator's managed-school set from Settings (#178). When unset, the
+      // linker falls back to the WISA snapshot's MarkAsOurs flags, as bootstrap
+      // does for a not-yet-configured group.
+      ourSchoolIds: ourSchoolIds,
     );
 
     final signalHub = hub;

--- a/packages/account_state/lib/src/apply/state_applier.dart
+++ b/packages/account_state/lib/src/apply/state_applier.dart
@@ -66,6 +66,7 @@ class StateApplier {
     required StaffActionConfig staffConfig,
     this.classTree = const SmartschoolClassTree(),
     this.passwordQueue,
+    this.ourSchoolIds,
   })  : _studentConfig = _uniqueStudentConfig(studentConfig, _uidsFrom(app)),
         _staffConfig = _uniqueStaffConfig(staffConfig, _uidsFrom(app));
 
@@ -96,6 +97,13 @@ class StateApplier {
   /// still written to the target system but not queued.
   final PasswordQueueStore? passwordQueue;
 
+  /// The WISA school ids the operator actually manages (from the persisted
+  /// `AppSettings.wisaSchools` ownership flags, #178). Threaded into `link()` so
+  /// a student present only in a non-managed sibling school is classified
+  /// [core.WisaPresence.groupOnly] and kept out of the managed-school Actions
+  /// view. Null falls back to the snapshot's `MarkAsOurs` flags (see `link()`).
+  final Set<int>? ourSchoolIds;
+
   final StudentActionConfig _studentConfig;
   final StaffActionConfig _staffConfig;
 
@@ -119,6 +127,7 @@ class StateApplier {
         studentConfig: _studentConfig,
         staffConfig: _staffConfig,
         classTree: classTree,
+        ourSchoolIds: ourSchoolIds,
       );
 
   /// Applies a [StudentAction] and refreshes the snapshot on a real write.

--- a/packages/account_state/lib/src/link/linked_state.dart
+++ b/packages/account_state/lib/src/link/linked_state.dart
@@ -59,6 +59,12 @@ class LinkedState {
   /// binding a [PlacementResolver] built from the WISA + Smartschool snapshots
   /// and the injected [classTree] to the student and group `placementFor`
   /// callbacks.
+  ///
+  /// [ourSchoolIds] is the set of WISA school ids the operator actually manages
+  /// (from the persisted `AppSettings.wisaSchools` ownership flags, #178). It is
+  /// threaded into `link()` so `wisaPresence` is authoritative from Settings
+  /// rather than only the snapshot's `MarkAsOurs` flags. When null, `link()`
+  /// falls back to those snapshot flags (see its doc-comment).
   factory LinkedState.recompute({
     required wapi.WisaSnapshot wisa,
     required ss.SmartschoolSnapshot smartschool,
@@ -67,6 +73,7 @@ class LinkedState {
     required actions.StudentActionConfig studentConfig,
     required actions.StaffActionConfig staffConfig,
     SmartschoolClassTree classTree = const SmartschoolClassTree(),
+    Set<int>? ourSchoolIds,
   }) {
     assert(
       studentConfig.schoolPrefix == staffConfig.schoolPrefix,
@@ -79,6 +86,7 @@ class LinkedState {
       azure,
       resolver,
       schoolPrefix: studentConfig.schoolPrefix,
+      ourSchoolIds: ourSchoolIds,
     );
 
     final placements = PlacementResolver(
@@ -120,6 +128,7 @@ class LinkedState {
     required actions.StudentActionConfig studentConfig,
     required actions.StaffActionConfig staffConfig,
     SmartschoolClassTree classTree = const SmartschoolClassTree(),
+    Set<int>? ourSchoolIds,
   }) async {
     if (resolver is PreparablePersonIdResolver) {
       final keys = naturalKeysFor(
@@ -138,6 +147,7 @@ class LinkedState {
       studentConfig: studentConfig,
       staffConfig: staffConfig,
       classTree: classTree,
+      ourSchoolIds: ourSchoolIds,
     );
   }
 
@@ -152,6 +162,7 @@ class LinkedState {
     required actions.StudentActionConfig studentConfig,
     required actions.StaffActionConfig staffConfig,
     SmartschoolClassTree classTree = const SmartschoolClassTree(),
+    Set<int>? ourSchoolIds,
   }) {
     final (wisa, smartschool, azure) = _syncedSnapshots(app);
     return LinkedState.recompute(
@@ -162,6 +173,7 @@ class LinkedState {
       studentConfig: studentConfig,
       staffConfig: staffConfig,
       classTree: classTree,
+      ourSchoolIds: ourSchoolIds,
     );
   }
 
@@ -176,6 +188,7 @@ class LinkedState {
     required actions.StudentActionConfig studentConfig,
     required actions.StaffActionConfig staffConfig,
     SmartschoolClassTree classTree = const SmartschoolClassTree(),
+    Set<int>? ourSchoolIds,
   }) async {
     final (wisa, smartschool, azure) = _syncedSnapshots(app);
     return recomputeAsync(
@@ -186,6 +199,7 @@ class LinkedState {
       studentConfig: studentConfig,
       staffConfig: staffConfig,
       classTree: classTree,
+      ourSchoolIds: ourSchoolIds,
     );
   }
 

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -45,6 +45,17 @@ MaterializedView materialize(
 
   final accounts = <MaterializedAccount>[];
   for (final account in linked.snapshot.accounts) {
+    // #178: keep the Actions view to schools we manage. A student present only
+    // in a sibling school we do not manage ([WisaPresence.groupOnly]) with no
+    // account of ours is purely a sibling-school student — never surface them.
+    // A groupOnly student who still has one of *our* accounts is a departed
+    // student whose Smartschool/Azure cleanup we keep (#134); [_placeAccount]
+    // re-buckets them to "Niet toegewezen" so no non-managed school node shows.
+    if (account.wisaPresence == core.WisaPresence.groupOnly &&
+        account.smartschool == null &&
+        account.azure == null) {
+      continue;
+    }
     final place = _placeAccount(account, schoolLabels);
     accounts.add(MaterializedAccount(
       id: account.id,
@@ -225,16 +236,19 @@ class _Placement {
   final String classroom;
 }
 
-/// A student's location comes from its WISA record (school id + class group).
-/// An account with no WISA record — an Azure-/Smartschool-only leaver flagged
-/// for deletion — has no class, so it lands in the `unassigned` bucket (there is
-/// no "alumni" state; a departed student is an incomplete account, per #47).
+/// A student's location comes from its WISA record (school id + class group),
+/// but only when they are present in a school we **manage**
+/// ([LinkedAccount.isInOurWisa]). A student who left our school — gone from the
+/// group ([WisaPresence.absent]) or moved to a sibling school we don't manage
+/// ([WisaPresence.groupOnly], #178) — has no class *of ours*, so it lands in the
+/// `unassigned` bucket rather than surfacing a non-managed school node. There is
+/// no "alumni" state; a departed student is an incomplete account (per #47).
 _Placement _placeAccount(
   core.LinkedAccount account,
   Map<int, String> schoolLabels,
 ) {
   final wisa = account.wisa;
-  if (wisa is wapi.WisaStudent) {
+  if (wisa is wapi.WisaStudent && account.isInOurWisa) {
     final school = wisa.schoolId.toString();
     return _Placement(
       school: school,

--- a/packages/account_state/lib/src/settings/app_settings.dart
+++ b/packages/account_state/lib/src/settings/app_settings.dart
@@ -72,6 +72,16 @@ class AppSettings {
   /// group-membership plumbing #113 slice 2 reads, but no action fires here.
   final List<WisaSchoolProfile> wisaSchools;
 
+  /// The set of WISA school ids the operator manages — the `ours`-flagged
+  /// entries of [wisaSchools] (#178). This is what the linker joins student
+  /// membership against so `wisaPresence` is authoritative from Settings; empty
+  /// when no school is flagged (the caller then falls back to the snapshot's
+  /// `MarkAsOurs` flags rather than passing an empty managed set).
+  Set<int> get managedWisaSchoolIds => <int>{
+        for (final p in wisaSchools)
+          if (p.ours) p.schoolId,
+      };
+
   /// Returns a copy with the given fields replaced.
   AppSettings copyWith({
     String? schoolPrefix,

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -372,6 +372,136 @@ void main() {
     });
   });
 
+  group('managed schools only (#178)', () {
+    // A fully-linked student (WISA + our Smartschool + our Azure) whose WISA
+    // record sits in [schoolId]. [ourSchoolIds] is the operator's managed set;
+    // when it omits [schoolId] the student is classified groupOnly.
+    LinkedState linkedInSchool({
+      required int schoolId,
+      Set<int>? ourSchoolIds,
+      bool withOurAccounts = true,
+    }) =>
+        LinkedState.recompute(
+          wisa: wapi.WisaSnapshot(
+            fetchedAt: _d,
+            students: [_wStudent(schoolId: schoolId)],
+            staff: const [],
+            classGroups: const [],
+            schools: const [],
+          ),
+          smartschool: ss.SmartschoolSnapshot(
+            fetchedAt: _d,
+            groups: const [],
+            accounts: withOurAccounts ? [_ssAccount()] : const [],
+            memberships: const [],
+          ),
+          azure: az.AzureSnapshot(
+            fetchedAt: _d,
+            users: withOurAccounts ? [_azUser()] : const [],
+            groups: const [],
+          ),
+          resolver: _SeqResolver(),
+          studentConfig: _studentConfig,
+          staffConfig: _staffConfig,
+          ourSchoolIds: ourSchoolIds,
+        );
+
+    test('a student in a managed school is placed under that school node', () {
+      final view = materialize(linkedInSchool(schoolId: 1, ourSchoolIds: {1}),
+          generation: 1);
+
+      expect(view.accounts, hasLength(1));
+      expect(view.accounts.single.school, '1');
+      expect(
+        view.rollups.any((r) => r.school == '1'),
+        isTrue,
+        reason: 'the managed school shows a rollup node',
+      );
+    });
+
+    test(
+        'a student in a non-managed sibling school (groupOnly) but still in our '
+        'systems is re-bucketed to unassigned — no non-managed school node',
+        () {
+      // School 1 is ours; the student sits in school 2 → groupOnly, yet keeps a
+      // Smartschool + Azure account we must clean up (#134).
+      final view = materialize(linkedInSchool(schoolId: 2, ourSchoolIds: {1}),
+          generation: 1);
+
+      expect(view.accounts, hasLength(1),
+          reason:
+              'the departed student is kept (its cleanup stays actionable)');
+      expect(view.accounts.single.school, 'unassigned',
+          reason: 'not under the non-managed school 2');
+      expect(
+        view.rollups.any((r) => r.school == '2'),
+        isFalse,
+        reason: 'no rollup node for a school we do not manage',
+      );
+    });
+
+    test(
+        'a WISA-only student present only in a non-managed school is suppressed '
+        'entirely', () {
+      // No account of ours anywhere — a pure sibling-school student we never
+      // touch. They must not surface in the Actions view at all.
+      final view = materialize(
+        linkedInSchool(schoolId: 2, ourSchoolIds: {1}, withOurAccounts: false),
+        generation: 1,
+      );
+
+      expect(view.accounts, isEmpty);
+      expect(view.rollups.where((r) => r.level == RollupLevel.school), isEmpty);
+    });
+
+    test('toggling the managed set flips which schools appear', () {
+      // Same student in school 2. Not managing school 2 → suppressed from the
+      // school tree (re-bucketed to unassigned); managing it → it shows.
+      final unmanaged = materialize(
+          linkedInSchool(schoolId: 2, ourSchoolIds: {1}),
+          generation: 1);
+      expect(unmanaged.rollups.any((r) => r.school == '2'), isFalse);
+
+      final managed = materialize(
+          linkedInSchool(schoolId: 2, ourSchoolIds: {1, 2}),
+          generation: 1);
+      expect(managed.accounts.single.school, '2');
+      expect(managed.rollups.any((r) => r.school == '2'), isTrue);
+    });
+
+    test(
+        'with no managed set the snapshot MarkAsOurs flags still classify '
+        '(fallback preserved)', () {
+      // ourSchoolIds null → link() derives ownership from the snapshot schools.
+      // Here school 1 is flagged ours, so a school-1 student is placed normally.
+      final linked = LinkedState.recompute(
+        wisa: wapi.WisaSnapshot(
+          fetchedAt: _d,
+          students: [_wStudent(schoolId: 1)],
+          staff: const [],
+          classGroups: const [],
+          schools: const [
+            wapi.WisaSchool(id: 1, name: 'One', description: '', isOurs: true),
+          ],
+        ),
+        smartschool: ss.SmartschoolSnapshot(
+          fetchedAt: _d,
+          groups: const [],
+          accounts: [_ssAccount()],
+          memberships: const [],
+        ),
+        azure: az.AzureSnapshot(
+            fetchedAt: _d, users: [_azUser()], groups: const []),
+        resolver: _SeqResolver(),
+        studentConfig: _studentConfig,
+        staffConfig: _staffConfig,
+      );
+
+      final view = materialize(linked, generation: 1);
+      expect(view.accounts.single.school, '1');
+    });
+  });
+
   group('gradeYearOf', () {
     test('takes the leading digits of the class group', () {
       expect(gradeYearOf('3C'), '3');

--- a/packages/account_state/test/settings_store_test.dart
+++ b/packages/account_state/test/settings_store_test.dart
@@ -122,6 +122,19 @@ void main() {
       expect(restored.wisaSchools.last.ours, isFalse);
     });
 
+    test('managedWisaSchoolIds is the set of ours-flagged school ids (#178)',
+        () {
+      const settings = AppSettings(
+        wisaSchools: [
+          WisaSchoolProfile(schoolId: 10, name: 'A', ours: true),
+          WisaSchoolProfile(schoolId: 20, name: 'B'),
+          WisaSchoolProfile(schoolId: 30, name: 'C', ours: true),
+        ],
+      );
+      expect(settings.managedWisaSchoolIds, {10, 30});
+      expect(const AppSettings().managedWisaSchoolIds, isEmpty);
+    });
+
     test(
         'a school profile predating the persisted name loads with an empty '
         'name (#171)', () {


### PR DESCRIPTION
## Summary
The Actions view listed actions for **every** school, including ones the operator does not manage — noise, and a risk of acting on accounts outside their remit. This wires the operator's managed-school choice (the `ours` marks in Settings, `AppSettings.wisaSchools`) into the linker and keeps the Actions drill-down to managed schools only, while still syncing every school so move-vs-leave detection keeps working.

## Linked issue
Closes #178

## Changes
- **Consume the persisted ownership flags.** Thread `ourSchoolIds` (derived from `AppSettings.wisaSchools` `ours` flags) through `LinkedState.recompute` / `recomputeAsync` / `fromApplication(Async)` and `StateApplier` into the pure `link()`, so `wisaPresence` is authoritative from Settings rather than only the snapshot's `MarkAsOurs` flags. `bootstrapReconcile` passes the managed set; it stays `null` (falling back to the snapshot flags) when no school is flagged, so a not-yet-configured group is unchanged. Added `AppSettings.managedWisaSchoolIds`.
- **Keep the Actions view to managed schools.** In the materializer, a student present only in a non-managed sibling school (`WisaPresence.groupOnly`) is re-bucketed to "Niet toegewezen" when they still have one of our accounts — so the Smartschool/Azure departure cleanup from #134 stays actionable — and fully suppressed when they are a pure sibling-school student with nothing of ours. `ours` students are placed under their school as before; `absent` leavers stay in the leaver bucket. No non-managed school node ever appears in the drill-down.

Non-managed schools still sync (only classification/placement changed), so `hasLeftGroup`/keep-Azure semantics are untouched.

## Test plan
- [x] `dart format --set-exit-if-changed` clean
- [x] `flutter analyze` clean (no issues)
- [x] Unit/widget tests pass — `flutter test packages` (844) + `flutter test account_manager/test` (179). New: `materialize_test` managed-schools group (managed placement, groupOnly re-bucket, pure-sibling suppression, toggle flips which schools appear, MarkAsOurs fallback preserved) and `settings_store_test` (`managedWisaSchoolIds`).
- [x] Integration/e2e tests pass — `flutter test integration_test -d windows` (31). Two new end-to-end scenarios drive the real Actions drill-down: a non-managed school is hidden (its student re-bucketed to the leaver group), and marking that same school managed surfaces it. The #134 integration test was updated to browse the re-bucketed departed student under "Niet toegewezen" (its keep-Azure/departure assertions unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)