### PR TITLE
Split Actions view into Personeel and Leerlingen tabs (#179)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -675,6 +675,71 @@ void main() {
   });
 
   testWidgets(
+      'the Actions view splits Personeel and Leerlingen into tabs end-to-end: '
+      'staff drill in one tab, students in the other (#179)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real window: one student plus one WISA staff
+    // member so both families have a rollup node. The Actions view must browse
+    // them as two separate workflows — a horizontal tab bar with a per-family
+    // drill-down — not one combined rollup.
+    useTallWindow(tester);
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(students: [wisaStudent()], staff: [wisaStaff()]),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // On the Actions tab the family tab bar carries both families.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(
+        find.byKey(const ValueKey('actions-tab-leerlingen')), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-tab-personeel')), findsOneWidget);
+
+    // Default Leerlingen tab: the student school node drills; the staff node
+    // does not appear here.
+    expect(
+        find.byKey(const ValueKey('rollup-school-school|1')), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('rollup-school-school|staff')), findsNothing);
+
+    // Switch to Personeel and drill down to the staff member — the drill-down
+    // is preserved within the tab, showing only staff.
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-school-school|1')), findsNothing);
+    final staffSchool =
+        find.byKey(const ValueKey('rollup-school-school|staff'));
+    expect(staffSchool, findsOneWidget);
+
+    await tester.ensureVisible(staffSchool);
+    await tester.tap(staffSchool);
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
+    await tester.pumpAndSettle();
+    final staffClass = find
+        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
+    await tester.ensureVisible(staffClass);
+    await tester.tap(staffClass);
+    await tester.pumpAndSettle();
+
+    // The staff member's account is browsed inside the Personeel tab.
+    expect(find.text('Anna Smit'), findsWidgets);
+    expect(
+        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+  });
+
+  testWidgets(
       'the Smartschool address action only fires on a real field drift and its '
       'diff shows the differing field, not an identical row (#153)',
       (WidgetTester tester) async {

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -565,6 +565,35 @@ class ReconcileController extends ChangeNotifier {
     return total;
   }
 
+  /// The pending-action count shown on the Personeel tab's badge (#179): the
+  /// live staff-family entry count in an active session, else the staff school
+  /// rollup's stored pending count in a passive session.
+  int get staffPendingCount {
+    if (_linked != null) {
+      return pendingEntries.where((e) => e.family == 'staff').length;
+    }
+    return staffSchoolRollup?.pendingCount ?? 0;
+  }
+
+  /// The pending-action count shown on the Leerlingen tab's badge (#179): the
+  /// live student- and group-family entry count in an active session, else the
+  /// summed student-school and "Klasgroepen" rollup pending counts in a passive
+  /// session. Together with [staffPendingCount] this partitions
+  /// [totalPendingCount] with no overlap or double-counting.
+  int get studentPendingCount {
+    if (_linked != null) {
+      return pendingEntries.where((e) => e.family != 'staff').length;
+    }
+    var total = 0;
+    for (final r in _rollups) {
+      if (r.level == RollupLevel.groups ||
+          (r.level == RollupLevel.school && r.school != staffPartition)) {
+        total += r.pendingCount;
+      }
+    }
+    return total;
+  }
+
   /// Builds one [PendingAccountEntry] per target from [actionList], collapsing
   /// mutually-exclusive alternatives (shared non-null [group]) into a single
   /// [PendingChoice].
@@ -829,6 +858,24 @@ class ReconcileController extends ChangeNotifier {
         if (r.level == RollupLevel.school) r,
     ]..sort((a, b) => a.label.compareTo(b.label));
     return schools;
+  }
+
+  /// The student-school rollups — every school-level rollup **except** the
+  /// synthetic staff bucket — sorted alphabetically. The drill-down roots of the
+  /// Leerlingen tab (#179), which shows only the student action family.
+  List<Rollup> get studentSchoolRollups => [
+        for (final r in schoolRollups)
+          if (r.school != staffPartition) r,
+      ];
+
+  /// The single synthetic staff ("Personeel") school rollup, or `null` when no
+  /// staff account has been materialized — the drill-down root of the Personeel
+  /// tab (#179), which shows only the staff action family.
+  Rollup? get staffSchoolRollup {
+    for (final r in _rollups) {
+      if (r.level == RollupLevel.school && r.school == staffPartition) return r;
+    }
+    return null;
   }
 
   /// The rollup nodes directly under [parentKey] (grade-years of a school, or

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -127,10 +127,55 @@ class _EntryRow extends _PendingRow {
   final PendingAccountEntry entry;
 }
 
-class _ActionsBody extends StatelessWidget {
+/// The two family tabs (#179): staff and student actions are reviewed as
+/// separate workflows, so the Actions view splits them across a horizontal tab
+/// bar rather than one combined rollup. Index order matches the Reconcile
+/// overview's category order (Leerlingen, then Personeel).
+enum _ActionFamilyTab { leerlingen, personeel }
+
+class _ActionsBody extends StatefulWidget {
   const _ActionsBody({required this.controller});
 
   final ReconcileController controller;
+
+  @override
+  State<_ActionsBody> createState() => _ActionsBodyState();
+}
+
+class _ActionsBodyState extends State<_ActionsBody>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabs;
+  int _shownIndex = 0;
+
+  ReconcileController get controller => widget.controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabs = TabController(length: _ActionFamilyTab.values.length, vsync: this)
+      ..addListener(_onTabChanged);
+  }
+
+  @override
+  void dispose() {
+    _tabs
+      ..removeListener(_onTabChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  /// Rebuilds the sliver content for the newly-selected family, and — when the
+  /// selected family actually changed — closes any open drill-down so each tab
+  /// opens at its own overview rather than showing the other family's detail.
+  void _onTabChanged() {
+    final index = _tabs.index;
+    if (index != _shownIndex) {
+      _shownIndex = index;
+      if (controller.selectedClassroom != null) controller.closeClassroom();
+      if (controller.showingGroups) controller.closeGroups();
+    }
+    if (mounted) setState(() {});
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -163,13 +208,32 @@ class _ActionsBody extends StatelessWidget {
       _gap(PlinkSpacing.s6),
       _section(_ActionsHeader(controller: controller)),
       _gap(PlinkSpacing.s5),
+      _section(_FamilyTabBar(controller: controller, tabs: _tabs)),
+      _gap(PlinkSpacing.s4),
     ];
+    final staffTab = _tabs.index == _ActionFamilyTab.personeel.index;
     if (controller.selectedClassroom != null) {
       slivers.addAll(_classroomSlivers(context));
     } else if (controller.showingGroups) {
       slivers.addAll(_groupSlivers(context));
     } else if (controller.hasOverview) {
-      slivers.add(_section(_DrillDownSection(controller: controller)));
+      // Partition the drill-down by family: the Personeel tab shows only the
+      // synthetic staff school node; the Leerlingen tab shows the student
+      // schools plus the class-groups node (class groups are student-oriented).
+      final staffRollup = controller.staffSchoolRollup;
+      slivers.add(_section(staffTab
+          ? _DrillDownSection(
+              controller: controller,
+              schools: <Rollup>[if (staffRollup != null) staffRollup],
+              groups: null,
+              emptyLabel: 'Geen openstaande personeelsacties.',
+            )
+          : _DrillDownSection(
+              controller: controller,
+              schools: controller.studentSchoolRollups,
+              groups: controller.groupRollup,
+              emptyLabel: 'Nog geen gematerialiseerd overzicht.',
+            )));
     } else {
       slivers.add(_section(_EmptyState(controller: controller)));
     }
@@ -400,6 +464,58 @@ class _ActionsHeader extends StatelessWidget {
   }
 }
 
+/// The horizontal family tab bar (#179): switches the drill-down below between
+/// the Leerlingen (student + class-group) and Personeel (staff) action
+/// families, each carrying a pending-count badge so the operator sees where the
+/// work sits without opening both. Staff and student actions are reviewed as
+/// separate workflows, mirroring the legacy WPF app.
+class _FamilyTabBar extends StatelessWidget {
+  const _FamilyTabBar({required this.controller, required this.tabs});
+
+  final ReconcileController controller;
+  final TabController tabs;
+
+  @override
+  Widget build(BuildContext context) {
+    return TabBar(
+      controller: tabs,
+      isScrollable: true,
+      tabAlignment: TabAlignment.start,
+      tabs: <Widget>[
+        _tab(
+          keyValue: 'actions-tab-leerlingen',
+          label: 'Leerlingen',
+          count: controller.studentPendingCount,
+        ),
+        _tab(
+          keyValue: 'actions-tab-personeel',
+          label: 'Personeel',
+          count: controller.staffPendingCount,
+        ),
+      ],
+    );
+  }
+
+  Widget _tab({
+    required String keyValue,
+    required String label,
+    required int count,
+  }) =>
+      Tab(
+        key: ValueKey(keyValue),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(label),
+            if (count > 0) ...<Widget>[
+              const SizedBox(width: PlinkSpacing.s2),
+              PlinkBadge('$count'),
+            ],
+          ],
+        ),
+      );
+}
+
 /// The empty state before any sync/overview exists: nothing to browse yet.
 class _EmptyState extends StatelessWidget {
   const _EmptyState({required this.controller});
@@ -465,9 +581,25 @@ Future<void> _confirmAndApply(
 /// even in a passive session that never pulled or re-linked. Tapping a classroom
 /// (or the Klasgroepen node) lazily loads just that node's actions (#154).
 class _DrillDownSection extends StatelessWidget {
-  const _DrillDownSection({required this.controller});
+  const _DrillDownSection({
+    required this.controller,
+    required this.schools,
+    required this.groups,
+    required this.emptyLabel,
+  });
 
   final ReconcileController controller;
+
+  /// The school-level rollup roots to render — student schools for the
+  /// Leerlingen tab, the single staff node for the Personeel tab (#179).
+  final List<Rollup> schools;
+
+  /// The "Klasgroepen" rollup node to append below [schools], or `null` when
+  /// this tab carries no group family (the Personeel tab).
+  final Rollup? groups;
+
+  /// The message shown when this tab has nothing to browse.
+  final String emptyLabel;
 
   String? _freshness() {
     final state = controller.syncState;
@@ -487,9 +619,8 @@ class _DrillDownSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     final Color hairline = Theme.of(context).dividerColor;
-    final schools = controller.schoolRollups;
-    final groups = controller.groupRollup;
     final freshness = _freshness();
+    final groupsNode = groups;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -500,8 +631,8 @@ class _DrillDownSection extends StatelessWidget {
           Text(freshness, style: text.bodySmall),
         ],
         const SizedBox(height: PlinkSpacing.s3),
-        if (schools.isEmpty && groups == null)
-          Text('Nog geen gematerialiseerd overzicht.', style: text.bodyMedium)
+        if (schools.isEmpty && groupsNode == null)
+          Text(emptyLabel, style: text.bodyMedium)
         else ...<Widget>[
           for (final school in schools)
             Container(
@@ -523,7 +654,7 @@ class _DrillDownSection extends StatelessWidget {
                 ],
               ),
             ),
-          if (groups != null)
+          if (groupsNode != null)
             Container(
               margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
               decoration: BoxDecoration(
@@ -533,10 +664,10 @@ class _DrillDownSection extends StatelessWidget {
               ),
               child: ListTile(
                 key: const ValueKey('rollup-groups'),
-                title: Text(groups.label, style: text.bodyLarge),
-                subtitle: Text('${groups.accountCount} klasgroep(en)',
+                title: Text(groupsNode.label, style: text.bodyLarge),
+                subtitle: Text('${groupsNode.accountCount} klasgroep(en)',
                     style: text.bodySmall),
-                trailing: _PendingBadge(count: groups.pendingCount),
+                trailing: _PendingBadge(count: groupsNode.pendingCount),
                 onTap: controller.openGroups,
               ),
             ),

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -98,6 +98,23 @@ wapi.WisaStudent wisaStudent({
 wapi.WisaSchool wisaSchool(int id, {bool ours = false}) =>
     wapi.WisaSchool(id: id, name: 'School $id', description: '', isOurs: ours);
 
+/// A WISA staff record — the personeel counterpart of [wisaStudent]. A staff
+/// member present only in WISA (no Smartschool / Azure counterpart) links as a
+/// [core.LinkedStaff] and materializes into the synthetic "Personeel" school
+/// rollup the Actions Personeel tab drills into (#179).
+wapi.WisaStaff wisaStaff({
+  String code = 'SMIT',
+  String wisaId = '42',
+  String firstName = 'Anna',
+  String lastName = 'Smit',
+}) =>
+    wapi.WisaStaff(
+      code: core.WisaStaffCode(code),
+      wisaId: core.WisaId(wisaId),
+      firstName: firstName,
+      lastName: lastName,
+    );
+
 ss.SmartschoolAccount ssAccount({
   String uid = 'jane',
   String accountId = '1',
@@ -161,12 +178,13 @@ ss.SmartschoolMembership member(String uid, String groupCode) =>
 wapi.WisaSnapshot wisaSnap({
   DateTime? fetchedAt,
   List<wapi.WisaStudent>? students,
+  List<wapi.WisaStaff> staff = const [],
   List<wapi.WisaSchool> schools = const [],
 }) =>
     wapi.WisaSnapshot(
       fetchedAt: fetchedAt ?? kFixtureDate,
       students: students ?? [wisaStudent()],
-      staff: const [],
+      staff: staff,
       classGroups: const [],
       schools: schools,
     );

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -261,6 +261,82 @@ void main() {
         reason: 'the first tile unloaded once scrolled far off-screen');
   });
 
+  // --- Personeel / Leerlingen family tabs (#179) ---------------------------
+
+  testWidgets(
+      'the Actions view splits staff and student actions into Personeel and '
+      'Leerlingen tabs, each drilling only its own family (#179)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // One student (default fixture) plus one WISA staff member, so both
+    // families carry a rollup node.
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(students: [wisaStudent()], staff: [wisaStaff()]),
+    );
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The horizontal family tab bar carries both tabs.
+    expect(
+        find.byKey(const ValueKey('actions-tab-leerlingen')), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-tab-personeel')), findsOneWidget);
+
+    // The counts are partitioned by family, and together they sum the total —
+    // nothing dropped or double-counted.
+    expect(harness.controller.staffPendingCount, greaterThan(0));
+    expect(harness.controller.studentPendingCount, greaterThan(0));
+    expect(
+      harness.controller.staffPendingCount +
+          harness.controller.studentPendingCount,
+      harness.controller.totalPendingCount,
+    );
+
+    // Default tab = Leerlingen: the student school node is a drill root and the
+    // class-groups node shows; the staff ("Personeel") school node does not.
+    expect(
+        find.byKey(const ValueKey('rollup-school-school|1')), findsOneWidget);
+    expect(find.byKey(const ValueKey('rollup-groups')), findsWidgets);
+    expect(
+        find.byKey(const ValueKey('rollup-school-school|staff')), findsNothing);
+
+    // Switch to Personeel: the staff node appears and the student school /
+    // class-groups nodes are gone — each tab shows only its own family.
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-school-school|staff')),
+        findsOneWidget);
+    expect(find.byKey(const ValueKey('rollup-school-school|1')), findsNothing);
+    expect(find.byKey(const ValueKey('rollup-groups')), findsNothing);
+  });
+
+  testWidgets(
+      'switching tabs mid-drill closes the open classroom so each tab opens at '
+      'its own overview (#179)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(students: [wisaStudent()], staff: [wisaStaff()]),
+    );
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // Drill into a student class on the Leerlingen tab.
+    await _drill(tester, school: 'School 1', grade: '3', classroom: '3C');
+    expect(harness.controller.selectedClassroom?.classroom, '3C');
+    expect(
+        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+
+    // Switching to Personeel closes the drill-down; that tab opens at its own
+    // staff overview rather than showing the student class.
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.selectedClassroom, isNull);
+    expect(find.byKey(const ValueKey('actions-classroom-back')), findsNothing);
+    expect(find.byKey(const ValueKey('rollup-school-school|staff')),
+        findsOneWidget);
+  });
+
   // --- Address diff in the drill-down (#153) -------------------------------
   const wisaAddr = Address(
     street: 'Koophandelstraat',


### PR DESCRIPTION
## Summary
The Actions view now splits staff and student actions across a horizontal
tab bar instead of one combined rollup, so the two workflows are reviewed
separately — mirroring the legacy WPF app.

- **Leerlingen** tab — student-school drill-down + the Klasgroepen node
  (class groups are student-oriented).
- **Personeel** tab — the synthetic staff ("Personeel") school drill-down.
- Each tab carries a per-family pending-count badge. `staffPendingCount` +
  `studentPendingCount` == `totalPendingCount` (verified in a test), so
  nothing is dropped or double-counted.
- Switching family tabs closes any open drill-down so each tab opens at its
  own overview rather than showing the other family's detail.

The existing school → grade-year → classroom drill-down is preserved inside
each tab, and the global Dry-run all / Apply all header stays above the tabs
as a cross-family escape hatch.

## Linked issue
Closes #179

## Changes
- `reconcile_controller.dart`: add `studentSchoolRollups` / `staffSchoolRollup`
  and `studentPendingCount` / `staffPendingCount` getters.
- `actions_screen.dart`: `_ActionsBody` is now stateful with a `TabController`;
  adds a `_FamilyTabBar`; `_DrillDownSection` takes its school/group roots and
  empty label as parameters so each tab renders only its own family.
- `reconcile_fakes.dart`: add a `wisaStaff()` builder and a `staff` param to
  `wisaSnap` for the staff-tab fixtures.
- Widget + integration tests for the split.

## Test plan
- [x] `dart format --set-exit-if-changed` clean
- [x] `flutter analyze` clean (no issues)
- [x] unit/widget tests pass (`flutter test` — 181 tests, incl. 2 new #179 cases)
- [x] integration/e2e tests pass (`flutter test integration_test -d windows` —
  32 tests, incl. a new #179 end-to-end that drives the real app: syncs, opens
  Actions, asserts the tab bar, and drills the Personeel tab down to the staff
  member while the student school stays out of that tab)
