### PR TITLE
Rework Passwords screen: leerlingen/personeel tabs with on-demand generation (#180)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -740,6 +740,73 @@ void main() {
   });
 
   testWidgets(
+      'the Passwords view generates a class password on demand and resets a '
+      'staff password across its two tabs end-to-end (#180)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real window: the Smartschool snapshot carries a
+    // "Leerlingen" class tree and a "Personeel" group (seeded so the screen has
+    // its tree without a full sync). The reworked Passwords view must generate a
+    // fresh class password on demand (Leerlingen) and reset a staff password
+    // (Personeel) — pushing both live through the recording backends.
+    useTallWindow(tester);
+    final harness = ReconcileHarness(ssInitial: passwordsSnap());
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // Open the Passwords view: the two family tabs render.
+    await tester.tap(find.text('Passwords'));
+    await tester.pumpAndSettle();
+    expect(find.byType(PasswordsScreen), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('passwords-tab-leerlingen')), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('passwords-tab-personeel')), findsOneWidget);
+
+    // Leerlingen: pick the class, check a student's Smartschool target, then
+    // generate on demand → confirm. The password is pushed live and queued.
+    await tester.tap(find.byKey(const ValueKey('password-class-3C')));
+    await tester.pumpAndSettle();
+    expect(find.text('jane'), findsOneWidget);
+    await tester
+        .tap(find.byKey(const ValueKey('passwords-cell-jane-smartschool')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-generate')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-generate-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(harness.passwordBackends.smartschoolPushes, hasLength(1));
+    expect(harness.passwordBackends.smartschoolPushes.single.$1, 'jane');
+    expect(find.byKey(const ValueKey('passwords-message')), findsOneWidget);
+
+    // Personeel: select a staff member and reset both passwords. The filter
+    // TextField's blinking cursor keeps pumpAndSettle from settling, so drive
+    // the dialog with explicit frames.
+    await tester.tap(find.byKey(const ValueKey('passwords-tab-personeel')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-staff-anna.smit')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-staff-reset-both')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester
+        .tap(find.byKey(const ValueKey('passwords-staff-reset-confirm')));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    // Both backends were pushed with one shared staff password.
+    expect(
+        harness.passwordBackends.smartschoolPushes
+            .where((p) => p.$1 == 'anna.smit'),
+        hasLength(1));
+    expect(harness.passwordBackends.azurePushes, hasLength(1));
+  });
+
+  testWidgets(
       'the Smartschool address action only fires on a real field drift and its '
       'diff shows the differing field, not an identical row (#153)',
       (WidgetTester tester) async {
@@ -1322,9 +1389,9 @@ void main() {
   });
 
   testWidgets(
-      'creating an account captures its password into the Passwords view, which '
-      'distributes it out of the shared queue (#105)',
-      (WidgetTester tester) async {
+      'creating an account captures its password into the shared queue, which '
+      'the Passwords view surfaces as a printable sheet and drains on export '
+      '(#105/#180)', (WidgetTester tester) async {
     // A brand-new student: present in WISA and Azure but not yet in Smartschool,
     // so the dispatcher yields exactly one AddStudentToSmartschool — an
     // account-creating apply that mints (and must capture) a password.
@@ -1373,21 +1440,30 @@ void main() {
         reason: 'the created account\'s password landed in the queue');
     expect(queued.single.smartschoolPassword, isNotNull);
 
-    // Switch to the Passwords view: the freshly captured sheet is listed in the
-    // real, laid-out app.
+    // Switch to the Passwords view: the freshly captured account sheet is
+    // surfaced as a printable student sheet (the reworked view no longer shows
+    // a per-entry distribute card — the queue feeds the print/CSV exports).
     await tester.tap(find.text('Passwords'));
     await tester.pumpAndSettle();
     expect(find.byType(PasswordsScreen), findsOneWidget);
-    expect(find.text('Jane Doe'), findsOneWidget);
-    expect(find.text('Smartschool:'), findsOneWidget);
+    final exportBtn = find.byKey(const ValueKey('passwords-export-students'));
+    expect(
+      tester.widget<OutlinedButton>(exportBtn).onPressed,
+      isNotNull,
+      reason: 'the captured sheet enables the print export',
+    );
+    expect(find.text('Print leerling-wachtwoorden (1)'), findsOneWidget);
 
-    // Mark it distributed → it drains from the shared queue (saved remainder is
-    // empty) and the view falls back to the all-distributed state.
-    await tester.tap(find.byIcon(Icons.done_all));
+    // Exporting the sheet drains it from the shared queue (saved remainder is
+    // empty) and disables the export again.
+    await tester.tap(exportBtn);
     await tester.pumpAndSettle();
-    expect(find.text('Jane Doe'), findsNothing);
-    expect(find.byKey(const ValueKey('passwords-empty')), findsOneWidget);
     expect(await harness.passwordQueue.load(), isEmpty);
+    expect(
+      tester.widget<OutlinedButton>(exportBtn).onPressed,
+      isNull,
+      reason: 'the queue is drained, so nothing left to print',
+    );
   });
 
   testWidgets(

--- a/account_manager/lib/src/passwords/password_backends.dart
+++ b/account_manager/lib/src/passwords/password_backends.dart
@@ -1,0 +1,66 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+
+/// The live write seam for on-demand password generation (#180).
+///
+/// On-demand generation pushes fresh passwords straight to Smartschool and
+/// Azure. Those writes are write-capable and, per the project's live-testing
+/// policy, are exercised manually against the real school APIs — never in CI.
+/// Splitting them behind this interface lets [PasswordController] be driven
+/// headlessly (a fake records the pushes and reports success/failure) while
+/// production wires [ConnectorPasswordBackends] to the real connectors.
+abstract interface class PasswordBackends {
+  /// Sets [uid]'s Smartschool [slot] password (the main account uses
+  /// [core.AccountType.student]; co-accounts use `coAccount1..6`). Returns
+  /// `true` on success.
+  Future<bool> setSmartschoolPassword(
+    String uid,
+    core.AccountType slot,
+    String password,
+  );
+
+  /// Resets the Azure / Office 365 password of the user identified by
+  /// [mailOrUpn]. Returns `true` when the user was found and updated, `false`
+  /// when no such user exists (mirroring the legacy "No account for …" skip).
+  Future<bool> setAzurePassword(String mailOrUpn, String password);
+}
+
+/// The production [PasswordBackends]: writes through the real connectors.
+///
+/// A `null` connector (the system is not configured for this build) makes the
+/// corresponding push a no-op that returns `false`, so the controller reports
+/// "not pushed" rather than crashing.
+class ConnectorPasswordBackends implements PasswordBackends {
+  ConnectorPasswordBackends({this.smartschool, this.azure, this.log});
+
+  final ss.SmartschoolConnector? smartschool;
+  final az.AzureConnector? azure;
+  final core.ILog? log;
+
+  @override
+  Future<bool> setSmartschoolPassword(
+    String uid,
+    core.AccountType slot,
+    String password,
+  ) async {
+    final connector = smartschool;
+    if (connector == null) return false;
+    return connector.setPassword(uid, slot, password);
+  }
+
+  @override
+  Future<bool> setAzurePassword(String mailOrUpn, String password) async {
+    final connector = azure;
+    if (connector == null) return false;
+    // Mirror legacy StudentPasswords: look the user up by principal name, skip
+    // (and log) when there is no Azure account, otherwise reset the password.
+    final user = await connector.users.getUser(mailOrUpn);
+    if (user == null) {
+      log?.addError(core.Origin.azure, 'Geen Azure-account voor $mailOrUpn.');
+      return false;
+    }
+    await connector.users.setPassword(user.id, password);
+    return true;
+  }
+}

--- a/account_manager/lib/src/passwords/password_controller.dart
+++ b/account_manager/lib/src/passwords/password_controller.dart
@@ -1,0 +1,549 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart';
+import 'package:flutter/foundation.dart';
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+
+import 'password_backends.dart';
+import 'password_export.dart';
+
+/// The eight per-account password targets a student row can regenerate: the two
+/// backends plus the six Smartschool co-account slots.
+enum PasswordTarget {
+  smartschool,
+  office365,
+  co1,
+  co2,
+  co3,
+  co4,
+  co5,
+  co6;
+
+  /// The 1-based co-account slot (1..6), or `null` for the two backends.
+  int? get coSlot => switch (this) {
+        co1 => 1,
+        co2 => 2,
+        co3 => 3,
+        co4 => 4,
+        co5 => 5,
+        co6 => 6,
+        _ => null,
+      };
+
+  /// Short badge label used in the selection grid.
+  String get label => switch (this) {
+        PasswordTarget.smartschool => 'SS',
+        PasswordTarget.office365 => 'O365',
+        _ => '${coSlot!}',
+      };
+}
+
+/// The fields a staff list can be filtered on (#180, legacy `FilterTypes`).
+enum StaffFilterField { naam, voornaam, gebruikersnaam }
+
+/// One student in the currently-selected class, with its per-target selection.
+class StudentRow {
+  StudentRow(this.account);
+
+  final ss.SmartschoolAccount account;
+  final Set<PasswordTarget> selected = <PasswordTarget>{};
+
+  String get username => account.uid;
+  String get name => '${account.givenName} ${account.surname}'.trim();
+}
+
+/// Drives the reworked Passwords screen (#180): on-demand password generation
+/// for students (per-class, per-target, bulk) and staff (per-member resets),
+/// reading the current Smartschool group tree from the last sync and pushing
+/// fresh passwords live through [PasswordBackends].
+///
+/// The key correction over the old distribution-only queue: passwords are
+/// generated **on demand from this screen**, not as a side effect of account
+/// creation. Generated student/co-account passwords are recorded in the shared
+/// [PasswordQueueStore] for printing/CSV; staff resets export a per-staff sheet
+/// immediately (they are never queued), mirroring the legacy app.
+class PasswordController extends ChangeNotifier {
+  PasswordController({
+    required ss.SmartschoolSnapshot? snapshot,
+    required PasswordQueueStore queue,
+    required PasswordBackends backends,
+    PasswordFileWriter writer = writePasswordExport,
+    String Function() generatePassword = core.Password.create,
+    String studentGroupName = 'Leerlingen',
+    String staffGroupName = 'Personeel',
+    core.ILog? log,
+  })  : _snapshot = snapshot,
+        _queue = queue,
+        _backends = backends,
+        _writer = writer,
+        _generate = generatePassword,
+        _log = log {
+    _indexTree();
+    studentRoot = _findGroupByName(studentGroupName);
+    _staffRoot = _findGroupByName(staffGroupName);
+    _loadStaff();
+  }
+
+  final ss.SmartschoolSnapshot? _snapshot;
+  final PasswordQueueStore _queue;
+  final PasswordBackends _backends;
+  final PasswordFileWriter _writer;
+  final String Function() _generate;
+  final core.ILog? _log;
+
+  // --- Group-tree index (built once from the snapshot) -----------------------
+
+  final Map<String, List<core.Group>> _childrenByParent =
+      <String, List<core.Group>>{};
+  final Map<String, ss.SmartschoolAccount> _accountByUid =
+      <String, ss.SmartschoolAccount>{};
+  final Map<String, List<String>> _uidsByGroup = <String, List<String>>{};
+
+  /// The "Leerlingen" root of the student class tree, or `null` when the last
+  /// sync carried no such group (or there was no sync this session).
+  core.Group? studentRoot;
+  core.Group? _staffRoot;
+
+  void _indexTree() {
+    final snap = _snapshot;
+    if (snap == null) return;
+    for (final account in snap.accounts) {
+      _accountByUid[account.uid] = account;
+    }
+    for (final group in snap.groups) {
+      final parent = group.parentId?.value;
+      if (parent != null) {
+        _childrenByParent.putIfAbsent(parent, () => <core.Group>[]).add(group);
+      }
+    }
+    for (final m in snap.memberships) {
+      _uidsByGroup.putIfAbsent(m.groupId.value, () => <String>[]).add(m.uid);
+    }
+  }
+
+  core.Group? _findGroupByName(String name) {
+    for (final group in _snapshot?.groups ?? const <core.Group>[]) {
+      if (group.name == name) return group;
+    }
+    return null;
+  }
+
+  /// The direct child groups of [group] in the class tree, sorted by name.
+  List<core.Group> childrenOf(core.Group group) {
+    final children = List<core.Group>.of(
+      _childrenByParent[group.id.value] ?? const <core.Group>[],
+    )..sort((a, b) => a.name.compareTo(b.name));
+    return children;
+  }
+
+  /// The direct member accounts of [group] (not recursive), sorted by surname —
+  /// the accounts shown when a class is selected.
+  List<ss.SmartschoolAccount> _directAccounts(core.Group group) {
+    final uids = _uidsByGroup[group.id.value] ?? const <String>[];
+    final accounts = <ss.SmartschoolAccount>[
+      for (final uid in uids)
+        if (_accountByUid[uid] != null) _accountByUid[uid]!,
+    ]..sort((a, b) => a.surname.compareTo(b.surname));
+    return accounts;
+  }
+
+  // --- Leerlingen tab --------------------------------------------------------
+
+  core.Group? _selectedClass;
+  core.Group? get selectedClass => _selectedClass;
+
+  final List<StudentRow> _rows = <StudentRow>[];
+  List<StudentRow> get rows => List<StudentRow>.unmodifiable(_rows);
+
+  /// The bulk "select all" state per target, inherited by a freshly-loaded
+  /// class so the header toggles persist across class selections (legacy
+  /// `StudentPasswords` seeds each new list from the header checkboxes).
+  final Set<PasswordTarget> _bulk = <PasswordTarget>{};
+  bool bulkSelected(PasswordTarget t) => _bulk.contains(t);
+
+  bool _busy = false;
+  bool get busy => _busy;
+
+  String? _message;
+  String? get message => _message;
+
+  /// Selects [group] as the active class and loads its rows, seeding each row's
+  /// selection from the current bulk state.
+  void selectClass(core.Group group) {
+    _selectedClass = group;
+    _rows
+      ..clear()
+      ..addAll(_directAccounts(group).map((a) {
+        final row = StudentRow(a)..selected.addAll(_bulk);
+        return row;
+      }));
+    notifyListeners();
+  }
+
+  void toggleRow(StudentRow row, PasswordTarget target, bool on) {
+    if (on) {
+      row.selected.add(target);
+    } else {
+      row.selected.remove(target);
+    }
+    notifyListeners();
+  }
+
+  /// Toggles [target] for every loaded row and records the bulk state so the
+  /// next class inherits it.
+  void toggleBulk(PasswordTarget target, bool on) {
+    if (on) {
+      _bulk.add(target);
+    } else {
+      _bulk.remove(target);
+    }
+    for (final row in _rows) {
+      if (on) {
+        row.selected.add(target);
+      } else {
+        row.selected.remove(target);
+      }
+    }
+    notifyListeners();
+  }
+
+  /// The number of (row, target) pushes a generate would perform — used to
+  /// guard the confirm dialog against an accidental mass reset.
+  int get selectedCount =>
+      _rows.fold(0, (sum, row) => sum + row.selected.length);
+
+  /// Generates and pushes a fresh password for every selected (row, target),
+  /// recording the results in the shared queue. A failed push is logged and its
+  /// field left blank; the selection is cleared on success.
+  Future<void> generate() async {
+    if (_busy || selectedCount == 0) return;
+    _setBusy(true);
+    try {
+      final entries = await _queue.load();
+      final byKey = <String, PasswordEntry>{
+        for (final e in entries) '${e.personId.value}|${e.kind.name}': e,
+      };
+      var pushed = 0;
+      var failed = 0;
+      final classLabel = _selectedClass?.name;
+
+      for (final row in _rows) {
+        if (row.selected.isEmpty) continue;
+        String? ssPw;
+        String? azPw;
+        final coPws = <int, String>{};
+
+        for (final target in row.selected) {
+          final password = _generate();
+          if (target == PasswordTarget.smartschool) {
+            if (await _backends.setSmartschoolPassword(
+                row.username, core.AccountType.student, password)) {
+              ssPw = password;
+              pushed++;
+            } else {
+              failed++;
+              _log?.addError(core.Origin.smartschool,
+                  'Smartschool-wachtwoord niet gezet voor ${row.username}.');
+            }
+          } else if (target == PasswordTarget.office365) {
+            final mail = row.account.mail;
+            if (mail.isNotEmpty &&
+                await _backends.setAzurePassword(mail, password)) {
+              azPw = password;
+              pushed++;
+            } else {
+              failed++;
+              _log?.addError(core.Origin.azure,
+                  'Office 365-wachtwoord niet gezet voor ${row.name}.');
+            }
+          } else {
+            final slot = target.coSlot!;
+            if (await _backends.setSmartschoolPassword(
+                row.username, _coAccountType(slot), password)) {
+              coPws[slot] = password;
+              pushed++;
+            } else {
+              failed++;
+              _log?.addError(core.Origin.smartschool,
+                  'Co-account $slot niet gezet voor ${row.username}.');
+            }
+          }
+        }
+
+        if (ssPw != null || azPw != null) {
+          _mergeAccount(byKey, row, classLabel, ssPw, azPw);
+        }
+        if (coPws.isNotEmpty) {
+          _mergeCoAccount(byKey, row, classLabel, coPws);
+        }
+        row.selected.clear();
+      }
+
+      await _queue.save(byKey.values.toList());
+      await _reloadQueue();
+      _message = failed == 0
+          ? '$pushed wachtwoord(en) gegenereerd en verstuurd.'
+          : '$pushed verstuurd, $failed mislukt — zie het logboek.';
+    } on Object catch (e) {
+      _message = 'Genereren mislukt: $e';
+    } finally {
+      _setBusy(false);
+    }
+  }
+
+  void _mergeAccount(
+    Map<String, PasswordEntry> byKey,
+    StudentRow row,
+    String? classLabel,
+    String? ssPw,
+    String? azPw,
+  ) {
+    final key = 'ss:${row.username}|${PasswordAccountKind.account.name}';
+    final existing = byKey[key];
+    byKey[key] = PasswordEntry(
+      personId: core.PersonId('ss:${row.username}'),
+      kind: PasswordAccountKind.account,
+      accountName: row.username,
+      displayName: row.name,
+      mail: row.account.mail.isEmpty ? null : row.account.mail,
+      classGroup: classLabel,
+      smartschoolPassword: ssPw ?? existing?.smartschoolPassword,
+      azurePassword: azPw ?? existing?.azurePassword,
+    );
+  }
+
+  void _mergeCoAccount(
+    Map<String, PasswordEntry> byKey,
+    StudentRow row,
+    String? classLabel,
+    Map<int, String> coPws,
+  ) {
+    final key = 'ss:${row.username}|${PasswordAccountKind.coAccount.name}';
+    final existing = byKey[key];
+    byKey[key] = PasswordEntry(
+      personId: core.PersonId('ss:${row.username}'),
+      kind: PasswordAccountKind.coAccount,
+      accountName: row.username,
+      displayName: row.name,
+      classGroup: classLabel,
+      coAccountPasswords: <int, String>{
+        ...?existing?.coAccountPasswords,
+        ...coPws,
+      },
+    );
+  }
+
+  static core.AccountType _coAccountType(int slot) => switch (slot) {
+        1 => core.AccountType.coAccount1,
+        2 => core.AccountType.coAccount2,
+        3 => core.AccountType.coAccount3,
+        4 => core.AccountType.coAccount4,
+        5 => core.AccountType.coAccount5,
+        _ => core.AccountType.coAccount6,
+      };
+
+  // --- Output queue (student sheets + co-account CSV) ------------------------
+
+  List<PasswordEntry> _studentSheets = <PasswordEntry>[];
+  List<PasswordEntry> _coAccountSheets = <PasswordEntry>[];
+
+  /// Queued student account sheets (Smartschool / Office 365 passwords).
+  List<PasswordEntry> get studentSheets =>
+      List<PasswordEntry>.unmodifiable(_studentSheets);
+
+  /// Queued co-account entries (Co1..Co6 passwords), destined for the CSV.
+  List<PasswordEntry> get coAccountSheets =>
+      List<PasswordEntry>.unmodifiable(_coAccountSheets);
+
+  /// Reads the shared queue and partitions it into the student-sheet and
+  /// co-account outputs shown on the Leerlingen tab.
+  Future<void> loadQueue() async {
+    await _reloadQueue();
+    notifyListeners();
+  }
+
+  Future<void> _reloadQueue() async {
+    final entries = await _queue.load();
+    _studentSheets = <PasswordEntry>[
+      for (final e in entries)
+        if (e.kind == PasswordAccountKind.account) e,
+    ];
+    _coAccountSheets = <PasswordEntry>[
+      for (final e in entries)
+        if (e.kind == PasswordAccountKind.coAccount) e,
+    ];
+  }
+
+  /// Exports the queued student sheets to a printable HTML file, then drains
+  /// them from the shared queue (as legacy clears its list after an export).
+  /// Returns the written path.
+  Future<String> exportStudentSheets() async {
+    final sheets = List<PasswordEntry>.of(_studentSheets);
+    final path = await _writer(
+        'leerling-wachtwoorden.html', studentPasswordsHtml(sheets));
+    await _drain(sheets);
+    _message = 'Leerling-wachtwoorden bewaard: $path';
+    notifyListeners();
+    return path;
+  }
+
+  /// Exports the queued co-account passwords to a CSV file, then drains them.
+  Future<String> exportCoAccounts() async {
+    final sheets = List<PasswordEntry>.of(_coAccountSheets);
+    final path = await _writer('co-accounts.csv', coAccountsCsv(sheets));
+    await _drain(sheets);
+    _message = 'Co-account wachtwoorden bewaard: $path';
+    notifyListeners();
+    return path;
+  }
+
+  Future<void> _drain(List<PasswordEntry> exported) async {
+    final drainedKeys = <String>{
+      for (final e in exported) '${e.personId.value}|${e.kind.name}',
+    };
+    final remainder = <PasswordEntry>[
+      for (final e in await _queue.load())
+        if (!drainedKeys.contains('${e.personId.value}|${e.kind.name}')) e,
+    ];
+    await _queue.save(remainder);
+    await _reloadQueue();
+  }
+
+  // --- Personeel tab ---------------------------------------------------------
+
+  final List<ss.SmartschoolAccount> _allStaff = <ss.SmartschoolAccount>[];
+  List<ss.SmartschoolAccount> _filteredStaff = <ss.SmartschoolAccount>[];
+
+  /// The filtered staff list shown in the Personeel tab.
+  List<ss.SmartschoolAccount> get staff =>
+      List<ss.SmartschoolAccount>.unmodifiable(_filteredStaff);
+
+  String _filterText = '';
+  String get filterText => _filterText;
+  StaffFilterField _filterField = StaffFilterField.naam;
+  StaffFilterField get filterField => _filterField;
+
+  ss.SmartschoolAccount? _selectedStaff;
+  ss.SmartschoolAccount? get selectedStaff => _selectedStaff;
+
+  void _loadStaff() {
+    final root = _staffRoot;
+    if (root == null) return;
+    final seen = <String>{};
+    void walk(core.Group group) {
+      for (final uid in _uidsByGroup[group.id.value] ?? const <String>[]) {
+        final account = _accountByUid[uid];
+        if (account != null && seen.add(uid)) _allStaff.add(account);
+      }
+      for (final child in childrenOf(group)) {
+        walk(child);
+      }
+    }
+
+    walk(root);
+    _allStaff.sort((a, b) => a.surname.compareTo(b.surname));
+    _applyStaffFilter();
+  }
+
+  void setStaffFilterText(String text) {
+    _filterText = text.trim();
+    _applyStaffFilter();
+    notifyListeners();
+  }
+
+  void setStaffFilterField(StaffFilterField field) {
+    _filterField = field;
+    _applyStaffFilter();
+    notifyListeners();
+  }
+
+  void selectStaff(ss.SmartschoolAccount account) {
+    _selectedStaff = account;
+    notifyListeners();
+  }
+
+  void _applyStaffFilter() {
+    final needle = _filterText.toLowerCase();
+    if (needle.isEmpty) {
+      _filteredStaff = List<ss.SmartschoolAccount>.of(_allStaff);
+      return;
+    }
+    _filteredStaff = <ss.SmartschoolAccount>[
+      for (final a in _allStaff)
+        if (_staffMatches(a, needle)) a,
+    ];
+  }
+
+  bool _staffMatches(ss.SmartschoolAccount a, String needle) =>
+      switch (_filterField) {
+        StaffFilterField.voornaam => a.givenName.toLowerCase().contains(needle),
+        StaffFilterField.naam => a.surname.toLowerCase().contains(needle),
+        StaffFilterField.gebruikersnaam => a.uid.toLowerCase().contains(needle),
+      };
+
+  /// Resets the selected staff member's password(s): a fresh Smartschool and/or
+  /// Office 365 password (when both are requested they share one password, as
+  /// legacy `NewPasswords` does), pushes them live, and exports a per-staff HTML
+  /// sheet. Returns the written path, or `null` when nothing was pushed.
+  Future<String?> resetStaff({
+    required bool smartschool,
+    required bool office365,
+  }) async {
+    final account = _selectedStaff;
+    if (account == null || _busy || (!smartschool && !office365)) return null;
+    _setBusy(true);
+    try {
+      final shared = _generate();
+      String? ssPw;
+      String? azPw;
+      var failed = false;
+
+      if (smartschool) {
+        final pw = office365 ? shared : _generate();
+        if (await _backends.setSmartschoolPassword(
+            account.uid, core.AccountType.student, pw)) {
+          ssPw = pw;
+        } else {
+          failed = true;
+        }
+      }
+      if (office365) {
+        final pw = smartschool ? shared : _generate();
+        if (account.mail.isNotEmpty &&
+            await _backends.setAzurePassword(account.mail, pw)) {
+          azPw = pw;
+        } else {
+          failed = true;
+        }
+      }
+
+      if (ssPw == null && azPw == null) {
+        _message = 'Geen wachtwoord gezet — zie het logboek.';
+        return null;
+      }
+      final path = await _writer(
+        '${account.uid}.html',
+        staffPasswordHtml(
+          name: '${account.givenName} ${account.surname}'.trim(),
+          username: account.uid,
+          mail: account.mail,
+          smartschoolPassword: ssPw,
+          office365Password: azPw,
+        ),
+      );
+      _message = failed
+          ? 'Deels gezet — sheet bewaard: $path'
+          : 'Wachtwoord gezet en sheet bewaard: $path';
+      return path;
+    } on Object catch (e) {
+      _message = 'Reset mislukt: $e';
+      return null;
+    } finally {
+      _setBusy(false);
+    }
+  }
+
+  void _setBusy(bool value) {
+    _busy = value;
+    notifyListeners();
+  }
+}

--- a/account_manager/lib/src/passwords/password_export.dart
+++ b/account_manager/lib/src/passwords/password_export.dart
@@ -1,0 +1,161 @@
+import 'dart:io';
+
+import 'package:account_state/account_state.dart';
+
+/// Writes an export payload under [suggestedName] and returns the path it was
+/// written to. Injected so the Passwords screen can be driven headlessly (a
+/// test records the calls) while production writes real files to disk.
+typedef PasswordFileWriter = Future<String> Function(
+  String suggestedName,
+  String content,
+);
+
+/// The default [PasswordFileWriter]: writes into a per-run `AccountManager`
+/// folder under the system temp directory and returns the absolute path. A
+/// timestamp prefix keeps successive exports from overwriting each other.
+Future<String> writePasswordExport(String suggestedName, String content) async {
+  final dir = Directory('${Directory.systemTemp.path}/AccountManager');
+  dir.createSync(recursive: true);
+  final stamp = DateTime.now()
+      .toIso8601String()
+      .replaceAll(':', '')
+      .replaceAll('.', '')
+      .replaceAll('-', '');
+  final file = File('${dir.path}/${stamp}_$suggestedName');
+  await file.writeAsString(content);
+  return file.path;
+}
+
+/// The co-account CSV, ported from legacy `PasswordManager.exportToCSV`
+/// (#180): a `;`-separated file with a header row and one row per co-account
+/// entry, columns `Gebruikersnaam;Naam;Klas;CoAccount1..CoAccount6`. Slots that
+/// were not regenerated are left blank.
+String coAccountsCsv(Iterable<PasswordEntry> entries) {
+  final lines = <String>[
+    'Gebruikersnaam;Naam;Klas;CoAccount1;CoAccount2;CoAccount3;'
+        'CoAccount4;CoAccount5;CoAccount6',
+  ];
+  for (final e in entries) {
+    final cells = <String>[
+      _csv(e.accountName),
+      _csv(e.displayName),
+      _csv(e.classGroup ?? ''),
+      for (var slot = 1; slot <= 6; slot++)
+        _csv(e.coAccountPasswords[slot] ?? ''),
+    ];
+    lines.add(cells.join(';'));
+  }
+  return '${lines.join('\n')}\n';
+}
+
+/// A printable HTML sheet with one section per student, ported from the legacy
+/// `PasswordManager.exportToPDF` layout (#180) but rendered as browser-printable
+/// HTML — the operator opens it and prints, avoiding a native PDF dependency.
+/// Each section shows the login, the Office 365 and Smartschool blocks (only
+/// for the passwords that were generated), a WiFi block, and a privacy note.
+String studentPasswordsHtml(Iterable<PasswordEntry> entries) {
+  final sections = <String>[];
+  for (final e in entries) {
+    final buf = StringBuffer()
+      ..writeln('<section>')
+      ..writeln(
+          '<h1>Account voor ${_html(e.displayName)}${e.classGroup != null && e.classGroup!.isNotEmpty ? ' - ${_html(e.classGroup!)}' : ''}</h1>')
+      ..writeln('<pre>Login     : ${_html(e.accountName)}</pre>');
+    final azure = e.azurePassword;
+    if (azure != null && azure.isNotEmpty) {
+      buf
+        ..writeln('<h2>Office 365</h2>')
+        ..writeln('<p>Aanmelden via office.com.</p>')
+        ..writeln(
+            '<pre>Login     : ${_html(e.mail ?? e.accountName)}\nWachtwoord: ${_html(azure)}</pre>')
+        ..writeln('<p>Dit is een eenmalig wachtwoord; kies zelf een nieuw '
+            'wachtwoord bij de eerste aanmelding.</p>');
+    }
+    final ss = e.smartschoolPassword;
+    if (ss != null && ss.isNotEmpty) {
+      buf
+        ..writeln('<h2>Smartschool</h2>')
+        ..writeln('<p>Aanmelden via de Smartschool-website of -app.</p>')
+        ..writeln(
+            '<pre>Login     : ${_html(e.accountName)}\nWachtwoord: ${_html(ss)}</pre>')
+        ..writeln('<p>Dit is een eenmalig wachtwoord; kies zelf een nieuw '
+            'wachtwoord bij de eerste aanmelding.</p>');
+    }
+    buf
+      ..writeln('<h2>WiFi</h2>')
+      ..writeln('<pre>Netwerk   : Smifi-L\nWachtwoord: SmifiDeWifi:)</pre>')
+      ..writeln('<h2>Privacy</h2>')
+      ..writeln('<p>Hou je wachtwoord geheim en deel het met niemand — ook '
+          'niet met leerkrachten.</p>')
+      ..writeln('</section>');
+    sections.add(buf.toString());
+  }
+  return _htmlDocument('Leerling-wachtwoorden', sections.join('\n'));
+}
+
+/// A single-staff printable HTML sheet, ported from legacy
+/// `ExportStaffPasswordToPDF` (#180). A `null` password omits that whole block,
+/// which is how the three staff reset buttons choose which sections appear.
+String staffPasswordHtml({
+  required String name,
+  required String username,
+  required String mail,
+  String? smartschoolPassword,
+  String? office365Password,
+}) {
+  final buf = StringBuffer()
+    ..writeln('<section>')
+    ..writeln('<h1>Account voor ${_html(name)}</h1>');
+  if (office365Password != null && office365Password.isNotEmpty) {
+    buf
+      ..writeln('<h2>Office 365</h2>')
+      ..writeln(
+          '<pre>Login     : ${_html(mail)}\nWachtwoord: ${_html(office365Password)}</pre>')
+      ..writeln('<p>Dit is een eenmalig wachtwoord; kies zelf een nieuw '
+          'wachtwoord bij de eerste aanmelding.</p>');
+  }
+  buf
+    ..writeln('<h2>WiFi</h2>')
+    ..writeln('<pre>Netwerk   : Smifi-P\nCode      : !TEAM!SMA!</pre>');
+  if (smartschoolPassword != null && smartschoolPassword.isNotEmpty) {
+    buf
+      ..writeln('<h2>Smartschool</h2>')
+      ..writeln(
+          '<pre>Login     : ${_html(username)}\nWachtwoord: ${_html(smartschoolPassword)}</pre>')
+      ..writeln('<p>Dit is een eenmalig wachtwoord; kies zelf een nieuw '
+          'wachtwoord bij de eerste aanmelding.</p>');
+  }
+  buf
+    ..writeln('<h2>Privacy</h2>')
+    ..writeln('<p>Hou je wachtwoord geheim en deel het met niemand — ook '
+        'niet aan collega\'s.</p>')
+    ..writeln('</section>');
+  return _htmlDocument('Personeelswachtwoord — $name', buf.toString());
+}
+
+String _htmlDocument(String title, String body) => '<!doctype html>\n'
+    '<html lang="nl"><head><meta charset="utf-8">'
+    '<title>${_html(title)}</title>'
+    '<style>body{font-family:sans-serif;margin:2rem;}'
+    'section{page-break-after:always;margin-bottom:2rem;}'
+    'h1{font-size:1.4rem;border-bottom:1px solid #333;}'
+    'pre{font-family:monospace;font-size:1rem;}</style>'
+    '</head><body>\n$body\n</body></html>\n';
+
+/// Escapes the five XML/HTML special characters. Passwords only ever contain
+/// `!?*`, letters, and digits, but names may carry `&`/`<`/`>`.
+String _html(String s) => s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
+/// Escapes a CSV cell for the `;`-separated legacy format: a cell containing a
+/// separator, quote, or newline is quoted with doubled inner quotes.
+String _csv(String s) {
+  if (s.contains(';') || s.contains('"') || s.contains('\n')) {
+    return '"${s.replaceAll('"', '""')}"';
+  }
+  return s;
+}

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -7,6 +7,7 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 
 import '../auth/aad_app_config.dart';
 import '../auth/sign_in_session.dart';
+import '../passwords/password_backends.dart';
 import 'log_buffer.dart';
 import 'reconcile_controller.dart';
 
@@ -88,6 +89,7 @@ class ReconcileServices {
     required this.controller,
     required this.log,
     required this.passwordQueue,
+    required this.passwordBackends,
   });
 
   final AppSettings settings;
@@ -101,6 +103,12 @@ class ReconcileServices {
   /// The same instance is wired into [applier], so an apply and the view see the
   /// one queue.
   final PasswordQueueStore passwordQueue;
+
+  /// The live write seam for the reworked Passwords view (#180): on-demand
+  /// student/staff password generation pushes fresh passwords straight through
+  /// the Smartschool and Azure connectors. Wired to [ConnectorPasswordBackends]
+  /// in production; the offline harness substitutes a recording fake.
+  final PasswordBackends passwordBackends;
 }
 
 /// A configuration problem the operator can act on (missing secret, malformed
@@ -427,6 +435,14 @@ Future<ReconcileServices> bootstrapReconcile({
     controller: controller,
     log: logBuffer,
     passwordQueue: passwordQueue,
+    // On-demand password generation (#180) writes through the same connectors
+    // the applier uses, behind the [PasswordBackends] seam so the screen can be
+    // driven headlessly.
+    passwordBackends: ConnectorPasswordBackends(
+      smartschool: ssConnector,
+      azure: azConnector,
+      log: logBuffer,
+    ),
   );
 }
 

--- a/account_manager/lib/src/screens/passwords_screen.dart
+++ b/account_manager/lib/src/screens/passwords_screen.dart
@@ -1,28 +1,36 @@
-import 'package:account_state/account_state.dart';
+import 'package:account_core/account_core.dart' as core;
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:plink_design_system/plink_design_system.dart';
+import 'package:smartschool_api/smartschool_api.dart' as ss;
 
+import '../passwords/password_controller.dart';
 import '../reconcile/reconcile_bootstrap.dart';
 
-/// The Passwords view (#105): the shared distribution queue of passwords minted
-/// when an apply creates an account.
+/// The reworked Passwords view (#180): on-demand password generation, split
+/// into a **Leerlingen** and a **Personeel** tab, matching the legacy WPF app.
 ///
-/// The whole point of the shared queue is the one-generates/one-prints flow —
-/// one operator runs the reconcile applies that fill the queue, another opens
-/// this view to read the sheets and mark them distributed. So this screen reads
-/// and drains the **same** [PasswordQueueStore] the [StateApplier] appends to
-/// (both come from the one memoized [ReconcileServices]).
+/// The old screen was a distribution-only queue built on the wrong assumption
+/// that a password exists the moment an account is created. Accounts are
+/// prepared months in advance with no remembered password; a password only
+/// becomes real here, when the operator explicitly generates or resets one.
 ///
-/// Deliberately minimal per the Phase C rethink (#75): list pending entries,
-/// copy a password, and mark an entry distributed (which drains it by saving the
-/// remainder). Ticket-printer output is a later slice.
+/// - **Leerlingen**: a tree of the Smartschool "Leerlingen" group; selecting a
+///   class loads its accounts into a grid of per-target checkboxes (Smartschool,
+///   Office 365, CoAccount 1–6). A guarded "Genereer wachtwoorden" pushes a
+///   fresh password live for each checked target and queues the result for the
+///   printable student sheet (PDF-style HTML) and the co-account CSV.
+/// - **Personeel**: the "Personeel" group, filterable by name/username; a
+///   per-member reset mints a fresh Smartschool and/or Office 365 password,
+///   pushes it live, and exports a per-staff sheet.
+///
+/// Shares the one memoized [ReconcileServices] with the Reconcile and Actions
+/// screens, so the class/staff tree comes from the same synced Smartschool
+/// snapshot and the generated sheets land in the same shared password queue.
 class PasswordsScreen extends StatefulWidget {
   const PasswordsScreen({super.key, required this.bootstrap});
 
   /// Assembles (or returns the already-assembled) reconcile stack, or `null`
-  /// when Azure AD is not configured for this build. The same memoized closure
-  /// the reconcile screen uses, so both share one queue instance.
+  /// when Azure AD is not configured for this build.
   final Future<ReconcileServices> Function()? bootstrap;
 
   @override
@@ -30,8 +38,7 @@ class PasswordsScreen extends StatefulWidget {
 }
 
 class _PasswordsScreenState extends State<PasswordsScreen> {
-  ReconcileServices? _services;
-  List<PasswordEntry>? _entries;
+  PasswordController? _controller;
   Object? _error;
   bool _busy = false;
   int _attempts = 0;
@@ -39,11 +46,20 @@ class _PasswordsScreenState extends State<PasswordsScreen> {
   @override
   void initState() {
     super.initState();
-    _load();
+    _bootstrap();
   }
 
-  /// Bootstraps the stack (once, memoized) if needed, then (re)reads the queue.
-  Future<void> _load() async {
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  /// Bootstraps the shared stack (once), then builds the [PasswordController]
+  /// over the current Smartschool snapshot, the shared password queue, and the
+  /// live write seam. Reads the queue so the export buttons reflect any pending
+  /// sheets straight away.
+  Future<void> _bootstrap() async {
     final make = widget.bootstrap;
     if (make == null) return;
     setState(() {
@@ -52,54 +68,25 @@ class _PasswordsScreenState extends State<PasswordsScreen> {
       _error = null;
     });
     try {
-      final services = _services ?? await make();
-      final entries = await services.passwordQueue.load();
+      final services = await make();
       if (!mounted) return;
-      setState(() {
-        _services = services;
-        _entries = entries;
-      });
+      final controller = PasswordController(
+        snapshot: services.app.smartschool.snapshot,
+        queue: services.passwordQueue,
+        backends: services.passwordBackends,
+        log: services.log,
+      );
+      await controller.loadQueue();
+      if (!mounted) {
+        controller.dispose();
+        return;
+      }
+      setState(() => _controller = controller);
     } on Object catch (e) {
       if (mounted) setState(() => _error = e);
     } finally {
       if (mounted) setState(() => _busy = false);
     }
-  }
-
-  /// Marks [entry] distributed: drops it from the queue and persists the
-  /// remainder (the queue store replaces the whole list on save). Optimistic —
-  /// the row disappears immediately; a failed save restores it and surfaces the
-  /// error.
-  Future<void> _distribute(PasswordEntry entry) async {
-    final services = _services;
-    final current = _entries;
-    if (services == null || current == null) return;
-
-    final remainder = <PasswordEntry>[
-      for (final e in current)
-        if (e.personId.value != entry.personId.value) e,
-    ];
-    setState(() => _entries = remainder);
-    try {
-      await services.passwordQueue.save(remainder);
-      if (mounted) _toast('Gemarkeerd als verdeeld — ${entry.displayName}.');
-    } on Object catch (e) {
-      if (!mounted) return;
-      // Restore the row so the operator can retry; the store rejected the drain.
-      setState(() => _entries = current);
-      _toast('Kon niet opslaan: $e');
-    }
-  }
-
-  Future<void> _copy(String label, String password) async {
-    await Clipboard.setData(ClipboardData(text: password));
-    if (mounted) _toast('$label gekopieerd.');
-  }
-
-  void _toast(String message) {
-    ScaffoldMessenger.of(context)
-      ..hideCurrentSnackBar()
-      ..showSnackBar(SnackBar(content: Text(message)));
   }
 
   @override
@@ -108,339 +95,655 @@ class _PasswordsScreenState extends State<PasswordsScreen> {
       return const _MessagePanel(
         eyebrow: 'Arcadia · wachtwoorden',
         title: 'Not configured',
-        message: 'Azure AD is not configured for this build, so the shared '
-            'password queue cannot be reached. Provide the AAD --dart-define '
-            'values and restart.',
+        message: 'Azure AD is not configured for this build, so the connectors '
+            'and the shared password queue cannot be reached. Provide the AAD '
+            '--dart-define values and restart.',
       );
     }
     final error = _error;
-    if (error != null && _entries == null) {
+    if (error != null && _controller == null) {
       final retryNote = _attempts > 1 ? '\n\n(Attempt $_attempts failed.)' : '';
       return _MessagePanel(
         eyebrow: 'Arcadia · wachtwoorden',
-        title: 'Kon de wachtwoordenlijst niet laden',
+        title: 'Kon het wachtwoordscherm niet laden',
         message: '$error$retryNote',
         action: FilledButton(
           key: const ValueKey('passwords-retry'),
-          onPressed: _load,
+          onPressed: _bootstrap,
           child: const Text('Opnieuw proberen'),
         ),
       );
     }
-    final entries = _entries;
-    if (entries == null) {
+    final controller = _controller;
+    if (_busy || controller == null) {
       return const _MessagePanel(
         eyebrow: 'Arcadia · wachtwoorden',
         title: 'Laden…',
-        message: 'De gedeelde wachtwoordenlijst wordt opgehaald.',
+        message: 'De klassen en het personeel worden voorbereid.',
         progress: true,
       );
     }
-    return _PasswordsBody(
-      entries: entries,
-      busy: _busy,
-      onRefresh: _load,
-      onCopy: _copy,
-      onDistribute: _distribute,
-    );
+    return _PasswordsBody(controller: controller);
   }
 }
 
-class _PasswordsBody extends StatelessWidget {
-  const _PasswordsBody({
-    required this.entries,
-    required this.busy,
-    required this.onRefresh,
-    required this.onCopy,
-    required this.onDistribute,
-  });
+class _PasswordsBody extends StatefulWidget {
+  const _PasswordsBody({required this.controller});
 
-  final List<PasswordEntry> entries;
-  final bool busy;
-  final VoidCallback onRefresh;
-  final Future<void> Function(String label, String password) onCopy;
-  final Future<void> Function(PasswordEntry entry) onDistribute;
+  final PasswordController controller;
+
+  @override
+  State<_PasswordsBody> createState() => _PasswordsBodyState();
+}
+
+class _PasswordsBodyState extends State<_PasswordsBody>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabs;
+
+  PasswordController get controller => widget.controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabs = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabs.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 960),
-        child: CustomScrollView(
-          slivers: <Widget>[
-            const SliverToBoxAdapter(child: SizedBox(height: PlinkSpacing.s6)),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: PlinkSpacing.s6),
-              sliver: SliverToBoxAdapter(
-                child: _Header(
-                    count: entries.length, busy: busy, onRefresh: onRefresh),
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (context, _) {
+        final TextTheme text = Theme.of(context).textTheme;
+        final bool ink = Theme.of(context).brightness == Brightness.dark;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                PlinkSpacing.s6,
+                PlinkSpacing.s6,
+                PlinkSpacing.s6,
+                0,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Eyebrow('Arcadia · wachtwoorden', onInk: ink),
+                  const SizedBox(height: PlinkSpacing.s4),
+                  Text('Wachtwoorden', style: text.headlineMedium),
+                  const SizedBox(height: PlinkSpacing.s2),
+                  Text(
+                    'Genereer wachtwoorden op aanvraag — voor klassen '
+                    '(Leerlingen) of per personeelslid (Personeel).',
+                    style: text.bodyMedium,
+                  ),
+                  if (controller.message != null) ...<Widget>[
+                    const SizedBox(height: PlinkSpacing.s2),
+                    Text(
+                      controller.message!,
+                      key: const ValueKey('passwords-message'),
+                      style: text.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    ),
+                  ],
+                  if (controller.busy) ...<Widget>[
+                    const SizedBox(height: PlinkSpacing.s3),
+                    const LinearProgressIndicator(),
+                  ],
+                  const SizedBox(height: PlinkSpacing.s3),
+                  TabBar(
+                    controller: _tabs,
+                    isScrollable: true,
+                    tabAlignment: TabAlignment.start,
+                    tabs: const <Widget>[
+                      Tab(
+                        key: ValueKey('passwords-tab-leerlingen'),
+                        text: 'Leerlingen',
+                      ),
+                      Tab(
+                        key: ValueKey('passwords-tab-personeel'),
+                        text: 'Personeel',
+                      ),
+                    ],
+                  ),
+                ],
               ),
             ),
-            const SliverToBoxAdapter(child: SizedBox(height: PlinkSpacing.s5)),
-            if (entries.isEmpty)
-              SliverPadding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: PlinkSpacing.s6),
-                sliver: const SliverToBoxAdapter(child: _EmptyState()),
-              )
-            else
-              SliverPadding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: PlinkSpacing.s6),
-                sliver: SliverList.builder(
-                  itemCount: entries.length,
-                  itemBuilder: (context, index) => _PasswordCard(
-                    entry: entries[index],
-                    onCopy: onCopy,
-                    onDistribute: onDistribute,
-                  ),
-                ),
+            const Divider(height: 1),
+            Expanded(
+              child: TabBarView(
+                controller: _tabs,
+                children: <Widget>[
+                  _LeerlingenTab(controller: controller),
+                  _PersoneelTab(controller: controller),
+                ],
               ),
-            const SliverToBoxAdapter(child: SizedBox(height: PlinkSpacing.s6)),
+            ),
           ],
-        ),
-      ),
+        );
+      },
     );
   }
 }
 
