### PR TITLE
Passwords personeel: default filter to voornaam + sort alphabetically (#186)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -807,6 +807,37 @@ void main() {
   });
 
   testWidgets(
+      'the Passwords personeel tab defaults its filter to Voornaam and lists '
+      'staff alphabetically end-to-end (#186)', (WidgetTester tester) async {
+    // The real app, real fonts, real window: a "Personeel" group holding three
+    // staff seeded out of alphabetical order across mixed casing. On opening the
+    // personeel tab the filter selector must default to Voornaam and the list
+    // must render sorted by the displayed "Voornaam Naam" name.
+    useTallWindow(tester);
+    final harness = ReconcileHarness(ssInitial: staffOrderSnap());
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Passwords'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-tab-personeel')));
+    await tester.pumpAndSettle();
+
+    // The filter selector renders its default selection: Voornaam.
+    expect(find.text('Voornaam'), findsOneWidget);
+
+    // The tiles render top-to-bottom in alphabetical order: alice, Bob, Charlie.
+    double y(String uid) =>
+        tester.getTopLeft(find.byKey(ValueKey('passwords-staff-$uid'))).dy;
+    expect(y('alice'), lessThan(y('bob')));
+    expect(y('bob'), lessThan(y('charlie')));
+  });
+
+  testWidgets(
       'the Smartschool address action only fires on a real field drift and its '
       'diff shows the differing field, not an identical row (#153)',
       (WidgetTester tester) async {

--- a/account_manager/lib/src/passwords/password_controller.dart
+++ b/account_manager/lib/src/passwords/password_controller.dart
@@ -419,7 +419,8 @@ class PasswordController extends ChangeNotifier {
 
   String _filterText = '';
   String get filterText => _filterText;
-  StaffFilterField _filterField = StaffFilterField.naam;
+  // Voornaam (first name) is the more natural default to filter staff by (#186).
+  StaffFilterField _filterField = StaffFilterField.voornaam;
   StaffFilterField get filterField => _filterField;
 
   ss.SmartschoolAccount? _selectedStaff;
@@ -440,7 +441,13 @@ class PasswordController extends ChangeNotifier {
     }
 
     walk(root);
-    _allStaff.sort((a, b) => a.surname.compareTo(b.surname));
+    // Alphabetical by the displayed "Voornaam Naam" name, case-insensitive, so
+    // the list is easy to scan when locating a person to (re)generate a
+    // password for (#186).
+    _allStaff.sort((a, b) => '${a.givenName} ${a.surname}'
+        .trim()
+        .toLowerCase()
+        .compareTo('${b.givenName} ${b.surname}'.trim().toLowerCase()));
     _applyStaffFilter();
   }
 

--- a/account_manager/test/passwords/password_controller_test.dart
+++ b/account_manager/test/passwords/password_controller_test.dart
@@ -247,6 +247,24 @@ void main() {
       expect(c.staff.map((a) => a.uid), ['anna.smit']);
     });
 
+    test('defaults the staff filter field to voornaam (#186)', () {
+      expect(build().filterField, StaffFilterField.voornaam);
+    });
+
+    test('orders the staff list alphabetically by name (#186)', () {
+      // Three staff seeded out of alphabetical order across mixed casing; the
+      // controller must expose them sorted by display name (alice, Bob, Charlie).
+      final c = PasswordController(
+        snapshot: staffOrderSnap(),
+        queue: queue,
+        backends: backends,
+        generatePassword: _seqGenerator(),
+        writer: (name, content) async => 'C:/tmp/$name',
+      );
+      // Alphabetical by "Voornaam Naam", case-insensitive: alice, Bob, Charlie.
+      expect(c.staff.map((a) => a.uid), ['alice', 'bob', 'charlie']);
+    });
+
     test('filters staff by username', () {
       final c = build()
         ..setStaffFilterField(StaffFilterField.gebruikersnaam)

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -163,6 +163,8 @@ ss.SmartschoolAccount ssAccount({
   String uid = 'jane',
   String accountId = '1',
   String mail = 'jane.doe@student.school.example',
+  String givenName = 'Jane',
+  String surname = 'Doe',
   core.Address address = _addr,
 }) =>
     ss.SmartschoolAccount(
@@ -172,8 +174,8 @@ ss.SmartschoolAccount ssAccount({
       registerId: '',
       stemId: 0,
       role: core.PersonRole.student,
-      givenName: 'Jane',
-      surname: 'Doe',
+      givenName: givenName,
+      surname: surname,
       extraNames: '',
       initials: '',
       preferredName: '',
@@ -289,6 +291,34 @@ ss.SmartschoolSnapshot passwordsSnap() => ss.SmartschoolSnapshot(
         member('jane', '3C'),
         member('bob', '3C'),
         member('anna.smit', 'personeel'),
+      ],
+    );
+
+/// A Smartschool snapshot with a "Personeel" group holding three staff members
+/// seeded **out of alphabetical order** and across mixed casing (Charlie/alice/
+/// Bob) — the fixture for the Passwords personeel default-filter + sort rework
+/// (#186). The controller must expose them sorted by the displayed "Voornaam
+/// Naam" name (alice, Bob, Charlie) with voornaam as the default filter field.
+ss.SmartschoolSnapshot staffOrderSnap() => ss.SmartschoolSnapshot(
+      fetchedAt: kFixtureDate,
+      groups: <core.Group>[
+        ssGroup('Personeel', code: 'personeel', type: core.GroupType.group),
+      ],
+      accounts: <ss.SmartschoolAccount>[
+        ssAccount(
+            uid: 'charlie',
+            accountId: '1',
+            givenName: 'Charlie',
+            surname: 'Zulu'),
+        ssAccount(
+            uid: 'alice', accountId: '2', givenName: 'alice', surname: 'Bravo'),
+        ssAccount(
+            uid: 'bob', accountId: '3', givenName: 'Bob', surname: 'Alpha'),
+      ],
+      memberships: <ss.SmartschoolMembership>[
+        member('charlie', 'personeel'),
+        member('alice', 'personeel'),
+        member('bob', 'personeel'),
       ],
     );
 

--- a/account_manager/test/screens/passwords_screen_test.dart
+++ b/account_manager/test/screens/passwords_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:account_core/account_core.dart' as core;
+import 'package:account_manager/src/passwords/password_controller.dart';
 import 'package:account_manager/src/screens/passwords_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -156,6 +157,32 @@ void main() {
     expect(harness.passwordBackends.azurePushes, hasLength(1));
     expect(harness.passwordBackends.smartschoolPushes.single.$3,
         harness.passwordBackends.azurePushes.single.$2);
+  });
+
+  testWidgets(
+      'Personeel: filter defaults to Voornaam and the list is alphabetical '
+      '(#186)', (WidgetTester tester) async {
+    // Three staff seeded out of alphabetical order across mixed casing; the
+    // Personeel tab must default its filter selector to voornaam and render the
+    // list sorted by the displayed "Voornaam Naam" name.
+    final harness = ReconcileHarness(ssInitial: staffOrderSnap());
+    await tester
+        .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('passwords-tab-personeel')));
+    await tester.pumpAndSettle();
+
+    // The filter selector defaults to voornaam.
+    final dropdown = tester.widget<DropdownButton<StaffFilterField>>(
+        find.byKey(const ValueKey('passwords-staff-filter-field')));
+    expect(dropdown.value, StaffFilterField.voornaam);
+
+    // The tiles render top-to-bottom in alphabetical order: alice, Bob, Charlie.
+    double y(String uid) =>
+        tester.getTopLeft(find.byKey(ValueKey('passwords-staff-$uid'))).dy;
+    expect(y('alice'), lessThan(y('bob')));
+    expect(y('bob'), lessThan(y('charlie')));
   });
 
   testWidgets('Personeel filter narrows the staff list',


### PR DESCRIPTION
## Summary
On the Wachtwoorden/Passwords **Personeel** (staff) tab, default the name filter selector to **voornaam** (first name) instead of naam (last name), and sort the staff list **alphabetically** by the displayed "Voornaam Naam" name (case-insensitive). Follow-up to the Passwords rework in #180 (PR #185). UI-only change in `account_manager/`; no connector or linker logic touched.

## Linked issue
Closes #186

## Changes
- `password_controller.dart`: default `_filterField` is now `StaffFilterField.voornaam`; `_loadStaff()` sorts `_allStaff` by the displayed "Voornaam Naam" name, case-insensitive (was surname-only).
- Tests: added a shared `staffOrderSnap()` fixture (three staff seeded out of order across mixed casing) and gave the `ssAccount` fake optional `givenName`/`surname` params. New unit tests (default field + alphabetical order), a widget test (dropdown default value + tile order), and an end-to-end integration test in the real app (Voornaam default + alphabetical tile order).

## Test plan
- [x] `dart format --set-exit-if-changed` clean
- [x] `flutter analyze` clean (No issues found)
- [x] unit/widget tests pass (`flutter test` — 206 tests, incl. 3 new #186 cases)
- [x] integration/e2e tests pass (`flutter test integration_test -d windows` — 34 tests, incl. the new #186 end-to-end case in the real app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
