### PR TITLE
Batch: Smartschool ids, dated sync stamp, copyable log, WISA school code, PDF password sheets (#138 #192 #193 #194 #195 #197)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  // The app reads its Azure AD app-registration values from --dart-define
+  // (see account_manager/lib/src/auth/aad_app_config.dart). Without them the
+  // sign-in gate renders "Not configured" and every screen that needs a token
+  // — Settings included — stays unreachable. The values live in the gitignored
+  // account_manager/aad.local.json (copy aad.local.json.example).
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Account Manager (Windows)",
+      "request": "launch",
+      "type": "dart",
+      "cwd": "account_manager",
+      "program": "lib/main.dart",
+      "deviceId": "windows",
+      "toolArgs": ["--dart-define-from-file=aad.local.json"]
+    },
+    {
+      "name": "Account Manager (Windows, profile)",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "profile",
+      "cwd": "account_manager",
+      "program": "lib/main.dart",
+      "deviceId": "windows",
+      "toolArgs": ["--dart-define-from-file=aad.local.json"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -13,4 +13,40 @@ This repository is in transition from a WPF / .NET Framework 4.8 desktop applica
 - **Spec for the port:** [docs/domain-model.md](docs/domain-model.md)
 - **Legacy WPF code (read-only reference):** [legacy-wpf/](legacy-wpf/)
 
+## Running the app (Windows)
+
+The Azure AD app-registration values are school-specific and are **not** baked
+into the binary — they come from `--dart-define` at run time
+([aad_app_config.dart](account_manager/lib/src/auth/aad_app_config.dart)).
+A build started without them launches, but `isConfigured` is `false`, so the
+sign-in gate shows **"Not configured"** and every screen that needs a token —
+Settings included — stays unreachable.
+
+Copy [aad.local.json.example](account_manager/aad.local.json.example) to
+`account_manager/aad.local.json` (gitignored), fill it in, then:
+
+```powershell
+cd account_manager
+flutter run -d windows --dart-define-from-file=aad.local.json
+```
+
+Or press <kbd>F5</kbd> in VS Code — **Account Manager (Windows)** in
+[.vscode/launch.json](.vscode/launch.json) passes the same flag.
+
+The client id must be a **public-client** app registration with
+`http://localhost:8765/auth-redirect` registered under *Authentication → Mobile
+and desktop applications*; sign-in opens the system browser and captures the
+redirect there. See
+[README-aad-broker.md](account_manager/windows/runner/README-aad-broker.md) for
+the loopback flow and the (not yet wired) native WAM broker.
+
+Everything else — Cosmos, Key Vault, Blob, SignalR endpoints — defaults to the
+provisioned infrastructure in `StoreEndpoints`
+([reconcile_bootstrap.dart](account_manager/lib/src/reconcile/reconcile_bootstrap.dart))
+and only needs a `--dart-define` to point at a different environment.
+
+The `.*.env` files in the repo root are unrelated to running the app: they hold
+credentials for the opt-in live integration tests
+([tool/live-tests.ps1](tool/live-tests.ps1)).
+
 The SonarCloud badges above will activate once the operator finishes the SonarCloud project setup — see [.github/workflows/ci.yml](.github/workflows/ci.yml) for the steps.

--- a/account_manager/aad.local.json.example
+++ b/account_manager/aad.local.json.example
@@ -1,0 +1,17 @@
+{
+  "//": "Azure AD app-registration values the app reads at build/run time.",
+  "//1": "Copy this file to aad.local.json (gitignored) and fill in the real",
+  "//2": "values, then run:",
+  "//3": "  flutter run -d windows --dart-define-from-file=aad.local.json",
+  "//4": "Without these defines AadAppConfig.isConfigured is false and the app",
+  "//5": "renders 'Not configured' on every screen that needs a token.",
+  "//6": "AAD_CLIENT_ID must be a public-client app registration with",
+  "//7": "http://localhost:8765/auth-redirect registered under Authentication →",
+  "//8": "Mobile and desktop applications (see windows/runner/README-aad-broker.md).",
+  "//9": "SCHOOL_PREFIX is only a fallback: the persisted settings win when set.",
+
+  "AAD_CLIENT_ID": "",
+  "AAD_TENANT_ID": "",
+  "AAD_DOMAIN": "",
+  "SCHOOL_PREFIX": ""
+}

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1780,6 +1780,72 @@ void main() {
   });
 
   testWidgets(
+      'the Settings view identifies WISA schools by their code end-to-end, '
+      'never showing the id twice (#194)', (WidgetTester tester) async {
+    // The real app composition, real navigation and real fonts over the
+    // in-memory settings seams. One school is stored from before #194 (name,
+    // no code); the fetch backfills the code and the grid must lead with it.
+    useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    // `SMAGetInst`'s CSV NAME column (the short code) lands on `description`.
+    final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
+      WisaSchool(id: 7, name: 'Sint-Pieter', description: 'ismab'),
+    ]);
+    final settings = SettingsHarness(
+      initial: const AppSettings(
+        wisa: WisaConnection(server: 'db.school.example', port: '1433'),
+        wisaSchools: [
+          WisaSchoolProfile(schoolId: 7, name: 'Sint-Pieter', ours: true),
+        ],
+      ),
+      secrets: {passwordRef: 'stored-pw'},
+      fetchWisaSchools: fetcher.call,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+    await openSettingsTab(tester, 'settings-tab-wisa');
+
+    // Before the fetch: the stored name leads, the id is the secondary line and
+    // appears exactly once.
+    final tile = find.byKey(const ValueKey('settings-wisa-school-7-ours'));
+    await tester.ensureVisible(tile);
+    await tester.pumpAndSettle();
+    expect(find.descendant(of: tile, matching: find.text('Sint-Pieter')),
+        findsOneWidget);
+    expect(find.descendant(of: tile, matching: find.text('id: 7')),
+        findsOneWidget);
+    expect(find.text('School 7'), findsNothing);
+
+    // Fetch: the code takes the lead and the long name drops to the subtitle,
+    // so the id no longer shows at all.
+    final button = find.byKey(const ValueKey('settings-wisa-fetch-schools'));
+    await tester.ensureVisible(button);
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+    expect(find.descendant(of: tile, matching: find.text('ismab')),
+        findsOneWidget);
+    expect(find.descendant(of: tile, matching: find.text('Sint-Pieter')),
+        findsOneWidget);
+    expect(find.text('id: 7'), findsNothing);
+
+    // Saving persists the code, so a restart keeps identifying it by code.
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    final saved = await settings.store.load();
+    expect(saved.wisaSchools.single.code, 'ismab');
+    expect(saved.wisaSchools.single.ours, isTrue);
+  });
+
+  testWidgets(
       'the Settings/Algemeen werkdatum controls read clearly end-to-end: '
       'renamed virtual label + right-aligned switch instruction (#141)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -37,7 +37,7 @@ import 'package:account_state/account_state.dart'
 import 'package:azure_api/azure_api.dart'
     show AzureCredentials, StaticAuthProvider;
 import 'package:wisa_api/wisa_api.dart' show WisaSchool;
-import 'package:flutter/gestures.dart' show PointerDeviceKind;
+import 'package:flutter/gestures.dart' show PointerDeviceKind, kSecondaryButton;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -2197,6 +2197,85 @@ void main() {
     expect(copied.last.split('\n'), hasLength(harness.log.entries.length));
     expect(copied.last.split('\n').length, greaterThan(2));
     expect(copied.last, endsWith('00:00:00  [azure]  Ready.'));
+  });
+
+  testWidgets(
+      'the operator right-clicks one log line and Copy line puts just that '
+      'message on the clipboard end-to-end (#197)',
+      (WidgetTester tester) async {
+    // Grabbing a single message was already possible after #193 - a
+    // triple-click selects one paragraph, which is one entry - but nothing on
+    // screen said so. The affordance is a context-menu entry whose target is
+    // resolved from the paragraph line the pointer landed on, so it has to be
+    // driven through the real app: the real font decides where the second row
+    // starts, and the menu itself goes through the real overlay.
+    final List<String> copied = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (MethodCall call) async {
+        if (call.method == 'Clipboard.setData') {
+          final args = call.arguments as Map<Object?, Object?>;
+          copied.add(args['text']! as String);
+        }
+        return null;
+      },
+    );
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null));
+
+    useTallWindow(tester);
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+
+    // A real pass fills the panel, then a known short tail so the row the
+    // click lands on has stable contents and cannot soft-wrap (the harness
+    // clock is fixed at 00:00:00).
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.log.entries, isNotEmpty);
+    harness.log
+      ..clear()
+      ..addMessage(Origin.wisa, 'Sync done.')
+      ..addError(Origin.smartschool, 'Set-Password failed: rc=42')
+      ..addMessage(Origin.azure, 'Ready.');
+    await tester.pumpAndSettle();
+
+    // Newest first, so the error is the middle of the three rendered lines.
+    final Finder block = find.byKey(const ValueKey('reconcile-log-text'));
+    expect(block, findsOneWidget);
+    final List<String> onScreen =
+        tester.widget<Text>(block).textSpan!.toPlainText().split('\n');
+    expect(onScreen, hasLength(3));
+    expect(onScreen[1], '00:00:00  [smartschool]  Set-Password failed: rc=42');
+
+    // Right-click that middle line with the mouse.
+    final Rect rect = tester.getRect(block);
+    final double lineHeight = rect.height / onScreen.length;
+    final TestGesture click = await tester.startGesture(
+      Offset(rect.left + 8, rect.top + lineHeight * 1.5),
+      kind: PointerDeviceKind.mouse,
+      buttons: kSecondaryButton,
+    );
+    await click.up();
+    await tester.pumpAndSettle();
+
+    // The affordance is on screen, and it takes exactly the entry under the
+    // pointer: one line, neither neighbour, no trailing newline.
+    expect(find.text('Copy line'), findsOneWidget);
+    await tester.tap(find.text('Copy line'));
+    await tester.pumpAndSettle();
+
+    expect(copied, hasLength(1));
+    expect(copied.single, onScreen[1]);
+    expect(copied.single, isNot(contains('\n')));
   });
 }
 

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -949,6 +949,65 @@ void main() {
   });
 
   testWidgets(
+      'the Passwords view prints the queued sheets as a real PDF and opens it '
+      'for printing end-to-end (#195)', (WidgetTester tester) async {
+    // The real app, real fonts, real window. Printing used to drop browser-
+    // printable HTML into %TEMP% and leave the operator to go find it and print
+    // from a browser. It is a real PDF now, written outside temp and handed
+    // straight to the platform viewer — so drive it the way the operator does:
+    // pick the class, tick the whole column, generate, then press Print.
+    useTallWindow(tester);
+    final harness = ReconcileHarness(ssInitial: passwordsSnap());
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Passwords'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('password-class-3C')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-bulk-smartschool')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-generate')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-generate-confirm')));
+    await tester.pumpAndSettle();
+
+    // Both students of 3C were pushed, so both are queued for printing.
+    expect(harness.passwordBackends.smartschoolPushes, hasLength(2));
+    final printButton = find.byKey(const ValueKey('passwords-export-students'));
+    await tester.ensureVisible(printButton);
+    expect(tester.widget<OutlinedButton>(printButton).onPressed, isNotNull);
+
+    await tester.tap(printButton);
+    await tester.pumpAndSettle();
+
+    // One real PDF document, one page per queued student, under a .pdf name.
+    expect(harness.passwordWrites, hasLength(1));
+    final String name = harness.passwordWrites.single.$1;
+    final List<int> bytes = harness.passwordWrites.single.$2;
+    expect(name, 'leerling-wachtwoorden.pdf');
+    expect(latin1.decode(bytes.sublist(0, 5)), '%PDF-');
+    expect(
+      RegExp(r'/Type\s*/Page(?!s)').allMatches(latin1.decode(bytes)),
+      hasLength(2),
+      reason: 'one page per student, as the sheets are handed out per person',
+    );
+
+    // It was opened for printing, and the operator is told where it went.
+    expect(harness.passwordOpens, hasLength(1));
+    expect(harness.passwordOpens.single, endsWith(name));
+    expect(find.byKey(const ValueKey('passwords-message')), findsOneWidget);
+    expect(find.textContaining('geopend'), findsOneWidget);
+
+    // The queue drained only after the export succeeded, so the button is spent.
+    expect(tester.widget<OutlinedButton>(printButton).onPressed, isNull);
+  });
+
+  testWidgets(
       'the Smartschool address action only fires on a real field drift and its '
       'diff shows the differing field, not an identical row (#153)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -37,7 +37,9 @@ import 'package:account_state/account_state.dart'
 import 'package:azure_api/azure_api.dart'
     show AzureCredentials, StaticAuthProvider;
 import 'package:wisa_api/wisa_api.dart' show WisaSchool;
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:plink_design_system/plink_design_system.dart';
@@ -1988,6 +1990,88 @@ void main() {
     expect(find.text('Anna Smit'), findsOneWidget);
     expect(find.text('Clara Smit'), findsNothing);
     expect(find.text('Bram Jansen'), findsNothing);
+  });
+
+  testWidgets(
+      'the operator drag-selects two log lines and copies them one per line, '
+      'then Copy all takes the whole buffer end-to-end (#193)',
+      (WidgetTester tester) async {
+    // The real app composition — real fonts, real window, real text layout —
+    // is where a "selectable" log panel drifts: the line metrics a drag is
+    // resolved against come from the real font, and the copy path runs through
+    // the real SelectionArea/shortcut plumbing, not a widget-test stub.
+    final List<String> copied = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (MethodCall call) async {
+        if (call.method == 'Clipboard.setData') {
+          final args = call.arguments as Map<Object?, Object?>;
+          copied.add(args['text']! as String);
+        }
+        return null;
+      },
+    );
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null));
+
+    useTallWindow(tester);
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+
+    // A real pass fills the panel; then a known tail so the drag has stable
+    // line contents to land on (the harness clock is fixed at 00:00:00).
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.log.entries, isNotEmpty);
+    harness.log
+      ..addError(Origin.smartschool, 'Set-Password failed: rc=42')
+      ..addMessage(Origin.azure, 'Ready.');
+    await tester.pumpAndSettle();
+
+    // Newest first, so the two lines just added are the top two on screen.
+    final Finder block = find.byKey(const ValueKey('reconcile-log-text'));
+    expect(block, findsOneWidget);
+    final List<String> onScreen =
+        tester.widget<Text>(block).textSpan!.toPlainText().split('\n');
+    expect(onScreen.first, '00:00:00  [azure]  Ready.');
+    expect(onScreen[1], '00:00:00  [smartschool]  Set-Password failed: rc=42');
+
+    // Drag across those two lines with the mouse and hit Ctrl+C.
+    final Rect rect = tester.getRect(block);
+    final double lineHeight = rect.height / onScreen.length;
+    final TestGesture drag = await tester.startGesture(
+      Offset(rect.left + 1, rect.top + lineHeight * 0.5),
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pump();
+    await drag.moveTo(Offset(rect.right - 1, rect.top + lineHeight * 1.5));
+    await tester.pump();
+    await drag.up();
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyC);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pumpAndSettle();
+
+    expect(copied, hasLength(1));
+    expect(copied.single, '${onScreen.first}\n${onScreen[1]}');
+
+    // Copy all reaches past what is laid out: the whole buffer, oldest first.
+    await tester.tap(find.byKey(const ValueKey('reconcile-log-copy-all')));
+    await tester.pumpAndSettle();
+    expect(copied.last, harness.log.toPlainText());
+    expect(copied.last.split('\n'), hasLength(harness.log.entries.length));
+    expect(copied.last.split('\n').length, greaterThan(2));
+    expect(copied.last, endsWith('00:00:00  [azure]  Ready.'));
   });
 }
 

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -21,6 +21,7 @@ import 'package:account_state/account_state.dart'
         ChangeSignal,
         InMemoryLinkedStore,
         InMemorySignalHub,
+        MaterializedAccount,
         SecretRef,
         SignalRConfig,
         SignalRRequest,