-class _Header extends StatelessWidget {
-  const _Header({
-    required this.count,
-    required this.busy,
-    required this.onRefresh,
-  });
+// ---------------------------------------------------------------------------
+// Leerlingen tab
+// ---------------------------------------------------------------------------
 
-  final int count;
-  final bool busy;
-  final VoidCallback onRefresh;
+class _LeerlingenTab extends StatelessWidget {
+  const _LeerlingenTab({required this.controller});
+
+  final PasswordController controller;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
-    final bool ink = Theme.of(context).brightness == Brightness.dark;
-    final String subtitle = count == 0
-        ? 'Geen wachtwoorden in de wachtrij.'
-        : count == 1
-            ? '1 wachtwoord wacht op verdeling.'
-            : '$count wachtwoorden wachten op verdeling.';
-
+    final root = controller.studentRoot;
+    final Color hairline = Theme.of(context).dividerColor;
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Eyebrow('Arcadia · wachtwoorden', onInk: ink),
-        const SizedBox(height: PlinkSpacing.s4),
-        Text('Wachtwoorden', style: text.headlineMedium),
-        const SizedBox(height: PlinkSpacing.s4),
-        Wrap(
-          spacing: PlinkSpacing.s3,
-          runSpacing: PlinkSpacing.s2,
-          crossAxisAlignment: WrapCrossAlignment.center,
-          children: <Widget>[
-            OutlinedButton.icon(
-              key: const ValueKey('passwords-refresh'),
-              onPressed: busy ? null : onRefresh,
-              icon: const Icon(Icons.refresh),
-              label: const Text('Vernieuwen'),
-            ),
-            Text(subtitle, style: text.bodySmall),
-          ],
+        Expanded(
+          child: root == null
+              ? Padding(
+                  padding: const EdgeInsets.all(PlinkSpacing.s6),
+                  child: Text(
+                    'Geen "Leerlingen"-groep gevonden. Synchroniseer eerst op '
+                    'het Reconcile-scherm zodat de klasboom geladen is.',
+                    key: const ValueKey('passwords-no-leerlingen'),
+                    style: text.bodyMedium,
+                  ),
+                )
+              : Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    SizedBox(
+                      width: 280,
+                      child: ListView(
+                        padding: const EdgeInsets.symmetric(
+                            vertical: PlinkSpacing.s3),
+                        children: <Widget>[
+                          for (final child in controller.childrenOf(root))
+                            _ClassTreeNode(
+                                controller: controller, group: child),
+                        ],
+                      ),
+                    ),
+                    VerticalDivider(width: 1, thickness: 1, color: hairline),
+                    Expanded(child: _StudentGrid(controller: controller)),
+                  ],
+                ),
         ),
-        if (busy) ...<Widget>[
-          const SizedBox(height: PlinkSpacing.s4),
-          const LinearProgressIndicator(),
-        ],
+        const Divider(height: 1),
+        // The generate + export actions act on the selected class and the
+        // accumulated queue respectively, so they stay visible below both
+        // panels rather than being gated behind a class selection (the queue
+        // can hold sheets even when no "Leerlingen" tree is present).
+        _LeerlingenActionBar(controller: controller),
       ],
     );
   }
 }
 
