### PR TITLE
Reconcile: last-sync status as a per-system box (#188)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -263,11 +263,11 @@ void main() {
 
   testWidgets(
       'a completed sync logs a terminal "Sync complete … Ready." line and the '
-      'prominent last-sync freshness row renders end-to-end (#162)',
+      'last-sync box renders a row per system end-to-end (#162/#188)',
       (WidgetTester tester) async {
     // The real app composition over the offline harness, driven the way the
-    // operator drives it. (Restart survival of the freshness line is covered by
-    // the passive-session freshness scenario below and the widget test.)
+    // operator drives it. (Restart survival of the box is covered by the
+    // passive-session scenario below and the widget test.)
     useTallWindow(tester);
     final harness = ReconcileHarness();
     await tester.pumpWidget(AccountManagerApp(
@@ -280,8 +280,8 @@ void main() {
     await tester.tap(find.text('Reconcile'));
     await tester.pumpAndSettle();
 
-    // Before syncing there is no freshness row yet.
-    expect(find.byKey(const ValueKey('reconcile-freshness')), findsNothing);
+    // Before syncing there is no last-sync box yet.
+    expect(find.byKey(const ValueKey('reconcile-last-sync')), findsNothing);
 
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -292,10 +292,17 @@ void main() {
       find.textContaining('Sync complete — 4 pending action(s). Ready.'),
       findsOneWidget,
     );
-    // The last-sync freshness now renders in its own prominent row.
-    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
-    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
-    expect(find.textContaining('by operator@school.example'), findsOneWidget);
+    // The last-sync freshness now renders as a dedicated box headed "Last sync"
+    // with one row per system (#188).
+    expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
+    expect(find.text('Last sync'), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('reconcile-last-sync-wisa')), findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-last-sync-smartschool')),
+        findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-last-sync-azure')),
+        findsOneWidget);
+    expect(find.textContaining('by operator@school.example'), findsWidgets);
 
     // A second, unchanged re-sync logs the no-change ready line too.
     harness.wisaResult =
@@ -309,13 +316,13 @@ void main() {
   });
 
   testWidgets(
-      'the freshness line surfaces Smartschool and Azure as a drift check '
-      'alongside the WISA sync, and a Check for drift advances only those two '
-      '(#170)', (WidgetTester tester) async {
+      'the last-sync box shows WISA as a sync and Smartschool/Azure as drift '
+      'checks per row, and a Check for drift advances only those two '
+      '(#170/#188)', (WidgetTester tester) async {
     // The real app over the offline harness: a first full sync stamps all three
     // systems, then Check for drift re-reads Smartschool/Azure at a later time
-    // while WISA keeps its earlier sync stamp. The freshness line must show both
-    // clauses throughout — the WISA sync time and the drift-checked pair.
+    // while WISA keeps its earlier sync stamp. The box must show WISA as a sync
+    // and Smartschool/Azure as drift checks — each on its own row — throughout.
     useTallWindow(tester);
     final harness = ReconcileHarness();
     await tester.pumpWidget(AccountManagerApp(
@@ -330,18 +337,23 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    // After the first full sync all three systems appear, split into the WISA
-    // "Last sync" clause and the Smartschool/Azure "drift check" clause.
-    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
-    Text freshnessText() => tester.widget<Text>(
-          find.descendant(
-            of: find.byKey(const ValueKey('reconcile-freshness')),
-            matching: find.byType(Text),
-          ),
-        );
-    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
-    expect(find.textContaining('drift check — Smartschool'), findsOneWidget);
-    expect(freshnessText().data, contains('Azure'));
+    // Collect the text of one system's row.
+    String rowText(String system) => tester
+        .widgetList<Text>(find.descendant(
+          of: find.byKey(ValueKey('reconcile-last-sync-$system')),
+          matching: find.byType(Text),
+        ))
+        .map((t) => t.data)
+        .whereType<String>()
+        .join(' ');
+
+    // After the first full sync all three systems appear on their own rows:
+    // WISA as a sync, Smartschool and Azure as drift checks.
+    expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
+    expect(rowText('wisa'), contains('sync'));
+    expect(rowText('wisa'), isNot(contains('drift check')));
+    expect(rowText('smartschool'), contains('drift check'));
+    expect(rowText('azure'), contains('drift check'));
 
     // Check for drift re-pulls Smartschool and Azure at a later time; WISA is
     // not re-pulled, so its sync stamp stays put while the drift pair advances.
@@ -352,10 +364,10 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
     await tester.pumpAndSettle();
 
-    // The line still carries both clauses, and the underlying state proves the
+    // The rows still carry the right kinds, and the underlying state proves the
     // drift pair advanced while WISA held its earlier sync time.
-    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
-    expect(find.textContaining('drift check — Smartschool'), findsOneWidget);
+    expect(rowText('wisa'), contains('sync'));
+    expect(rowText('smartschool'), contains('drift check'));
     final systems = harness.controller.syncState.systems;
     expect(systems[Origin.wisa]?.at, kFixtureDate);
     expect(systems[Origin.smartschool]?.at, driftAt);
@@ -364,13 +376,13 @@ void main() {
 
   testWidgets(
       'the operator decoded from the real loopback broker JWT names the last '
-      'sync in the freshness line end-to-end (#169)',
+      'sync in the last-sync box end-to-end (#169)',
       (WidgetTester tester) async {
     // The production sign-in path on a machine without the native WAM broker:
     // the *real* LoopbackAadBroker signs in and now decodes the operator UPN
     // from the JWT access token — the piece that was empty, which left the
-    // freshness line without its "by …". Drive the real app with that broker
-    // and a JWT-bearing provider, sync, and read the line the operator sees.
+    // last-sync box without its "by …". Drive the real app with that broker
+    // and a JWT-bearing provider, sync, and read the box the operator sees.
     useTallWindow(tester);
     final jwt = _jwt({'upn': 'yvan@school.example'});
     final session = SignInSession(
@@ -398,10 +410,11 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    // The freshness line names the signed-in operator…
-    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
-    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
-    expect(find.textContaining('by yvan@school.example'), findsOneWidget);
+    // The last-sync box names the signed-in operator on its rows…
+    expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('reconcile-last-sync-wisa')), findsOneWidget);
+    expect(find.textContaining('by yvan@school.example'), findsWidgets);
     // …and the terminal "Sync complete" line names them too (#169).
     expect(
       find.textContaining('Operator: yvan@school.example'),
@@ -1204,12 +1217,14 @@ void main() {
     await tester.tap(find.text('Reconcile'));
     await tester.pumpAndSettle();
 
-    // The shared per-system freshness line renders in its prominent row (#162)
-    // straight from the store (who last synced each system — not this passive
-    // session), proving it survives a restart.
-    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
-    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
-    expect(find.textContaining('by operator@school.example'), findsOneWidget);
+    // The shared per-system last-sync box renders (#162/#188) straight from the
+    // store (who last synced each system — not this passive session), proving it
+    // survives a restart.
+    expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
+    expect(find.text('Last sync'), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('reconcile-last-sync-wisa')), findsOneWidget);
+    expect(find.textContaining('by operator@school.example'), findsWidgets);
 
     // The lock is surfaced by name and Synchronise/Check-for-drift are disabled
     // so two operators cannot sync at once.

--- a/account_manager/lib/src/auth/loopback_aad_broker.dart
+++ b/account_manager/lib/src/auth/loopback_aad_broker.dart
@@ -9,8 +9,8 @@ import 'aad_resource.dart';
 
 /// Best-effort extraction of the signed-in operator's UPN / e-mail from a JWT
 /// access token, so the session can name *who* signed in (#169): the value is
-/// stamped onto each per-system sync and shown in the reconcile freshness line
-/// ("Last sync — WISA 10:21 by yvan@…").
+/// stamped onto each per-system sync and shown in the reconcile last-sync box
+/// (the WISA row reads "sync · 10:21 · by yvan@…").
 ///
 /// The loopback OAuth path only ever hands back a raw access-token string, so
 /// the identity has to be read off the token itself. This reads the standard

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart' show SystemSyncMeta;
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
@@ -179,52 +180,12 @@ class _Header extends StatelessWidget {
 
   final ReconcileController controller;
 
-  /// The shared per-system freshness line, e.g. "Last sync — WISA 09:12 by
-  /// jan@… · drift check — Smartschool 10:24 · Azure 10:25". Read from the
-  /// materialized store so it names *whichever* operator last synced each system
-  /// — not just this session (#108). WISA (the Synchronise target) and the
-  /// drift-checked pair (Smartschool, Azure) render as two clauses so their
-  /// differing times are self-explanatory (#170). Null before any sync.
-  String? _freshness() {
-    final systems = controller.syncState.systems;
-    String? stamp(core.Origin system, String label) {
-      final meta = systems[system];
-      if (meta == null) return null;
-      final t = meta.at.toLocal();
-      final hhmm = '${t.hour.toString().padLeft(2, '0')}:'
-          '${t.minute.toString().padLeft(2, '0')}';
-      final by = meta.syncedBy.isEmpty ? '' : ' by ${meta.syncedBy}';
-      return '$label $hhmm$by';
-    }
-
-    // WISA is refreshed by Synchronise; Smartschool and Azure are refreshed by
-    // Check for drift. Present them as two labelled clauses so a later WISA-only
-    // smart-sync reads as "synced then, drift-checked earlier" rather than an
-    // unexplained gap between the timestamps (#170).
-    final segments = <String>[];
-    if (stamp(core.Origin.wisa, 'WISA') case final wisa?) {
-      segments.add('Last sync — $wisa');
-    }
-    final drift = <String>[
-      for (final (system, label) in const [
-        (core.Origin.smartschool, 'Smartschool'),
-        (core.Origin.azure, 'Azure'),
-      ])
-        if (stamp(system, label) case final s?) s,
-    ];
-    if (drift.isNotEmpty) {
-      segments.add('drift check — ${drift.join(' · ')}');
-    }
-    if (segments.isEmpty) return null;
-    return segments.join(' · ');
-  }
-
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     final ColorScheme colors = Theme.of(context).colorScheme;
     final bool ink = Theme.of(context).brightness == Brightness.dark;
-    final freshness = _freshness();
+    final bool hasFreshness = controller.syncState.systems.isNotEmpty;
     final lockedByOther = controller.syncLockedByOther;
 
     return Column(
@@ -256,24 +217,9 @@ class _Header extends StatelessWidget {
             ),
           ],
         ),
-        if (freshness != null) ...<Widget>[
-          const SizedBox(height: PlinkSpacing.s3),
-          Row(
-            key: const ValueKey('reconcile-freshness'),
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Icon(Icons.schedule_outlined, size: 16, color: colors.primary),
-              const SizedBox(width: PlinkSpacing.s2),
-              Flexible(
-                child: Text(
-                  freshness,
-                  style: text.bodyMedium?.copyWith(
-                    color: colors.onSurfaceVariant,
-                  ),
-                ),
-              ),
-            ],
-          ),
+        if (hasFreshness) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s4),
+          _LastSyncBox(controller: controller),
         ],
         if (lockedByOther) ...<Widget>[
           const SizedBox(height: PlinkSpacing.s3),
@@ -304,6 +250,140 @@ class _Header extends StatelessWidget {
           ),
         ],
       ],
+    );
+  }
+}
+
+/// The shared per-system "Last sync" box (#188): a bordered card headed
+/// "Last sync" with one row per system — WISA, Smartschool, Azure — each on its
+/// own line showing whether it was refreshed by a sync or a drift check, the
+/// time, and which operator ran it. This replaces the old run-on freshness line
+/// that packed all three systems into a single wrapped sentence.
+///
+/// Read from the materialized store so it names *whichever* operator last synced
+/// each system — not just this session (#108). WISA is the Synchronise target;
+/// Smartschool and Azure are refreshed by Check for drift, so a later WISA-only
+/// smart-sync reads as "synced then, drift-checked earlier" per row rather than
+/// an unexplained gap between timestamps (#170). Only rendered once at least one
+/// system has been synced.
+class _LastSyncBox extends StatelessWidget {
+  const _LastSyncBox({required this.controller});
+
+  final ReconcileController controller;
+
+  /// The systems in display order, each with its label and whether it is
+  /// refreshed by Synchronise (`isSync`) or by Check for drift.
+  static const List<(core.Origin, String, bool)> _rows =
+      <(core.Origin, String, bool)>[
+    (core.Origin.wisa, 'WISA', true),
+    (core.Origin.smartschool, 'Smartschool', false),
+    (core.Origin.azure, 'Azure', false),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final Color hairline = Theme.of(context).dividerColor;
+    final systems = controller.syncState.systems;
+
+    return Container(
+      key: const ValueKey('reconcile-last-sync'),
+      padding: const EdgeInsets.all(PlinkSpacing.s4),
+      decoration: BoxDecoration(
+        border: Border.all(color: hairline),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(Icons.schedule_outlined, size: 18, color: colors.primary),
+              const SizedBox(width: PlinkSpacing.s2),
+              Text('Last sync', style: text.titleMedium),
+            ],
+          ),
+          const SizedBox(height: PlinkSpacing.s3),
+          for (final (system, label, isSync) in _rows)
+            _SystemRow(
+              system: system,
+              label: label,
+              isSync: isSync,
+              meta: systems[system],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One system's row inside the [_LastSyncBox]: a fixed-width name column so the
+/// three statuses line up, then the sync/drift icon and a "kind · time · by who"
+/// status. A system that has never been synced shows a muted placeholder rather
+/// than being dropped, so all three systems are always accounted for.
+class _SystemRow extends StatelessWidget {
+  const _SystemRow({
+    required this.system,
+    required this.label,
+    required this.isSync,
+    required this.meta,
+  });
+
+  final core.Origin system;
+  final String label;
+  final bool isSync;
+  final SystemSyncMeta? meta;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final SystemSyncMeta? meta = this.meta;
+
+    final String status;
+    if (meta == null) {
+      status = 'not synced yet';
+    } else {
+      final DateTime t = meta.at.toLocal();
+      final String hhmm = '${t.hour.toString().padLeft(2, '0')}:'
+          '${t.minute.toString().padLeft(2, '0')}';
+      final String kind = isSync ? 'sync' : 'drift check';
+      final String by = meta.syncedBy.isEmpty ? '' : ' · by ${meta.syncedBy}';
+      status = '$kind · $hhmm$by';
+    }
+
+    return Padding(
+      key: ValueKey('reconcile-last-sync-${system.name}'),
+      padding: const EdgeInsets.only(bottom: PlinkSpacing.s2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          SizedBox(
+            width: 104,
+            child: Text(
+              label,
+              style: text.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Icon(
+              isSync ? Icons.sync : Icons.difference_outlined,
+              size: 16,
+              color: meta == null ? colors.onSurfaceVariant : colors.primary,
+            ),
+          ),
+          const SizedBox(width: PlinkSpacing.s2),
+          Expanded(
+            child: Text(
+              status,
+              style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -189,35 +189,43 @@ void main() {
     expect(drift.onPressed, isNull);
   });
 
-  testWidgets('the header shows the shared per-system freshness (#108)',
-      (WidgetTester tester) async {
+  testWidgets(
+      'the header shows the shared per-system last-sync box with a row per '
+      'system (#108/#188)', (WidgetTester tester) async {
     final harness = ReconcileHarness();
     await tester.pumpWidget(
       _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
     );
     await tester.pumpAndSettle();
 
-    // No sync yet → no freshness row.
-    expect(find.byKey(const ValueKey('reconcile-freshness')), findsNothing);
+    // No sync yet → no box.
+    expect(find.byKey(const ValueKey('reconcile-last-sync')), findsNothing);
 
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    // The freshness now sits in its own prominent row (#162), not trailing the
-    // buttons.
-    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
-    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
+    // The freshness now renders as a dedicated box headed "Last sync", with one
+    // row per system rather than a run-on line (#188).
+    expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
+    expect(find.text('Last sync'), findsOneWidget);
     expect(
-      find.textContaining('by operator@school.example'),
-      findsOneWidget,
-    );
+        find.byKey(const ValueKey('reconcile-last-sync-wisa')), findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-last-sync-smartschool')),
+        findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-last-sync-azure')),
+        findsOneWidget);
+    expect(find.text('WISA'), findsOneWidget);
+    expect(find.text('Smartschool'), findsOneWidget);
+    expect(find.text('Azure'), findsOneWidget);
+    // Each row names the operator who last synced it.
+    expect(find.textContaining('by operator@school.example'), findsWidgets);
   });
 
   testWidgets(
-      'the freshness line surfaces Smartschool and Azure as a drift check next '
-      'to the WISA sync time (#170)', (WidgetTester tester) async {
-    // Distinct fetch times per system so the line shows the WISA sync time and
-    // the (later) Smartschool/Azure drift-check times side by side.
+      'the last-sync box shows WISA as a sync and Smartschool/Azure as drift '
+      'checks, each on its own row (#170/#188)', (WidgetTester tester) async {
+    // Distinct fetch times per system so WISA carries its sync time and the
+    // (later) Smartschool/Azure rows carry their drift-check times.
     final wisaAt = kFixtureDate.add(const Duration(hours: 1));
     final ssAt = kFixtureDate.add(const Duration(hours: 1, minutes: 3));
     final azAt = kFixtureDate.add(const Duration(hours: 1, minutes: 4));
@@ -234,24 +242,27 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    // One row, three systems, split into a "Last sync" clause (WISA) and a
-    // "drift check" clause (Smartschool · Azure).
-    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
-    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
-    expect(find.textContaining('drift check — Smartschool'), findsOneWidget);
-    // Azure rides in the same (single) freshness Text.
-    final freshness = tester.widget<Text>(
-      find.descendant(
-        of: find.byKey(const ValueKey('reconcile-freshness')),
-        matching: find.byType(Text),
-      ),
-    );
-    expect(freshness.data, contains('Azure'));
-    expect(freshness.data, contains('Smartschool'));
-    expect(freshness.data, contains('WISA'));
+    expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
+
+    // Collect the text of one system's row.
+    String rowText(String system) => tester
+        .widgetList<Text>(find.descendant(
+          of: find.byKey(ValueKey('reconcile-last-sync-$system')),
+          matching: find.byType(Text),
+        ))
+        .map((t) => t.data)
+        .whereType<String>()
+        .join(' ');
+
+    // WISA is the sync; Smartschool and Azure are drift checks — each on its
+    // own row, no longer packed into one wrapped sentence.
+    expect(rowText('wisa'), contains('sync'));
+    expect(rowText('wisa'), isNot(contains('drift check')));
+    expect(rowText('smartschool'), contains('drift check'));
+    expect(rowText('azure'), contains('drift check'));
   });
 
-  testWidgets('the last-sync line survives a restart / passive session (#162)',
+  testWidgets('the last-sync box survives a restart / passive session (#162)',
       (WidgetTester tester) async {
     // Session 1 syncs and persists freshness to the shared store.
     final linkedStore = InMemoryLinkedStore();
@@ -265,12 +276,11 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(passive.wisaSyncs, 0, reason: 'a passive session pulls nothing');
-    expect(find.byKey(const ValueKey('reconcile-freshness')), findsOneWidget);
-    expect(find.textContaining('Last sync — WISA'), findsOneWidget);
+    expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
+    expect(find.text('Last sync'), findsOneWidget);
     expect(
-      find.textContaining('by operator@school.example'),
-      findsOneWidget,
-    );
+        find.byKey(const ValueKey('reconcile-last-sync-wisa')), findsOneWidget);
+    expect(find.textContaining('by operator@school.example'), findsWidgets);
   });
 
   testWidgets(


### PR DESCRIPTION
## Summary
Replaces the run-on last-sync / drift-check status line on the Reconcile screen with a dedicated bordered box headed **"Last sync"**, rendering one row per system — **WISA**, **Smartschool**, **Azure** — so each system's most recent sync/drift state is easy to scan instead of packed into a single wrapped sentence.

Each row shows, on its own line: whether the system was refreshed by a **sync** (WISA, the Synchronise target) or a **drift check** (Smartschool, Azure), the time, and which operator last ran it — read from the same shared materialized store as before (#108/#170). The box is styled with the same bordered-card treatment used elsewhere on the screen (overview tiles, status banner) for visual consistency.

UI-only presentation change in `account_manager/`; no sync/drift logic touched. The Actions screen has its own separate freshness line and is out of scope.

## Linked issue
Closes #188

## Changes
- `lib/src/screens/reconcile_screen.dart`: removed the run-on `_freshness()` string builder; added `_LastSyncBox` (header + per-system rows) and `_SystemRow` (fixed-width name column, sync/drift icon, `kind · time · by who` status, muted "not synced yet" placeholder for an unsynced system). New keys: `reconcile-last-sync`, `reconcile-last-sync-{wisa,smartschool,azure}`.
- `lib/src/auth/loopback_aad_broker.dart`: updated a doc comment that referenced the old line format.
- Widget tests (`test/reconcile/reconcile_screen_test.dart`) and the end-to-end integration tests (`integration_test/app_launch_test.dart`) updated to assert the box + per-row structure.

## Test plan
- [x] `dart format --set-exit-if-changed` clean (files reformatted and committed)
- [x] `flutter analyze` clean — no issues
- [x] unit/widget tests pass (`flutter test`) — 208 pass, incl. the reworked reconcile screen tests
- [x] integration/e2e tests pass (`flutter test integration_test/app_launch_test.dart -d windows`) — 35 pass, incl. the last-sync box rendering, per-system sync-vs-drift rows (#170/#188), operator-name row (#169), and passive-session restart (#108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)