@@ -372,6 +373,101 @@ void main() {
     expect(systems[Origin.wisa]?.at, kFixtureDate);
     expect(systems[Origin.smartschool]?.at, driftAt);
     expect(systems[Origin.azure]?.at, driftAt);
+  });
+
+  testWidgets(
+      'the last-sync box dates a row that is not from today end-to-end: today '
+      "stays time-only, yesterday reads 'gisteren', an older one carries the "
+      'date (#192)', (WidgetTester tester) async {
+    // The real app, real fonts, real window: the three systems are stamped on
+    // three different calendar days. Time-only rendered all three identically,
+    // so a WISA pull from last year was indistinguishable from this morning's
+    // — the freshness check the operator makes before pressing
+    // Synchronise. Composition matters here: the status shares its row with a
+    // fixed-width name column and an icon, and a dated stamp is the longest
+    // text that row has ever carried.
+    useTallWindow(tester);
+    final DateTime now = DateTime.now();
+    final DateTime today = DateTime(now.year, now.month, now.day, 9, 14);
+    final DateTime yesterday = DateTime(now.year, now.month, now.day - 1, 8, 5);
+    final DateTime lastYear = DateTime(now.year - 1, 8, 15, 16, 40);
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(fetchedAt: today),
+      smartschool: ssSnap(fetchedAt: yesterday),
+      azure: azSnap(fetchedAt: lastYear),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    String rowText(String system) => tester
+        .widgetList<Text>(find.descendant(
+          of: find.byKey(ValueKey('reconcile-last-sync-$system')),
+          matching: find.byType(Text),
+        ))
+        .map((t) => t.data)
+        .whereType<String>()
+        .join(' ');
+
+    // Today: unchanged — the common case stays short.
+    expect(rowText('wisa'), contains('09:14'));
+    expect(rowText('wisa'), isNot(contains('/')));
+    expect(rowText('wisa'), isNot(contains('gisteren')));
+
+    // Yesterday and an older stamp are now readable as stale at a glance.
+    expect(rowText('smartschool'), contains('gisteren 08:05'));
+    expect(rowText('azure'), contains('15/08/${now.year - 1} 16:40'));
+
+    // The longer status still lays out on one line per row in the real font:
+    // the three rows stay stacked and none has collapsed into the next.
+    double rowTop(String system) => tester
+        .getTopLeft(find.byKey(ValueKey('reconcile-last-sync-$system')))
+        .dy;
+    expect(rowTop('wisa'), lessThan(rowTop('smartschool')));
+    expect(rowTop('smartschool'), lessThan(rowTop('azure')));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      "the Actions overview's freshness stamp carries the date once the shared "
+      'state is no longer from today end-to-end (#192)',
+      (WidgetTester tester) async {
+    // A passive session over a shared view that was materialized in the past.
+    // The header line used to read "Generatie 1 · 02:00 door …",
+    // which is exactly as reassuring as a stamp from five minutes ago.
+    useTallWindow(tester);
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+
+    // Derived independently of the production formatter: the store was stamped
+    // at kFixtureDate, which the operator reads on their own clock.
+    final DateTime t = kFixtureDate.toLocal();
+    final String dm = '${t.day.toString().padLeft(2, '0')}/'
+        '${t.month.toString().padLeft(2, '0')}';
+    final String hhmm = '${t.hour.toString().padLeft(2, '0')}:'
+        '${t.minute.toString().padLeft(2, '0')}';
+    expect(find.textContaining('Generatie 1 · $dm'), findsOneWidget);
+    expect(find.textContaining('Generatie 1 · $hhmm'), findsNothing,
+        reason: 'a stamp from a past day is never rendered as bare time');
   });
 
   testWidgets(

--- a/account_manager/lib/src/format/timestamps.dart
+++ b/account_manager/lib/src/format/timestamps.dart
@@ -1,0 +1,42 @@
+/// Formatting helpers for the freshness stamps the operator reads before
+/// deciding whether the shared state is current enough to act on.
+library;
+
+/// Renders [at] as the "when was this last touched" stamp shown on the
+/// Reconcile last-sync box and the Actions overview header (#192).
+///
+/// Time-only would make a sync from three days ago read exactly like one from
+/// this morning, which is the one case those stamps exist to surface. So the
+/// date is included as soon as the stamp leaves today, while today's — the
+/// common case — stays as short as it was:
+///
+/// * today             → `09:14`
+/// * yesterday         → `gisteren 09:14`
+/// * earlier this year → `15/08 09:14`
+/// * an earlier year   → `15/08/2025 09:14`
+///
+/// Both [at] and [now] are converted to local time before being compared, so a
+/// UTC stamp is bucketed against the operator's own calendar day. [now]
+/// defaults to the current time; tests pass a fixed clock.
+String formatFreshnessStamp(DateTime at, {DateTime? now}) {
+  final DateTime t = at.toLocal();
+  final DateTime n = (now ?? DateTime.now()).toLocal();
+
+  final String hhmm = '${t.hour.toString().padLeft(2, '0')}:'
+      '${t.minute.toString().padLeft(2, '0')}';
+
+  // Compare calendar days, not elapsed hours: 23:50 and 00:10 are a different
+  // day to the operator even though they are twenty minutes apart. Building the
+  // neighbouring day through the DateTime constructor (rather than subtracting
+  // a Duration) keeps it at local midnight across a DST shift.
+  final DateTime day = DateTime(t.year, t.month, t.day);
+  final DateTime today = DateTime(n.year, n.month, n.day);
+  if (day == today) return hhmm;
+  if (day == DateTime(n.year, n.month, n.day - 1)) return 'gisteren $hhmm';
+
+  final String dm = '${t.day.toString().padLeft(2, '0')}/'
+      '${t.month.toString().padLeft(2, '0')}';
+  // The year is only worth the width once the stamp leaves the current one.
+  final String date = t.year == n.year ? dm : '$dm/${t.year}';
+  return '$date $hhmm';
+}

--- a/account_manager/lib/src/passwords/password_controller.dart
+++ b/account_manager/lib/src/passwords/password_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart';
 import 'package:flutter/foundation.dart';
@@ -67,6 +69,7 @@ class PasswordController extends ChangeNotifier {
     required PasswordQueueStore queue,
     required PasswordBackends backends,
     PasswordFileWriter writer = writePasswordExport,
+    PasswordFileOpener opener = openPasswordExport,
     String Function() generatePassword = core.Password.create,
     String studentGroupName = 'Leerlingen',
     String staffGroupName = 'Personeel',
@@ -75,6 +78,7 @@ class PasswordController extends ChangeNotifier {
         _queue = queue,
         _backends = backends,
         _writer = writer,
+        _opener = opener,
         _generate = generatePassword,
         _log = log {
     _indexTree();
@@ -87,6 +91,7 @@ class PasswordController extends ChangeNotifier {
   final PasswordQueueStore _queue;
   final PasswordBackends _backends;
   final PasswordFileWriter _writer;
+  final PasswordFileOpener _opener;
   final String Function() _generate;
   final core.ILog? _log;
 
@@ -373,23 +378,32 @@ class PasswordController extends ChangeNotifier {
     ];
   }
 
-  /// Exports the queued student sheets to a printable HTML file, then drains
-  /// them from the shared queue (as legacy clears its list after an export).
-  /// Returns the written path.
+  /// Exports the queued student sheets as a printable PDF — one page per
+  /// student (#195) — drains them from the shared queue (as legacy clears its
+  /// list after an export), and opens the file so the operator can print
+  /// straight away. Returns the written path.
   Future<String> exportStudentSheets() async {
     final sheets = List<PasswordEntry>.of(_studentSheets);
     final path = await _writer(
-        'leerling-wachtwoorden.html', studentPasswordsHtml(sheets));
+      'leerling-wachtwoorden.pdf',
+      await studentPasswordsPdf(sheets),
+    );
     await _drain(sheets);
-    _message = 'Leerling-wachtwoorden bewaard: $path';
+    _message =
+        _exportMessage('Leerling-wachtwoorden', path, await _tryOpen(path));
     notifyListeners();
     return path;
   }
 
   /// Exports the queued co-account passwords to a CSV file, then drains them.
+  /// Not opened afterwards: unlike the sheets this file is fed to other tooling
+  /// rather than printed — it only moved out of the temp folder (#195).
   Future<String> exportCoAccounts() async {
     final sheets = List<PasswordEntry>.of(_coAccountSheets);
-    final path = await _writer('co-accounts.csv', coAccountsCsv(sheets));
+    final path = await _writer(
+      'co-accounts.csv',
+      utf8.encode(coAccountsCsv(sheets)),
+    );
     await _drain(sheets);
     _message = 'Co-account wachtwoorden bewaard: $path';
     notifyListeners();
@@ -407,6 +421,25 @@ class PasswordController extends ChangeNotifier {
     await _queue.save(remainder);
     await _reloadQueue();
   }
+
+  /// Opens [path] with the platform PDF viewer. Returns `null` on success, or
+  /// the failure text. By the time this runs the file is already written and
+  /// the queue already drained, so a viewer that will not launch costs the
+  /// operator one double-click — never the export itself (#195).
+  Future<String?> _tryOpen(String path) async {
+    try {
+      await _opener(path);
+      return null;
+    } on Object catch (e) {
+      _log?.addError(core.Origin.other, 'Kon "$path" niet openen: $e');
+      return '$e';
+    }
+  }
+
+  static String _exportMessage(String what, String path, String? openError) =>
+      openError == null
+          ? '$what bewaard en geopend: $path'
+          : '$what bewaard: $path — openen mislukt ($openError).';
 
   // --- Personeel tab ---------------------------------------------------------
 
@@ -489,8 +522,9 @@ class PasswordController extends ChangeNotifier {
 
   /// Resets the selected staff member's password(s): a fresh Smartschool and/or
   /// Office 365 password (when both are requested they share one password, as
-  /// legacy `NewPasswords` does), pushes them live, and exports a per-staff HTML
-  /// sheet. Returns the written path, or `null` when nothing was pushed.
+  /// legacy `NewPasswords` does), pushes them live, exports a one-page per-staff
+  /// PDF sheet and opens it for printing (#195). Returns the written path, or
+  /// `null` when nothing was pushed.
   Future<String?> resetStaff({
     required bool smartschool,
     required bool office365,
@@ -528,8 +562,8 @@ class PasswordController extends ChangeNotifier {
         return null;
       }
       final path = await _writer(
-        '${account.uid}.html',
-        staffPasswordHtml(
+        '${account.uid}.pdf',
+        await staffPasswordPdf(
           name: '${account.givenName} ${account.surname}'.trim(),
           username: account.uid,
           mail: account.mail,
@@ -537,9 +571,11 @@ class PasswordController extends ChangeNotifier {
           office365Password: azPw,
         ),
       );
-      _message = failed
-          ? 'Deels gezet — sheet bewaard: $path'
-          : 'Wachtwoord gezet en sheet bewaard: $path';
+      _message = _exportMessage(
+        failed ? 'Deels gezet — sheet' : 'Wachtwoord gezet en sheet',
+        path,
+        await _tryOpen(path),
+      );
       return path;
     } on Object catch (e) {
       _message = 'Reset mislukt: $e';

--- a/account_manager/lib/src/passwords/password_export.dart
+++ b/account_manager/lib/src/passwords/password_export.dart
@@ -1,35 +1,435 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:account_state/account_state.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
 
 /// Writes an export payload under [suggestedName] and returns the path it was
 /// written to. Injected so the Passwords screen can be driven headlessly (a
 /// test records the calls) while production writes real files to disk.
+///
+/// Takes bytes rather than a string because the printable sheets are PDFs
+/// (#195); the co-account CSV is UTF-8 encoded by the caller.
 typedef PasswordFileWriter = Future<String> Function(
   String suggestedName,
-  String content,
+  List<int> bytes,
 );
 
-/// The default [PasswordFileWriter]: writes into a per-run `AccountManager`
-/// folder under the system temp directory and returns the absolute path. A
-/// timestamp prefix keeps successive exports from overwriting each other.
-Future<String> writePasswordExport(String suggestedName, String content) async {
-  final dir = Directory('${Directory.systemTemp.path}/AccountManager');
-  dir.createSync(recursive: true);
+/// Opens an already-written export with whatever the platform associates with
+/// its file type — for a password sheet, the PDF viewer, one keystroke away
+/// from the printer. Injected alongside [PasswordFileWriter] so a headless test
+/// records the call instead of launching a viewer.
+typedef PasswordFileOpener = Future<void> Function(String path);
+
+/// The directory password exports are written to.
+///
+/// Deliberately **not** the system temp directory (#195): cleartext password
+/// sheets are the most sensitive artefact this app produces, and `%TEMP%` is a
+/// place nothing owns and nothing cleans up. They land in a known, operator-
+/// owned folder instead — `Documents\AccountManager\Wachtwoorden` — which the
+/// operator can find, print from, and delete.
+String passwordExportDirectory() {
+  final String home = Platform.environment['USERPROFILE'] ??
+      Platform.environment['HOME'] ??
+      Directory.current.path;
+  final String sep = Platform.pathSeparator;
+  final Directory documents = Directory('$home${sep}Documents');
+  final String base = documents.existsSync() ? documents.path : home;
+  return '$base${sep}AccountManager${sep}Wachtwoorden';
+}
+
+/// The default [PasswordFileWriter]: writes into [passwordExportDirectory] and
+/// returns the absolute path. A timestamp prefix keeps successive exports from
+/// overwriting each other.
+Future<String> writePasswordExport(
+  String suggestedName,
+  List<int> bytes,
+) async {
+  final dir = Directory(passwordExportDirectory())..createSync(recursive: true);
   final stamp = DateTime.now()
       .toIso8601String()
       .replaceAll(':', '')
       .replaceAll('.', '')
       .replaceAll('-', '');
-  final file = File('${dir.path}/${stamp}_$suggestedName');
-  await file.writeAsString(content);
+  final file =
+      File('${dir.path}${Platform.pathSeparator}${stamp}_$suggestedName');
+  await file.writeAsBytes(bytes, flush: true);
   return file.path;
 }
+
+/// The default [PasswordFileOpener]: hands [path] to the platform default
+/// handler, so an exported sheet lands in the PDF viewer ready to print.
+///
+/// A plain process launch on purpose — the `printing` plugin would add native
+/// Windows code to the build for the same result.
+Future<void> openPasswordExport(String path) async {
+  final (String executable, List<String> arguments) =
+      switch (Platform.operatingSystem) {
+    // `start` needs an (empty) window-title argument before the file, else a
+    // quoted path is swallowed as the title.
+    'windows' => ('cmd', <String>['/c', 'start', '', path]),
+    'macos' => ('open', <String>[path]),
+    _ => ('xdg-open', <String>[path]),
+  };
+  final result = await Process.run(executable, arguments);
+  if (result.exitCode != 0) {
+    throw ProcessException(
+      executable,
+      arguments,
+      '${result.stderr}'.trim(),
+      result.exitCode,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sheet model
+// ---------------------------------------------------------------------------
+
+/// One `label: value` line of a [PasswordSheetBlock], rendered monospaced so
+/// the login and the password line up on the printed sheet.
+class PasswordSheetField {
+  const PasswordSheetField(this.label, this.value);
+
+  final String label;
+  final String value;
+}
+
+/// One section of a [PasswordSheet] — the Office 365, Smartschool, WiFi, or
+/// privacy block. A section that has no password to show is simply not built,
+/// which is how the sheets omit blocks.
+class PasswordSheetBlock {
+  const PasswordSheetBlock({
+    this.heading = '',
+    this.intro = const <String>[],
+    this.fields = const <PasswordSheetField>[],
+    this.notes = const <String>[],
+  });
+
+  /// The section heading. Empty for the leading login line, which sits directly
+  /// under the sheet title.
+  final String heading;
+
+  /// Prose shown above the fields ("Aanmelden via office.com.").
+  final List<String> intro;
+
+  /// The monospaced `label: value` lines.
+  final List<PasswordSheetField> fields;
+
+  /// Prose shown below the fields (the one-time-password note).
+  final List<String> notes;
+}
+
+/// One printed page: everything one person is handed on paper.
+class PasswordSheet {
+  const PasswordSheet({required this.title, required this.blocks});
+
+  final String title;
+  final List<PasswordSheetBlock> blocks;
+}
+
+const String _oneTimeNote = 'Dit is een eenmalig wachtwoord; kies zelf een '
+    'nieuw wachtwoord bij de eerste aanmelding.';
+
+/// The student sheets, one per queued entry, ported from the legacy
+/// `PasswordManager.exportToPDF` layout (#180) and kept identical in content
+/// and section order when the format became a real PDF (#195): the login, the
+/// Office 365 and Smartschool blocks (only for the passwords that were actually
+/// generated), a WiFi block, and a privacy note.
+List<PasswordSheet> studentPasswordSheets(Iterable<PasswordEntry> entries) {
+  final sheets = <PasswordSheet>[];
+  for (final e in entries) {
+    final klas = e.classGroup;
+    final title = klas != null && klas.isNotEmpty
+        ? 'Account voor ${e.displayName} - $klas'
+        : 'Account voor ${e.displayName}';
+    final blocks = <PasswordSheetBlock>[
+      PasswordSheetBlock(
+        fields: <PasswordSheetField>[
+          PasswordSheetField('Login', e.accountName),
+        ],
+      ),
+    ];
+    final azure = e.azurePassword;
+    if (azure != null && azure.isNotEmpty) {
+      blocks.add(PasswordSheetBlock(
+        heading: 'Office 365',
+        intro: const <String>['Aanmelden via office.com.'],
+        fields: <PasswordSheetField>[
+          PasswordSheetField('Login', e.mail ?? e.accountName),
+          PasswordSheetField('Wachtwoord', azure),
+        ],
+        notes: const <String>[_oneTimeNote],
+      ));
+    }
+    final ss = e.smartschoolPassword;
+    if (ss != null && ss.isNotEmpty) {
+      blocks.add(PasswordSheetBlock(
+        heading: 'Smartschool',
+        intro: const <String>['Aanmelden via de Smartschool-website of -app.'],
+        fields: <PasswordSheetField>[
+          PasswordSheetField('Login', e.accountName),
+          PasswordSheetField('Wachtwoord', ss),
+        ],
+        notes: const <String>[_oneTimeNote],
+      ));
+    }
+    blocks.add(const PasswordSheetBlock(
+      heading: 'WiFi',
+      fields: <PasswordSheetField>[
+        PasswordSheetField('Netwerk', 'Smifi-L'),
+        PasswordSheetField('Wachtwoord', 'SmifiDeWifi:)'),
+      ],
+    ));
+    blocks.add(const PasswordSheetBlock(
+      heading: 'Privacy',
+      notes: <String>[
+        'Hou je wachtwoord geheim en deel het met niemand — ook niet met '
+            'leerkrachten.',
+      ],
+    ));
+    sheets.add(PasswordSheet(title: title, blocks: blocks));
+  }
+  return sheets;
+}
+
+/// The single-staff sheet, ported from legacy `ExportStaffPasswordToPDF`
+/// (#180). A `null` password omits that whole block, which is how the three
+/// staff reset buttons choose which sections appear.
+PasswordSheet staffPasswordSheet({
+  required String name,
+  required String username,
+  required String mail,
+  String? smartschoolPassword,
+  String? office365Password,
+}) {
+  final blocks = <PasswordSheetBlock>[];
+  if (office365Password != null && office365Password.isNotEmpty) {
+    blocks.add(PasswordSheetBlock(
+      heading: 'Office 365',
+      fields: <PasswordSheetField>[
+        PasswordSheetField('Login', mail),
+        PasswordSheetField('Wachtwoord', office365Password),
+      ],
+      notes: const <String>[_oneTimeNote],
+    ));
+  }
+  blocks.add(const PasswordSheetBlock(
+    heading: 'WiFi',
+    fields: <PasswordSheetField>[
+      PasswordSheetField('Netwerk', 'Smifi-P'),
+      PasswordSheetField('Code', '!TEAM!SMA!'),
+    ],
+  ));
+  if (smartschoolPassword != null && smartschoolPassword.isNotEmpty) {
+    blocks.add(PasswordSheetBlock(
+      heading: 'Smartschool',
+      fields: <PasswordSheetField>[
+        PasswordSheetField('Login', username),
+        PasswordSheetField('Wachtwoord', smartschoolPassword),
+      ],
+      notes: const <String>[_oneTimeNote],
+    ));
+  }
+  blocks.add(const PasswordSheetBlock(
+    heading: 'Privacy',
+    notes: <String>[
+      'Hou je wachtwoord geheim en deel het met niemand — ook niet aan '
+          "collega's.",
+    ],
+  ));
+  return PasswordSheet(title: 'Account voor $name', blocks: blocks);
+}
+
+// ---------------------------------------------------------------------------
+// PDF rendering
+// ---------------------------------------------------------------------------
+
+/// The three typefaces a sheet is set in.
+///
+/// The PDF base-14 faces (Helvetica / Courier) only carry Latin-1, so every
+/// Turkish, Polish, or Croatian name — the names this school hands sheets to
+/// every September — would print as a row of empty boxes. The design system
+/// already ships Latin-Extended faces with the app, so the sheets are typeset
+/// in the product's own fonts and no extra binary joins the repo.
+class PasswordSheetFonts {
+  const PasswordSheetFonts({
+    required this.body,
+    required this.heading,
+    required this.mono,
+  });
+
+  /// Prose: the intro lines and the one-time-password / privacy notes.
+  final pw.Font body;
+
+  /// The sheet title and the section headings.
+  final pw.Font heading;
+
+  /// The `label : value` credential lines, so login and password line up.
+  final pw.Font mono;
+
+  static const String _bodyAsset =
+      'packages/plink_design_system/fonts/hanken-grotesk/'
+      'HankenGrotesk-Variable.ttf';
+  static const String _headingAsset =
+      'packages/plink_design_system/fonts/space-mono/SpaceMono-Bold.ttf';
+  static const String _monoAsset =
+      'packages/plink_design_system/fonts/space-mono/SpaceMono-Regular.ttf';
+
+  static PasswordSheetFonts? _cached;
+
+  /// The PDF base-14 faces. Latin-1 only — used solely as the last-resort
+  /// stand-in when the bundled fonts cannot be read, because a sheet with a
+  /// mangled name still beats no sheet at all.
+  static PasswordSheetFonts fallback() => PasswordSheetFonts(
+        body: pw.Font.helvetica(),
+        heading: pw.Font.helveticaBold(),
+        mono: pw.Font.courier(),
+      );
+
+  /// Reads the bundled faces once and caches them: parsing a TrueType file per
+  /// export would be paid on every print.
+  static Future<PasswordSheetFonts> load() async {
+    final cached = _cached;
+    if (cached != null) return cached;
+    try {
+      return _cached = PasswordSheetFonts(
+        body: pw.Font.ttf(await rootBundle.load(_bodyAsset)),
+        heading: pw.Font.ttf(await rootBundle.load(_headingAsset)),
+        mono: pw.Font.ttf(await rootBundle.load(_monoAsset)),
+      );
+    } on Object {
+      return fallback();
+    }
+  }
+}
+
+/// Renders [sheets] as an A4 PDF, one page per sheet.
+///
+/// Typeset in [PasswordSheetFonts.load]'s bundled faces unless [fonts] says
+/// otherwise. [compress] is a test seam: with it off the page content streams
+/// stay plain text, so a unit test can read what was actually drawn —
+/// production always ships the compressed document.
+Future<Uint8List> passwordSheetsPdf(
+  List<PasswordSheet> sheets, {
+  required String title,
+  bool compress = true,
+  PasswordSheetFonts? fonts,
+}) async {
+  final faces = fonts ?? await PasswordSheetFonts.load();
+  final doc = pw.Document(title: title, compress: compress);
+  if (sheets.isEmpty) {
+    // Never emit a page-less PDF: viewers refuse to open one, and the operator
+    // would be left staring at an error instead of an empty sheet.
+    doc.addPage(pw.Page(
+      pageFormat: PdfPageFormat.a4,
+      margin: const pw.EdgeInsets.all(40),
+      build: (context) => pw.Text(
+        'Geen wachtwoorden om af te drukken.',
+        style: pw.TextStyle(font: faces.body, fontSize: 11),
+      ),
+    ));
+  }
+  for (final sheet in sheets) {
+    doc.addPage(pw.Page(
+      pageFormat: PdfPageFormat.a4,
+      margin: const pw.EdgeInsets.all(40),
+      build: (context) => _sheetColumn(sheet, faces),
+    ));
+  }
+  return doc.save();
+}
+
+/// The student sheets as a PDF — one page per student.
+Future<Uint8List> studentPasswordsPdf(Iterable<PasswordEntry> entries) =>
+    passwordSheetsPdf(
+      studentPasswordSheets(entries),
+      title: 'Leerling-wachtwoorden',
+    );
+
+/// A single staff member sheet as a one-page PDF.
+Future<Uint8List> staffPasswordPdf({
+  required String name,
+  required String username,
+  required String mail,
+  String? smartschoolPassword,
+  String? office365Password,
+}) =>
+    passwordSheetsPdf(
+      <PasswordSheet>[
+        staffPasswordSheet(
+          name: name,
+          username: username,
+          mail: mail,
+          smartschoolPassword: smartschoolPassword,
+          office365Password: office365Password,
+        ),
+      ],
+      title: 'Personeelswachtwoord — $name',
+    );
+
+pw.Widget _sheetColumn(PasswordSheet sheet, PasswordSheetFonts fonts) {
+  final children = <pw.Widget>[
+    pw.Text(sheet.title,
+        style: pw.TextStyle(font: fonts.heading, fontSize: 16)),
+    pw.Divider(thickness: 1),
+  ];
+  for (final block in sheet.blocks) {
+    if (block.heading.isNotEmpty) {
+      children.add(pw.SizedBox(height: 14));
+      children.add(pw.Text(
+        block.heading,
+        style: pw.TextStyle(font: fonts.heading, fontSize: 12),
+      ));
+      children.add(pw.SizedBox(height: 4));
+    }
+    for (final line in block.intro) {
+      children.add(pw.Text(
+        line,
+        style: pw.TextStyle(font: fonts.body, fontSize: 11),
+      ));
+      children.add(pw.SizedBox(height: 4));
+    }
+    // Pad the labels so `Login` and `Wachtwoord` line up under each other, the
+    // way the legacy <pre> block did.
+    final width = block.fields.fold<int>(
+      0,
+      (widest, f) => f.label.length > widest ? f.label.length : widest,
+    );
+    for (final field in block.fields) {
+      children.add(pw.Text(
+        '${field.label.padRight(width)} : ${field.value}',
+        style: pw.TextStyle(font: fonts.mono, fontSize: 11),
+      ));
+    }
+    if (block.notes.isNotEmpty) {
+      children.add(pw.SizedBox(height: 4));
+    }
+    for (final note in block.notes) {
+      children.add(pw.Text(
+        note,
+        style: pw.TextStyle(font: fonts.body, fontSize: 11),
+      ));
+    }
+  }
+  return pw.Column(
+    crossAxisAlignment: pw.CrossAxisAlignment.start,
+    children: children,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Co-account CSV
+// ---------------------------------------------------------------------------
 
 /// The co-account CSV, ported from legacy `PasswordManager.exportToCSV`
 /// (#180): a `;`-separated file with a header row and one row per co-account
 /// entry, columns `Gebruikersnaam;Naam;Klas;CoAccount1..CoAccount6`. Slots that
 /// were not regenerated are left blank.
+///
+/// Stays a CSV on purpose (#195) — it is fed to other tooling, not printed.
 String coAccountsCsv(Iterable<PasswordEntry> entries) {
   final lines = <String>[
     'Gebruikersnaam;Naam;Klas;CoAccount1;CoAccount2;CoAccount3;'
@@ -47,109 +447,6 @@ String coAccountsCsv(Iterable<PasswordEntry> entries) {
   }
   return '${lines.join('\n')}\n';
 }
-
-/// A printable HTML sheet with one section per student, ported from the legacy
-/// `PasswordManager.exportToPDF` layout (#180) but rendered as browser-printable
-/// HTML — the operator opens it and prints, avoiding a native PDF dependency.
-/// Each section shows the login, the Office 365 and Smartschool blocks (only
-/// for the passwords that were generated), a WiFi block, and a privacy note.
-String studentPasswordsHtml(Iterable<PasswordEntry> entries) {
-  final sections = <String>[];
-  for (final e in entries) {
-    final buf = StringBuffer()
-      ..writeln('<section>')
-      ..writeln(
-          '<h1>Account voor ${_html(e.displayName)}${e.classGroup != null && e.classGroup!.isNotEmpty ? ' - ${_html(e.classGroup!)}' : ''}</h1>')
-      ..writeln('<pre>Login     : ${_html(e.accountName)}</pre>');
-    final azure = e.azurePassword;
-    if (azure != null && azure.isNotEmpty) {
-      buf
-        ..writeln('<h2>Office 365</h2>')
-        ..writeln('<p>Aanmelden via office.com.</p>')
-        ..writeln(
-            '<pre>Login     : ${_html(e.mail ?? e.accountName)}\nWachtwoord: ${_html(azure)}</pre>')
-        ..writeln('<p>Dit is een eenmalig wachtwoord; kies zelf een nieuw '
-            'wachtwoord bij de eerste aanmelding.</p>');
-    }
-    final ss = e.smartschoolPassword;
-    if (ss != null && ss.isNotEmpty) {
-      buf
-        ..writeln('<h2>Smartschool</h2>')
-        ..writeln('<p>Aanmelden via de Smartschool-website of -app.</p>')
-        ..writeln(
-            '<pre>Login     : ${_html(e.accountName)}\nWachtwoord: ${_html(ss)}</pre>')
-        ..writeln('<p>Dit is een eenmalig wachtwoord; kies zelf een nieuw '
-            'wachtwoord bij de eerste aanmelding.</p>');
-    }
-    buf
-      ..writeln('<h2>WiFi</h2>')
-      ..writeln('<pre>Netwerk   : Smifi-L\nWachtwoord: SmifiDeWifi:)</pre>')
-      ..writeln('<h2>Privacy</h2>')
-      ..writeln('<p>Hou je wachtwoord geheim en deel het met niemand — ook '
-          'niet met leerkrachten.</p>')
-      ..writeln('</section>');
-    sections.add(buf.toString());
-  }
-  return _htmlDocument('Leerling-wachtwoorden', sections.join('\n'));
-}
-
-/// A single-staff printable HTML sheet, ported from legacy
-/// `ExportStaffPasswordToPDF` (#180). A `null` password omits that whole block,
-/// which is how the three staff reset buttons choose which sections appear.
-String staffPasswordHtml({
-  required String name,
-  required String username,
-  required String mail,
-  String? smartschoolPassword,
-  String? office365Password,
-}) {
-  final buf = StringBuffer()
-    ..writeln('<section>')
-    ..writeln('<h1>Account voor ${_html(name)}</h1>');
-  if (office365Password != null && office365Password.isNotEmpty) {
-    buf
-      ..writeln('<h2>Office 365</h2>')
-      ..writeln(
-          '<pre>Login     : ${_html(mail)}\nWachtwoord: ${_html(office365Password)}</pre>')
-      ..writeln('<p>Dit is een eenmalig wachtwoord; kies zelf een nieuw '
-          'wachtwoord bij de eerste aanmelding.</p>');
-  }
-  buf
-    ..writeln('<h2>WiFi</h2>')
-    ..writeln('<pre>Netwerk   : Smifi-P\nCode      : !TEAM!SMA!</pre>');
-  if (smartschoolPassword != null && smartschoolPassword.isNotEmpty) {
-    buf
-      ..writeln('<h2>Smartschool</h2>')
-      ..writeln(
-          '<pre>Login     : ${_html(username)}\nWachtwoord: ${_html(smartschoolPassword)}</pre>')
-      ..writeln('<p>Dit is een eenmalig wachtwoord; kies zelf een nieuw '
-          'wachtwoord bij de eerste aanmelding.</p>');
-  }
-  buf
-    ..writeln('<h2>Privacy</h2>')
-    ..writeln('<p>Hou je wachtwoord geheim en deel het met niemand — ook '
-        'niet aan collega\'s.</p>')
-    ..writeln('</section>');
-  return _htmlDocument('Personeelswachtwoord — $name', buf.toString());
-}
-
-String _htmlDocument(String title, String body) => '<!doctype html>\n'
-    '<html lang="nl"><head><meta charset="utf-8">'
-    '<title>${_html(title)}</title>'
-    '<style>body{font-family:sans-serif;margin:2rem;}'
-    'section{page-break-after:always;margin-bottom:2rem;}'
-    'h1{font-size:1.4rem;border-bottom:1px solid #333;}'
-    'pre{font-family:monospace;font-size:1rem;}</style>'
-    '</head><body>\n$body\n</body></html>\n';
-
-/// Escapes the five XML/HTML special characters. Passwords only ever contain
-/// `!?*`, letters, and digits, but names may carry `&`/`<`/`>`.
-String _html(String s) => s
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
 
 /// Escapes a CSV cell for the `;`-separated legacy format: a cell containing a
 /// separator, quote, or newline is quoted with doubled inner quotes.

--- a/account_manager/lib/src/reconcile/log_buffer.dart
+++ b/account_manager/lib/src/reconcile/log_buffer.dart
@@ -14,6 +14,18 @@ class LogEntry {
   final Origin origin;
   final String message;
   final bool isError;
+
+  /// The entry as one plain-text line — `HH:mm:ss  [origin]  message`.
+  ///
+  /// This is both what the panel renders and what a copy puts on the clipboard
+  /// (#193), deliberately in one place: an operator pasting a log excerpt into
+  /// a support ticket must be quoting exactly what they read on screen.
+  String get line {
+    final String hhmmss = '${time.hour.toString().padLeft(2, '0')}:'
+        '${time.minute.toString().padLeft(2, '0')}:'
+        '${time.second.toString().padLeft(2, '0')}';
+    return '$hhmmss  [${origin.name}]  $message';
+  }
 }
 
 /// The app's [ILog] sink: an in-memory, notifying buffer the inline log panel
@@ -36,6 +48,14 @@ class LogBuffer extends ChangeNotifier implements ILog {
   List<LogEntry> get entries => List.unmodifiable(_entries);
 
   bool get hasErrors => _entries.any((e) => e.isError);
+
+  /// The whole buffer as plain text, oldest first, one [LogEntry.line] per
+  /// line — what the panel's **Copy all** writes to the clipboard (#193).
+  ///
+  /// Reads the entries rather than the rendered selection on purpose: the
+  /// panel only lays out what fits, so a selection can never reach the older
+  /// end of a [capacity]-entry buffer.
+  String toPlainText() => _entries.map((LogEntry e) => e.line).join('\n');
 
   @override
   void addMessage(Origin origin, String message) =>

--- a/account_manager/lib/src/reconcile/log_buffer.dart
+++ b/account_manager/lib/src/reconcile/log_buffer.dart
@@ -28,6 +28,29 @@ class LogEntry {
   }
 }
 
+/// Which entry a [characterOffset] into the panel's rendered paragraph falls
+/// in (#197).
+///
+/// The panel renders its entries as a *single* selectable paragraph — one
+/// [LogEntry.line] per line, joined by newlines (#193) — because a
+/// `SelectionArea` over per-row widgets concatenates them with no separator
+/// and would copy a multi-line selection as one blob. That leaves no widget
+/// per row to hang a per-line action on, so the line under the pointer is
+/// resolved from the paragraph itself: the entry index is how many newlines
+/// precede the character the pointer landed on.
+///
+/// Counting newlines rather than dividing a hit by a line height is what makes
+/// this survive soft wrapping: a message wider than the panel occupies several
+/// visual rows but is still one entry.
+int logEntryIndexAt(String paragraph, int characterOffset) {
+  final int end = characterOffset.clamp(0, paragraph.length);
+  var index = 0;
+  for (var i = 0; i < end; i++) {
+    if (paragraph.codeUnitAt(i) == 0x0a) index++;
+  }
+  return index;
+}
+
 /// The app's [ILog] sink: an in-memory, notifying buffer the inline log panel
 /// renders (#99). Wired into the connectors at bootstrap and used by the
 /// reconcile controller for its own progress messages, so every diagnostic in

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -8,6 +8,7 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 import '../auth/aad_app_config.dart';
 import '../auth/sign_in_session.dart';
 import '../passwords/password_backends.dart';
+import '../passwords/password_export.dart';
 import 'log_buffer.dart';
 import 'reconcile_controller.dart';
 
@@ -90,6 +91,8 @@ class ReconcileServices {
     required this.log,
     required this.passwordQueue,
     required this.passwordBackends,
+    this.passwordFileWriter = writePasswordExport,
+    this.passwordFileOpener = openPasswordExport,
   });
 
   final AppSettings settings;
@@ -109,6 +112,15 @@ class ReconcileServices {
   /// the Smartschool and Azure connectors. Wired to [ConnectorPasswordBackends]
   /// in production; the offline harness substitutes a recording fake.
   final PasswordBackends passwordBackends;
+
+  /// Where an exported password sheet is written (#195). Defaults to the real
+  /// file writer; a headless test substitutes a recorder so driving the export
+  /// button never puts cleartext passwords on the test machine's disk.
+  final PasswordFileWriter passwordFileWriter;
+
+  /// How a written sheet is opened for printing (#195). Defaults to the
+  /// platform PDF viewer; a headless test records the call instead.
+  final PasswordFileOpener passwordFileOpener;
 }
 
 /// A configuration problem the operator can act on (missing secret, malformed

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -6,6 +6,7 @@ import 'package:account_state/account_state.dart'
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
+import '../format/timestamps.dart';
 import '../reconcile/reconcile_bootstrap.dart';
 import '../reconcile/reconcile_controller.dart';
 
@@ -695,10 +696,9 @@ class _DrillDownSection extends StatelessWidget {
     final state = controller.syncState;
     if (state.generation == 0) return null;
     final at = state.updatedAt;
-    final when = at == null
-        ? ''
-        : ' · ${at.toLocal().hour.toString().padLeft(2, '0')}:'
-            '${at.toLocal().minute.toString().padLeft(2, '0')}';
+    // Same dated stamp as the Reconcile last-sync box (#192): time-only made
+    // a generation from last week look like one from this morning.
+    final when = at == null ? '' : ' · ${formatFreshnessStamp(at)}';
     final who = state.updatedBy == null || state.updatedBy!.isEmpty
         ? ''
         : ' door ${state.updatedBy}';

--- a/account_manager/lib/src/screens/passwords_screen.dart
+++ b/account_manager/lib/src/screens/passwords_screen.dart
@@ -18,10 +18,10 @@ import '../reconcile/reconcile_bootstrap.dart';
 ///   class loads its accounts into a grid of per-target checkboxes (Smartschool,
 ///   Office 365, CoAccount 1–6). A guarded "Genereer wachtwoorden" pushes a
 ///   fresh password live for each checked target and queues the result for the
-///   printable student sheet (PDF-style HTML) and the co-account CSV.
+///   printable student sheet (a real PDF, #195) and the co-account CSV.
 /// - **Personeel**: the "Personeel" group, filterable by name/username; a
 ///   per-member reset mints a fresh Smartschool and/or Office 365 password,
-///   pushes it live, and exports a per-staff sheet.
+///   pushes it live, and exports a per-staff PDF sheet.
 ///
 /// Shares the one memoized [ReconcileServices] with the Reconcile and Actions
 /// screens, so the class/staff tree comes from the same synced Smartschool
@@ -74,6 +74,8 @@ class _PasswordsScreenState extends State<PasswordsScreen> {
         snapshot: services.app.smartschool.snapshot,
         queue: services.passwordQueue,
         backends: services.passwordBackends,
+        writer: services.passwordFileWriter,
+        opener: services.passwordFileOpener,
         log: services.log,
       );
       await controller.loadQueue();

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -5,6 +5,7 @@ import 'package:account_state/account_state.dart' show SystemSyncMeta;
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
+import '../format/timestamps.dart';
 import '../reconcile/log_buffer.dart';
 import '../reconcile/reconcile_bootstrap.dart';
 import '../reconcile/reconcile_controller.dart';
@@ -320,9 +321,11 @@ class _LastSyncBox extends StatelessWidget {
 }
 
 /// One system's row inside the [_LastSyncBox]: a fixed-width name column so the
-/// three statuses line up, then the sync/drift icon and a "kind · time · by who"
-/// status. A system that has never been synced shows a muted placeholder rather
-/// than being dropped, so all three systems are always accounted for.
+/// three statuses line up, then the sync/drift icon and a
+/// "kind · when · by who" status, where the stamp is dated as soon as it
+/// leaves today (#192). A system that has never been synced shows a muted
+/// placeholder rather than being dropped, so all three systems are always
+/// accounted for.
 class _SystemRow extends StatelessWidget {
   const _SystemRow({
     required this.system,
@@ -346,12 +349,13 @@ class _SystemRow extends StatelessWidget {
     if (meta == null) {
       status = 'not synced yet';
     } else {
-      final DateTime t = meta.at.toLocal();
-      final String hhmm = '${t.hour.toString().padLeft(2, '0')}:'
-          '${t.minute.toString().padLeft(2, '0')}';
+      // Dated as soon as it leaves today (#192): a stamp from three days ago
+      // must not read like this morning's, since a stale row is exactly what
+      // this box exists to surface.
+      final String when = formatFreshnessStamp(meta.at);
       final String kind = isSync ? 'sync' : 'drift check';
       final String by = meta.syncedBy.isEmpty ? '' : ' · by ${meta.syncedBy}';
-      status = '$kind · $hhmm$by';
+      status = '$kind · $when$by';
     }
 
     return Padding(

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart' show SystemSyncMeta;
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
@@ -774,29 +775,115 @@ class _LogResizeHandle extends StatelessWidget {
   }
 }
 
-class _LogPanel extends StatelessWidget {
+class _LogPanel extends StatefulWidget {
   const _LogPanel({required this.log, required this.height});
 
   final LogBuffer log;
   final double height;
+
+  @override
+  State<_LogPanel> createState() => _LogPanelState();
+}
+
+class _LogPanelState extends State<_LogPanel> {
+  /// Anchors the rendered paragraph so a right-click can be resolved back to
+  /// the entry underneath it (#197).
+  ///
+  /// It sits on a [KeyedSubtree] around the paragraph rather than on the [Text]
+  /// itself, which keeps `reconcile-log-text` the plain [ValueKey] #193 left.
+  final GlobalKey _paragraphKey = GlobalKey();
+
+  static void _copy(String text) {
+    unawaited(Clipboard.setData(ClipboardData(text: text)));
+  }
 
   /// Puts the whole buffer on the clipboard, oldest first (#193).
   ///
   /// Reads [LogBuffer.toPlainText] rather than the on-screen selection: only
   /// what fits the panel is laid out, so a selection can never cover all 500
   /// entries a long reconcile pass leaves behind.
-  static void _copyAll(LogBuffer log) {
-    unawaited(Clipboard.setData(ClipboardData(text: log.toPlainText())));
+  void _copyAll() => _copy(widget.log.toPlainText());
+
+  /// The paragraph's render object, or `null` before it has been laid out.
+  ///
+  /// Descends instead of casting whatever the key points at: [Text] wraps its
+  /// [RichText] in semantics and selection plumbing, so the [RenderParagraph]
+  /// is not necessarily the topmost render object under the key.
+  static RenderParagraph? _firstParagraph(RenderObject? node) {
+    if (node is RenderParagraph) return node;
+    RenderParagraph? found;
+    node?.visitChildren((RenderObject child) {
+      found ??= _firstParagraph(child);
+    });
+    return found;
+  }
+
+  /// Which rendered entry sits under a global [position], or `null` when the
+  /// pointer is not over the paragraph at all — right-clicking the empty space
+  /// under a short log has no line to copy (#197).
+  int? _entryIndexAt(Offset position) {
+    final RenderParagraph? paragraph =
+        _firstParagraph(_paragraphKey.currentContext?.findRenderObject());
+    if (paragraph == null || !paragraph.hasSize) return null;
+    final Offset local = paragraph.globalToLocal(position);
+    if (!(Offset.zero & paragraph.size).contains(local)) return null;
+    return logEntryIndexAt(
+      paragraph.text.toPlainText(),
+      paragraph.getPositionForOffset(local).offset,
+    );
+  }
+
+  /// The panel's right-click menu: the framework's own items plus **Copy
+  /// line**, which takes the single entry under the pointer (#197).
+  ///
+  /// Grabbing one message was already possible — the entries render as one
+  /// paragraph (#193), so a triple-click selects exactly one line — but
+  /// nothing on screen said so, which is what this makes visible. The line
+  /// index has to come from the paragraph's own text, because that single
+  /// paragraph is precisely what leaves no per-row widget to hang a hover
+  /// button on: SelectionArea concatenates separate selectables with no
+  /// separator, so a widget per entry would copy a multi-line selection as one
+  /// unreadable blob.
+  Widget _contextMenu(
+    BuildContext context,
+    SelectableRegionState region,
+    List<LogEntry> entries,
+  ) {
+    // Read once and hold on to it: SelectableRegionState clears the
+    // right-click position the first time contextMenuAnchors is read.
+    final TextSelectionToolbarAnchors anchors = region.contextMenuAnchors;
+    final List<ContextMenuButtonItem> items = <ContextMenuButtonItem>[
+      ...region.contextMenuButtonItems,
+    ];
+    final int? index = _entryIndexAt(anchors.primaryAnchor);
+    if (index != null && index < entries.length) {
+      final LogEntry entry = entries[index];
+      items.insert(
+        0,
+        ContextMenuButtonItem(
+          label: 'Copy line',
+          onPressed: () {
+            region.hideToolbar();
+            _copy(entry.line);
+          },
+        ),
+      );
+    }
+    return AdaptiveTextSelectionToolbar.buttonItems(
+      anchors: anchors,
+      buttonItems: items,
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     final ColorScheme colors = Theme.of(context).colorScheme;
+    final LogBuffer log = widget.log;
 
     return SizedBox(
       key: const ValueKey('reconcile-log-panel'),
-      height: height,
+      height: widget.height,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
@@ -819,7 +906,7 @@ class _LogPanel extends StatelessWidget {
                       children: <Widget>[
                         TextButton(
                           key: const ValueKey('reconcile-log-copy-all'),
-                          onPressed: empty ? null : () => _copyAll(log),
+                          onPressed: empty ? null : _copyAll,
                           child: const Text('Copy all'),
                         ),
                         TextButton(
@@ -858,29 +945,38 @@ class _LogPanel extends StatelessWidget {
                 // thing an operator is pasting into a support ticket. Keeping
                 // the newlines inside a single paragraph makes the copy line
                 // per entry, and makes triple-click select exactly one entry;
-                // per-entry spans keep the error colour.
+                // per-entry spans keep the error colour. The per-line copy
+                // affordance (#197) therefore hangs off the context menu, with
+                // the line resolved from the paragraph's own text.
                 return SelectionArea(
+                  contextMenuBuilder:
+                      (BuildContext context, SelectableRegionState region) =>
+                          _contextMenu(context, region, entries),
                   child: SingleChildScrollView(
                     padding: const EdgeInsets.symmetric(
                       horizontal: PlinkSpacing.s4,
                       vertical: PlinkSpacing.s2,
                     ),
-                    child: Text.rich(
-                      TextSpan(
-                        children: <InlineSpan>[
-                          for (int i = 0; i < entries.length; i++)
-                            TextSpan(
-                              text: i == entries.length - 1
-                                  ? entries[i].line
-                                  : '${entries[i].line}\n',
-                              style: entries[i].isError
-                                  ? TextStyle(color: colors.error)
-                                  : null,
-                            ),
-                        ],
+                    child: KeyedSubtree(
+                      key: _paragraphKey,
+                      child: Text.rich(
+                        TextSpan(
+                          children: <InlineSpan>[
+                            for (int i = 0; i < entries.length; i++)
+                              TextSpan(
+                                text: i == entries.length - 1
+                                    ? entries[i].line
+                                    : '${entries[i].line}\n',
+                                style: entries[i].isError
+                                    ? TextStyle(color: colors.error)
+                                    : null,
+                              ),
+                          ],
+                        ),
+                        key: const ValueKey('reconcile-log-text'),
+                        style:
+                            text.bodySmall?.copyWith(fontFamily: 'monospace'),
                       ),
-                      key: const ValueKey('reconcile-log-text'),
-                      style: text.bodySmall?.copyWith(fontFamily: 'monospace'),
                     ),
                   ),
                 );

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart' show SystemSyncMeta;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
 import '../format/timestamps.dart';
@@ -779,6 +780,15 @@ class _LogPanel extends StatelessWidget {
   final LogBuffer log;
   final double height;
 
+  /// Puts the whole buffer on the clipboard, oldest first (#193).
+  ///
+  /// Reads [LogBuffer.toPlainText] rather than the on-screen selection: only
+  /// what fits the panel is laid out, so a selection can never cover all 500
+  /// entries a long reconcile pass leaves behind.
+  static void _copyAll(LogBuffer log) {
+    unawaited(Clipboard.setData(ClipboardData(text: log.toPlainText())));
+  }
+
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
@@ -803,10 +813,23 @@ class _LogPanel extends StatelessWidget {
                 const Spacer(),
                 ListenableBuilder(
                   listenable: log,
-                  builder: (context, _) => TextButton(
-                    onPressed: log.entries.isEmpty ? null : log.clear,
-                    child: const Text('Clear'),
-                  ),
+                  builder: (context, _) {
+                    final bool empty = log.entries.isEmpty;
+                    return Row(
+                      children: <Widget>[
+                        TextButton(
+                          key: const ValueKey('reconcile-log-copy-all'),
+                          onPressed: empty ? null : () => _copyAll(log),
+                          child: const Text('Copy all'),
+                        ),
+                        TextButton(
+                          key: const ValueKey('reconcile-log-clear'),
+                          onPressed: empty ? null : log.clear,
+                          child: const Text('Clear'),
+                        ),
+                      ],
+                    );
+                  },
                 ),
               ],
             ),
@@ -825,25 +848,41 @@ class _LogPanel extends StatelessWidget {
                   );
                 }
                 // Newest first, anchored to the top — reads like a tail.
-                return ListView.builder(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: PlinkSpacing.s4,
-                    vertical: PlinkSpacing.s2,
-                  ),
-                  itemCount: entries.length,
-                  itemBuilder: (context, i) {
-                    final e = entries[i];
-                    final time = '${e.time.hour.toString().padLeft(2, '0')}:'
-                        '${e.time.minute.toString().padLeft(2, '0')}:'
-                        '${e.time.second.toString().padLeft(2, '0')}';
-                    return Text(
-                      '$time  [${e.origin.name}]  ${e.message}',
-                      style: text.bodySmall?.copyWith(
-                        color: e.isError ? colors.error : null,
-                        fontFamily: 'monospace',
+                //
+                // One selectable paragraph rather than a widget per entry
+                // (#193): SelectionArea concatenates the text of separate
+                // selectables with no separator at all
+                // (MultiSelectableSelectionContainerDelegate.getSelectedContent),
+                // so dragging across a list of per-entry Texts would copy the
+                // lines run together into one unreadable blob — exactly the
+                // thing an operator is pasting into a support ticket. Keeping
+                // the newlines inside a single paragraph makes the copy line
+                // per entry, and makes triple-click select exactly one entry;
+                // per-entry spans keep the error colour.
+                return SelectionArea(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: PlinkSpacing.s4,
+                      vertical: PlinkSpacing.s2,
+                    ),
+                    child: Text.rich(
+                      TextSpan(
+                        children: <InlineSpan>[
+                          for (int i = 0; i < entries.length; i++)
+                            TextSpan(
+                              text: i == entries.length - 1
+                                  ? entries[i].line
+                                  : '${entries[i].line}\n',
+                              style: entries[i].isError
+                                  ? TextStyle(color: colors.error)
+                                  : null,
+                            ),
+                        ],
                       ),
-                    );
-                  },
+                      key: const ValueKey('reconcile-log-text'),
+                      style: text.bodySmall?.copyWith(fontFamily: 'monospace'),
+                    ),
+                  ),
                 );
               },
             ),

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -269,10 +269,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
     }
   }
 
-  /// Merges the [fetched] WISA schools (id + name) into the current known list:
-  /// keeps every already-known school (preserving its `ours`/`prefix`, refreshing
-  /// its name when the fetch supplies one) and appends any fetched school not yet
-  /// known as unmanaged. Order is stable by school id so the grid does not jump.
+  /// Merges the [fetched] WISA schools (id + code + name) into the current known
+  /// list: keeps every already-known school (preserving its `ours`/`prefix`,
+  /// refreshing its code and name when the fetch supplies them) and appends any
+  /// fetched school not yet known as unmanaged. Order is stable by school id so
+  /// the grid does not jump.
+  ///
+  /// The short code (`ismaa`, `ismab`, …) rides on `WisaSchool.description`, not
+  /// `.name` — `SMAGetInst`'s CSV is `ID,NAME,DESCRIPTION` and the connector
+  /// preserves the legacy swap of the last two columns (#194).
   List<WisaSchoolProfile> _mergeFetchedSchools(List<WisaSchool> fetched) {
     final byId = <int, WisaSchoolProfile>{
       for (final p in _wisaSchools) p.schoolId: p,
@@ -280,8 +285,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     for (final s in fetched) {
       final existing = byId[s.id];
       byId[s.id] = existing == null
-          ? WisaSchoolProfile(schoolId: s.id, name: s.name)
-          : existing.copyWith(name: s.name.isEmpty ? existing.name : s.name);
+          ? WisaSchoolProfile(schoolId: s.id, code: s.description, name: s.name)
+          : existing.copyWith(
+              code: s.description.isEmpty ? existing.code : s.description,
+              name: s.name.isEmpty ? existing.name : s.name,
+            );
     }
     final merged = byId.values.toList()
       ..sort((a, b) => a.schoolId.compareTo(b.schoolId));
@@ -1057,10 +1065,15 @@ class _WisaSchoolsEditor extends StatelessWidget {
   }
 }
 
-/// A single cell in the known-WISA-school grid (#171): the school name (falling
-/// back to `School <id>` for a profile stored before the name was persisted),
-/// its id, and an inline checkbox marking whether we manage it. Keyed by school
-/// id so a test can flip a specific school's managed flag.
+/// A single cell in the known-WISA-school grid (#171): the school's WISA code
+/// (`ismaa`, `ismab`, …) — the identifier operators actually use — with the long
+/// name beneath it, plus an inline checkbox marking whether we manage it. Keyed
+/// by school id so a test can flip a specific school's managed flag.
+///
+/// The numeric id is strictly a fallback and never appears twice (#194): the
+/// title degrades code → name → `School <id>`, and the subtitle shows whichever
+/// of name / `id: <id>` the title has not already used — nothing at all when the
+/// title is already the id.
 class _SchoolCell extends StatelessWidget {
   const _SchoolCell({
     required this.state,
@@ -1074,17 +1087,28 @@ class _SchoolCell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final String code = profile.code;
+    final String name = profile.name;
+    final String title = code.isNotEmpty
+        ? code
+        : (name.isNotEmpty ? name : 'School ${profile.schoolId}');
+    final String? subtitle = code.isNotEmpty && name.isNotEmpty
+        ? name
+        : (code.isEmpty && name.isEmpty ? null : 'id: ${profile.schoolId}');
+
     return CheckboxListTile(
       key: ValueKey('settings-wisa-school-${profile.schoolId}-ours'),
       contentPadding: EdgeInsets.zero,
       controlAffinity: ListTileControlAffinity.leading,
       dense: true,
       title: Text(
-        profile.name.isEmpty ? 'School ${profile.schoolId}' : profile.name,
+        title,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
-      subtitle: Text('id: ${profile.schoolId}'),
+      subtitle: subtitle == null
+          ? null
+          : Text(subtitle, maxLines: 1, overflow: TextOverflow.ellipsis),
       value: profile.ours,
       onChanged: (v) => state._toggleSchoolOurs(index, v ?? false),
     );

--- a/account_manager/pubspec.yaml
+++ b/account_manager/pubspec.yaml
@@ -41,6 +41,14 @@ dependencies:
   # persisted token cache at rest (#103).
   ffi: ^2.1.0
 
+  # Password sheets render as real PDFs (#195). `pdf` is pure Dart: no platform
+  # plugin, so nothing to register in the Windows CMake build, and it runs
+  # headlessly under `flutter test` — which is why the sheet bytes are asserted
+  # directly in unit tests. The sibling `printing` plugin (native Windows code,
+  # its own print dialog) is deliberately NOT pulled in: the export opens in the
+  # platform's default PDF viewer through a plain `Process.start` instead.
+  pdf: ^3.11.0
+
   # Plink Labs design system — Flutter binding, external to this workspace
   # (not on pub.dev). Consumed as a git dependency so it resolves everywhere
   # (CI + fresh clones), pinned to a commit for reproducibility. To hack on the

--- a/account_manager/test/format/timestamps_test.dart
+++ b/account_manager/test/format/timestamps_test.dart
@@ -1,0 +1,117 @@
+import 'package:account_manager/src/format/timestamps.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pins the freshness stamp (#192) against a fixed clock. Time-only used to
+/// make a sync from days ago read exactly like this morning's, which is the one
+/// case the Reconcile last-sync box exists to surface.
+void main() {
+  // A fixed "now" so every expectation below is deterministic.
+  final DateTime now = DateTime(2026, 8, 18, 17, 30);
+
+  test('a stamp from today renders time-only', () {
+    expect(
+      formatFreshnessStamp(DateTime(2026, 8, 18, 9, 14), now: now),
+      '09:14',
+    );
+  });
+
+  test('today stays time-only even when the stamp is later than now', () {
+    expect(
+      formatFreshnessStamp(DateTime(2026, 8, 18, 23, 50), now: now),
+      '23:50',
+    );
+  });
+
+  test('the hour and minute are zero-padded', () {
+    expect(
+      formatFreshnessStamp(DateTime(2026, 8, 18, 5, 3), now: now),
+      '05:03',
+    );
+  });
+
+  test("a stamp from yesterday is labelled 'gisteren'", () {
+    expect(
+      formatFreshnessStamp(DateTime(2026, 8, 17, 9, 14), now: now),
+      'gisteren 09:14',
+    );
+  });
+
+  test('yesterday is a calendar day, not 24 elapsed hours', () {
+    // Twenty minutes apart, but either side of midnight: to the operator that
+    // is yesterday, and reading it as "23:50" would be the exact confusion
+    // #192 fixes.
+    expect(
+      formatFreshnessStamp(
+        DateTime(2026, 8, 17, 23, 50),
+        now: DateTime(2026, 8, 18, 0, 10),
+      ),
+      'gisteren 23:50',
+    );
+  });
+
+  test('yesterday works across a month boundary', () {
+    expect(
+      formatFreshnessStamp(
+        DateTime(2026, 7, 31, 23, 0),
+        now: DateTime(2026, 8, 1, 8, 0),
+      ),
+      'gisteren 23:00',
+    );
+  });
+
+  test('yesterday works across a year boundary', () {
+    expect(
+      formatFreshnessStamp(
+        DateTime(2025, 12, 31, 23, 0),
+        now: DateTime(2026, 1, 1, 8, 0),
+      ),
+      'gisteren 23:00',
+    );
+  });
+
+  test('an older stamp in the current year renders day/month', () {
+    expect(
+      formatFreshnessStamp(DateTime(2026, 8, 15, 9, 14), now: now),
+      '15/08 09:14',
+    );
+  });
+
+  test('two days ago is already dated, never bare time', () {
+    final String s =
+        formatFreshnessStamp(DateTime(2026, 8, 16, 9, 14), now: now);
+    expect(s, '16/08 09:14');
+    expect(s, isNot('09:14'));
+  });
+
+  test('a stamp from an earlier year carries the year', () {
+    expect(
+      formatFreshnessStamp(DateTime(2025, 8, 15, 9, 14), now: now),
+      '15/08/2025 09:14',
+    );
+  });
+
+  test('the day and month are zero-padded on a dated stamp', () {
+    expect(
+      formatFreshnessStamp(DateTime(2026, 1, 5, 9, 14), now: now),
+      '05/01 09:14',
+    );
+  });
+
+  test('a UTC stamp is bucketed against the local calendar day', () {
+    // The store hands back UTC instants; the operator reads their own clock.
+    final DateTime local = DateTime(2026, 8, 18, 9, 14);
+    expect(formatFreshnessStamp(local.toUtc(), now: local), '09:14');
+    expect(
+        formatFreshnessStamp(local.toUtc(), now: local), isNot(contains('/')));
+  });
+
+  test('now defaults to the current clock', () {
+    final DateTime today = DateTime.now();
+    expect(formatFreshnessStamp(today), isNot(contains('/')));
+    expect(formatFreshnessStamp(today), isNot(contains('gisteren')));
+    expect(
+      formatFreshnessStamp(DateTime(today.year - 1, 8, 15, 9, 14)),
+      '15/08/${today.year - 1} 09:14',
+    );
+  });
+}

--- a/account_manager/test/passwords/password_controller_test.dart
+++ b/account_manager/test/passwords/password_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_manager/src/passwords/password_controller.dart';
 import 'package:account_state/account_state.dart';
@@ -50,33 +52,47 @@ ss.SmartschoolSnapshot _snapshot() => ss.SmartschoolSnapshot(
       ],
     );
 
-/// A deterministic password generator: `pw1`, `pw2`, … in call order.
+/// A deterministic password generator: `pw1`, `pw2`, ... in call order.
 String Function() _seqGenerator() {
   var n = 0;
   return () => 'pw${++n}';
 }
 
+/// The PDF magic bytes, so a test can assert the payload really is a document
+/// rather than the old HTML string.
+bool _isPdf(List<int> bytes) =>
+    bytes.length > 5 && latin1.decode(bytes.sublist(0, 5)) == '%PDF-';
+
 void main() {
-  group('PasswordController — Leerlingen', () {
+  group('PasswordController - Leerlingen', () {
     late InMemoryPasswordQueueStore queue;
     late RecordingPasswordBackends backends;
-    late List<(String, String)> writes;
+    late List<(String, List<int>)> writes;
+    late List<String> opens;
+    Object? openError;
 
     PasswordController build({String Function()? gen}) => PasswordController(
           snapshot: _snapshot(),
           queue: queue,
           backends: backends,
           generatePassword: gen ?? _seqGenerator(),
-          writer: (name, content) async {
-            writes.add((name, content));
-            return 'C:/tmp/$name';
+          writer: (name, bytes) async {
+            writes.add((name, List<int>.of(bytes)));
+            return 'C:/exports/$name';
+          },
+          opener: (path) async {
+            final error = openError;
+            if (error != null) throw error;
+            opens.add(path);
           },
         );
 
     setUp(() {
       queue = InMemoryPasswordQueueStore();
       backends = RecordingPasswordBackends();
-      writes = <(String, String)>[];
+      writes = <(String, List<int>)>[];
+      opens = <String>[];
+      openError = null;
     });
 
     test('exposes the Leerlingen root and its classes', () {
@@ -188,20 +204,49 @@ void main() {
       expect(backends.azurePushes, isEmpty);
     });
 
-    test('exporting student sheets writes HTML and drains them', () async {
+    Future<PasswordController> queuedStudent() async {
       final c = build();
       final klas = c.childrenOf(c.studentRoot!).single;
       c.selectClass(klas);
       final jane = c.rows.firstWhere((r) => r.username == 'jane');
       c.toggleRow(jane, PasswordTarget.smartschool, true);
       await c.generate();
+      return c;
+    }
+
+    test(
+        'exporting student sheets writes a PDF, opens it, and drains them '
+        '(#195)', () async {
+      final c = await queuedStudent();
       expect(c.studentSheets, isNotEmpty);
 
-      await c.exportStudentSheets();
-      expect(writes.single.$1, 'leerling-wachtwoorden.html');
-      expect(writes.single.$2, contains('jane'));
+      final path = await c.exportStudentSheets();
+
+      expect(writes.single.$1, 'leerling-wachtwoorden.pdf');
+      expect(_isPdf(writes.single.$2), isTrue,
+          reason: 'a real PDF document, not printable HTML');
+      // The written file is handed to the platform viewer, ready to print.
+      expect(opens, <String>[path]);
+      expect(c.message, contains('geopend'));
+      expect(c.message, contains(path));
       // Drained from the queue afterwards.
       expect(c.studentSheets, isEmpty);
+    });
+
+    test('a viewer that will not launch keeps the file and the drain (#195)',
+        () async {
+      openError = StateError('geen PDF-viewer geregistreerd');
+      final c = await queuedStudent();
+
+      final path = await c.exportStudentSheets();
+
+      // The write happened and the queue is drained: an open failure must not
+      // throw the export away or re-queue the drained entries.
+      expect(writes.single.$1, 'leerling-wachtwoorden.pdf');
+      expect(c.studentSheets, isEmpty);
+      expect(opens, isEmpty);
+      expect(c.message, contains(path));
+      expect(c.message, contains('openen mislukt'));
     });
 
     test('exporting co-accounts writes a CSV and drains them', () async {
@@ -215,31 +260,36 @@ void main() {
 
       await c.exportCoAccounts();
       expect(writes.single.$1, 'co-accounts.csv');
-      expect(writes.single.$2, contains('CoAccount1'));
+      expect(utf8.decode(writes.single.$2), contains('CoAccount1'));
+      // The CSV is not printed, so it is not opened either.
+      expect(opens, isEmpty);
       expect(c.coAccountSheets, isEmpty);
     });
   });
 
-  group('PasswordController — Personeel', () {
+  group('PasswordController - Personeel', () {
     late InMemoryPasswordQueueStore queue;
     late RecordingPasswordBackends backends;
-    late List<(String, String)> writes;
+    late List<(String, List<int>)> writes;
+    late List<String> opens;
 
     PasswordController build() => PasswordController(
           snapshot: _snapshot(),
           queue: queue,
           backends: backends,
           generatePassword: _seqGenerator(),
-          writer: (name, content) async {
-            writes.add((name, content));
-            return 'C:/tmp/$name';
+          writer: (name, bytes) async {
+            writes.add((name, List<int>.of(bytes)));
+            return 'C:/exports/$name';
           },
+          opener: (path) async => opens.add(path),
         );
 
     setUp(() {
       queue = InMemoryPasswordQueueStore();
       backends = RecordingPasswordBackends();
-      writes = <(String, String)>[];
+      writes = <(String, List<int>)>[];
+      opens = <String>[];
     });
 
     test('loads the Personeel group members', () {
@@ -259,7 +309,7 @@ void main() {
         queue: queue,
         backends: backends,
         generatePassword: _seqGenerator(),
-        writer: (name, content) async => 'C:/tmp/$name',
+        writer: (name, bytes) async => 'C:/exports/$name',
       );
       // Alphabetical by "Voornaam Naam", case-insensitive: alice, Bob, Charlie.
       expect(c.staff.map((a) => a.uid), ['alice', 'bob', 'charlie']);
@@ -286,8 +336,11 @@ void main() {
       // Both legs share the same password (legacy NewPasswords).
       expect(
           backends.smartschoolPushes.single.$3, backends.azurePushes.single.$2);
-      // A per-staff HTML sheet was written (not queued).
-      expect(writes.single.$1, 'anna.smit.html');
+      // A per-staff PDF sheet was written and opened for printing (#195), not
+      // queued.
+      expect(writes.single.$1, 'anna.smit.pdf');
+      expect(_isPdf(writes.single.$2), isTrue);
+      expect(opens, <String>[path!]);
       expect(await queue.load(), isEmpty);
     });
 

--- a/account_manager/test/passwords/password_export_test.dart
+++ b/account_manager/test/passwords/password_export_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:account_manager/src/passwords/password_export.dart';
 import 'package:account_state/account_state.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,7 +11,7 @@ PasswordEntry _account({
   String? mail = 'jane@student.school',
   String klas = '3C',
   String? ss = 'Sa2b!x',
-  String? az = 'Ku9d?y',
+  String? az = 'Ku9dQy',
 }) =>
     PasswordEntry(
       personId: PersonId('ss:$uid'),
@@ -36,7 +39,32 @@ PasswordEntry _co({
       coAccountPasswords: co,
     );
 
+/// The headings of a sheet, in the order they are printed. The leading login
+/// block carries no heading, so it shows up as an empty string.
+List<String> _headings(PasswordSheet sheet) =>
+    <String>[for (final b in sheet.blocks) b.heading];
+
+/// Every field value on a sheet, flattened — used to assert a password made it
+/// onto (or stayed off) the page.
+List<String> _values(PasswordSheet sheet) => <String>[
+      for (final b in sheet.blocks)
+        for (final f in b.fields) f.value,
+    ];
+
+/// The number of page objects in a rendered PDF. Page dictionaries are written
+/// plainly even in a compressed document, so this reads the real production
+/// bytes.
+int _pageCount(List<int> bytes) =>
+    RegExp(r'/Type\s*/Page(?!s)').allMatches(latin1.decode(bytes)).length;
+
+/// The crossed-box placeholder the renderer draws for a glyph the font has no
+/// outline for: a stroked rectangle at line width 1.
+final RegExp _missingGlyph = RegExp(r're\s+1 w\s+S');
+
 void main() {
+  // Loading the bundled sheet fonts reads package assets through rootBundle.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('coAccountsCsv', () {
     test('emits the legacy header and one row per entry, blank for unset slots',
         () {
@@ -57,34 +85,165 @@ void main() {
     });
   });
 
-  group('studentPasswordsHtml', () {
-    test('includes only the blocks for the passwords that were generated', () {
-      final html = studentPasswordsHtml([_account(az: null)]);
-      expect(html, contains('Jane Doe'));
-      expect(html, contains('Smartschool'));
-      // No Azure password → no Office 365 login block for this student.
-      expect(html, isNot(contains('Ku9d?y')));
-      expect(html, contains('Sa2b!x'));
+  group('studentPasswordSheets', () {
+    test('builds one sheet per entry, titled with the name and class', () {
+      final sheets = studentPasswordSheets(
+        [_account(), _account(uid: 'bob', name: 'Bob Bee', klas: '4A')],
+      );
+      expect(sheets, hasLength(2));
+      expect(sheets[0].title, 'Account voor Jane Doe - 3C');
+      expect(sheets[1].title, 'Account voor Bob Bee - 4A');
     });
 
-    test('escapes HTML-special characters in a name', () {
-      final html = studentPasswordsHtml([_account(name: 'A & B <x>')]);
-      expect(html, contains('A &amp; B &lt;x&gt;'));
+    test(
+        'keeps the legacy section order: login, O365, Smartschool, WiFi, '
+        'privacy', () {
+      final sheet = studentPasswordSheets([_account()]).single;
+      expect(_headings(sheet),
+          <String>['', 'Office 365', 'Smartschool', 'WiFi', 'Privacy']);
+      // The headingless first block is the login line.
+      expect(sheet.blocks.first.fields.single.label, 'Login');
+      expect(sheet.blocks.first.fields.single.value, 'jane.doe');
+    });
+
+    test('includes only the blocks for the passwords that were generated', () {
+      final sheet = studentPasswordSheets([_account(az: null)]).single;
+      expect(_headings(sheet), isNot(contains('Office 365')));
+      expect(_headings(sheet), contains('Smartschool'));
+      expect(_values(sheet), contains('Sa2b!x'));
+      expect(_values(sheet), isNot(contains('Ku9dQy')));
+    });
+
+    test('the Office 365 block logs in with the mail address', () {
+      final sheet = studentPasswordSheets([_account(ss: null)]).single;
+      final office = sheet.blocks.firstWhere((b) => b.heading == 'Office 365');
+      expect(office.fields.first.value, 'jane@student.school');
+      expect(office.fields.last.value, 'Ku9dQy');
+    });
+
+    test('a name with markup characters is carried through verbatim', () {
+      // The HTML sheet had to escape these; a PDF string does not, so the
+      // operator sees the real name.
+      final sheet = studentPasswordSheets([_account(name: 'A & B <x>')]).single;
+      expect(sheet.title, 'Account voor A & B <x> - 3C');
     });
   });
 
-  group('staffPasswordHtml', () {
+  group('staffPasswordSheet', () {
     test('omits the block for a null password', () {
-      final html = staffPasswordHtml(
+      final sheet = staffPasswordSheet(
         name: 'Anna Smit',
         username: 'anna.smit',
         mail: 'anna@school',
         smartschoolPassword: 'Zz9!',
         office365Password: null,
       );
-      expect(html, contains('Smartschool'));
-      expect(html, contains('Zz9!'));
-      expect(html, isNot(contains('Office 365')));
+      expect(_headings(sheet), <String>['WiFi', 'Smartschool', 'Privacy']);
+      expect(_values(sheet), contains('Zz9!'));
+    });
+
+    test('both passwords give both blocks, in the legacy order', () {
+      final sheet = staffPasswordSheet(
+        name: 'Anna Smit',
+        username: 'anna.smit',
+        mail: 'anna@school',
+        smartschoolPassword: 'Zz9!',
+        office365Password: 'Qq1?',
+      );
+      expect(_headings(sheet),
+          <String>['Office 365', 'WiFi', 'Smartschool', 'Privacy']);
+    });
+  });
+
+  group('PDF rendering', () {
+    test('student sheets render as a PDF with one page per student', () async {
+      final bytes = await studentPasswordsPdf(
+        [_account(), _account(uid: 'bob', name: 'Bob Bee')],
+      );
+      expect(latin1.decode(bytes.sublist(0, 5)), '%PDF-');
+      expect(latin1.decode(bytes).trimRight(), endsWith('%%EOF'));
+      expect(_pageCount(bytes), 2);
+    });
+
+    test('the per-staff sheet renders as a one-page PDF', () async {
+      final bytes = await staffPasswordPdf(
+        name: 'Anna Smit',
+        username: 'anna.smit',
+        mail: 'anna@school',
+        smartschoolPassword: 'Zz9!',
+        office365Password: null,
+      );
+      expect(latin1.decode(bytes.sublist(0, 5)), '%PDF-');
+      expect(_pageCount(bytes), 1);
+    });
+
+    test('an empty queue still renders one openable page, not a page-less file',
+        () async {
+      final bytes = await studentPasswordsPdf(const <PasswordEntry>[]);
+      expect(_pageCount(bytes), 1);
+    });
+
+    test('the password really lands on the page', () async {
+      // Rendered uncompressed and with the base-14 faces, which draw literal
+      // text into the content stream, so the test can read what was put on the
+      // page: the generated password and the login must both be there.
+      final bytes = await passwordSheetsPdf(
+        studentPasswordSheets([_account(az: null)]),
+        title: 'Leerling-wachtwoorden',
+        compress: false,
+        fonts: PasswordSheetFonts.fallback(),
+      );
+      final stream = latin1.decode(bytes);
+      expect(stream, contains('(Sa2b!x)'));
+      expect(stream, contains('(jane.doe)'));
+      expect(stream, contains('(Smartschool)'));
+      // No Azure password was generated, so it is nowhere on the sheet.
+      expect(stream, isNot(contains('(Ku9dQy)')));
+    });
+  });
+
+  group('export destination', () {
+    test('is a known operator-owned folder, never the system temp dir (#195)',
+        () {
+      // Cleartext password sheets used to accumulate in %TEMP%\AccountManager,
+      // which nothing owns and nothing cleans up.
+      final dir = passwordExportDirectory();
+      expect(dir, isNot(contains(Directory.systemTemp.path)));
+      expect(dir, contains('AccountManager'));
+      expect(dir, endsWith('Wachtwoorden'));
+    });
+  });
+
+  group('sheet fonts', () {
+    test('the bundled design-system faces load, not the base-14 stand-ins',
+        () async {
+      final fonts = await PasswordSheetFonts.load();
+      expect(fonts.body.fontName, contains('HankenGrotesk'));
+      expect(fonts.heading.fontName, contains('SpaceMono'));
+      expect(fonts.mono.fontName, contains('SpaceMono'));
+    });
+
+    test('a name outside Latin-1 prints as glyphs, not empty boxes', () async {
+      // Turkish and Polish names are routine here, and every one of them falls
+      // outside the Latin-1 range the PDF base-14 faces carry. Rendering the
+      // same sheet with those faces is the proof: it fills the page with
+      // missing-glyph boxes, which is what the bundled fonts fix.
+      final sheets = studentPasswordSheets([_account(name: 'Işık Ćwik')]);
+      final good = latin1.decode(await passwordSheetsPdf(
+        sheets,
+        title: 'Leerling-wachtwoorden',
+        compress: false,
+      ));
+      final base14 = latin1.decode(await passwordSheetsPdf(
+        sheets,
+        title: 'Leerling-wachtwoorden',
+        compress: false,
+        fonts: PasswordSheetFonts.fallback(),
+      ));
+      expect(_missingGlyph.hasMatch(base14), isTrue,
+          reason: 'the base-14 faces cannot draw these names');
+      expect(_missingGlyph.hasMatch(good), isFalse,
+          reason: 'the bundled faces cover Latin Extended');
     });
   });
 }

--- a/account_manager/test/reconcile/log_buffer_test.dart
+++ b/account_manager/test/reconcile/log_buffer_test.dart
@@ -50,4 +50,41 @@ void main() {
     expect(lines.last, endsWith('kept-2'));
     expect(log.toPlainText(), isNot(contains('dropped')));
   });
+
+  // The line under the pointer (#197). The panel renders its entries as one
+  // paragraph (#193), so a per-line action cannot ask "which row widget was
+  // clicked" — it has to map a character offset in that paragraph back to an
+  // entry. Counting newlines is what keeps that right when a long message
+  // soft-wraps over several visual rows but is still one entry.
+  group('logEntryIndexAt', () {
+    const String paragraph = '00:00:00  [azure]  gamma\n'
+        '00:00:00  [smartschool]  beta\n'
+        '00:00:00  [wisa]  alpha';
+
+    test('an offset inside a line resolves to that line', () {
+      expect(logEntryIndexAt(paragraph, 0), 0);
+      expect(logEntryIndexAt(paragraph, 5), 0);
+      expect(logEntryIndexAt(paragraph, paragraph.indexOf('beta')), 1);
+      expect(logEntryIndexAt(paragraph, paragraph.indexOf('alpha')), 2);
+    });
+
+    test('a caret on either edge of a newline stays on its own line', () {
+      final int newline = paragraph.indexOf('\n');
+      // Before the newline is still the end of the first line...
+      expect(logEntryIndexAt(paragraph, newline), 0);
+      // ...and just past it is the start of the second.
+      expect(logEntryIndexAt(paragraph, newline + 1), 1);
+      expect(logEntryIndexAt(paragraph, paragraph.length), 2);
+    });
+
+    test('an offset off either end clamps to the first and last line', () {
+      expect(logEntryIndexAt(paragraph, -20), 0);
+      expect(logEntryIndexAt(paragraph, paragraph.length + 99), 2);
+    });
+
+    test('a paragraph without newlines is always line 0', () {
+      expect(logEntryIndexAt('09:04:07  [wisa]  only', 12), 0);
+      expect(logEntryIndexAt('', 0), 0);
+    });
+  });
 }

--- a/account_manager/test/reconcile/log_buffer_test.dart
+++ b/account_manager/test/reconcile/log_buffer_test.dart
@@ -1,0 +1,53 @@
+import 'package:account_core/account_core.dart' show Origin;
+import 'package:account_manager/src/reconcile/log_buffer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The plain-text shape of the log (#193): what the panel renders is what an
+/// operator pastes into a bug report or a support ticket, so the line format
+/// and the copy format are the same code and are pinned here.
+void main() {
+  final DateTime at = DateTime(2026, 7, 1, 9, 4, 7);
+
+  test('a log line reads HH:mm:ss  [origin]  message, zero padded', () {
+    final entry = LogEntry(
+      time: DateTime(2026, 7, 1, 9, 4, 7),
+      origin: Origin.wisa,
+      message: 'Syncing WISA...',
+      isError: false,
+    );
+
+    expect(entry.line, '09:04:07  [wisa]  Syncing WISA...');
+  });
+
+  test('an empty buffer copies as the empty string', () {
+    expect(LogBuffer().toPlainText(), isEmpty);
+  });
+
+  test('toPlainText renders oldest first, one line per entry', () {
+    final log = LogBuffer(clock: () => at)
+      ..addMessage(Origin.wisa, 'first')
+      ..addError(Origin.smartschool, 'second')
+      ..addMessage(Origin.azure, 'third');
+
+    expect(
+      log.toPlainText(),
+      '09:04:07  [wisa]  first\n'
+      '09:04:07  [smartschool]  second\n'
+      '09:04:07  [azure]  third',
+    );
+  });
+
+  test('toPlainText covers the whole retained buffer, dropped entries aside',
+      () {
+    final log = LogBuffer(capacity: 2, clock: () => at)
+      ..addMessage(Origin.wisa, 'dropped')
+      ..addMessage(Origin.wisa, 'kept-1')
+      ..addMessage(Origin.wisa, 'kept-2');
+
+    final List<String> lines = log.toPlainText().split('\n');
+    expect(lines, hasLength(2));
+    expect(lines.first, endsWith('kept-1'));
+    expect(lines.last, endsWith('kept-2'));
+    expect(log.toPlainText(), isNot(contains('dropped')));
+  });
+}

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -871,6 +871,18 @@ class ReconcileHarness {
   final RecordingPasswordBackends passwordBackends =
       RecordingPasswordBackends();
 
+  /// Every password export the screen wrote (#195), as
+  /// `(suggestedName, bytes)`. Recorded instead of written so driving the
+  /// export button never drops cleartext password sheets on the test machine.
+  final List<(String, List<int>)> passwordWrites = <(String, List<int>)>[];
+
+  /// Every path the screen asked the platform to open after an export (#195).
+  final List<String> passwordOpens = <String>[];
+
+  /// When set, the recording opener throws it — the "the viewer would not
+  /// launch" case, which must not cost the operator the written file.
+  Object? passwordOpenError;
+
   /// The bundle the screen's bootstrap seam expects.
   ReconcileServices get services => ReconcileServices(
         settings: const AppSettings(),
@@ -880,6 +892,15 @@ class ReconcileHarness {
         log: log,
         passwordQueue: passwordQueue,
         passwordBackends: passwordBackends,
+        passwordFileWriter: (name, bytes) async {
+          passwordWrites.add((name, List<int>.of(bytes)));
+          return 'C:/exports/$name';
+        },
+        passwordFileOpener: (path) async {
+          final error = passwordOpenError;
+          if (error != null) throw error;
+          passwordOpens.add(path);
+        },
       );
 
   /// A ready-made bootstrap closure for [ReconcileScreen]/[AccountManagerApp].

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
 
+import 'package:account_core/account_core.dart' show Origin;
 import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
 import 'package:account_manager/src/screens/reconcile_screen.dart';
 import 'package:account_state/account_state.dart';
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'reconcile_fakes.dart';
@@ -502,5 +505,111 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('No messages yet.'), findsOneWidget);
+  });
+
+  testWidgets(
+      'the log panel copies a multi-entry selection one line per entry, keeps '
+      'the error colour, and Copy all takes the whole buffer (#193)',
+      (WidgetTester tester) async {
+    final List<String> copied = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (MethodCall call) async {
+        if (call.method == 'Clipboard.setData') {
+          final args = call.arguments as Map<Object?, Object?>;
+          copied.add(args['text']! as String);
+        }
+        return null;
+      },
+    );
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null));
+
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    // A known buffer: the harness clock is fixed, so every stamp is 00:00:00.
+    harness.log
+      ..clear()
+      ..addMessage(Origin.wisa, 'alpha')
+      ..addError(Origin.smartschool, 'beta')
+      ..addMessage(Origin.azure, 'gamma');
+    await tester.pumpAndSettle();
+
+    // Rendered newest first as one selectable paragraph.
+    final Finder block = find.byKey(const ValueKey('reconcile-log-text'));
+    expect(block, findsOneWidget);
+    final Text rendered = tester.widget<Text>(block);
+    expect(
+      rendered.textSpan!.toPlainText(),
+      '00:00:00  [azure]  gamma\n'
+      '00:00:00  [smartschool]  beta\n'
+      '00:00:00  [wisa]  alpha',
+    );
+
+    // The error entry keeps its error colour while selectable; the others are
+    // left on the panel's base style.
+    final ColorScheme colors = Theme.of(tester.element(block)).colorScheme;
+    final List<TextSpan> spans =
+        ((rendered.textSpan! as TextSpan).children ?? const <InlineSpan>[])
+            .cast<TextSpan>();
+    expect(
+      spans.firstWhere((TextSpan s) => s.text!.contains('beta')).style?.color,
+      colors.error,
+    );
+    expect(
+      spans.firstWhere((TextSpan s) => s.text!.contains('gamma')).style,
+      isNull,
+    );
+
+    // Drag the mouse across the first two rendered lines, then Ctrl+C: the two
+    // entries land on the clipboard one per line, not run together.
+    final Rect rect = tester.getRect(block);
+    final double lineHeight = rect.height / 3;
+    final TestGesture drag = await tester.startGesture(
+      Offset(rect.left + 1, rect.top + lineHeight * 0.5),
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pump();
+    await drag.moveTo(Offset(rect.right - 1, rect.top + lineHeight * 1.5));
+    await tester.pump();
+    await drag.up();
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyC);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pumpAndSettle();
+
+    expect(copied, hasLength(1));
+    expect(
+      copied.single,
+      '00:00:00  [azure]  gamma\n00:00:00  [smartschool]  beta',
+    );
+
+    // Copy all ignores the selection and takes the buffer, oldest first.
+    await tester.tap(find.byKey(const ValueKey('reconcile-log-copy-all')));
+    await tester.pumpAndSettle();
+    expect(copied, hasLength(2));
+    expect(
+      copied.last,
+      '00:00:00  [wisa]  alpha\n'
+      '00:00:00  [smartschool]  beta\n'
+      '00:00:00  [azure]  gamma',
+    );
+
+    // Both actions are dead while there is nothing to copy.
+    harness.log.clear();
+    await tester.pumpAndSettle();
+    expect(
+      tester
+          .widget<TextButton>(
+              find.byKey(const ValueKey('reconcile-log-copy-all')))
+          .onPressed,
+      isNull,
+    );
   });
 }

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -262,6 +262,52 @@ void main() {
     expect(rowText('azure'), contains('drift check'));
   });
 
+  testWidgets(
+      'the last-sync box dates a stamp that is not from today: today stays '
+      "time-only, yesterday reads 'gisteren', an older one carries the date "
+      '(#192)', (WidgetTester tester) async {
+    // Three systems stamped on three different calendar days, pinned against
+    // the clock the row renders with. Time-only made all three read identically
+    // (`sync · 09:14`), which is exactly how an operator ends up
+    // reconciling against a snapshot that is days old.
+    final DateTime now = DateTime.now();
+    final DateTime today = DateTime(now.year, now.month, now.day, 9, 14);
+    final DateTime yesterday = DateTime(now.year, now.month, now.day - 1, 8, 5);
+    final DateTime lastYear = DateTime(now.year - 1, 8, 15, 16, 40);
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(fetchedAt: today),
+      smartschool: ssSnap(fetchedAt: yesterday),
+      azure: azSnap(fetchedAt: lastYear),
+    );
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    String rowText(String system) => tester
+        .widgetList<Text>(find.descendant(
+          of: find.byKey(ValueKey('reconcile-last-sync-$system')),
+          matching: find.byType(Text),
+        ))
+        .map((t) => t.data)
+        .whereType<String>()
+        .join(' ');
+
+    // Today: unchanged, still the short time-only form.
+    expect(rowText('wisa'), contains('sync · 09:14'));
+    expect(rowText('wisa'), isNot(contains('/')));
+    expect(rowText('wisa'), isNot(contains('gisteren')));
+
+    // Yesterday and older are now distinguishable at a glance.
+    expect(rowText('smartschool'), contains('gisteren 08:05'));
+    expect(rowText('azure'), contains('15/08/${now.year - 1} 16:40'));
+    // …and the operator is still named on every row.
+    expect(rowText('azure'), contains('by operator@school.example'));
+  });
+
   testWidgets('the last-sync box survives a restart / passive session (#162)',
       (WidgetTester tester) async {
     // Session 1 syncs and persists freshness to the shared store.

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -4,7 +4,7 @@ import 'package:account_core/account_core.dart' show Origin;
 import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
 import 'package:account_manager/src/screens/reconcile_screen.dart';
 import 'package:account_state/account_state.dart';
-import 'package:flutter/gestures.dart' show PointerDeviceKind;
+import 'package:flutter/gestures.dart' show PointerDeviceKind, kSecondaryButton;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -612,4 +612,132 @@ void main() {
       isNull,
     );
   });
+
+  testWidgets(
+      'right-clicking a log line offers Copy line and copies exactly that '
+      'entry (#197)', (WidgetTester tester) async {
+    final List<String> copied = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (MethodCall call) async {
+        if (call.method == 'Clipboard.setData') {
+          final args = call.arguments as Map<Object?, Object?>;
+          copied.add(args['text']! as String);
+        }
+        return null;
+      },
+    );
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null));
+
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    // A known buffer: the harness clock is fixed, so every stamp is 00:00:00.
+    harness.log
+      ..clear()
+      ..addMessage(Origin.wisa, 'alpha')
+      ..addError(Origin.smartschool, 'beta')
+      ..addMessage(Origin.azure, 'gamma');
+    await tester.pumpAndSettle();
+
+    // Rendered newest first, so "beta" is the middle of three lines.
+    final Finder block = find.byKey(const ValueKey('reconcile-log-text'));
+    final Rect rect = tester.getRect(block);
+    final double lineHeight = rect.height / 3;
+
+    await _rightClickAt(
+      tester,
+      Offset(rect.left + 8, rect.top + lineHeight * 1.5),
+    );
+
+    expect(find.text('Copy line'), findsOneWidget);
+    await tester.tap(find.text('Copy line'));
+    await tester.pumpAndSettle();
+
+    // Exactly the one entry under the pointer — no timestamp of its
+    // neighbours, and no trailing newline.
+    expect(copied, hasLength(1));
+    expect(copied.single, '00:00:00  [smartschool]  beta');
+
+    // The empty space under the last line has no entry to copy, so the menu
+    // there offers only what the framework itself contributes.
+    await _rightClickAt(tester, Offset(rect.left + 8, rect.bottom + 24));
+    expect(find.text('Copy line'), findsNothing);
+  });
+
+  testWidgets(
+      'Copy line takes the whole entry when the message soft-wraps over '
+      'several rows (#197)', (WidgetTester tester) async {
+    final List<String> copied = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (MethodCall call) async {
+        if (call.method == 'Clipboard.setData') {
+          final args = call.arguments as Map<Object?, Object?>;
+          copied.add(args['text']! as String);
+        }
+        return null;
+      },
+    );
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null));
+
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    final Finder block = find.byKey(const ValueKey('reconcile-log-text'));
+
+    // One short entry first: its height is one rendered row.
+    harness.log
+      ..clear()
+      ..addMessage(Origin.wisa, 'short');
+    await tester.pumpAndSettle();
+    final double oneRow = tester.getRect(block).height;
+
+    // Now a long entry that cannot fit the panel's width. It is added last, so
+    // it renders first (newest first) and the short one sits underneath it.
+    final String long = 'Set-Password failed for ${'a' * 400}';
+    harness.log.addError(Origin.smartschool, long);
+    await tester.pumpAndSettle();
+
+    final Rect rect = tester.getRect(block);
+    // It really did wrap: the paragraph is taller than the two entries would
+    // be if each took a single row.
+    expect(rect.height, greaterThan(oneRow * 2));
+
+    // Right-click the *second* rendered row. That row is a continuation of
+    // the first (wrapped) entry, so a per-line action that divided the hit by
+    // a row height would hand back the second entry, "short". Counting
+    // newlines gives back the entry the row actually belongs to.
+    await _rightClickAt(
+      tester,
+      Offset(rect.left + 8, rect.top + oneRow * 1.5),
+    );
+
+    expect(find.text('Copy line'), findsOneWidget);
+    await tester.tap(find.text('Copy line'));
+    await tester.pumpAndSettle();
+
+    expect(copied, hasLength(1));
+    expect(copied.single, '00:00:00  [smartschool]  $long');
+  });
+}
+
+/// A right-click (secondary mouse button) at a global [at], which is what puts
+/// the panel's selection context menu on screen (#197).
+Future<void> _rightClickAt(WidgetTester tester, Offset at) async {
+  final TestGesture gesture = await tester.startGesture(
+    at,
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryButton,
+  );
+  await gesture.up();
+  await tester.pumpAndSettle();
 }

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -600,4 +600,31 @@ void main() {
     expect(find.textContaining('Generatie 2'), findsOneWidget);
     expect(find.textContaining('Generatie 1'), findsNothing);
   });
+
+  testWidgets(
+      "the overview's freshness stamp carries the date once the shared state "
+      'is no longer from today (#192)', (WidgetTester tester) async {
+    // The shared view was materialized at kFixtureDate, a past day. Time-only
+    // rendered that as "Generatie 1 · 02:00 door …" —
+    // indistinguishable from a view materialized minutes ago, the same
+    // confusion #192 fixes on the Reconcile last-sync box.
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // Derived here rather than through the production formatter, so this pins
+    // the rendered text instead of restating the implementation.
+    final DateTime t = kFixtureDate.toLocal();
+    final String dm = '${t.day.toString().padLeft(2, '0')}/'
+        '${t.month.toString().padLeft(2, '0')}';
+    final String hhmm = '${t.hour.toString().padLeft(2, '0')}:'
+        '${t.minute.toString().padLeft(2, '0')}';
+
+    expect(find.textContaining('Generatie 1 · $dm'), findsOneWidget);
+    expect(find.textContaining('Generatie 1 · $hhmm'), findsNothing,
+        reason: 'a stamp from a past day is never rendered as bare time');
+  });
 }

--- a/account_manager/test/screens/passwords_screen_test.dart
+++ b/account_manager/test/screens/passwords_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_manager/src/passwords/password_controller.dart';
 import 'package:account_manager/src/screens/passwords_screen.dart';
@@ -124,6 +126,42 @@ void main() {
           .onPressed,
       isNotNull,
     );
+  });
+
+  testWidgets(
+      'Leerlingen: printing the queued sheets writes a PDF and opens it for '
+      'printing (#195)', (WidgetTester tester) async {
+    final harness = ReconcileHarness(ssInitial: _snap());
+    await tester
+        .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // Generate a password for Jane so the print queue holds a sheet.
+    await tester.tap(find.byKey(const ValueKey('password-class-3C')));
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(const ValueKey('passwords-cell-jane-smartschool')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-generate')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-generate-confirm')));
+    await tester.pumpAndSettle();
+
+    final print = find.byKey(const ValueKey('passwords-export-students'));
+    await tester.tap(print);
+    await tester.pumpAndSettle();
+
+    // A real PDF was written — not the old browser-printable HTML — and handed
+    // to the platform viewer so the operator can print straight away.
+    expect(harness.passwordWrites, hasLength(1));
+    expect(harness.passwordWrites.single.$1, 'leerling-wachtwoorden.pdf');
+    expect(
+      latin1.decode(harness.passwordWrites.single.$2.sublist(0, 5)),
+      '%PDF-',
+    );
+    expect(harness.passwordOpens, hasLength(1));
+    // The queue drained on a successful export, so the button goes quiet again.
+    expect(tester.widget<OutlinedButton>(print).onPressed, isNull);
   });
 
   testWidgets(

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -332,6 +332,124 @@ void main() {
         findsOneWidget);
   });
 
+  testWidgets(
+      'a school cell is titled by its WISA code with the long name beneath '
+      '(#194)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // The code (`ismaa`) is how the schools are identified day to day, so it
+    // leads; the long name is the secondary line and the numeric id is gone.
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisaSchools: [
+          WisaSchoolProfile(schoolId: 42, code: 'ismaa', name: 'Sint-Jan'),
+        ],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    final tile = find.byKey(const ValueKey('settings-wisa-school-42-ours'));
+    expect(tile, findsOneWidget);
+    expect(find.descendant(of: tile, matching: find.text('ismaa')),
+        findsOneWidget);
+    expect(find.descendant(of: tile, matching: find.text('Sint-Jan')),
+        findsOneWidget);
+    expect(find.text('id: 42'), findsNothing);
+    expect(find.text('School 42'), findsNothing);
+  });
+
+  testWidgets(
+      'a school known only by its id shows that id once, not twice (#194)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // Neither code nor name stored: the id is the only identifier left, so it
+    // must appear exactly once instead of as both title and subtitle.
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisaSchools: [WisaSchoolProfile(schoolId: 9)],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    expect(find.text('School 9'), findsOneWidget);
+    expect(find.text('id: 9'), findsNothing);
+  });
+
+  testWidgets(
+      'a code-less profile falls back to the name, with the id as the '
+      'secondary line (#194)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // Written before #194: name but no code. The name leads and the id is the
+    // secondary line — still no duplication.
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisaSchools: [WisaSchoolProfile(schoolId: 43, name: 'Sint-Pieter')],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    expect(find.text('Sint-Pieter'), findsOneWidget);
+    expect(find.text('id: 43'), findsOneWidget);
+    expect(find.text('School 43'), findsNothing);
+  });
+
+  testWidgets('fetch backfills the school code and save persists it (#194)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    // `SMAGetInst` puts the short code in the CSV NAME column, which the
+    // connector maps onto `WisaSchool.description` (the legacy swap).
+    final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
+      WisaSchool(id: 7, name: 'Sint-Pieter', description: 'ismab'),
+    ]);
+    // Stored before #194: managed, named, but with no code.
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisa: WisaConnection(server: 'db.school.example', port: '1433'),
+        wisaSchools: [
+          WisaSchoolProfile(schoolId: 7, name: 'Sint-Pieter', ours: true),
+        ],
+      ),
+      secrets: {passwordRef: 'stored-pw'},
+      fetchWisaSchools: fetcher.call,
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    expect(find.text('ismab'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-fetch-schools')));
+    await tester.pumpAndSettle();
+
+    // The code now leads the cell and the managed mark survived the merge.
+    expect(find.text('ismab'), findsOneWidget);
+    expect(find.text('Sint-Pieter'), findsOneWidget);
+    expect(
+        tester
+            .widget<CheckboxListTile>(
+                find.byKey(const ValueKey('settings-wisa-school-7-ours')))
+            .value,
+        isTrue);
+
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.wisaSchools.single.code, 'ismab');
+    expect(saved.wisaSchools.single.name, 'Sint-Pieter');
+    expect(saved.wisaSchools.single.ours, isTrue);
+  });
+
   testWidgets('no manual add-by-id UI remains (#171)',
       (WidgetTester tester) async {
     _useTallWindow(tester);

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -375,8 +375,9 @@ class ModifySmartschoolData extends GroupAction {
   /// The Smartschool group as it will look once synced. Institute number and
   /// description are pulled from WISA; Untis is converged to the class name
   /// (legacy's fixed remediation target); everything else
-  /// (id/name/type/official/parent/admin number) is preserved. Idempotent for a
-  /// field that already agrees.
+  /// (id/name/type/official/parent/admin number, and the Smartschool-internal
+  /// [Group.sourceId] this write does not touch) is preserved. Idempotent for
+  /// a field that already agrees.
   Group _synced() => Group(
         id: _ss.id,
         name: _ss.name,
@@ -387,6 +388,7 @@ class ModifySmartschoolData extends GroupAction {
         instituteNumber: _wisa.instituteNumber,
         adminNumber: _ss.adminNumber,
         untis: _ss.name,
+        sourceId: _ss.sourceId,
         origin: _ss.origin,
       );
 

--- a/packages/account_actions/test/group_apply_test.dart
+++ b/packages/account_actions/test/group_apply_test.dart
@@ -42,6 +42,7 @@ void main() {
             instituteNumber: '123456',
             description: 'Oud',
             adminNumber: 7,
+            sourceId: 298,
           ),
         ),
       );
@@ -52,9 +53,11 @@ void main() {
       expect(result.system, Origin.smartschool);
       expect(result.group?.instituteNumber, '999999');
       expect(result.group?.description, 'Nieuw');
-      // Untouched fields are preserved on the mutated record.
+      // Untouched fields are preserved on the mutated record, including the
+      // Smartschool-internal group id this write never touches (#138).
       expect(result.group?.adminNumber, 7);
       expect(result.group?.name, '3A');
+      expect(result.group?.sourceId, 298);
     });
 
     test('a failed saveClass leaves the bound record untouched (INV-41)',

--- a/packages/account_actions/test/support/fixtures.dart
+++ b/packages/account_actions/test/support/fixtures.dart
@@ -337,6 +337,7 @@ Group ssGroup({
   int? adminNumber = 7,
   String? parentId = 'jaar-3',
   String? untis,
+  int? sourceId,
 }) =>
     Group(
       id: GroupId(code),
@@ -348,6 +349,7 @@ Group ssGroup({
       instituteNumber: instituteNumber,
       adminNumber: adminNumber,
       untis: untis ?? name,
+      sourceId: sourceId,
       origin: Origin.smartschool,
     );
 

--- a/packages/account_core/lib/src/group.dart
+++ b/packages/account_core/lib/src/group.dart
@@ -29,6 +29,18 @@ class Group {
   /// `IGroup.Untis`; `ModifySmartschoolData` converges a drifted value to [name].
   final String untis;
 
+  /// The [origin] system's own numeric identifier for this group, when it
+  /// exposes one distinct from [id].
+  ///
+  /// Smartschool returns it in the per-account `groups` arrays of
+  /// `getAllAccountsExtended` (e.g. `298` for class code `SSM1A`) but *not* in
+  /// the `getAllGroupsAndClasses` tree these records are built from, so the
+  /// connector backfills it by joining on the code (#138). It is the id
+  /// Smartschool uses to address a group outside its SOAP API. `null` when the
+  /// sync could not resolve one — a group with no members anywhere — or when
+  /// the system carries no such id (WISA class groups).
+  final int? sourceId;
+
   final Origin origin;
 
   const Group({
@@ -41,6 +53,7 @@ class Group {
     this.instituteNumber,
     this.adminNumber,
     this.untis = '',
+    this.sourceId,
     required this.origin,
   });
 
@@ -54,6 +67,7 @@ class Group {
         if (instituteNumber != null) 'instituteNumber': instituteNumber,
         if (adminNumber != null) 'adminNumber': adminNumber,
         if (untis.isNotEmpty) 'untis': untis,
+        if (sourceId != null) 'sourceId': sourceId,
         'origin': origin.toJson(),
       };
 
@@ -69,6 +83,7 @@ class Group {
         instituteNumber: json['instituteNumber'] as String?,
         adminNumber: json['adminNumber'] as int?,
         untis: json['untis'] as String? ?? '',
+        sourceId: json['sourceId'] as int?,
         origin: Origin.fromJson(json['origin'] as String),
       );
 
@@ -85,6 +100,7 @@ class Group {
           instituteNumber == other.instituteNumber &&
           adminNumber == other.adminNumber &&
           untis == other.untis &&
+          sourceId == other.sourceId &&
           origin == other.origin;
 
   @override
@@ -98,6 +114,7 @@ class Group {
         instituteNumber,
         adminNumber,
         untis,
+        sourceId,
         origin,
       );
 }

--- a/packages/account_core/test/group_test.dart
+++ b/packages/account_core/test/group_test.dart
@@ -9,6 +9,7 @@ Group _group({
   String? institute,
   int? admin,
   String untis = '',
+  int? sourceId,
   GroupType type = GroupType.classGroup,
   bool official = true,
 }) =>
@@ -22,6 +23,7 @@ Group _group({
       instituteNumber: institute,
       adminNumber: admin,
       untis: untis,
+      sourceId: sourceId,
       origin: Origin.wisa,
     );
 
@@ -32,10 +34,16 @@ void main() {
       expect(Group.fromJson(g.toJson()), equals(g));
     });
 
-    test('full (parent, institute, admin, untis)', () {
-      final g =
-          _group(parent: 'root', institute: '12345', admin: 7, untis: '5A');
+    test('full (parent, institute, admin, untis, sourceId)', () {
+      final g = _group(
+        parent: 'root',
+        institute: '12345',
+        admin: 7,
+        untis: '5A',
+        sourceId: 298,
+      );
       expect(Group.fromJson(g.toJson()), equals(g));
+      expect(Group.fromJson(g.toJson()).sourceId, 298);
     });
 
     test('survives encode/decode through dart:convert', () {
@@ -54,11 +62,17 @@ void main() {
       expect(json.containsKey('instituteNumber'), isFalse);
       expect(json.containsKey('adminNumber'), isFalse);
       expect(json.containsKey('untis'), isFalse);
+      expect(json.containsKey('sourceId'), isFalse);
     });
 
     test('legacy JSON without untis decodes to an empty untis', () {
       final json = _group(institute: '12345').toJson()..remove('untis');
       expect(Group.fromJson(json).untis, '');
+    });
+
+    test('JSON written before #138 decodes to a null sourceId', () {
+      final json = _group(sourceId: 298).toJson()..remove('sourceId');
+      expect(Group.fromJson(json).sourceId, isNull);
     });
   });
 
@@ -68,6 +82,8 @@ void main() {
       expect(_group().hashCode, equals(_group().hashCode));
       expect(_group(official: true), isNot(equals(_group(official: false))));
       expect(_group(untis: '5A'), isNot(equals(_group(untis: 'stale'))));
+      expect(_group(sourceId: 298), isNot(equals(_group(sourceId: 4))));
+      expect(_group(sourceId: 298), isNot(equals(_group())));
       expect(
         _group(type: GroupType.group),
         isNot(equals(_group(type: GroupType.classGroup))),

--- a/packages/account_state/lib/src/settings/wisa_school_profile.dart
+++ b/packages/account_state/lib/src/settings/wisa_school_profile.dart
@@ -9,12 +9,14 @@
 /// operator-editable ownership record keyed by school *id* that survives in the
 /// settings blob.
 ///
-/// The shape (`{ schoolId, name, ours, prefix }`) is the per-WISA-school ownership
-/// link #112/#113 called for, so the settings document is not reshaped twice.
-/// This slice only carries the data — no action reads it yet (#134 is slice 2).
+/// The shape (`{ schoolId, code, name, ours, prefix }`) is the per-WISA-school
+/// ownership link #112/#113 called for, so the settings document is not reshaped
+/// twice. This slice only carries the data — no action reads it yet (#134 is
+/// slice 2).
 class WisaSchoolProfile {
   const WisaSchoolProfile({
     required this.schoolId,
+    this.code = '',
     this.name = '',
     this.ours = false,
     this.prefix = '',
@@ -23,10 +25,19 @@ class WisaSchoolProfile {
   /// The WISA school id (`WisaSchool.id`) this ownership entry is keyed by.
   final int schoolId;
 
-  /// The WISA school name (`WisaSchool.name`), persisted so the settings editor
-  /// can render the full known-school list by name without re-fetching. Empty
-  /// for profiles stored before the name was persisted (#171) — the editor
-  /// falls back to `School <id>` and a later fetch fills the name in.
+  /// The short WISA school code (`ismaa`, `ismab`, …) — how the schools are
+  /// identified day to day, and what the settings editor leads each cell with
+  /// (#194). It arrives on `WisaSchool.description`, not `.name`: the
+  /// `SMAGetInst` CSV columns are `ID,NAME,DESCRIPTION` and the connector
+  /// preserves the legacy swap of the last two. Empty for profiles stored
+  /// before the code was persisted — the editor falls back to the [name] and
+  /// a later fetch fills the code in.
+  final String code;
+
+  /// The WISA school name (`WisaSchool.name`), the long descriptive name shown
+  /// beneath the [code]. Empty for profiles stored before the name was
+  /// persisted (#171) — the editor falls back to `School <id>` and a later
+  /// fetch fills the name in.
   final String name;
 
   /// Whether we manage this school. A student found only in schools where this
@@ -40,12 +51,14 @@ class WisaSchoolProfile {
 
   WisaSchoolProfile copyWith({
     int? schoolId,
+    String? code,
     String? name,
     bool? ours,
     String? prefix,
   }) =>
       WisaSchoolProfile(
         schoolId: schoolId ?? this.schoolId,
+        code: code ?? this.code,
         name: name ?? this.name,
         ours: ours ?? this.ours,
         prefix: prefix ?? this.prefix,
@@ -53,6 +66,7 @@ class WisaSchoolProfile {
 
   Map<String, dynamic> toJson() => {
         'schoolId': schoolId,
+        'code': code,
         'name': name,
         'ours': ours,
         'prefix': prefix,
@@ -61,6 +75,7 @@ class WisaSchoolProfile {
   factory WisaSchoolProfile.fromJson(Map<String, dynamic> json) =>
       WisaSchoolProfile(
         schoolId: json['schoolId'] as int,
+        code: (json['code'] as String?) ?? '',
         name: (json['name'] as String?) ?? '',
         ours: (json['ours'] as bool?) ?? false,
         prefix: (json['prefix'] as String?) ?? '',
@@ -71,15 +86,16 @@ class WisaSchoolProfile {
       identical(this, other) ||
       other is WisaSchoolProfile &&
           schoolId == other.schoolId &&
+          code == other.code &&
           name == other.name &&
           ours == other.ours &&
           prefix == other.prefix;
 
   @override
-  int get hashCode => Object.hash(schoolId, name, ours, prefix);
+  int get hashCode => Object.hash(schoolId, code, name, ours, prefix);
 
   @override
   String toString() =>
-      'WisaSchoolProfile(schoolId: $schoolId, name: $name, ours: $ours, '
-      'prefix: $prefix)';
+      'WisaSchoolProfile(schoolId: $schoolId, code: $code, name: $name, '
+      'ours: $ours, prefix: $prefix)';
 }

--- a/packages/account_state/test/settings_store_test.dart
+++ b/packages/account_state/test/settings_store_test.dart
@@ -122,6 +122,38 @@ void main() {
       expect(restored.wisaSchools.last.ours, isFalse);
     });
 
+    test('the WISA school code round-trips through JSON (#194)', () {
+      const original = AppSettings(
+        wisaSchools: [
+          WisaSchoolProfile(
+              schoolId: 10, code: 'ismaa', name: 'Sint-Jan', ours: true),
+        ],
+      );
+      final restored = AppSettings.fromJson(original.toJson());
+      expect(restored.wisaSchools, original.wisaSchools);
+      expect(restored.wisaSchools.single.code, 'ismaa');
+      expect(restored.wisaSchools.single.name, 'Sint-Jan');
+    });
+
+    test(
+        'a school profile predating the persisted code loads with an empty '
+        'code (#194)', () {
+      final settings = AppSettings.fromJson({
+        'wisaSchools': [
+          {'schoolId': 42, 'name': 'Sint-Jan', 'ours': true, 'prefix': ''},
+        ],
+      });
+      expect(settings.wisaSchools.single.code, isEmpty);
+      expect(settings.wisaSchools.single.name, 'Sint-Jan');
+    });
+
+    test('copyWith preserves and can replace the school code (#194)', () {
+      const profile =
+          WisaSchoolProfile(schoolId: 10, code: 'ismaa', name: 'Sint-Jan');
+      expect(profile.copyWith(ours: true).code, 'ismaa');
+      expect(profile.copyWith(code: 'ismab').code, 'ismab');
+    });
+
     test('managedWisaSchoolIds is the set of ours-flagged school ids (#178)',
         () {
       const settings = AppSettings(

--- a/packages/smartschool_api/lib/smartschool_api.dart
+++ b/packages/smartschool_api/lib/smartschool_api.dart
@@ -19,7 +19,12 @@ export 'src/models/smartschool_account.dart' show SmartschoolAccount;
 export 'src/models/smartschool_group.dart' show SmartschoolGroup;
 export 'src/models/smartschool_membership.dart' show SmartschoolMembership;
 export 'src/parsing/account_json.dart'
-    show parseSmartschoolAccount, parseSmartschoolAccounts;
+    show
+        SmartschoolAccountPayload,
+        parseSmartschoolAccount,
+        parseSmartschoolAccountPayload,
+        parseSmartschoolAccounts,
+        parseSmartschoolGroupIds;
 export 'src/parsing/date_format.dart'
     show formatSmartschoolDate, parseSmartschoolDate;
 export 'src/parsing/group_tree.dart' show parseGroupTree;
@@ -34,6 +39,7 @@ export 'src/parsing/mappings.dart'
         personRoleFromBasisrol,
         smartschoolGender,
         smartschoolRole,
+        smartschoolUserIdFrom,
         statusFromAccountState;
 export 'src/rules/import_rules.dart'
     show

--- a/packages/smartschool_api/lib/src/connector.dart
+++ b/packages/smartschool_api/lib/src/connector.dart
@@ -105,6 +105,13 @@ class SmartschoolConnector {
   /// emitted per (account, group) pair, so an account appearing in several
   /// subtrees produces several membership rows (PAIN-1); the account record
   /// itself is deduplicated by `uid`.
+  ///
+  /// Smartschool's internal group ids are backfilled onto the projected
+  /// groups from the `groups` arrays the account payloads carry (#138) — the
+  /// group tree itself does not return them, and this join costs no extra
+  /// API call. Projection is deferred until the whole walk is done so a group
+  /// still gets its id when only another group's payload named it. A group
+  /// with no members anywhere stays unresolved (`sourceId == null`).
   Future<SmartschoolSnapshot> sync({
     Iterable<SmartschoolImportRule> rules = const [],
   }) async {
@@ -115,11 +122,24 @@ class SmartschoolConnector {
     final payload = decodeReturn(treeXml).text;
     final forest = applyImportRules(parseGroupTree(payload), rules);
 
-    final groups = <core.Group>[];
+    final visited = <SmartschoolGroup>[];
     final accountsByUid = <String, SmartschoolAccount>{};
     final memberships = <SmartschoolMembership>[];
+    final groupIdsByCode = <String, int>{};
 
-    await _walkGroups(forest, groups, accountsByUid, memberships);
+    await _walkGroups(
+      forest,
+      visited,
+      accountsByUid,
+      memberships,
+      groupIdsByCode,
+    );
+
+    final groups = <core.Group>[];
+    for (final node in visited) {
+      node.id ??= groupIdsByCode[node.code];
+      groups.add(node.toCoreGroup());
+    }
 
     return SmartschoolSnapshot(
       fetchedAt: DateTime.now(),
@@ -129,18 +149,23 @@ class SmartschoolConnector {
     );
   }
 
+  /// Depth-first walk over [nodes], collecting the visited nodes in tree order
+  /// plus their accounts, membership rows, and the group ids their account
+  /// payloads carry.
   Future<void> _walkGroups(
     List<SmartschoolGroup> nodes,
-    List<core.Group> groups,
+    List<SmartschoolGroup> visited,
     Map<String, SmartschoolAccount> accountsByUid,
     List<SmartschoolMembership> memberships,
+    Map<String, int> groupIdsByCode,
   ) async {
     for (final node in nodes) {
-      groups.add(node.toCoreGroup());
+      visited.add(node);
 
       if (node.code.isNotEmpty) {
-        final accounts = await _loadAccounts(node.code, node.name);
-        for (final account in accounts) {
+        final payload = await _loadAccounts(node.code, node.name);
+        groupIdsByCode.addAll(payload.groupIds);
+        for (final account in payload.accounts) {
           accountsByUid.putIfAbsent(account.uid, () => account);
           memberships.add(
             SmartschoolMembership(
@@ -151,14 +176,21 @@ class SmartschoolConnector {
         }
       }
 
-      await _walkGroups(node.children, groups, accountsByUid, memberships);
+      await _walkGroups(
+        node.children,
+        visited,
+        accountsByUid,
+        memberships,
+        groupIdsByCode,
+      );
     }
   }
 
   /// Loads the direct accounts of one group (non-recursive), filtering out
-  /// disabled accounts. Returns an empty list when the group has no direct
-  /// accounts (Smartschool code 19) or the payload is empty.
-  Future<List<SmartschoolAccount>> _loadAccounts(
+  /// disabled accounts, together with the Smartschool group ids the payload
+  /// carries. Returns an empty payload when the group has no direct accounts
+  /// (Smartschool code 19) or the payload is empty.
+  Future<SmartschoolAccountPayload> _loadAccounts(
     String groupCode,
     String groupName,
   ) async {
@@ -182,19 +214,19 @@ class SmartschoolConnector {
       } else if (code != 0) {
         _log?.addError(core.Origin.smartschool, await _message(code));
       }
-      return const [];
+      return const SmartschoolAccountPayload(accounts: [], groupIds: {});
     }
 
-    final parsed = parseSmartschoolAccounts(ret.text);
+    final parsed = parseSmartschoolAccountPayload(ret.text);
     final kept = [
-      for (final a in parsed)
+      for (final a in parsed.accounts)
         if (a.status != disabledStatus) a,
     ];
     _log?.addMessage(
       core.Origin.smartschool,
       'Added ${kept.length} accounts to $groupName',
     );
-    return kept;
+    return SmartschoolAccountPayload(accounts: kept, groupIds: parsed.groupIds);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/smartschool_api/lib/src/models/smartschool_account.dart
+++ b/packages/smartschool_api/lib/src/models/smartschool_account.dart
@@ -1,5 +1,6 @@
 import 'package:account_core/account_core.dart' as core;
 
+import '../parsing/mappings.dart';
 import 'co_account_slot.dart';
 
 /// A Smartschool account record — one entry from `getAllAccountsExtended`
@@ -70,6 +71,23 @@ class SmartschoolAccount implements core.SmartschoolAccount {
   /// `uitgeschakeld`.
   final String status;
 
+  /// Smartschool's raw `referenceIdentifier`, verbatim as returned —
+  /// `<platformId>_<userId>_<coAccountIndex>`, e.g. `4069_12016_0` (#138).
+  ///
+  /// `null` when the payload omits it (older tenants, some co-account rows);
+  /// the parser never fails on a missing or malformed value. Use
+  /// [internalUserId] for the middle segment on its own.
+  final String? referenceIdentifier;
+
+  /// Smartschool's internal user id — the middle segment of
+  /// [referenceIdentifier], e.g. `12016` for `4069_12016_0` (#138).
+  ///
+  /// This is the id Smartschool uses to address a user outside this SOAP API;
+  /// it is none of [accountId] ("Internnummer"), [stemId], or the scannable
+  /// code. `null` when [referenceIdentifier] is absent or does not have the
+  /// documented three-segment shape.
+  int? get internalUserId => smartschoolUserIdFrom(referenceIdentifier);
+
   /// Parent/guardian co-account slots, in ascending slot order. Only
   /// non-empty slots are present.
   final List<CoAccountSlot> coAccounts;
@@ -96,6 +114,7 @@ class SmartschoolAccount implements core.SmartschoolAccount {
     required this.fax,
     required this.untisId,
     required this.status,
+    this.referenceIdentifier,
     this.coAccounts = const [],
   });
 
@@ -124,6 +143,7 @@ class SmartschoolAccount implements core.SmartschoolAccount {
     String? fax,
     String? untisId,
     String? status,
+    String? referenceIdentifier,
     List<CoAccountSlot>? coAccounts,
   }) =>
       SmartschoolAccount(
@@ -148,6 +168,7 @@ class SmartschoolAccount implements core.SmartschoolAccount {
         fax: fax ?? this.fax,
         untisId: untisId ?? this.untisId,
         status: status ?? this.status,
+        referenceIdentifier: referenceIdentifier ?? this.referenceIdentifier,
         coAccounts: coAccounts ?? this.coAccounts,
       );
 
@@ -175,6 +196,8 @@ class SmartschoolAccount implements core.SmartschoolAccount {
         'fax': fax,
         'untisId': untisId,
         'status': status,
+        if (referenceIdentifier != null)
+          'referenceIdentifier': referenceIdentifier,
         'coAccounts': [for (final c in coAccounts) c.toJson()],
       };
 
@@ -205,6 +228,7 @@ class SmartschoolAccount implements core.SmartschoolAccount {
         fax: json['fax'] as String,
         untisId: json['untisId'] as String,
         status: json['status'] as String,
+        referenceIdentifier: json['referenceIdentifier'] as String?,
         coAccounts: [
           for (final e in (json['coAccounts'] as List<dynamic>? ?? const []))
             CoAccountSlot.fromJson(e as Map<String, dynamic>),
@@ -236,6 +260,7 @@ class SmartschoolAccount implements core.SmartschoolAccount {
           fax == other.fax &&
           untisId == other.untisId &&
           status == other.status &&
+          referenceIdentifier == other.referenceIdentifier &&
           _listEquals(coAccounts, other.coAccounts);
 
   @override
@@ -261,6 +286,7 @@ class SmartschoolAccount implements core.SmartschoolAccount {
         fax,
         untisId,
         status,
+        referenceIdentifier,
         ...coAccounts,
       ]);
 

--- a/packages/smartschool_api/lib/src/models/smartschool_group.dart
+++ b/packages/smartschool_api/lib/src/models/smartschool_group.dart
@@ -16,6 +16,16 @@ class SmartschoolGroup {
   /// [core.GroupId] value.
   String code;
 
+  /// Smartschool's own numeric group id (e.g. `298` for class code `SSM1A`) —
+  /// the id it uses to address a group outside this SOAP API.
+  ///
+  /// `getAllGroupsAndClasses`, the payload this node is parsed from, does
+  /// **not** carry it, so the connector backfills it during `sync` from the
+  /// per-account `groups` arrays of `getAllAccountsExtended` (#138). Stays
+  /// `null` when nothing in the sync resolved it — a group with no members
+  /// anywhere is named by no account payload.
+  int? id;
+
   core.GroupType type;
 
   /// `true` ⇒ official class (has students); requires an institute and
@@ -44,6 +54,7 @@ class SmartschoolGroup {
     this.name = '',
     this.description = '',
     this.code = '',
+    this.id,
     this.type = core.GroupType.invalid,
     this.official = false,
     this.visible = false,
@@ -59,7 +70,9 @@ class SmartschoolGroup {
 
   /// Projects this node to an immutable [core.Group]. `parentId` is set from
   /// [parentCode] when it is non-empty. [untis] is carried through so the
-  /// action engine can detect Untis-only drift (`ModifySmartschoolData`).
+  /// action engine can detect Untis-only drift (`ModifySmartschoolData`), and
+  /// [id] becomes `core.Group.sourceId` so consumers of the snapshot can
+  /// resolve the Smartschool-internal group id without extra API calls (#138).
   core.Group toCoreGroup() => core.Group(
         id: core.GroupId(code),
         name: name,
@@ -72,6 +85,7 @@ class SmartschoolGroup {
         instituteNumber: instituteNumber.isEmpty ? null : instituteNumber,
         adminNumber: adminNumber == 0 ? null : adminNumber,
         untis: untis,
+        sourceId: id,
         origin: core.Origin.smartschool,
       );
 }

--- a/packages/smartschool_api/lib/src/parsing/account_json.dart
+++ b/packages/smartschool_api/lib/src/parsing/account_json.dart
@@ -7,28 +7,86 @@ import '../models/smartschool_account.dart';
 import 'date_format.dart';
 import 'mappings.dart';
 
+/// Everything one `getAllAccountsExtended` payload carries: the account
+/// records plus the Smartschool-internal group ids embedded in each account's
+/// `groups` array (#138).
+class SmartschoolAccountPayload {
+  /// The parsed accounts, in payload order. Disabled accounts are **not**
+  /// filtered here — the connector does that.
+  final List<SmartschoolAccount> accounts;
+
+  /// Smartschool's numeric group id per group code, e.g. `SSM1A: 298`,
+  /// harvested from every account's `groups` array. Covers the account's whole
+  /// group set, not just the group the payload was requested for, so one
+  /// response resolves ids for several groups at once.
+  final Map<String, int> groupIds;
+
+  const SmartschoolAccountPayload({
+    required this.accounts,
+    required this.groupIds,
+  });
+}
+
 /// Parses the JSON payload of `getAllAccountsExtended` (a JSON array of
 /// account objects) into [SmartschoolAccount]s.
 ///
 /// Unlike the legacy `LoadFromJSON`, the six co-account slots are preserved
 /// (issue #21, spec §3.5). Throws [FormatException] if [jsonText] is not a
 /// JSON array.
-List<SmartschoolAccount> parseSmartschoolAccounts(String jsonText) {
+List<SmartschoolAccount> parseSmartschoolAccounts(String jsonText) =>
+    parseSmartschoolAccountPayload(jsonText).accounts;
+
+/// Parses a `getAllAccountsExtended` payload into its accounts *and* the group
+/// ids its `groups` arrays carry, decoding the JSON only once.
+///
+/// Throws [FormatException] if [jsonText] is not a JSON array.
+SmartschoolAccountPayload parseSmartschoolAccountPayload(String jsonText) {
   final decoded = json.decode(jsonText);
   if (decoded is! List) {
     throw FormatException(
       'Expected a JSON array of accounts, got ${decoded.runtimeType}',
     );
   }
-  return [
-    for (final e in decoded) parseSmartschoolAccount(e as Map<String, dynamic>),
-  ];
+  final accounts = <SmartschoolAccount>[];
+  final groupIds = <String, int>{};
+  for (final e in decoded) {
+    final row = e as Map<String, dynamic>;
+    accounts.add(parseSmartschoolAccount(row));
+    groupIds.addAll(parseSmartschoolGroupIds(row));
+  }
+  return SmartschoolAccountPayload(accounts: accounts, groupIds: groupIds);
+}
+
+/// Reads the `groups` array of one decoded account object into a
+/// `code → Smartschool group id` map, e.g.
+/// `[{"id":"298","code":"SSM1A"},{"id":"4","code":"LLN"}]` → `{SSM1A: 298,
+/// LLN: 4}` (#138).
+///
+/// The id arrives as a numeric string on the live wire; an int is accepted
+/// too. Entries without a usable code or a numeric id are skipped — the ids
+/// are informational and must never fail a sync.
+Map<String, int> parseSmartschoolGroupIds(Map<String, dynamic> json) {
+  final raw = _lowerKeyed(json)['groups'];
+  if (raw is! List) return const {};
+  final ids = <String, int>{};
+  for (final entry in raw) {
+    if (entry is! Map) continue;
+    final fields = <String, dynamic>{
+      for (final e in entry.entries) e.key.toString().toLowerCase(): e.value,
+    };
+    final code = fields['code']?.toString().trim() ?? '';
+    final id = _asInt(fields['id']);
+    if (code.isEmpty || id == null) continue;
+    ids[code] = id;
+  }
+  return ids;
 }
 
 /// Parses a single decoded account object into a [SmartschoolAccount].
 ///
 /// Field mapping mirrors legacy `AccountManager.LoadFromJSON`
-/// (`AccountManager.cs:507-575`), extended to retain co-account slots.
+/// (`AccountManager.cs:507-575`), extended to retain co-account slots and the
+/// Smartschool-internal `referenceIdentifier` (#138).
 ///
 /// The live `getAllAccountsExtended` payload uses **lowercase** wire keys
 /// (`gebruikersnaam`, `internnummer`, …). The legacy connector deserialized
@@ -39,17 +97,14 @@ List<SmartschoolAccount> parseSmartschoolAccounts(String jsonText) {
 /// directly (as this parser first did) returned `null` for every field — the
 /// cause of the empty/duplicate snapshot in #37.
 SmartschoolAccount parseSmartschoolAccount(Map<String, dynamic> json) {
-  // Lowercase every key once so lookups are case-insensitive (Newtonsoft
-  // semantics). On the off chance two keys collide when lowercased, last wins.
-  final byLowerKey = <String, dynamic>{
-    for (final entry in json.entries) entry.key.toLowerCase(): entry.value,
-  };
+  final byLowerKey = _lowerKeyed(json);
   String s(String key) {
     final v = byLowerKey[key.toLowerCase()];
     return v == null ? '' : v.toString();
   }
 
   final roepnaam = s('Roepnaam');
+  final reference = s('referenceIdentifier');
 
   return SmartschoolAccount(
     uid: s('Gebruikersnaam'),
@@ -81,8 +136,24 @@ SmartschoolAccount parseSmartschoolAccount(Map<String, dynamic> json) {
     // Smartschool does not return UntisID via getAllAccountsExtended.
     untisId: '',
     status: s('Status'),
+    // Absent on older tenants and some co-account rows: keep it null rather
+    // than storing an empty string (#138).
+    referenceIdentifier: reference.isEmpty ? null : reference,
     coAccounts: _parseCoAccounts(s),
   );
+}
+
+/// Lowercases every key once so lookups are case-insensitive (Newtonsoft
+/// semantics). On the off chance two keys collide when lowercased, last wins.
+Map<String, dynamic> _lowerKeyed(Map<String, dynamic> json) => {
+      for (final entry in json.entries) entry.key.toLowerCase(): entry.value,
+    };
+
+/// Reads a wire value that may arrive as an int or as a numeric string.
+int? _asInt(Object? value) {
+  if (value is int) return value;
+  if (value is String) return int.tryParse(value.trim());
+  return null;
 }
 
 /// Reads the six `*_coaccountN` slot groups. Empty slots are dropped, so the

--- a/packages/smartschool_api/lib/src/parsing/mappings.dart
+++ b/packages/smartschool_api/lib/src/parsing/mappings.dart
@@ -138,3 +138,21 @@ String statusFromAccountState(core.AccountState state) {
       return 'invalid';
   }
 }
+
+/// Extracts Smartschool's internal user id from a raw `referenceIdentifier`.
+///
+/// The field is shaped `<platformId>_<userId>_<coAccountIndex>` — e.g.
+/// `4069_12016_0` yields `12016`. Only `getUserDetails*` and
+/// `getAllAccountsExtended` return it (#138).
+///
+/// Returns `null` for anything that is not exactly three underscore-separated
+/// segments with a numeric middle one: a missing field (older tenants), an
+/// empty string, or a malformed row. The value is informational, so a bad one
+/// must never fail a sync.
+int? smartschoolUserIdFrom(String? referenceIdentifier) {
+  final raw = referenceIdentifier?.trim();
+  if (raw == null || raw.isEmpty) return null;
+  final parts = raw.split('_');
+  if (parts.length != 3) return null;
+  return int.tryParse(parts[1]);
+}

--- a/packages/smartschool_api/test/connector_test.dart
+++ b/packages/smartschool_api/test/connector_test.dart
@@ -235,6 +235,51 @@ void main() {
       expect(jand.stemId, 123456);
     });
 
+    test('carries the referenceIdentifier and internal user id (#138)',
+        () async {
+      final t = _FakeTransport();
+      final snap = await _connector(t).sync();
+      final jand = snap.accounts.firstWhere((a) => a.uid == 'jand');
+      expect(jand.referenceIdentifier, '4069_1001_0');
+      expect(jand.internalUserId, 1001);
+
+      // A truncated value (older tenants) survives the sync as-is; only the
+      // derived id is null. The account is not dropped or degraded.
+      final saral = snap.accounts.firstWhere((a) => a.uid == 'saral');
+      expect(saral.referenceIdentifier, '4069');
+      expect(saral.internalUserId, isNull);
+    });
+
+    test('backfills Smartschool group ids onto the snapshot groups (#138)',
+        () async {
+      final t = _FakeTransport();
+      final snap = await _connector(t).sync();
+      final byCode = {for (final g in snap.groups) g.id.value: g.sourceId};
+      // C1A/C1B come from their own account payloads; GSPORT's id is also
+      // named by jand's C1A payload, so the join is a union over every
+      // response, not a per-group read.
+      expect(byCode['C1A'], 101);
+      expect(byCode['C1B'], 102);
+      expect(byCode['GSPORT'], 401);
+      // SCH has no direct accounts (code 19), so nothing names its id.
+      expect(byCode['SCH'], isNull);
+      // No extra API call was made to resolve them.
+      expect(t.sentTo('getClassListJson'), isFalse);
+    });
+
+    test('leaves group ids null when no payload names them (#138)', () async {
+      // Discarding Sport removes the only payload that names GSPORT *and*
+      // GSPORT itself; C1A is still resolved from its own payload.
+      final t = _FakeTransport();
+      final snap = await _connector(t).sync(
+        rules: const [DiscardSmartschoolGroup('Sport')],
+      );
+      final byCode = {for (final g in snap.groups) g.id.value: g.sourceId};
+      expect(byCode.keys, ['SCH', 'C1A', 'C1B']);
+      expect(byCode['C1A'], 101);
+      expect(byCode['SCH'], isNull);
+    });
+
     test('applies DiscardSmartschoolGroup before loading accounts', () async {
       final t = _FakeTransport();
       final snap = await _connector(t).sync(

--- a/packages/smartschool_api/test/fixtures/README.md
+++ b/packages/smartschool_api/test/fixtures/README.md
@@ -29,3 +29,11 @@ Scenarios encoded in the fixtures:
   (Vader) partial; slot 2 is empty and must be dropped → two slots surfaced.
 - **Duplicate mail (INV-13/23):** `miek` and `saral` share
   `shared@school.be`; both survive.
+- **Smartschool-internal ids (#138):** accounts carry a `referenceIdentifier`
+  (`4069_1001_0` → internal user id `1001`), except `saral`, whose truncated
+  `4069` exercises the malformed case — raw value kept, `internalUserId` null.
+  Each account's `groups` array carries the numeric group id (`C1A: 101`,
+  `C1B: 102`, `GSPORT: 401`), which the sync backfills onto the group records
+  by joining on the code. `GSPORT`'s id reaches the snapshot through `jand`'s
+  `C1A` payload as well, and `SCH` — which has no account payload at all —
+  stays unresolved (`sourceId == null`).

--- a/packages/smartschool_api/test/fixtures/accounts_C1A.json
+++ b/packages/smartschool_api/test/fixtures/accounts_C1A.json
@@ -4,6 +4,7 @@
     "naam": "Desmet",
     "gebruikersnaam": "jand",
     "internnummer": "W001",
+    "referenceIdentifier": "4069_1001_0",
     "status": "actief",
     "basisrol": "1",
     "geslacht": "m",
@@ -24,16 +25,22 @@
     "mobielnummer": "0470111222",
     "telefoonnummer": "016111222",
     "fax": "",
-    "stamboeknummer": "123456"
+    "stamboeknummer": "123456",
+    "groups": [
+      { "id": "101", "code": "C1A", "name": "1A" },
+      { "id": "401", "code": "GSPORT", "name": "Sport" }
+    ]
   },
   {
     "voornaam": "Old",
     "naam": "Gebruiker",
     "gebruikersnaam": "olduser",
     "internnummer": "W099",
+    "referenceIdentifier": "4069_1099_0",
     "status": "uitgeschakeld",
     "basisrol": "1",
     "geslacht": "f",
-    "emailadres": "old@school.be"
+    "emailadres": "old@school.be",
+    "groups": [{ "id": "101", "code": "C1A", "name": "1A" }]
   }
 ]

--- a/packages/smartschool_api/test/fixtures/accounts_C1B.json
+++ b/packages/smartschool_api/test/fixtures/accounts_C1B.json
@@ -4,6 +4,7 @@
     "naam": "Janssens",
     "gebruikersnaam": "miek",
     "internnummer": "W002",
+    "referenceIdentifier": "4069_1002_0",
     "status": "actief",
     "basisrol": "1",
     "geslacht": "f",
@@ -15,6 +16,7 @@
     "woonplaats": "Leuven",
     "land": "België",
     "emailadres": "shared@school.be",
-    "stamboeknummer": "0"
+    "stamboeknummer": "0",
+    "groups": [{ "id": "102", "code": "C1B", "name": "1B" }]
   }
 ]

--- a/packages/smartschool_api/test/fixtures/accounts_GSPORT.json
+++ b/packages/smartschool_api/test/fixtures/accounts_GSPORT.json
@@ -4,6 +4,7 @@
     "naam": "Desmet",
     "gebruikersnaam": "jand",
     "internnummer": "W001",
+    "referenceIdentifier": "4069_1001_0",
     "status": "actief",
     "basisrol": "1",
     "geslacht": "m",
@@ -19,13 +20,18 @@
     "emailadres": "jan.desmet@school.be",
     "mobielnummer": "0470111222",
     "telefoonnummer": "016111222",
-    "stamboeknummer": "123456"
+    "stamboeknummer": "123456",
+    "groups": [
+      { "id": "101", "code": "C1A", "name": "1A" },
+      { "id": "401", "code": "GSPORT", "name": "Sport" }
+    ]
   },
   {
     "voornaam": "Sara",
     "naam": "Lemmens",
     "gebruikersnaam": "saral",
     "internnummer": "W003",
+    "referenceIdentifier": "4069",
     "status": "actief",
     "basisrol": "1",
     "geslacht": "f",
@@ -46,6 +52,7 @@
     "type_coaccount2": 0,
     "voornaam_coaccount3": "Peter",
     "naam_coaccount3": "Lemmens",
-    "type_coaccount3": "Vader"
+    "type_coaccount3": "Vader",
+    "groups": [{ "id": "401", "code": "GSPORT", "name": "Sport" }]
   }
 ]

--- a/packages/smartschool_api/test/models/models_test.dart
+++ b/packages/smartschool_api/test/models/models_test.dart
@@ -5,6 +5,7 @@ import 'package:test/test.dart';
 SmartschoolAccount _account({
   String uid = 'jand',
   String mail = 'jan@school.be',
+  String? referenceIdentifier,
   List<CoAccountSlot> coAccounts = const [],
 }) {
   return SmartschoolAccount(
@@ -35,6 +36,7 @@ SmartschoolAccount _account({
     fax: '',
     untisId: '',
     status: 'actief',
+    referenceIdentifier: referenceIdentifier,
     coAccounts: coAccounts,
   );
 }
@@ -105,6 +107,78 @@ void main() {
 
     test('accountType is always student for the primary record', () {
       expect(_account().accountType, core.AccountType.student);
+    });
+
+    test('exposes the referenceIdentifier and its user id (#138)', () {
+      final a = _account(referenceIdentifier: '4069_12016_0');
+      expect(a.referenceIdentifier, '4069_12016_0');
+      expect(a.internalUserId, 12016);
+      expect(_account().referenceIdentifier, isNull);
+      expect(_account().internalUserId, isNull);
+    });
+
+    test('referenceIdentifier takes part in equality (#138)', () {
+      expect(
+        _account(referenceIdentifier: '4069_12016_0'),
+        _account(referenceIdentifier: '4069_12016_0'),
+      );
+      expect(
+        _account(referenceIdentifier: '4069_12016_0').hashCode,
+        _account(referenceIdentifier: '4069_12016_0').hashCode,
+      );
+      expect(
+        _account(referenceIdentifier: '4069_12016_0') ==
+            _account(referenceIdentifier: '4069_99999_0'),
+        isFalse,
+      );
+      expect(
+        _account(referenceIdentifier: '4069_12016_0') == _account(),
+        isFalse,
+      );
+    });
+
+    test('referenceIdentifier survives copyWith and JSON (#138)', () {
+      final a = _account(referenceIdentifier: '4069_12016_0');
+      expect(
+          a.copyWith(mail: 'x@school.be').referenceIdentifier, '4069_12016_0');
+      expect(
+        a.copyWith(referenceIdentifier: '4069_99999_0').internalUserId,
+        99999,
+      );
+      expect(SmartschoolAccount.fromJson(a.toJson()), a);
+      // Absent stays absent rather than round-tripping as an empty string.
+      expect(_account().toJson().containsKey('referenceIdentifier'), isFalse);
+      expect(
+        SmartschoolAccount.fromJson(_account().toJson()).referenceIdentifier,
+        isNull,
+      );
+    });
+  });
+
+  group('SmartschoolGroup', () {
+    SmartschoolGroup node({int? id}) => SmartschoolGroup(
+          name: '1A',
+          description: 'Klas 1A',
+          code: 'C1A',
+          id: id,
+          type: core.GroupType.classGroup,
+          official: true,
+          untis: '1A',
+          instituteNumber: '30024',
+          adminNumber: 12345,
+          parentCode: 'SCH',
+        );
+
+    test('toCoreGroup carries the Smartschool group id as sourceId (#138)', () {
+      final g = node(id: 298).toCoreGroup();
+      expect(g.sourceId, 298);
+      expect(g.id, const core.GroupId('C1A'));
+      expect(g.parentId, const core.GroupId('SCH'));
+    });
+
+    test('toCoreGroup leaves sourceId null while the id is unresolved', () {
+      expect(node().id, isNull);
+      expect(node().toCoreGroup().sourceId, isNull);
     });
   });
 

--- a/packages/smartschool_api/test/parsing/account_json_test.dart
+++ b/packages/smartschool_api/test/parsing/account_json_test.dart
@@ -67,6 +67,44 @@ void main() {
       expect(a.preferredName, '');
       expect(a.birthDate, isNull);
       expect(a.coAccounts, isEmpty);
+      expect(a.referenceIdentifier, isNull);
+      expect(a.internalUserId, isNull);
+    });
+
+    test('keeps the referenceIdentifier and splits out the user id (#138)', () {
+      final a = parseSmartschoolAccount(const {
+        'Gebruikersnaam': 'gulinv',
+        'referenceIdentifier': '4069_12016_0',
+      });
+      expect(a.referenceIdentifier, '4069_12016_0');
+      expect(a.internalUserId, 12016);
+    });
+
+    test('reads the referenceIdentifier whatever its wire casing (#138)', () {
+      // The lookup is case-insensitive like every other field (see #37).
+      final a = parseSmartschoolAccount(const {
+        'gebruikersnaam': 'gulinv',
+        'referenceidentifier': '4069_12016_0',
+      });
+      expect(a.internalUserId, 12016);
+    });
+
+    test('a malformed referenceIdentifier is kept raw, id null (#138)', () {
+      // Older tenants can truncate the field; it must not fail the parse.
+      final a = parseSmartschoolAccount(const {
+        'gebruikersnaam': 'saral',
+        'referenceIdentifier': '4069',
+      });
+      expect(a.referenceIdentifier, '4069');
+      expect(a.internalUserId, isNull);
+    });
+
+    test('an empty referenceIdentifier reads as absent, not as "" (#138)', () {
+      final a = parseSmartschoolAccount(const {
+        'gebruikersnaam': 'saral',
+        'referenceIdentifier': '',
+      });
+      expect(a.referenceIdentifier, isNull);
     });
 
     test('reads the live lowercase wire keys (regression #37)', () {
@@ -132,6 +170,66 @@ void main() {
       expect(mother.email, 'anne@example.be');
       expect(mother.accountType, core.AccountType.coAccount1);
       expect(a.coAccounts.last.accountType, core.AccountType.coAccount3);
+    });
+  });
+
+  group('parseSmartschoolGroupIds', () {
+    test('reads the per-account groups array (#138)', () {
+      final ids = parseSmartschoolGroupIds(const {
+        'gebruikersnaam': 'gulinv',
+        'groups': [
+          {'id': '298', 'code': 'SSM1A', 'name': '1A'},
+          {'id': '4', 'code': 'LLN', 'name': 'Leerlingen'},
+        ],
+      });
+      expect(ids, {'SSM1A': 298, 'LLN': 4});
+    });
+
+    test('accepts an int id and trims the code', () {
+      final ids = parseSmartschoolGroupIds(const {
+        'GROUPS': [
+          {'ID': 298, 'CODE': '  SSM1A  '},
+        ],
+      });
+      expect(ids, {'SSM1A': 298});
+    });
+
+    test('skips rows without a usable code or numeric id', () {
+      final ids = parseSmartschoolGroupIds(const {
+        'groups': [
+          {'id': '298'},
+          {'code': 'NOID'},
+          {'id': 'abc', 'code': 'BAD'},
+          {'id': '', 'code': 'EMPTY'},
+          'not-a-map',
+          {'id': '7', 'code': 'OK'},
+        ],
+      });
+      expect(ids, {'OK': 7});
+    });
+
+    test('returns an empty map when the payload carries no groups', () {
+      expect(parseSmartschoolGroupIds(const {'gebruikersnaam': 'x'}), isEmpty);
+      expect(parseSmartschoolGroupIds(const {'groups': 'nonsense'}), isEmpty);
+    });
+  });
+
+  group('parseSmartschoolAccountPayload', () {
+    test('returns accounts and the union of their group ids (#138)', () {
+      final payload = parseSmartschoolAccountPayload(
+        '[{"gebruikersnaam":"a","groups":[{"id":"101","code":"C1A"}]},'
+        '{"gebruikersnaam":"b","groups":[{"id":"401","code":"GSPORT"},'
+        '{"id":"101","code":"C1A"}]}]',
+      );
+      expect(payload.accounts.map((a) => a.uid), ['a', 'b']);
+      expect(payload.groupIds, {'C1A': 101, 'GSPORT': 401});
+    });
+
+    test('throws on a non-array payload', () {
+      expect(
+        () => parseSmartschoolAccountPayload('{"gebruikersnaam":"a"}'),
+        throwsA(isA<FormatException>()),
+      );
     });
   });
 

--- a/packages/smartschool_api/test/parsing/mappings_test.dart
+++ b/packages/smartschool_api/test/parsing/mappings_test.dart
@@ -113,4 +113,25 @@ void main() {
       expect(statusFromAccountState(core.AccountState.invalid), 'invalid');
     });
   });
+
+  group('smartschoolUserIdFrom', () {
+    test('takes the middle segment of a referenceIdentifier (#138)', () {
+      expect(smartschoolUserIdFrom('4069_12016_0'), 12016);
+      // Co-account rows carry the same user id with a non-zero slot index.
+      expect(smartschoolUserIdFrom('4069_12016_2'), 12016);
+      expect(smartschoolUserIdFrom('  4069_1001_0  '), 1001);
+    });
+
+    test('returns null for a missing or malformed value', () {
+      expect(smartschoolUserIdFrom(null), isNull);
+      expect(smartschoolUserIdFrom(''), isNull);
+      expect(smartschoolUserIdFrom('   '), isNull);
+      // Too few / too many segments, or a non-numeric user segment.
+      expect(smartschoolUserIdFrom('4069'), isNull);
+      expect(smartschoolUserIdFrom('4069_12016'), isNull);
+      expect(smartschoolUserIdFrom('4069_12016_0_1'), isNull);
+      expect(smartschoolUserIdFrom('4069__0'), isNull);
+      expect(smartschoolUserIdFrom('4069_abc_0'), isNull);
+    });
+  });
 }

--- a/packages/smartschool_api/test/snapshot_test.dart
+++ b/packages/smartschool_api/test/snapshot_test.dart
@@ -52,6 +52,7 @@ void main() {
           type: core.GroupType.classGroup,
           official: true,
           untis: '1A',
+          sourceId: 298,
           origin: core.Origin.smartschool,
         ),
       ],
@@ -84,6 +85,7 @@ void main() {
           fax: '',
           untisId: '',
           status: 'actief',
+          referenceIdentifier: '4069_12016_0',
           coAccounts: [
             CoAccountSlot(
               slot: 1,
@@ -109,5 +111,9 @@ void main() {
     expect(restored.memberships, full.memberships);
     // Co-account slots survive the round-trip (they were the point of #21).
     expect(restored.accounts.single.coAccounts, hasLength(1));
+    // The Smartschool-internal ids reach the persisted snapshot too (#138).
+    expect(restored.groups.single.sourceId, 298);
+    expect(restored.accounts.single.referenceIdentifier, '4069_12016_0');
+    expect(restored.accounts.single.internalUserId, 12016);
   });
 }


### PR DESCRIPTION
Batch of six issues, one commit each, plus a docs commit. Every commit was verified on its own (format, analyzer, full unit/widget suite, and the integration file it touches) before the next was started.

## What changed

- **#138 — Smartschool internal ids.** `SmartschoolAccount` now parses `referenceIdentifier` and a derived `internalUserId` (null-safe on missing/malformed values), and `parseSmartschoolAccountPayload` returns the group ids from each row's `groups` array in the same decode. `sync` backfills them onto `SmartschoolGroup.id` joining on code, with projection deferred until the walk ends so any payload can resolve a group without an extra API call. Surfaced through the snapshot as a new nullable `core.Group.sourceId`, which `ModifySmartschoolData` preserves.
- **#192 — Dated last-sync stamp.** New `formatFreshnessStamp` in `account_manager/lib/src/format/timestamps.dart`: today stays `09:14`, yesterday becomes `gisteren 09:14`, older `15/08 09:14`, a prior year `15/08/2025 09:14`. Buckets compare calendar days rather than elapsed hours, and both instants are localised first. Wired into the Reconcile last-sync box and the Actions overview's `Generatie N · …` header, which carried the same time-only bug.
- **#193 — Selectable log panel.** Log entries render as one selectable `Text.rich` paragraph inside a `SelectionArea` (drag-select plus Ctrl+C), with a `Copy all` button reading a new `LogBuffer.toPlainText()`. A per-row selectable layout was rejected: `MultiSelectableSelectionContainerDelegate.getSelectedContent` concatenates selectables with no separator, which would have copied lines run together and broken the issue's one-per-line acceptance criterion.
- **#194 — WISA school identity.** The school code rides on `WisaSchool.description` (an `SMAGetInst` `ID,NAME,DESCRIPTION` legacy column swap) and was being dropped at merge time, so the settings list rendered the id twice. Adds a backwards-compatible `code` field to `WisaSchoolProfile`, carries it through `_mergeFetchedSchools`, and reworks `_SchoolCell` to lead with the code and degrade code → name → `School <id>`.
- **#195 — Password sheets as PDF.** Sheets render as real one-page-per-person PDFs via the pure-Dart `pdf` package — no native plugin, no Windows CMake registration. Typeset in the design system's already-bundled Hanken Grotesk / Space Mono, because the PDF base-14 faces are Latin-1 only and would box out every Turkish or Polish name. Exports move from `%TEMP%\AccountManager` to `Documents\AccountManager\Wachtwoorden` and open in the platform viewer after the write and queue drain, so a failure to open is reported without losing the file. `PasswordFileWriter` now takes bytes, and a `PasswordFileOpener` seam keeps the screen headlessly testable.
- **#197 — Per-line copy** (follow-up filed while working #193). Adds a **Copy line** entry to the log panel's right-click menu via `SelectionArea.contextMenuBuilder`. #193's single-paragraph layout is untouched: the line under the pointer is resolved from the paragraph itself (right-click anchor → `RenderParagraph.getPositionForOffset` → a new pure `logEntryIndexAt` counting newlines), which also makes soft-wrapped entries resolve to their own line.
- **Docs** (no issue). The Azure AD app-registration values come from `--dart-define` at run time, so a build started without them launches but renders "Not configured" on every screen needing a token — and nothing in the repo said so. Adds a README section, an `aad.local.json.example` to copy, and VS Code launch configurations that pass `--dart-define-from-file` for F5.

## Test plan

Run per commit, on the commit itself:

| Commit | Unit (`dart test packages/*/test`) | Widget (`flutter test`) | Integration (`app_launch_test.dart -d windows`) |
|---|---|---|---|
| #138 | 869 pass / 11 skipped | 208 pass | not touched — connector/model data only |
| #192 | 861 pass / 11 skipped¹ | 223 pass | 37 pass |
| #193 | 869 pass / 11 skipped | 228 pass | 38 pass |
| #194 | 872 pass / 11 skipped | 232 pass | 39 pass |
| #195 | 872 pass / 11 skipped | 245 pass | 40 pass |
| #197 | 872 pass / 11 skipped | 251 pass | 41 pass |

`dart format --output=none --set-exit-if-changed .` and the analyzer were clean on every commit. The 11 skips are the opt-in live tests throughout.

Every commit proved fail-without-fix rather than asserting it: #138 by deleting the backfill line (the two new sync tests failed `Expected <101>, Actual <null>`), #192 by stash-and-run on all four new UI-level tests, #193 and #194 by stashing `lib` back to its unpatched state, #197 by removing the `contextMenuBuilder` (both new widget tests went 0 pass / 2 fail). #197 was additionally checked against #193's selection test, which stays green.

¹ The #192 line is the same suite; PowerShell does not expand the `packages/*/test` glob and bash does, so that run covered fewer files. Re-run bash-expanded at #193 it is 869, matching CI.

## Notes

The `pdf` dependency added in #195 is pure Dart, so it needs no platform plugin registration — `windows/flutter/generated_plugins.cmake` is untouched.

Closes #138
Closes #192
Closes #193
Closes #194
Closes #195
Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)