-class _EmptyState extends StatelessWidget {
-  const _EmptyState();
+/// One node of the class tree: a leaf class is a selectable tile; a group with
+/// children is an [ExpansionTile] holding its subtree.
+class _ClassTreeNode extends StatelessWidget {
+  const _ClassTreeNode({required this.controller, required this.group});
+
+  final PasswordController controller;
+  final core.Group group;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
-    final ColorScheme colors = Theme.of(context).colorScheme;
-    return Container(
-      key: const ValueKey('passwords-empty'),
-      padding: const EdgeInsets.all(PlinkSpacing.s5),
-      decoration: BoxDecoration(
-        border: Border.all(color: colors.outlineVariant),
-        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
-      ),
-      child: Row(
+    final children = controller.childrenOf(group);
+    if (children.isNotEmpty) {
+      return ExpansionTile(
+        key: ValueKey('password-branch-${group.id.value}'),
+        shape: const Border(),
+        collapsedShape: const Border(),
+        title: Text(group.name, style: text.bodyMedium),
+        childrenPadding: const EdgeInsets.only(left: PlinkSpacing.s4),
         children: <Widget>[
-          Icon(Icons.check_circle_outline, color: colors.primary),
-          const SizedBox(width: PlinkSpacing.s3),
-          Flexible(
-            child: Text(
-              'Alle wachtwoorden zijn verdeeld. Nieuwe accounts die je aanmaakt '
-              'bij het reconcilen verschijnen hier.',
-              style: text.bodyMedium,
+          for (final child in children)
+            _ClassTreeNode(controller: controller, group: child),
+        ],
+      );
+    }
+    final selected = controller.selectedClass?.id.value == group.id.value;
+    return ListTile(
+      key: ValueKey('password-class-${group.id.value}'),
+      dense: true,
+      selected: selected,
+      title: Text(group.name, style: text.bodyMedium),
+      onTap: () => controller.selectClass(group),
+    );
+  }
+}
+
+/// The per-target selection grid for the selected class, plus the guarded
+/// generate action and the two export outputs.
+class _StudentGrid extends StatelessWidget {
+  const _StudentGrid({required this.controller});
+
+  final PasswordController controller;
+
+  static const double _cellWidth = 46;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final selectedClass = controller.selectedClass;
+    if (selectedClass == null) {
+      return Padding(
+        padding: const EdgeInsets.all(PlinkSpacing.s6),
+        child: Text(
+          'Kies een klas links om de leerlingen te tonen.',
+          key: const ValueKey('passwords-no-class'),
+          style: text.bodyMedium,
+        ),
+      );
+    }
+    final rows = controller.rows;
+    return ListView(
+      padding: const EdgeInsets.all(PlinkSpacing.s4),
+      children: <Widget>[
+        Text(selectedClass.name, style: text.titleMedium),
+        const SizedBox(height: PlinkSpacing.s3),
+        if (rows.isEmpty)
+          Text(
+            'Geen leerlingen in deze klas.',
+            key: const ValueKey('passwords-empty-class'),
+            style: text.bodyMedium,
+          )
+        else ...<Widget>[
+          _headerRow(context),
+          const Divider(),
+          for (final row in rows) _studentRow(context, row),
+        ],
+      ],
+    );
+  }
+
+  Widget _headerRow(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    return Row(
+      children: <Widget>[
+        Expanded(child: Text('Leerling', style: text.labelLarge)),
+        for (final target in PasswordTarget.values)
+          SizedBox(
+            width: _cellWidth,
+            child: Column(
+              children: <Widget>[
+                Text(target.label, style: text.labelSmall),
+                Checkbox(
+                  key: ValueKey('passwords-bulk-${target.name}'),
+                  value: controller.bulkSelected(target),
+                  onChanged: controller.busy
+                      ? null
+                      : (v) => controller.toggleBulk(target, v ?? false),
+                ),
+              ],
             ),
           ),
+      ],
+    );
+  }
+
+  Widget _studentRow(BuildContext context, StudentRow row) {
+    final TextTheme text = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(row.name, style: text.bodyMedium),
+                Text(row.username,
+                    style: text.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    )),
+              ],
+            ),
+          ),
+          for (final target in PasswordTarget.values)
+            SizedBox(
+              width: _cellWidth,
+              child: Checkbox(
+                key: ValueKey('passwords-cell-${row.username}-${target.name}'),
+                value: row.selected.contains(target),
+                onChanged: controller.busy
+                    ? null
+                    : (v) => controller.toggleRow(row, target, v ?? false),
+              ),
+            ),
         ],
       ),
     );
   }
 }
 
