### PR TITLE
Acties: only-with-actions toggle (both tabs) + Personeel name search (#187)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1813,6 +1813,71 @@ void main() {
     expect(loopback.interactiveCalls, ['graph']);
     expect(find.byType(AppShell), findsOneWidget);
   });
+
+  testWidgets(
+      'the Actions Personeel classroom filters by name and by the '
+      'only-with-actions toggle end-to-end, combining both (#187)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real window over a passive session: three staff
+    // seeded into the one synthetic Personeel class — two share the surname
+    // "Smit" (one carrying an action, one not) and one has a distinct voornaam.
+    // The operator narrows the list by name and by the has-actions toggle, and
+    // the two filters combine.
+    useTallWindow(tester);
+    final store = await seededLinkedStore([
+      matStaff(id: 't1', label: 'Anna Smit', withAction: true),
+      matStaff(id: 't2', label: 'Bram Jansen', withAction: false),
+      matStaff(id: 't3', label: 'Clara Smit', withAction: false),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // Open the Actions tab (passive overview from the store), go to Personeel,
+    // and drill into the single staff class.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('rollup-school-school|staff')));
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
+    await tester.pumpAndSettle();
+    final staffClass = find
+        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
+    await tester.ensureVisible(staffClass);
+    await tester.tap(staffClass);
+    await tester.pumpAndSettle();
+
+    // All three staff render, and the Personeel tab carries the name search.
+    expect(find.text('Anna Smit'), findsOneWidget);
+    expect(find.text('Bram Jansen'), findsOneWidget);
+    expect(find.text('Clara Smit'), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-search')), findsOneWidget);
+
+    // Search on the surname "Smit": both Smits match, Jansen drops out.
+    await tester.enterText(
+        find.byKey(const ValueKey('actions-search')), 'smit');
+    await tester.pump();
+    expect(find.text('Anna Smit'), findsOneWidget);
+    expect(find.text('Clara Smit'), findsOneWidget);
+    expect(find.text('Bram Jansen'), findsNothing);
+
+    // Combine with the only-with-actions toggle: only Anna keeps an action, so
+    // Clara (name-matched but action-free) drops too.
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pump();
+    expect(find.text('Anna Smit'), findsOneWidget);
+    expect(find.text('Clara Smit'), findsNothing);
+    expect(find.text('Bram Jansen'), findsNothing);
+  });
 }
 
 /// A broker scripted per test — a fake WAM broker so no live tenant is touched.

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -147,6 +147,13 @@ class _ActionsBodyState extends State<_ActionsBody>
   late final TabController _tabs;
   int _shownIndex = 0;
 
+  /// The classroom drill-down filters (#187): show only accounts carrying an
+  /// applyable action (both tabs), and a name search (Personeel tab). They
+  /// combine — a filtered account list respects both. Reset when the family tab
+  /// changes so each tab opens at a clean, unfiltered list.
+  bool _onlyWithActions = false;
+  final TextEditingController _search = TextEditingController();
+
   ReconcileController get controller => widget.controller;
 
   @override
@@ -154,6 +161,7 @@ class _ActionsBodyState extends State<_ActionsBody>
     super.initState();
     _tabs = TabController(length: _ActionFamilyTab.values.length, vsync: this)
       ..addListener(_onTabChanged);
+    _search.addListener(_onSearchChanged);
   }
 
   @override
@@ -161,7 +169,60 @@ class _ActionsBodyState extends State<_ActionsBody>
     _tabs
       ..removeListener(_onTabChanged)
       ..dispose();
+    _search
+      ..removeListener(_onSearchChanged)
+      ..dispose();
     super.dispose();