-class _PasswordCard extends StatelessWidget {
-  const _PasswordCard({
-    required this.entry,
-    required this.onCopy,
-    required this.onDistribute,
-  });
+/// The persistent Leerlingen action bar: generate for the selected class plus
+/// the two queue-wide export outputs. Always visible below the tree/grid so the
+/// print/CSV exports are reachable regardless of which class (if any) is open.
+class _LeerlingenActionBar extends StatelessWidget {
+  const _LeerlingenActionBar({required this.controller});
 
-  final PasswordEntry entry;
-  final Future<void> Function(String label, String password) onCopy;
-  final Future<void> Function(PasswordEntry entry) onDistribute;
+  final PasswordController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final count = controller.selectedCount;
+    return Padding(
+      padding: const EdgeInsets.all(PlinkSpacing.s4),
+      child: Wrap(
+        spacing: PlinkSpacing.s3,
+        runSpacing: PlinkSpacing.s2,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: <Widget>[
+          FilledButton.icon(
+            key: const ValueKey('passwords-generate'),
+            onPressed: controller.busy || count == 0
+                ? null
+                : () => _confirmAndGenerate(context, count),
+            icon: const Icon(Icons.password, size: 18),
+            label: Text(count == 0
+                ? 'Genereer wachtwoorden'
+                : 'Genereer wachtwoorden ($count)'),
+          ),
+          OutlinedButton.icon(
+            key: const ValueKey('passwords-export-students'),
+            onPressed: controller.busy || controller.studentSheets.isEmpty
+                ? null
+                : () => controller.exportStudentSheets(),
+            icon: const Icon(Icons.print_outlined, size: 18),
+            label: Text(
+                'Print leerling-wachtwoorden (${controller.studentSheets.length})'),
+          ),
+          OutlinedButton.icon(
+            key: const ValueKey('passwords-export-coaccounts'),
+            onPressed: controller.busy || controller.coAccountSheets.isEmpty
+                ? null
+                : () => controller.exportCoAccounts(),
+            icon: const Icon(Icons.table_view_outlined, size: 18),
+            label: Text(
+                'Bewaar co-accounts (CSV) (${controller.coAccountSheets.length})'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _confirmAndGenerate(BuildContext context, int count) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Wachtwoorden genereren?'),
+        content: Text(
+          'Dit genereert en verstuurt $count nieuw(e) wachtwoord(en) live naar '
+          'Smartschool en Office 365. Bestaande wachtwoorden worden overschreven.',
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Annuleren'),
+          ),
+          FilledButton(
+            key: const ValueKey('passwords-generate-confirm'),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Genereren'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed ?? false) await controller.generate();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Personeel tab
+// ---------------------------------------------------------------------------
+
+class _PersoneelTab extends StatelessWidget {
+  const _PersoneelTab({required this.controller});
+
+  final PasswordController controller;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
-    final ColorScheme colors = Theme.of(context).colorScheme;
-    final subtitleParts = <String>[
-      entry.accountName,
-      if (entry.classGroup != null && entry.classGroup!.isNotEmpty)
-        entry.classGroup!,
-      if (entry.mail != null && entry.mail!.isNotEmpty) entry.mail!,
-    ];
-
-    return Container(
-      key: ValueKey('password-entry-${entry.personId.value}'),
-      margin: const EdgeInsets.only(bottom: PlinkSpacing.s3),
-      padding: const EdgeInsets.all(PlinkSpacing.s4),
-      decoration: BoxDecoration(
-        border: Border.all(color: colors.outlineVariant),
-        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
+    final Color hairline = Theme.of(context).dividerColor;
+    if (controller.staff.isEmpty && controller.filterText.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.all(PlinkSpacing.s6),
+        child: Text(
+          'Geen personeel gevonden. Synchroniseer eerst op het Reconcile-scherm '
+          'zodat de "Personeel"-groep geladen is.',
+          key: const ValueKey('passwords-no-personeel'),
+          style: text.bodyMedium,
+        ),
+      );
+    }
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        SizedBox(
+          width: 320,
+          child: Column(
             children: <Widget>[
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+              Padding(
+                padding: const EdgeInsets.all(PlinkSpacing.s3),
+                child: Row(
                   children: <Widget>[
-                    Text(
-                      entry.displayName.isEmpty
-                          ? entry.accountName
-                          : entry.displayName,
-                      style: text.titleMedium,
-                    ),
-                    if (subtitleParts.isNotEmpty) ...<Widget>[
-                      const SizedBox(height: PlinkSpacing.s1),
-                      Text(
-                        subtitleParts.join(' · '),
-                        style: text.bodySmall
-                            ?.copyWith(color: colors.onSurfaceVariant),
+                    Expanded(
+                      child: TextField(
+                        key: const ValueKey('passwords-staff-filter'),
+                        decoration: const InputDecoration(
+                          isDense: true,
+                          prefixIcon: Icon(Icons.search, size: 18),
+                          hintText: 'Filter…',
+                        ),
+                        onChanged: controller.setStaffFilterText,
                       ),
-                    ],
+                    ),
+                    const SizedBox(width: PlinkSpacing.s2),
+                    DropdownButton<StaffFilterField>(
+                      key: const ValueKey('passwords-staff-filter-field'),
+                      value: controller.filterField,
+                      onChanged: (f) {
+                        if (f != null) controller.setStaffFilterField(f);
+                      },
+                      items: const <DropdownMenuItem<StaffFilterField>>[
+                        DropdownMenuItem(
+                          value: StaffFilterField.naam,
+                          child: Text('Naam'),
+                        ),
+                        DropdownMenuItem(
+                          value: StaffFilterField.voornaam,
+                          child: Text('Voornaam'),
+                        ),
+                        DropdownMenuItem(
+                          value: StaffFilterField.gebruikersnaam,
+                          child: Text('Gebruiker'),
+                        ),
+                      ],
+                    ),
                   ],
                 ),
               ),
-              TextButton.icon(
-                key: ValueKey('password-distribute-${entry.personId.value}'),
-                onPressed: () => onDistribute(entry),
-                icon: const Icon(Icons.done_all, size: 18),
-                label: const Text('Verdeeld'),
+              const Divider(height: 1),
+              Expanded(
+                child: ListView(
+                  children: <Widget>[
+                    for (final account in controller.staff)
+                      _StaffTile(controller: controller, account: account),
+                  ],
+                ),
               ),
             ],
           ),
+        ),
+        VerticalDivider(width: 1, thickness: 1, color: hairline),
+        Expanded(child: _StaffDetail(controller: controller)),
+      ],
+    );
+  }
+}
+
+class _StaffTile extends StatelessWidget {
+  const _StaffTile({required this.controller, required this.account});
+
+  final PasswordController controller;
+  final ss.SmartschoolAccount account;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final selected = controller.selectedStaff?.uid == account.uid;
+    return ListTile(
+      key: ValueKey('passwords-staff-${account.uid}'),
+      dense: true,
+      selected: selected,
+      title: Text('${account.givenName} ${account.surname}'.trim(),
+          style: text.bodyMedium),
+      subtitle: Text(account.uid, style: text.bodySmall),
+      onTap: () => controller.selectStaff(account),
+    );
+  }
+}
+
+class _StaffDetail extends StatelessWidget {
+  const _StaffDetail({required this.controller});
+
+  final PasswordController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final account = controller.selectedStaff;
+    if (account == null) {
+      return Padding(
+        padding: const EdgeInsets.all(PlinkSpacing.s6),
+        child: Text(
+          'Kies een personeelslid links om een wachtwoord te resetten.',
+          key: const ValueKey('passwords-no-staff'),
+          style: text.bodyMedium,
+        ),
+      );
+    }
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(PlinkSpacing.s6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text('${account.givenName} ${account.surname}'.trim(),
+              style: text.titleMedium),
+          const SizedBox(height: PlinkSpacing.s1),
+          Text(account.uid, style: text.bodySmall),
+          if (account.mail.isNotEmpty)
+            Text(account.mail, style: text.bodySmall),
+          const SizedBox(height: PlinkSpacing.s4),
+          Text(
+              'Reset een wachtwoord — het nieuwe wordt live verstuurd en in '
+              'een afdrukbaar blad bewaard.',
+              style: text.bodyMedium),
           const SizedBox(height: PlinkSpacing.s3),
           Wrap(
             spacing: PlinkSpacing.s3,
             runSpacing: PlinkSpacing.s2,
             children: <Widget>[
-              if (entry.smartschoolPassword != null &&
-                  entry.smartschoolPassword!.isNotEmpty)
-                _PasswordChip(
-                  keyValue: 'password-copy-ss-${entry.personId.value}',
-                  label: 'Smartschool',
-                  password: entry.smartschoolPassword!,
-                  onCopy: () => onCopy(
-                    'Smartschool-wachtwoord',
-                    entry.smartschoolPassword!,
-                  ),
-                ),
-              if (entry.azurePassword != null &&
-                  entry.azurePassword!.isNotEmpty)
-                _PasswordChip(
-                  keyValue: 'password-copy-azure-${entry.personId.value}',
-                  label: 'Office 365',
-                  password: entry.azurePassword!,
-                  onCopy: () => onCopy(
-                    'Office 365-wachtwoord',
-                    entry.azurePassword!,
-                  ),
-                ),
+              OutlinedButton(
+                key: const ValueKey('passwords-staff-reset-ss'),
+                onPressed: controller.busy
+                    ? null
+                    : () => _confirmAndReset(
+                          context,
+                          label: 'Smartschool',
+                          smartschool: true,
+                          office365: false,
+                        ),
+                child: const Text('Nieuw Smartschool-wachtwoord'),
+              ),
+              OutlinedButton(
+                key: const ValueKey('passwords-staff-reset-o365'),
+                onPressed: controller.busy
+                    ? null
+                    : () => _confirmAndReset(
+                          context,
+                          label: 'Office 365',
+                          smartschool: false,
+                          office365: true,
+                        ),
+                child: const Text('Nieuw Office 365-wachtwoord'),
+              ),
+              FilledButton(
+                key: const ValueKey('passwords-staff-reset-both'),
+                onPressed: controller.busy
+                    ? null
+                    : () => _confirmAndReset(
+                          context,
+                          label: 'beide',
+                          smartschool: true,
+                          office365: true,
+                        ),
+                child: const Text('Beide'),
+              ),
             ],
           ),
         ],
       ),
     );
   }
-}
 
-class _PasswordChip extends StatelessWidget {
-  const _PasswordChip({
-    required this.keyValue,
-    required this.label,
-    required this.password,
-    required this.onCopy,
-  });
-
-  final String keyValue;
-  final String label;
-  final String password;
-  final VoidCallback onCopy;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final ColorScheme colors = Theme.of(context).colorScheme;
-    return Container(
-      padding: const EdgeInsets.fromLTRB(
-        PlinkSpacing.s3,
-        PlinkSpacing.s2,
-        PlinkSpacing.s2,
-        PlinkSpacing.s2,
-      ),
-      decoration: BoxDecoration(
-        color: colors.surfaceContainerHighest,
-        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          Text('$label:', style: text.labelMedium),
-          const SizedBox(width: PlinkSpacing.s2),
-          SelectableText(
-            password,
-            style: text.bodyMedium?.copyWith(fontFeatures: const <FontFeature>[
-              FontFeature.tabularFigures(),
-            ]),
+  Future<void> _confirmAndReset(
+    BuildContext context, {
+    required String label,
+    required bool smartschool,
+    required bool office365,
+  }) async {
+    final account = controller.selectedStaff;
+    if (account == null) return;
+    final who = '${account.givenName} ${account.surname}'.trim();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Wachtwoord resetten?'),
+        content: Text(
+          'Dit genereert een nieuw $label-wachtwoord voor $who en verstuurt '
+          'het live.',
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Annuleren'),
           ),
-          const SizedBox(width: PlinkSpacing.s1),
-          IconButton(
-            key: ValueKey(keyValue),
-            visualDensity: VisualDensity.compact,
-            tooltip: 'Kopieer $label-wachtwoord',
-            icon: const Icon(Icons.copy, size: 18),
-            onPressed: onCopy,
+          FilledButton(
+            key: const ValueKey('passwords-staff-reset-confirm'),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Resetten'),
           ),
         ],
       ),
     );
+    if (confirmed ?? false) {
+      await controller.resetStaff(
+        smartschool: smartschool,
+        office365: office365,
+      );
+    }
   }
 }
 
-/// Full-panel message (loading / not-configured / error), mirroring the
-/// reconcile screen's panel so the two views read as one app.
+/// Full-panel message (loading / not-configured / error), mirroring the other
+/// screens' panels so the views read as one app.
 class _MessagePanel extends StatelessWidget {
   const _MessagePanel({
     required this.eyebrow,

--- a/account_manager/test/passwords/password_backends_test.dart
+++ b/account_manager/test/passwords/password_backends_test.dart
@@ -1,0 +1,121 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_manager/src/passwords/password_backends.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+
+/// A recording SOAP transport whose every write succeeds (return code 0).
+class _RecordingSoap implements ss.SmartschoolSoapTransport {
+  final List<String> actions = <String>[];
+
+  @override
+  Future<String> send({
+    required Uri endpoint,
+    required String soapAction,
+    required String envelope,
+  }) async {
+    actions.add(soapAction);
+    return '<?xml version="1.0" encoding="utf-8"?>'
+        '<soap:Envelope '
+        'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        '<soap:Body><response><return>0</return></response>'
+        '</soap:Body></soap:Envelope>';
+  }
+}
+
+/// A Graph transport that answers GETs (user lookup) from [userExists] and
+/// records PATCHes (the password reset).
+class _FakeGraph implements az.GraphTransport {
+  _FakeGraph({required this.userExists});
+
+  final bool userExists;
+  final List<az.GraphRequest> patches = <az.GraphRequest>[];
+
+  @override
+  Future<az.GraphResponse> send(az.GraphRequest request) async {
+    if (request.method == 'GET') {
+      return userExists
+          ? const az.GraphResponse(
+              statusCode: 200,
+              body: '{"id":"az1","userPrincipalName":"jane@student.school"}',
+            )
+          : const az.GraphResponse(statusCode: 404);
+    }
+    patches.add(request);
+    return const az.GraphResponse(statusCode: 204);
+  }
+}
+
+ss.SmartschoolConnector _ss(ss.SmartschoolSoapTransport transport) =>
+    ss.SmartschoolConnector.fromParts(
+      site: 'demo',
+      accessCode: 'secret',
+      transport: transport,
+    );
+
+az.AzureConnector _az(az.GraphTransport transport) => az.AzureConnector(
+      credentials: az.AzureCredentials(
+        clientId: 'c',
+        tenantId: 't',
+        azureDomain: 'school.example',
+        schoolPrefix: 'GBS',
+      ),
+      authProvider: const az.StaticAuthProvider('token'),
+      transport: transport,
+    );
+
+void main() {
+  group('ConnectorPasswordBackends (#180)', () {
+    test('setSmartschoolPassword delegates to the connector savePassword',
+        () async {
+      final soap = _RecordingSoap();
+      final backends = ConnectorPasswordBackends(smartschool: _ss(soap));
+      final ok = await backends.setSmartschoolPassword(
+          'jane', core.AccountType.coAccount1, 'Sw0rd!');
+      expect(ok, isTrue);
+      expect(soap.actions, isNotEmpty);
+    });
+
+    test('setAzurePassword looks the user up then PATCHes a new password',
+        () async {
+      final graph = _FakeGraph(userExists: true);
+      final backends = ConnectorPasswordBackends(azure: _az(graph));
+      final ok =
+          await backends.setAzurePassword('jane@student.school', 'Sw0rd!');
+      expect(ok, isTrue);
+      expect(graph.patches, hasLength(1));
+      expect(graph.patches.single.method, 'PATCH');
+    });
+
+    test('setAzurePassword skips (false) when the user does not exist',
+        () async {
+      final graph = _FakeGraph(userExists: false);
+      final log = _CollectingLog();
+      final backends = ConnectorPasswordBackends(azure: _az(graph), log: log);
+      final ok = await backends.setAzurePassword('ghost@student.school', 'x');
+      expect(ok, isFalse);
+      expect(graph.patches, isEmpty);
+      expect(log.errors, isNotEmpty);
+    });
+
+    test('a null connector makes the push a no-op that returns false',
+        () async {
+      final backends = ConnectorPasswordBackends();
+      expect(
+          await backends.setSmartschoolPassword(
+              'x', core.AccountType.student, 'p'),
+          isFalse);
+      expect(await backends.setAzurePassword('x@school', 'p'), isFalse);
+    });
+  });
+}
+
+class _CollectingLog implements core.ILog {
+  final List<String> errors = <String>[];
+
+  @override
+  void addError(core.Origin origin, String message) => errors.add(message);
+
+  @override
+  void addMessage(core.Origin origin, String message) {}
+}

--- a/account_manager/test/passwords/password_controller_test.dart
+++ b/account_manager/test/passwords/password_controller_test.dart
@@ -1,0 +1,292 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_manager/src/passwords/password_controller.dart';
+import 'package:account_state/account_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+
+import '../reconcile/reconcile_fakes.dart';
+
+/// A Smartschool snapshot shaped like the Passwords screen needs it: a
+/// "Leerlingen" root with one class (3C) holding two students, and a
+/// "Personeel" group holding one staff member.
+ss.SmartschoolSnapshot _snapshot() => ss.SmartschoolSnapshot(
+      fetchedAt: kFixtureDate,
+      groups: <core.Group>[
+        core.Group(
+          id: const core.GroupId('leerlingen'),
+          name: 'Leerlingen',
+          description: '',
+          type: core.GroupType.group,
+          official: false,
+          origin: core.Origin.smartschool,
+        ),
+        core.Group(
+          id: const core.GroupId('3C'),
+          name: '3C',
+          description: '',
+          type: core.GroupType.classGroup,
+          official: true,
+          origin: core.Origin.smartschool,
+          parentId: const core.GroupId('leerlingen'),
+        ),
+        core.Group(
+          id: const core.GroupId('personeel'),
+          name: 'Personeel',
+          description: '',
+          type: core.GroupType.group,
+          official: false,
+          origin: core.Origin.smartschool,
+        ),
+      ],
+      accounts: <ss.SmartschoolAccount>[
+        ssAccount(uid: 'jane', accountId: '1', mail: 'jane@student.school'),
+        ssAccount(uid: 'bob', accountId: '2', mail: 'bob@student.school'),
+        ssAccount(uid: 'anna.smit', accountId: '3', mail: 'anna@school'),
+      ],
+      memberships: <ss.SmartschoolMembership>[
+        member('jane', '3C'),
+        member('bob', '3C'),
+        member('anna.smit', 'personeel'),
+      ],
+    );
+
+/// A deterministic password generator: `pw1`, `pw2`, … in call order.
+String Function() _seqGenerator() {
+  var n = 0;
+  return () => 'pw${++n}';
+}
+
+void main() {
+  group('PasswordController — Leerlingen', () {
+    late InMemoryPasswordQueueStore queue;
+    late RecordingPasswordBackends backends;
+    late List<(String, String)> writes;
+
+    PasswordController build({String Function()? gen}) => PasswordController(
+          snapshot: _snapshot(),
+          queue: queue,
+          backends: backends,
+          generatePassword: gen ?? _seqGenerator(),
+          writer: (name, content) async {
+            writes.add((name, content));
+            return 'C:/tmp/$name';
+          },
+        );
+
+    setUp(() {
+      queue = InMemoryPasswordQueueStore();
+      backends = RecordingPasswordBackends();
+      writes = <(String, String)>[];
+    });
+
+    test('exposes the Leerlingen root and its classes', () {
+      final c = build();
+      expect(c.studentRoot?.name, 'Leerlingen');
+      final classes = c.childrenOf(c.studentRoot!);
+      expect(classes.map((g) => g.name), ['3C']);
+    });
+
+    test('selecting a class loads its accounts sorted by surname', () {
+      final c = build()
+        ..selectClass(const core.Group(
+            id: core.GroupId('3C'),
+            name: '3C',
+            description: '',
+            type: core.GroupType.classGroup,
+            official: true,
+            origin: core.Origin.smartschool,
+            parentId: core.GroupId('leerlingen')));
+      expect(c.rows.map((r) => r.username), ['jane', 'bob']);
+    });
+
+    test(
+        'generate pushes a fresh password per checked target and queues the '
+        'result (#180)', () async {
+      final c = build();
+      final klas = c.childrenOf(c.studentRoot!).single;
+      c.selectClass(klas);
+      final jane = c.rows.firstWhere((r) => r.username == 'jane');
+      c
+        ..toggleRow(jane, PasswordTarget.smartschool, true)
+        ..toggleRow(jane, PasswordTarget.office365, true)
+        ..toggleRow(jane, PasswordTarget.co2, true);
+      expect(c.selectedCount, 3);
+
+      await c.generate();
+
+      // Three live pushes: two Smartschool slots (main + co2) and one Azure.
+      expect(backends.smartschoolPushes.length, 2);
+      expect(backends.azurePushes.length, 1);
+      expect(
+        backends.smartschoolPushes.map((p) => p.$2),
+        containsAll(<core.AccountType>[
+          core.AccountType.student,
+          core.AccountType.coAccount2,
+        ]),
+      );
+      // Azure was pushed by mail.
+      expect(backends.azurePushes.single.$1, 'jane@student.school');
+
+      // The selection is cleared and the results are queued: one account sheet
+      // (SS + Azure) and one co-account entry (slot 2).
+      expect(c.selectedCount, 0);
+      final entries = await queue.load();
+      final account =
+          entries.firstWhere((e) => e.kind == PasswordAccountKind.account);
+      final co =
+          entries.firstWhere((e) => e.kind == PasswordAccountKind.coAccount);
+      expect(account.smartschoolPassword, isNotNull);
+      expect(account.azurePassword, isNotNull);
+      expect(account.classGroup, '3C');
+      expect(co.coAccountPasswords.keys, <int>[2]);
+    });
+
+    test('bulk toggle selects the target for every row and persists per class',
+        () {
+      final c = build();
+      final klas = c.childrenOf(c.studentRoot!).single;
+      c
+        ..selectClass(klas)
+        ..toggleBulk(PasswordTarget.smartschool, true);
+      expect(
+          c.rows.every((r) => r.selected.contains(PasswordTarget.smartschool)),
+          isTrue);
+      expect(c.bulkSelected(PasswordTarget.smartschool), isTrue);
+      // Re-selecting the class inherits the bulk state.
+      c.selectClass(klas);
+      expect(
+          c.rows.every((r) => r.selected.contains(PasswordTarget.smartschool)),
+          isTrue);
+    });
+
+    test('a failed Azure push leaves the field blank and counts as failed',
+        () async {
+      backends = RecordingPasswordBackends(failAzure: {'jane@student.school'});
+      final c = build();
+      final klas = c.childrenOf(c.studentRoot!).single;
+      c.selectClass(klas);
+      final jane = c.rows.firstWhere((r) => r.username == 'jane');
+      c
+        ..toggleRow(jane, PasswordTarget.smartschool, true)
+        ..toggleRow(jane, PasswordTarget.office365, true);
+
+      await c.generate();
+
+      final entries = await queue.load();
+      final account =
+          entries.firstWhere((e) => e.kind == PasswordAccountKind.account);
+      expect(account.smartschoolPassword, isNotNull);
+      expect(account.azurePassword, isNull, reason: 'Azure push failed');
+      expect(c.message, contains('mislukt'));
+    });
+
+    test('generate is a no-op when nothing is selected', () async {
+      final c = build();
+      c.selectClass(c.childrenOf(c.studentRoot!).single);
+      await c.generate();
+      expect(backends.smartschoolPushes, isEmpty);
+      expect(backends.azurePushes, isEmpty);
+    });
+
+    test('exporting student sheets writes HTML and drains them', () async {
+      final c = build();
+      final klas = c.childrenOf(c.studentRoot!).single;
+      c.selectClass(klas);
+      final jane = c.rows.firstWhere((r) => r.username == 'jane');
+      c.toggleRow(jane, PasswordTarget.smartschool, true);
+      await c.generate();
+      expect(c.studentSheets, isNotEmpty);
+
+      await c.exportStudentSheets();
+      expect(writes.single.$1, 'leerling-wachtwoorden.html');
+      expect(writes.single.$2, contains('jane'));
+      // Drained from the queue afterwards.
+      expect(c.studentSheets, isEmpty);
+    });
+
+    test('exporting co-accounts writes a CSV and drains them', () async {
+      final c = build();
+      final klas = c.childrenOf(c.studentRoot!).single;
+      c.selectClass(klas);
+      final jane = c.rows.firstWhere((r) => r.username == 'jane');
+      c.toggleRow(jane, PasswordTarget.co1, true);
+      await c.generate();
+      expect(c.coAccountSheets, isNotEmpty);
+
+      await c.exportCoAccounts();
+      expect(writes.single.$1, 'co-accounts.csv');
+      expect(writes.single.$2, contains('CoAccount1'));
+      expect(c.coAccountSheets, isEmpty);
+    });
+  });
+
+  group('PasswordController — Personeel', () {
+    late InMemoryPasswordQueueStore queue;
+    late RecordingPasswordBackends backends;
+    late List<(String, String)> writes;
+
+    PasswordController build() => PasswordController(
+          snapshot: _snapshot(),
+          queue: queue,
+          backends: backends,
+          generatePassword: _seqGenerator(),
+          writer: (name, content) async {
+            writes.add((name, content));
+            return 'C:/tmp/$name';
+          },
+        );
+
+    setUp(() {
+      queue = InMemoryPasswordQueueStore();
+      backends = RecordingPasswordBackends();
+      writes = <(String, String)>[];
+    });
+
+    test('loads the Personeel group members', () {
+      final c = build();
+      expect(c.staff.map((a) => a.uid), ['anna.smit']);
+    });
+
+    test('filters staff by username', () {
+      final c = build()
+        ..setStaffFilterField(StaffFilterField.gebruikersnaam)
+        ..setStaffFilterText('anna');
+      expect(c.staff, hasLength(1));
+      c.setStaffFilterText('zzz');
+      expect(c.staff, isEmpty);
+    });
+
+    test('reset both mints one shared password, pushes both, exports a sheet',
+        () async {
+      final c = build();
+      c.selectStaff(c.staff.single);
+      final path = await c.resetStaff(smartschool: true, office365: true);
+
+      expect(path, isNotNull);
+      expect(backends.smartschoolPushes, hasLength(1));
+      expect(backends.azurePushes, hasLength(1));
+      // Both legs share the same password (legacy NewPasswords).
+      expect(
+          backends.smartschoolPushes.single.$3, backends.azurePushes.single.$2);
+      // A per-staff HTML sheet was written (not queued).
+      expect(writes.single.$1, 'anna.smit.html');
+      expect(await queue.load(), isEmpty);
+    });
+
+    test('reset Smartschool only pushes Smartschool', () async {
+      final c = build();
+      c.selectStaff(c.staff.single);
+      await c.resetStaff(smartschool: true, office365: false);
+      expect(backends.smartschoolPushes, hasLength(1));
+      expect(backends.azurePushes, isEmpty);
+    });
+
+    test('reset with no target selected is a no-op', () async {
+      final c = build();
+      c.selectStaff(c.staff.single);
+      final path = await c.resetStaff(smartschool: false, office365: false);
+      expect(path, isNull);
+      expect(backends.smartschoolPushes, isEmpty);
+    });
+  });
+}

--- a/account_manager/test/passwords/password_export_test.dart
+++ b/account_manager/test/passwords/password_export_test.dart
@@ -1,0 +1,90 @@
+import 'package:account_manager/src/passwords/password_export.dart';
+import 'package:account_state/account_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+PasswordEntry _account({
+  String uid = 'jane.doe',
+  String name = 'Jane Doe',
+  String? mail = 'jane@student.school',
+  String klas = '3C',
+  String? ss = 'Sa2b!x',
+  String? az = 'Ku9d?y',
+}) =>
+    PasswordEntry(
+      personId: PersonId('ss:$uid'),
+      kind: PasswordAccountKind.account,
+      accountName: uid,
+      displayName: name,
+      mail: mail,
+      classGroup: klas,
+      smartschoolPassword: ss,
+      azurePassword: az,
+    );
+
+PasswordEntry _co({
+  String uid = 'jane.doe',
+  String name = 'Jane Doe',
+  String klas = '3C',
+  Map<int, String> co = const {1: 'Aa1!', 3: 'Cc3?'},
+}) =>
+    PasswordEntry(
+      personId: PersonId('ss:$uid'),
+      kind: PasswordAccountKind.coAccount,
+      accountName: uid,
+      displayName: name,
+      classGroup: klas,
+      coAccountPasswords: co,
+    );
+
+void main() {
+  group('coAccountsCsv', () {
+    test('emits the legacy header and one row per entry, blank for unset slots',
+        () {
+      final csv = coAccountsCsv([_co()]);
+      final lines = csv.trim().split('\n');
+      expect(
+        lines.first,
+        'Gebruikersnaam;Naam;Klas;CoAccount1;CoAccount2;CoAccount3;'
+        'CoAccount4;CoAccount5;CoAccount6',
+      );
+      // slot 1 and 3 filled; 2, 4, 5, 6 blank.
+      expect(lines[1], 'jane.doe;Jane Doe;3C;Aa1!;;Cc3?;;;');
+    });
+
+    test('quotes a cell containing the separator', () {
+      final csv = coAccountsCsv([_co(name: 'Doe; Jane')]);
+      expect(csv, contains('"Doe; Jane"'));
+    });
+  });
+
+  group('studentPasswordsHtml', () {
+    test('includes only the blocks for the passwords that were generated', () {
+      final html = studentPasswordsHtml([_account(az: null)]);
+      expect(html, contains('Jane Doe'));
+      expect(html, contains('Smartschool'));
+      // No Azure password → no Office 365 login block for this student.
+      expect(html, isNot(contains('Ku9d?y')));
+      expect(html, contains('Sa2b!x'));
+    });
+
+    test('escapes HTML-special characters in a name', () {
+      final html = studentPasswordsHtml([_account(name: 'A & B <x>')]);
+      expect(html, contains('A &amp; B &lt;x&gt;'));
+    });
+  });
+
+  group('staffPasswordHtml', () {
+    test('omits the block for a null password', () {
+      final html = staffPasswordHtml(
+        name: 'Anna Smit',
+        username: 'anna.smit',
+        mail: 'anna@school',
+        smartschoolPassword: 'Zz9!',
+        office365Password: null,
+      );
+      expect(html, contains('Smartschool'));
+      expect(html, contains('Zz9!'));
+      expect(html, isNot(contains('Office 365')));
+    });
+  });
+}

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -13,6 +13,7 @@ import 'dart:async';
 
 import 'package:account_actions/account_actions.dart' as actions;
 import 'package:account_core/account_core.dart' as core;
+import 'package:account_manager/src/passwords/password_backends.dart';
 import 'package:account_manager/src/reconcile/log_buffer.dart';
 import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
 import 'package:account_manager/src/reconcile/reconcile_controller.dart';
@@ -62,6 +63,49 @@ class RecordingGraph implements az.GraphTransport {
   Future<az.GraphResponse> send(az.GraphRequest request) async {
     requests.add(request);
     return const az.GraphResponse(statusCode: 204);
+  }
+}
+
+/// A recording [PasswordBackends] for the on-demand Passwords screen (#180):
+/// captures every live push a generation/reset would make and reports success,
+/// so the reworked Passwords screen can be driven end-to-end with zero network.
+/// A username in [failSmartschool] / mail in [failAzure] makes that push report
+/// failure, exercising the controller's per-target failure handling.
+class RecordingPasswordBackends implements PasswordBackends {
+  RecordingPasswordBackends({
+    this.failSmartschool = const <String>{},
+    this.failAzure = const <String>{},
+  });
+
+  /// Smartschool usernames whose push should fail.
+  final Set<String> failSmartschool;
+
+  /// Azure mails/UPNs whose push should fail (models "no Azure account").
+  final Set<String> failAzure;
+
+  /// Every Smartschool push: `(uid, slot, password)`.
+  final List<(String, core.AccountType, String)> smartschoolPushes =
+      <(String, core.AccountType, String)>[];
+
+  /// Every Azure push: `(mailOrUpn, password)`.
+  final List<(String, String)> azurePushes = <(String, String)>[];
+
+  @override
+  Future<bool> setSmartschoolPassword(
+    String uid,
+    core.AccountType slot,
+    String password,
+  ) async {
+    if (failSmartschool.contains(uid)) return false;
+    smartschoolPushes.add((uid, slot, password));
+    return true;
+  }
+
+  @override
+  Future<bool> setAzurePassword(String mailOrUpn, String password) async {
+    if (failAzure.contains(mailOrUpn)) return false;
+    azurePushes.add((mailOrUpn, password));
+    return true;
   }
 }
 
@@ -201,6 +245,51 @@ ss.SmartschoolSnapshot ssSnap({
           [ssGroup('2B', code: '2B_ss'), ssGroup('3C', code: '3C_ss')],
       accounts: accounts ?? [ssAccount()],
       memberships: memberships ?? [member('jane', '2B_ss')],
+    );
+
+/// A Smartschool snapshot shaped for the reworked Passwords screen (#180): a
+/// "Leerlingen" root holding one class (3C) with two students, and a
+/// "Personeel" group with one staff member. Drives the on-demand generation /
+/// reset flows end-to-end.
+ss.SmartschoolSnapshot passwordsSnap() => ss.SmartschoolSnapshot(
+      fetchedAt: kFixtureDate,
+      groups: <core.Group>[
+        const core.Group(
+          id: core.GroupId('leerlingen'),
+          name: 'Leerlingen',
+          description: '',
+          type: core.GroupType.group,
+          official: false,
+          origin: core.Origin.smartschool,
+        ),
+        const core.Group(
+          id: core.GroupId('3C'),
+          name: '3C',
+          description: '',
+          type: core.GroupType.classGroup,
+          official: true,
+          origin: core.Origin.smartschool,
+          parentId: core.GroupId('leerlingen'),
+        ),
+        const core.Group(
+          id: core.GroupId('personeel'),
+          name: 'Personeel',
+          description: '',
+          type: core.GroupType.group,
+          official: false,
+          origin: core.Origin.smartschool,
+        ),
+      ],
+      accounts: <ss.SmartschoolAccount>[
+        ssAccount(uid: 'jane', accountId: '1', mail: 'jane@student.school'),
+        ssAccount(uid: 'bob', accountId: '2', mail: 'bob@student.school'),
+        ssAccount(uid: 'anna.smit', accountId: '3', mail: 'anna@school'),
+      ],
+      memberships: <ss.SmartschoolMembership>[
+        member('jane', '3C'),
+        member('bob', '3C'),
+        member('anna.smit', 'personeel'),
+      ],
     );
 
 /// A Smartschool snapshot whose [uids] accounts all share one [mail] — the
@@ -663,6 +752,11 @@ class ReconcileHarness {
   /// every account-creating apply, and the Passwords view reads and drains it.
   final InMemoryPasswordQueueStore passwordQueue = InMemoryPasswordQueueStore();
 
+  /// The recording live-write seam for the on-demand Passwords screen (#180):
+  /// captures every Smartschool/Azure push a generation or reset performs.
+  final RecordingPasswordBackends passwordBackends =
+      RecordingPasswordBackends();
+
   /// The bundle the screen's bootstrap seam expects.
   ReconcileServices get services => ReconcileServices(
         settings: const AppSettings(),
@@ -671,6 +765,7 @@ class ReconcileHarness {
         controller: controller,
         log: log,
         passwordQueue: passwordQueue,
+        passwordBackends: passwordBackends,
       );
 
   /// A ready-made bootstrap closure for [ReconcileScreen]/[AccountManagerApp].

--- a/account_manager/test/screens/passwords_screen_test.dart
+++ b/account_manager/test/screens/passwords_screen_test.dart
@@ -1,30 +1,59 @@
+import 'package:account_core/account_core.dart' as core;
 import 'package:account_manager/src/screens/passwords_screen.dart';
-import 'package:account_state/account_state.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:smartschool_api/smartschool_api.dart' as ss;
 
 import '../reconcile/reconcile_fakes.dart';
 
-Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
-
-PasswordEntry _entry({
-  required String pid,
-  String name = 'Jane Doe',
-  String uid = 'jane.doe',
-  String? smartschool = 'SS-pw',
-  String? azure = 'AZ-pw',
-}) =>
-    PasswordEntry(
-      personId: PersonId(pid),
-      kind: PasswordAccountKind.account,
-      accountName: uid,
-      displayName: name,
-      mail: '$uid@student.school.example',
-      classGroup: '3C',
-      smartschoolPassword: smartschool,
-      azurePassword: azure,
+/// A Smartschool snapshot shaped like the Passwords screen needs it: a
+/// "Leerlingen" root holding one class (3C) with one student, and a "Personeel"
+/// group with one staff member.
+ss.SmartschoolSnapshot _snap() => ss.SmartschoolSnapshot(
+      fetchedAt: kFixtureDate,
+      groups: <core.Group>[
+        core.Group(
+          id: const core.GroupId('leerlingen'),
+          name: 'Leerlingen',
+          description: '',
+          type: core.GroupType.group,
+          official: false,
+          origin: core.Origin.smartschool,
+        ),
+        ssGroup('3C', code: '3C', type: core.GroupType.classGroup)
+            .copyUnderLeerlingen(),
+        core.Group(
+          id: const core.GroupId('personeel'),
+          name: 'Personeel',
+          description: '',
+          type: core.GroupType.group,
+          official: false,
+          origin: core.Origin.smartschool,
+        ),
+      ],
+      accounts: <ss.SmartschoolAccount>[
+        ssAccount(uid: 'jane', accountId: '1', mail: 'jane@student.school'),
+        ssAccount(uid: 'anna.smit', accountId: '2', mail: 'anna@school'),
+      ],
+      memberships: <ss.SmartschoolMembership>[
+        member('jane', '3C'),
+        member('anna.smit', 'personeel'),
+      ],
     );
+
+extension on core.Group {
+  core.Group copyUnderLeerlingen() => core.Group(
+        id: id,
+        name: name,
+        description: description,
+        type: type,
+        official: official,
+        origin: origin,
+        parentId: const core.GroupId('leerlingen'),
+      );
+}
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
 
 void main() {
   testWidgets('shows the not-configured panel when AAD is absent',
@@ -33,88 +62,120 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Not configured'), findsOneWidget);
-    expect(find.byKey(const ValueKey('passwords-refresh')), findsNothing);
+    expect(
+        find.byKey(const ValueKey('passwords-tab-leerlingen')), findsNothing);
   });
 
-  testWidgets('lists the pending entries the shared queue holds',
+  testWidgets('renders the Leerlingen and Personeel tabs',
       (WidgetTester tester) async {
-    final harness = ReconcileHarness();
-    await harness.passwordQueue.save([
-      _entry(pid: 'p1', name: 'Jane Doe', uid: 'jane.doe'),
-      _entry(pid: 'p2', name: 'Jan Peeters', uid: 'jan.peeters', azure: null),
-    ]);
-
+    final harness = ReconcileHarness(ssInitial: _snap());
     await tester
         .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    expect(find.text('Jane Doe'), findsOneWidget);
-    expect(find.text('Jan Peeters'), findsOneWidget);
-    // Jane has both backends; Jan only Smartschool.
-    expect(find.text('SS-pw'), findsWidgets);
-    expect(find.text('AZ-pw'), findsOneWidget);
-    expect(find.text('2 wachtwoorden wachten op verdeling.'), findsOneWidget);
-  });
-
-  testWidgets('copy puts the password on the clipboard',
-      (WidgetTester tester) async {
-    final copied = <String>[];
-    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-      SystemChannels.platform,
-      (MethodCall call) async {
-        if (call.method == 'Clipboard.setData') {
-          copied.add((call.arguments as Map)['text'] as String);
-        }
-        return null;
-      },
-    );
-    addTearDown(() => tester.binding.defaultBinaryMessenger
-        .setMockMethodCallHandler(SystemChannels.platform, null));
-
-    final harness = ReconcileHarness();
-    await harness.passwordQueue.save([_entry(pid: 'p1')]);
-    await tester
-        .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const ValueKey('password-copy-ss-p1')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('password-copy-azure-p1')));
-    await tester.pumpAndSettle();
-
-    expect(copied, ['SS-pw', 'AZ-pw']);
+    expect(
+        find.byKey(const ValueKey('passwords-tab-leerlingen')), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('passwords-tab-personeel')), findsOneWidget);
+    expect(find.text('Wachtwoorden'), findsOneWidget);
   });
 
   testWidgets(
-      'marking an entry distributed drains it from the shared queue and shows '
-      'the empty state', (WidgetTester tester) async {
-    final harness = ReconcileHarness();
-    await harness.passwordQueue.save([_entry(pid: 'p1', name: 'Jane Doe')]);
+      'Leerlingen: select a class, check a target, generate → confirm pushes '
+      'live and reports success (#180)', (WidgetTester tester) async {
+    final harness = ReconcileHarness(ssInitial: _snap());
     await tester
         .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    expect(find.text('Jane Doe'), findsOneWidget);
+    // Select the class from the tree; its student appears.
+    await tester.tap(find.byKey(const ValueKey('password-class-3C')));
+    await tester.pumpAndSettle();
+    expect(find.text('jane'), findsOneWidget);
 
-    await tester.tap(find.byKey(const ValueKey('password-distribute-p1')));
+    // Generate is disabled with nothing checked.
+    expect(
+      tester
+          .widget<FilledButton>(
+              find.byKey(const ValueKey('passwords-generate')))
+          .onPressed,
+      isNull,
+    );
+
+    // Check Jane's Smartschool target, then generate → confirm.
+    await tester
+        .tap(find.byKey(const ValueKey('passwords-cell-jane-smartschool')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-generate')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-generate-confirm')));
     await tester.pumpAndSettle();
 
-    // The row is gone from the view and, crucially, from the persisted queue —
-    // draining means saving the remainder so the other operators no longer see
-    // it.
-    expect(find.text('Jane Doe'), findsNothing);
-    expect(find.byKey(const ValueKey('passwords-empty')), findsOneWidget);
-    expect(await harness.passwordQueue.load(), isEmpty);
+    // A live Smartschool push happened and the screen reports success.
+    expect(harness.passwordBackends.smartschoolPushes, hasLength(1));
+    expect(harness.passwordBackends.smartschoolPushes.single.$1, 'jane');
+    expect(find.byKey(const ValueKey('passwords-message')), findsOneWidget);
+    // The generated sheet can now be printed.
+    expect(
+      tester
+          .widget<OutlinedButton>(
+              find.byKey(const ValueKey('passwords-export-students')))
+          .onPressed,
+      isNotNull,
+    );
   });
 
-  testWidgets('an empty queue renders the all-distributed state',
-      (WidgetTester tester) async {
-    final harness = ReconcileHarness();
+  testWidgets(
+      'Personeel: filter, select a member, reset both pushes both backends '
+      '(#180)', (WidgetTester tester) async {
+    final harness = ReconcileHarness(ssInitial: _snap());
     await tester
         .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const ValueKey('passwords-empty')), findsOneWidget);
-    expect(find.text('Geen wachtwoorden in de wachtrij.'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('passwords-tab-personeel')));
+    await tester.pumpAndSettle();
+
+    // The staff member is listed; select them.
+    await tester.tap(find.byKey(const ValueKey('passwords-staff-anna.smit')));
+    await tester.pumpAndSettle();
+
+    // Reset both → confirm. The Personeel tab carries a filter TextField whose
+    // blinking cursor keeps `pumpAndSettle` from ever settling, so drive the
+    // dialog with explicit frames instead.
+    await tester.tap(find.byKey(const ValueKey('passwords-staff-reset-both')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester
+        .tap(find.byKey(const ValueKey('passwords-staff-reset-confirm')));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    // Both a Smartschool and an Azure push happened, sharing one password.
+    expect(harness.passwordBackends.smartschoolPushes, hasLength(1));
+    expect(harness.passwordBackends.azurePushes, hasLength(1));
+    expect(harness.passwordBackends.smartschoolPushes.single.$3,
+        harness.passwordBackends.azurePushes.single.$2);
+  });
+
+  testWidgets('Personeel filter narrows the staff list',
+      (WidgetTester tester) async {
+    final harness = ReconcileHarness(ssInitial: _snap());
+    await tester
+        .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('passwords-tab-personeel')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('passwords-staff-anna.smit')),
+        findsOneWidget);
+
+    // Focusing the field starts a blinking cursor, so drive with explicit
+    // frames rather than pumpAndSettle.
+    await tester.enterText(
+        find.byKey(const ValueKey('passwords-staff-filter')), 'zzz');
+    await tester.pump();
+    expect(
+        find.byKey(const ValueKey('passwords-staff-anna.smit')), findsNothing);
   });
 }

--- a/packages/account_state/lib/src/passwords/password_entry.dart
+++ b/packages/account_state/lib/src/passwords/password_entry.dart
@@ -14,9 +14,11 @@ enum PasswordAccountKind { account, coAccount }
 ///
 /// The fields mirror the legacy `AccountPassword` (the common new-student
 /// case): a login name, display name, mail, class group, and the two backend
-/// passwords. Co-account-specific fields (the `Co1..Co6` addresses) are not
-/// modelled in this scaffold slice — [kind] discriminates the two, and the
-/// extra co-account fields will be added when the Passwords page is ported.
+/// passwords. A [kind] of [PasswordAccountKind.coAccount] instead carries the
+/// freshly-generated co-account passwords in [coAccountPasswords], keyed by the
+/// 1-based Smartschool slot (1..6) — the port of the legacy `CoAccountPassword`
+/// with its `Co1..Co6` fields (#180). An `account`-kind entry leaves that map
+/// empty; a `coAccount`-kind entry leaves the two backend passwords null.
 ///
 /// [personId] anchors the entry to a stable [PersonId] so the queue survives a
 /// re-sync that changes a login or mail.
@@ -30,6 +32,7 @@ class PasswordEntry {
     this.classGroup,
     this.smartschoolPassword,
     this.azurePassword,
+    this.coAccountPasswords = const <int, String>{},
   });
 
   /// Stable identity of the person this sheet belongs to.
@@ -56,6 +59,13 @@ class PasswordEntry {
   /// The Azure / Office 365 password. Legacy `AzurePassword`.
   final String? azurePassword;
 
+  /// Freshly-generated co-account passwords, keyed by 1-based Smartschool slot
+  /// (1..6). Non-empty only for a [PasswordAccountKind.coAccount] entry; the
+  /// port of the legacy `CoAccountPassword.Co1..Co6` fields (#180). Only the
+  /// slots that were regenerated appear; the rest are absent (exported as blank
+  /// CSV cells).
+  final Map<int, String> coAccountPasswords;
+
   /// Serializes to a JSON-encodable map.
   Map<String, dynamic> toJson() {
     return {
@@ -68,6 +78,10 @@ class PasswordEntry {
       if (smartschoolPassword != null)
         'smartschoolPassword': smartschoolPassword,
       if (azurePassword != null) 'azurePassword': azurePassword,
+      if (coAccountPasswords.isNotEmpty)
+        'coAccountPasswords': <String, String>{
+          for (final e in coAccountPasswords.entries) '${e.key}': e.value,
+        },
     };
   }
 
@@ -90,6 +104,12 @@ class PasswordEntry {
       classGroup: json['classGroup'] as String?,
       smartschoolPassword: json['smartschoolPassword'] as String?,
       azurePassword: json['azurePassword'] as String?,
+      coAccountPasswords: <int, String>{
+        for (final e in (json['coAccountPasswords'] as Map<String, dynamic>? ??
+                const <String, dynamic>{})
+            .entries)
+          int.parse(e.key): e.value as String,
+      },
     );
   }
 }

--- a/packages/account_state/test/password_queue_store_test.dart
+++ b/packages/account_state/test/password_queue_store_test.dart
@@ -20,6 +20,8 @@ PasswordEntry _coAccountEntry() => const PasswordEntry(
       kind: PasswordAccountKind.coAccount,
       accountName: 'els.peeters',
       displayName: 'Els Peeters',
+      classGroup: '1A',
+      coAccountPasswords: <int, String>{1: 'Sa2b!x', 3: 'Ku9d?y'},
     );
 
 void expectSameEntry(PasswordEntry a, PasswordEntry b) {
@@ -45,6 +47,18 @@ void main() {
       final json = _coAccountEntry().toJson();
       expect(json.containsKey('mail'), isFalse);
       expect(json.containsKey('azurePassword'), isFalse);
+    });
+
+    test('round-trips co-account passwords keyed by slot (#180)', () {
+      final restored = PasswordEntry.fromJson(_coAccountEntry().toJson());
+      expect(restored.coAccountPasswords, {1: 'Sa2b!x', 3: 'Ku9d?y'});
+      expectSameEntry(restored, _coAccountEntry());
+    });
+
+    test('an account entry serializes no coAccountPasswords key', () {
+      expect(
+          _accountEntry().toJson().containsKey('coAccountPasswords'), isFalse);
+      expect(_accountEntry().coAccountPasswords, isEmpty);
     });
 
     test('throws on an unknown kind tag', () {

--- a/packages/azure_api/lib/src/user_manager.dart
+++ b/packages/azure_api/lib/src/user_manager.dart
@@ -274,6 +274,31 @@ class UserManager {
     _log?.addMessage(core.Origin.azure, 'Azure: deleted user $idOrUpn.');
   }
 
+  /// Resets an existing user's password (PATCH `users/{id}` with a
+  /// `passwordProfile`). Mirrors legacy `Azure.UserManager.SetPassword`, used by
+  /// the on-demand Passwords screen (#180) — distinct from [createUser], which
+  /// is the only other place a password is written.
+  ///
+  /// [idOrUpn] is the object id or UPN. [forceChangePasswordNextSignIn] defaults
+  /// to `true`, matching the legacy reset (the holder must pick a new password on
+  /// next login).
+  Future<void> setPassword(
+    String idOrUpn,
+    String password, {
+    bool forceChangePasswordNextSignIn = true,
+  }) async {
+    await _graph.patchJson(
+      _graph.uri('users/${Uri.encodeComponent(idOrUpn)}'),
+      <String, dynamic>{
+        'passwordProfile': <String, dynamic>{
+          'forceChangePasswordNextSignIn': forceChangePasswordNextSignIn,
+          'password': password,
+        },
+      },
+    );
+    _log?.addMessage(core.Origin.azure, 'Azure: reset password for $idOrUpn.');
+  }
+
   /// Builds a unique UPN from a name, appending a numeric suffix on collision.
   /// Ports the legacy `CreatePrincipalName`: accents stripped, lower-cased,
   /// non-`[a-z0-9_.+-]` removed. Students live under `student.<domain>`, staff

--- a/packages/azure_api/test/user_manager_test.dart
+++ b/packages/azure_api/test/user_manager_test.dart
@@ -260,6 +260,39 @@ void main() {
     });
   });
 
+  group('setPassword (#180)', () {
+    test('PATCHes a passwordProfile onto the user', () async {
+      final transport = FakeGraphTransport.constant(noContent());
+      final users = UserManager(clientWith(transport));
+      await users.setPassword('id-1', 'Bacoxy7!');
+      final body = jsonDecode(transport.last.body!) as Map<String, dynamic>;
+      final profile = body['passwordProfile'] as Map<String, dynamic>;
+      expect(transport.last.method, 'PATCH');
+      expect(transport.last.url.path, contains('users/id-1'));
+      expect(profile['password'], 'Bacoxy7!');
+      // Defaults to forcing a change on next sign-in, mirroring the legacy reset.
+      expect(profile['forceChangePasswordNextSignIn'], isTrue);
+    });
+
+    test('honours forceChangePasswordNextSignIn: false', () async {
+      final transport = FakeGraphTransport.constant(noContent());
+      final users = UserManager(clientWith(transport));
+      await users.setPassword(
+        'jane.doe@student.school.example',
+        'Bacoxy7!',
+        forceChangePasswordNextSignIn: false,
+      );
+      final body = jsonDecode(transport.last.body!) as Map<String, dynamic>;
+      final profile = body['passwordProfile'] as Map<String, dynamic>;
+      expect(profile['forceChangePasswordNextSignIn'], isFalse);
+      // The UPN is percent-encoded into the path segment.
+      expect(
+        Uri.decodeComponent(transport.last.url.pathSegments.last),
+        'jane.doe@student.school.example',
+      );
+    });
+  });
+
   group('deleteUser', () {
     test('issues DELETE on the user resource', () async {
       final transport = FakeGraphTransport.constant(noContent());


### PR DESCRIPTION
## Summary
Replaces the distribution-only password queue with an **on-demand** password-generation screen split into **Leerlingen** and **Personeel** tabs, matching the legacy WPF app. Passwords now become real only when the operator explicitly generates/resets them — not as a side effect of account creation — so a class prepared months in advance can finally get printable passwords.

## Linked issue
Closes #180

## Changes
- **Leerlingen tab**: a tree of the Smartschool "Leerlingen" group; selecting a class loads its accounts into a per-target checkbox grid (Smartschool, Office 365, CoAccount 1–6) with bulk per-target toggles. A guarded **Genereer wachtwoorden** pushes a fresh password live per checked target and queues the result. A persistent export bar prints student sheets (browser-printable HTML) and saves the co-account CSV, each draining the queue.
- **Personeel tab**: the "Personeel" group, filterable by naam/voornaam/gebruikersnaam; a selected member resets a new Smartschool and/or Office 365 password (both share one), pushed live and written to a per-staff sheet.
- `account_state`: models `Co1..Co6` on `PasswordEntry` (`coAccountPasswords`, keyed by slot) — the previously-stubbed field.
- `azure_api`: adds `UserManager.setPassword` (PATCH `passwordProfile`) for on-demand resets, distinct from `createUser`.
- `account_manager`: new headless `PasswordController`, a `PasswordBackends` live-write seam (`ConnectorPasswordBackends`, wired to the real connectors and exposed on `ReconcileServices`), and HTML/CSV export helpers ported from the legacy `PasswordManager`.
- The empty-state create-time assumption is removed; the create-time capture (#105) still enqueues, but now surfaces as a printable sheet through the export bar rather than a per-entry distribute card.

## Risk / notes
On-demand generation writes live to Smartschool and Azure (write-capable). Per the project's live-testing policy these live pushes are exercised in tests through a recording `PasswordBackends` fake (never real network in CI); the real writes are for manual/opt-in live testing. Bulk generation is guarded by a confirm dialog naming the exact number of pushes.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed` clean
- [x] `flutter analyze` clean (whole workspace)
- [x] Unit/widget tests pass: `flutter test` in `account_manager` (203), `account_state` (291), `azure_api` (78). New: `PasswordController` (Leerlingen + Personeel), export HTML/CSV, `ConnectorPasswordBackends` adapter, and a rewritten Passwords screen widget test.
- [x] Integration/e2e pass: `flutter test integration_test/app_launch_test.dart -d windows` (33 tests). New #180 scenario drives both tabs end-to-end in the real app (class password generate → confirm → live push; staff reset both → confirm → both backends). The #105 test is updated to the new export-drains-queue UI.