+  }
+
+  void _onSearchChanged() {
+    if (mounted) setState(() {});
+  }
+
+  /// Whether the Personeel family tab is the selected one — the only tab that
+  /// carries a name search (#187).
+  bool get _staffTab => _tabs.index == _ActionFamilyTab.personeel.index;
+
+  /// The active, normalized search query (empty on any non-Personeel tab).
+  String get _query => _staffTab ? _search.text.trim().toLowerCase() : '';
+
+  /// Whether [label] passes the current name search. A single searchbox matches
+  /// the person's display name ("Voornaam Naam"), so a query on either the
+  /// voornaam or the naam is a substring hit (#187).
+  bool _matchesSearch(String label) {
+    final q = _query;
+    return q.isEmpty || label.toLowerCase().contains(q);
+  }
+
+  /// The passive-session classroom accounts narrowed by the active filters: the
+  /// "only with actions" toggle keeps just the accounts with an applyable
+  /// candidate (the same `hasPending` predicate the rollup pending counts and
+  /// the tile badge use), and the name search keeps matching display names.
+  List<MaterializedAccount> _filterAccounts(
+      List<MaterializedAccount> accounts) {
+    return [
+      for (final a in accounts)
+        if ((!_onlyWithActions || a.hasPending) && _matchesSearch(a.label)) a,
+    ];
+  }
+
+  /// The active-session pending situations narrowed by the name search. The
+  /// "only with actions" toggle is a no-op here — every pending entry already
+  /// carries an action — so only the search filters, dropping any subset left
+  /// empty so the same-situation headers stay in sync (#187).
+  List<List<PendingAccountEntry>> _filterSituations(
+    List<List<PendingAccountEntry>> situations,
+  ) {
+    if (_query.isEmpty) return situations;
+    final out = <List<PendingAccountEntry>>[];
+    for (final subset in situations) {
+      final kept = <PendingAccountEntry>[
+        for (final e in subset)
+          if (_matchesSearch(e.target)) e,
+      ];
+      if (kept.isNotEmpty) out.add(kept);
+    }
+    return out;
   }
 
   /// Rebuilds the sliver content for the newly-selected family, and — when the
@@ -171,6 +232,9 @@ class _ActionsBodyState extends State<_ActionsBody>
     final index = _tabs.index;
     if (index != _shownIndex) {
       _shownIndex = index;
+      // A fresh tab opens at a clean, unfiltered list (#187).
+      _onlyWithActions = false;
+      _search.clear();
       if (controller.selectedClassroom != null) controller.closeClassroom();
       if (controller.showingGroups) controller.closeGroups();
     }
@@ -260,31 +324,57 @@ class _ActionsBodyState extends State<_ActionsBody>
     if (controller.loadingClassroom) {
       return slivers..add(_section(const LinearProgressIndicator()));
     }
+
+    Widget filterBar() => _section(_ClassroomFilterBar(
+          onlyWithActions: _onlyWithActions,
+          onOnlyWithActionsChanged: (v) => setState(() => _onlyWithActions = v),
+          showSearch: _staffTab,
+          searchController: _search,
+        ));
+
     if (controller.linked != null) {
-      final rows = _pendingRows(controller.classroomPendingSituations);
-      if (rows.isEmpty) {
+      final situations = controller.classroomPendingSituations;
+      if (situations.isEmpty) {
         return slivers
           ..add(_section(const _EmptyLine('Geen openstaande acties in deze '
               'klas.')));
       }
-      slivers.add(_rowsSliver(rows));
+      final rows = _pendingRows(_filterSituations(situations));
+      slivers
+        ..add(filterBar())
+        ..add(_gap(PlinkSpacing.s3))
+        ..add(rows.isEmpty
+            ? _section(const _EmptyLine(_noMatchLabel))
+            : _rowsSliver(rows));
     } else {
       final accounts = controller.classroomAccounts;
       if (accounts == null || accounts.isEmpty) {
         return slivers
           ..add(_section(const _EmptyLine('Geen accounts in deze klas.')));
       }
-      slivers.add(SliverPadding(
-        padding: _hPad,
-        sliver: SliverList.builder(
-          itemCount: accounts.length,
-          itemBuilder: (context, index) =>
-              _AccountTile(account: accounts[index]),
-        ),
-      ));
+      final filtered = _filterAccounts(accounts);
+      slivers
+        ..add(filterBar())
+        ..add(_gap(PlinkSpacing.s3))
+        ..add(filtered.isEmpty
+            ? _section(const _EmptyLine(_noMatchLabel))
+            : SliverPadding(
+                padding: _hPad,
+                sliver: SliverList.builder(
+                  itemCount: filtered.length,
+                  itemBuilder: (context, index) =>
+                      _AccountTile(account: filtered[index]),
+                ),
+              ));
     }
     return slivers;
   }
+
+  /// The line shown when the active filters (toggle and/or search) hide every
+  /// account in the open classroom (#187) — distinct from the "no accounts at
+  /// all" empty state so the operator knows to relax the filter.
+  static const String _noMatchLabel =
+      'Geen accounts die aan de filter voldoen.';
 
   /// The drilled-into "Klasgroepen" node (#119): the live interactive group
   /// entries (active) or the read-only materialized group docs (passive),
@@ -750,6 +840,71 @@ class _DetailHeader extends StatelessWidget {
         ),
         const SizedBox(width: PlinkSpacing.s2),
         Text(title, style: text.titleMedium),
+      ],
+    );
+  }
+}
+
+/// The filter bar above a drilled-into classroom's account list (#187): a
+/// "toon enkel accounts met acties" toggle (both tabs) and — on the Personeel
+/// tab — a name search. Both narrow the list below and combine: the shown list
+/// respects the toggle and the search together.
+class _ClassroomFilterBar extends StatelessWidget {
+  const _ClassroomFilterBar({
+    required this.onlyWithActions,
+    required this.onOnlyWithActionsChanged,
+    required this.showSearch,
+    required this.searchController,
+  });
+
+  final bool onlyWithActions;
+  final ValueChanged<bool> onOnlyWithActionsChanged;
+
+  /// Whether to render the name search field (Personeel tab only).
+  final bool showSearch;
+  final TextEditingController searchController;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        if (showSearch) ...<Widget>[
+          TextField(
+            key: const ValueKey('actions-search'),
+            controller: searchController,
+            decoration: InputDecoration(
+              isDense: true,
+              prefixIcon: const Icon(Icons.search, size: 18),
+              hintText: 'Zoek op voornaam of naam',
+              border: const OutlineInputBorder(),
+              suffixIcon: searchController.text.isEmpty
+                  ? null
+                  : IconButton(
+                      key: const ValueKey('actions-search-clear'),
+                      icon: const Icon(Icons.close, size: 18),
+                      tooltip: 'Wis zoekopdracht',
+                      onPressed: searchController.clear,
+                    ),
+            ),
+          ),
+          const SizedBox(height: PlinkSpacing.s3),
+        ],
+        Row(
+          children: <Widget>[
+            Switch(
+              key: const ValueKey('actions-only-with-actions'),
+              value: onlyWithActions,
+              onChanged: onOnlyWithActionsChanged,
+            ),
+            const SizedBox(width: PlinkSpacing.s2),
+            Expanded(
+              child: Text('Toon enkel accounts met acties',
+                  style: text.bodyMedium),
+            ),
+          ],
+        ),
       ],
     );
   }

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -414,6 +414,90 @@ ReconcileHarness managedSchoolsHarness({required Set<int> ourSchoolIds}) =>
       ourSchoolIds: ourSchoolIds,
     );
 
+// ---------------------------------------------------------------------------
+// Passive-session materialized-view fixtures for the Actions filter tests
+// (#187): hand-built account docs so one classroom can hold a controlled mix of
+// accounts with and without applyable actions and with distinct names, then
+// seeded straight into an [InMemoryLinkedStore] a passive session reads back.
+// ---------------------------------------------------------------------------
+
+/// One [MaterializedAccount] for a passive-session classroom, placed in
+/// [school]/[gradeYear]/[classroom]. [withAction] decides whether it carries an
+/// applyable candidate — i.e. whether [MaterializedAccount.hasPending] is true,
+/// the "has actions" predicate the toggle filters on.
+MaterializedAccount matAccount({
+  required String id,
+  required String label,
+  String school = '1',
+  String schoolLabel = 'School 1',
+  String gradeYear = '3',
+  String classroom = '3C',
+  bool isStaff = false,
+  bool withAction = false,
+}) =>
+    MaterializedAccount(
+      id: core.LinkedAccountId(id),
+      school: school,
+      schoolLabel: schoolLabel,
+      gradeYear: gradeYear,
+      classroom: classroom,
+      role: isStaff ? core.PersonRole.teacher : core.PersonRole.student,
+      isStaff: isStaff,
+      confidence: core.LinkConfidence.high,
+      label: label,
+      inWisa: true,
+      inSmartschool: true,
+      inAzure: true,
+      candidates: withAction
+          ? <CandidateAction>[
+              CandidateAction(
+                family: isStaff ? 'staff' : 'student',
+                kind: 'MoveToSmartschoolClassGroup',
+                system: core.Origin.smartschool,
+                summary: 'Wijzig de klas in Smartschool',
+              ),
+            ]
+          : const <CandidateAction>[],
+    );
+
+/// A staff [MaterializedAccount] in the synthetic "Personeel" school/class the
+/// Personeel tab drills into (all staff share one bucket).
+MaterializedAccount matStaff({
+  required String id,
+  required String label,
+  bool withAction = false,
+}) =>
+    matAccount(
+      id: id,
+      label: label,
+      school: staffPartition,
+      schoolLabel: 'Personeel',
+      gradeYear: 'Personeel',
+      classroom: 'Personeel',
+      isStaff: true,
+      withAction: withAction,
+    );
+
+/// An [InMemoryLinkedStore] seeded with [accounts] and their derived rollups —
+/// the shared materialized view a passive Actions session reads with no pull and
+/// no `link()` (#187).
+Future<InMemoryLinkedStore> seededLinkedStore(
+  List<MaterializedAccount> accounts, {
+  String syncedBy = 'operator@school.example',
+}) async {
+  final store = InMemoryLinkedStore();
+  await store.writeMaterialized(
+    MaterializedView(
+      generation: 1,
+      accounts: accounts,
+      rollups: buildRollups(accounts),
+    ),
+    syncedBy: syncedBy,
+    at: kFixtureDate,
+  );
+  return store;
+}
+
 az.AzureSnapshot azSnap({DateTime? fetchedAt, List<az.AzureUser>? users}) =>
     az.AzureSnapshot(
       fetchedAt: fetchedAt ?? kFixtureDate,

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -337,6 +337,109 @@ void main() {
         findsOneWidget);
   });
 
+  // --- Classroom filters: toggle + name search (#187) ----------------------
+
+  testWidgets(
+      'the Leerlingen classroom toggle shows only accounts with actions, and '
+      'that tab carries no name search (#187)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // A passive-session class with a mix: one student with an applyable action,
+    // one without. The toggle must narrow to the former (its `hasPending`).
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
+      matAccount(id: 's2', label: 'Kees Bakker', withAction: false),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _drill(tester, school: 'School 1', grade: '3', classroom: '3C');
+    // Both accounts show unfiltered; the Leerlingen tab has no search box.
+    expect(find.text('Jane Doe'), findsOneWidget);
+    expect(find.text('Kees Bakker'), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-search')), findsNothing);
+
+    // Toggle "only with actions": the action-free account drops out.
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    expect(find.text('Jane Doe'), findsOneWidget);
+    expect(find.text('Kees Bakker'), findsNothing);
+  });
+
+  testWidgets(
+      'the Personeel classroom search matches on voornaam or naam and combines '
+      'with the only-with-actions toggle (#187)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // Three staff in the one synthetic Personeel class: two share the surname
+    // "Smit" (one with an action, one without) and one distinct voornaam.
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matStaff(id: 't1', label: 'Anna Smit', withAction: true),
+      matStaff(id: 't2', label: 'Bram Jansen', withAction: false),
+      matStaff(id: 't3', label: 'Clara Smit', withAction: false),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // Switch to the Personeel tab and drill into its single staff class.
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('rollup-school-school|staff')));
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
+    await tester.pumpAndSettle();
+    final staffClass = find
+        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
+    await tester.ensureVisible(staffClass);
+    await tester.tap(staffClass);
+    await tester.pumpAndSettle();
+
+    // All three show; the Personeel tab carries the search box.
+    expect(find.text('Anna Smit'), findsOneWidget);
+    expect(find.text('Bram Jansen'), findsOneWidget);
+    expect(find.text('Clara Smit'), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-search')), findsOneWidget);
+
+    // Search on the naam "Smit": both Smits match, Jansen drops.
+    await tester.enterText(
+        find.byKey(const ValueKey('actions-search')), 'smit');
+    await tester.pump();
+    expect(find.text('Anna Smit'), findsOneWidget);
+    expect(find.text('Clara Smit'), findsOneWidget);
+    expect(find.text('Bram Jansen'), findsNothing);
+
+    // Search on the voornaam "Bram": only Jansen matches.
+    await tester.enterText(
+        find.byKey(const ValueKey('actions-search')), 'bram');
+    await tester.pump();
+    expect(find.text('Bram Jansen'), findsOneWidget);
+    expect(find.text('Anna Smit'), findsNothing);
+    expect(find.text('Clara Smit'), findsNothing);
+
+    // Combine the toggle with the search: search "Smit" AND only-with-actions
+    // keeps just Anna (Clara matches the name but has no action).
+    await tester.enterText(
+        find.byKey(const ValueKey('actions-search')), 'smit');
+    await tester.pump();
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pump();
+    expect(find.text('Anna Smit'), findsOneWidget);
+    expect(find.text('Clara Smit'), findsNothing);
+    expect(find.text('Bram Jansen'), findsNothing);
+
+    // A query matching nothing shows the filter-empty line, not the class-empty
+    // one.
+    await tester.enterText(find.byKey(const ValueKey('actions-search')), 'zzz');
+    await tester.pump();
+    expect(
+        find.text('Geen accounts die aan de filter voldoen.'), findsOneWidget);
+  });
+
   // --- Address diff in the drill-down (#153) -------------------------------
   const wisaAddr = Address(
     street: 'Koophandelstraat',


### PR DESCRIPTION
## Summary
On the Actions/Acties screen, add a filter bar to the classroom drill-down so operators can narrow a large account list to just what needs attention and locate a staff member by name (#187, follow-up to the personeel/leerlingen tab split in #179).

- **Only-with-actions toggle** on **both** the Leerlingen and Personeel tabs: hides accounts with no applyable action.
- **Name search** on the Personeel tab: a single searchbox matching the display name ("Voornaam Naam"), so a query on either the voornaam or the naam is a substring hit (the issue's preferred single-searchbox option).
- The two filters **combine** — the shown list respects the toggle and the search together. Filters reset when the family tab changes so each tab opens clean.

The "has actions" predicate is `MaterializedAccount.hasPending` (`candidates.any((c) => c.canApply)`) — the exact set the rollup pending counts and the account-tile badge already surface, so it matches the actions shown elsewhere.

Applies to the passive-session account list (which shows all accounts) and the active-session pending-situations list (search narrows; the toggle is a no-op there since those rows are already action-only).

## Linked issue
Closes #187

## Changes
- `account_manager/lib/src/screens/actions_screen.dart` — filter state + helpers on `_ActionsBodyState`, a `_ClassroomFilterBar` widget (search field + toggle), and filtering wired into the classroom drill-down for both session paths, with a distinct "no accounts match the filter" empty line.
- `account_manager/test/reconcile/reconcile_fakes.dart` — passive-session materialized-view fixtures (`matAccount`, `matStaff`, `seededLinkedStore`) for controlled mixed-account classrooms.
- `account_manager/test/screens/actions_screen_test.dart` — widget tests: Leerlingen toggle (and no search box there); Personeel search by voornaam and by naam, combined with the toggle, and the filter-empty line.
- `account_manager/integration_test/app_launch_test.dart` — end-to-end test driving the real app: Personeel drill-down, search by surname, then combine with the toggle.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed` clean
- [x] `flutter analyze lib test integration_test` clean (no issues)
- [x] unit/widget tests pass (`flutter test`) — 208 tests, incl. 2 new #187 cases
- [x] integration/e2e tests pass (`flutter test integration_test -d windows`) — 35 tests, incl. the new #187 case; confirmed it fails on the unpatched screen and passes with the fix
