### PR TITLE
fix(cosmos): survive throttling and stop rewriting unchanged documents

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -648,6 +648,80 @@ void main() {
   });
 
   testWidgets(
+      'a second pass that changed nothing offers the shared store no document '
+      'writes at all (#200)', (WidgetTester tester) async {
+    // The everyday pass, driven the way the operator drives it, over the
+    // *production* Cosmos write path. Before the fix every pass rewrote the
+    // whole view wholesale — ~4k account docs plus groups and rollups, nearly
+    // all byte-identical to what was already stored — and that is the write
+    // burst the serverless account answers with the 429s of #196. This account
+    // never throttles, so what is measured here is purely how much the persist
+    // offers it.
+    useTallWindow(tester);
+    // Throttling switched off: far beyond the writes this test makes.
+    final wire = ThrottlingCosmosWire(throttleFrom: 1000000);
+    final governor = CosmosThrottleGovernor();
+    final harness = manyDepartedHarness(
+      count: 120,
+      controllerStore: cosmosLinkedStoreOver(wire, governor: governor),
+    );
+
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+
+    // The persist is a few hundred real round trips; let each pass finish.
+    Future<void> runToIdle() async {
+      final DateTime deadline = DateTime.now().add(const Duration(seconds: 60));
+      while (harness.controller.busy && DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        await tester.pump();
+      }
+      await tester.pumpAndSettle();
+    }
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    await runToIdle();
+
+    // The first pass writes the whole view — there is nothing stored yet.
+    expect(wire.writesTo('linkedAccounts'), 120);
+    final int rollupWrites = wire.writesTo('rollups');
+    expect(rollupWrites, greaterThan(0));
+    final int generation = harness.controller.syncState.generation;
+
+    // Now "Check for drift": the same three systems, the same linked view, so
+    // every document materializes byte-identical to the one already stored.
+    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.pumpAndSettle();
+    await runToIdle();
+
+    // Not one document rewritten…
+    expect(wire.writesTo('linkedAccounts'), 120,
+        reason: 'an unchanged pass must not re-offer the whole account set');
+    expect(wire.writesTo('rollups'), rollupWrites);
+    // …while the shared state is still whole, and the unconditional generation
+    // bump still tells every passive session to re-read it (#116).
+    expect(wire.docCount('linkedAccounts'), 120);
+    expect(harness.controller.syncState.generation, greaterThan(generation));
+    expect(
+      harness.log.entries.where((e) => e.isError).map((e) => e.message),
+      isEmpty,
+    );
+    // The operator is told the pass was a no-op rather than seeing silence.
+    expect(
+      harness.log.entries.map((e) => e.message),
+      contains(contains('120 unchanged')),
+    );
+  });
+
+  testWidgets(
       'the pending list groups one entry per account and applies the chosen '
       'alternative: choose delete → delete, not unregister (#110)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -19,6 +19,7 @@ import 'package:account_state/account_state.dart'
     show
         AppSettings,
         ChangeSignal,
+        CosmosThrottleGovernor,
         InMemoryLinkedStore,
         InMemorySignalHub,
         MaterializedAccount,
@@ -573,6 +574,77 @@ void main() {
     );
     // The operator sees the timeout in the log panel, not silence.
     expect(find.textContaining('timed out'), findsOneWidget);
+  });
+
+  testWidgets(
+      'a persist that Cosmos throttles with 429s still lands the whole shared '
+      'view, and the operator sees it slow down rather than fail (#196)',
+      (WidgetTester tester) async {
+    // The real app, driven the way the operator drives it, over the *production*
+    // Cosmos write path — a real HttpCosmosClient and CosmosLinkedStore — with
+    // the account answering the middle of the write burst with 429s. Before the
+    // fix this ended the pass with "Could not persist the linked view:
+    // CosmosException(429 …)" and left the shared containers holding this sync's
+    // accounts next to the previous sync's groups and rollups.
+    useTallWindow(tester);
+    final wire = ThrottlingCosmosWire(throttleFrom: 30, throttleUntil: 120);
+    late final ReconcileHarness harness;
+    // Production wires one governor into both the client (which reports every
+    // 429) and the store (whose fan-out narrows), reporting into the operator
+    // log — bootstrapReconcile does exactly this.
+    final governor = CosmosThrottleGovernor(
+      onReport: (m) => harness.log.addMessage(Origin.all, m),
+    );
+    harness = manyDepartedHarness(
+      count: 300,
+      controllerStore: cosmosLinkedStoreOver(wire, governor: governor),
+    );
+
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // The persist is a few hundred real round trips; let the pass finish.
+    final DateTime deadline = DateTime.now().add(const Duration(seconds: 60));
+    while (harness.controller.busy && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      await tester.pump();
+    }
+    await tester.pumpAndSettle();
+
+    // The account really did throttle this burst.
+    expect(wire.throttledResponses, greaterThan(0));
+
+    // The pass finished normally: nothing failed, and the operator's log panel
+    // carries the terminal ready line rather than a Cosmos error.
+    expect(harness.controller.busy, isFalse);
+    expect(find.textContaining('Could not persist'), findsNothing);
+    expect(
+      harness.log.entries.where((e) => e.isError).map((e) => e.message),
+      isEmpty,
+    );
+    expect(find.textContaining('Sync complete'), findsOneWidget);
+
+    // Throttling was reported as progress, not silence (#196.5).
+    expect(
+      harness.log.entries.map((e) => e.message),
+      contains(contains('throttling')),
+    );
+
+    // …and the shared state is *whole*: every account document landed, plus the
+    // rollups and the generation bump that tell other operators to read them.
+    expect(wire.docCount('linkedAccounts'), 300);
+    expect(wire.docCount('rollups'), greaterThan(0));
+    expect(wire.docCount('syncState'), greaterThan(0));
+    expect(harness.controller.syncState.generation, greaterThan(0));
   });
 
   testWidgets(

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -167,6 +167,15 @@ Future<ReconcileServices> bootstrapReconcile({
   final logBuffer = log ?? LogBuffer();
   final now = clock ?? DateTime.now;
 
+  // Shared throttling state for this session's Cosmos account (#196): the
+  // client reports every 429 here (retrying it rather than failing the persist)
+  // and the linked store's write fan-out reads it, so a full-volume write
+  // narrows while the account is under pressure and widens again as it eases.
+  // Throttling is reported into the operator log, so a slow persist reads as
+  // slow rather than hung.
+  final throttle = CosmosThrottleGovernor(
+    onReport: (m) => logBuffer.addMessage(core.Origin.all, m),
+  );
   final client = cosmosClient ??
       HttpCosmosClient(
         config: CosmosConfig(
@@ -175,6 +184,7 @@ Future<ReconcileServices> bootstrapReconcile({
         ),
         transport: HttpCosmosTransport(),
         tokens: CosmosSessionTokenProvider(session),
+        governor: throttle,
       );
 
   // Ensure the Cosmos containers a sync reads or writes exist before anything
@@ -207,7 +217,7 @@ Future<ReconcileServices> bootstrapReconcile({
   // The materialized-view store (#115): a sync writes the derived per-account
   // docs + rollups here, and every passive session reads the overview back with
   // no pull and no link().
-  final linked = linkedStore ?? CosmosLinkedStore(client);
+  final linked = linkedStore ?? CosmosLinkedStore(client, governor: throttle);
 
   // The shared password-distribution queue (#105): the whole team's pending
   // password sheets in one Cosmos document, so one operator can generate and

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -656,6 +656,13 @@ class ThrottlingCosmosWire implements CosmosTransport {
   /// Every document write the client attempted, retries included.
   int writeAttempts = 0;
 
+  /// Accepted document writes per container (retries and 429s excluded) — what
+  /// the account was actually asked to store, so a test can tell a pass that
+  /// rewrote the world from one that wrote only what changed (#200).
+  final Map<String, int> writesByContainer = {};
+
+  int writesTo(String container) => writesByContainer[container] ?? 0;
+
   /// How many of those were answered with a 429.
   int throttledResponses = 0;
 
@@ -722,6 +729,7 @@ class ThrottlingCosmosWire implements CosmosTransport {
       );
     }
     final etag = 'etag-${++_etag}';
+    writesByContainer[container] = writesTo(container) + 1;
     store[id] = {...doc, '_etag': etag};
     return CosmosResponse(
       statusCode: isUpsert ? 200 : 201,
@@ -755,8 +763,17 @@ class ThrottlingCosmosWire implements CosmosTransport {
       ];
     }
     if (query.contains('SELECT c.id, c.pk')) {
+      // A projection returns the named fields only — including the content hash
+      // the store compares against (#200), absent where the document has none.
       rows = [
-        for (final d in rows) {'id': d['id'], 'pk': d['pk']},
+        for (final d in rows)
+          {
+            'id': d['id'],
+            'pk': d['pk'],
+            if (query.contains('c.$contentHashField') &&
+                d.containsKey(contentHashField))
+              contentHashField: d[contentHashField],
+          },
       ];
     }
     return CosmosResponse(

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -10,6 +10,7 @@
 library;
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:account_actions/account_actions.dart' as actions;
 import 'package:account_core/account_core.dart' as core;
@@ -358,7 +359,12 @@ ReconcileHarness dupMailHarness({
 /// unregister/delete choice (#110), so the pending list holds [count] entries in
 /// one "same situation" subset — a large set to exercise list virtualization
 /// (#111).
-ReconcileHarness manyDepartedHarness({int count = 2000}) => ReconcileHarness(
+ReconcileHarness manyDepartedHarness({
+  int count = 2000,
+  LinkedStore? controllerStore,
+}) =>
+    ReconcileHarness(
+      controllerStore: controllerStore,
       wisa: wisaSnap(students: const []),
       smartschool: ssSnap(
         groups: const [],
@@ -618,6 +624,169 @@ class StallingLinkedStore implements LinkedStore {
   Future<void> releaseLease({required String owner}) =>
       _in.releaseLease(owner: owner);
 }
+
+/// A [CosmosTransport] serving a tiny in-memory Cosmos data plane that answers
+/// a stretch of the write burst with **429 TooManyRequests** — the shared-store
+/// persist of #196 without an account.
+///
+/// Enough of the wire is modelled for the real [HttpCosmosClient] and
+/// [CosmosLinkedStore] to run against it unchanged (point reads, upserts,
+/// atomic creates, deletes, and the `SELECT`s the store issues), so a test can
+/// drive the *production* persist path end-to-end and watch a throttled write
+/// burst either survive or leave the containers half-written.
+class ThrottlingCosmosWire implements CosmosTransport {
+  ThrottlingCosmosWire({
+    this.throttleFrom = 30,
+    this.throttleUntil = 120,
+    this.retryAfterMs = 5,
+  });
+
+  /// Write attempt (1-based) from which the account starts throttling, and the
+  /// one after which it stops. Every attempt — retries included — advances the
+  /// counter, so the burst drains the window the way a real recovery does.
+  final int throttleFrom;
+  final int throttleUntil;
+
+  /// What the 429 puts in `x-ms-retry-after-ms`. Tiny, because the client's
+  /// sleep is collapsed to nothing in tests anyway.
+  final int retryAfterMs;
+
+  final Map<String, Map<String, Map<String, dynamic>>> _docs = {};
+
+  /// Every document write the client attempted, retries included.
+  int writeAttempts = 0;
+
+  /// How many of those were answered with a 429.
+  int throttledResponses = 0;
+
+  int _etag = 0;
+
+  /// How many documents the container holds — what the shared state actually
+  /// ended up with.
+  int docCount(String container) => _docs[container]?.length ?? 0;
+
+  Map<String, Map<String, dynamic>> _c(String name) =>
+      _docs.putIfAbsent(name, () => {});
+
+  @override
+  Future<CosmosResponse> send(CosmosRequest request) async {
+    // A real round trip is async, so writes genuinely overlap and the bounded
+    // fan-out is exercised rather than collapsing to a serial loop.
+    await Future<void>.delayed(Duration.zero);
+    final segments = request.url.pathSegments;
+    final container = segments.length > 3 ? segments[3] : '';
+    final isQuery = request.headers['x-ms-documentdb-isquery'] == 'true';
+    switch (request.method) {
+      case 'POST' when isQuery:
+        return _query(container, request);
+      case 'POST' when segments.length >= 5:
+        return _write(container, request);
+      case 'POST':
+        return const CosmosResponse(statusCode: 201, body: '{}');
+      case 'GET' when segments.length >= 6:
+        final doc = _c(container)[segments[5]];
+        return doc == null
+            ? const CosmosResponse(statusCode: 404)
+            : CosmosResponse(statusCode: 200, body: jsonEncode(doc));
+      case 'GET':
+        return const CosmosResponse(statusCode: 200, body: '{}');
+      case 'DELETE' when segments.length >= 6:
+        final gone = _c(container).remove(segments[5]);
+        return CosmosResponse(statusCode: gone == null ? 404 : 204);
+    }
+    return const CosmosResponse(statusCode: 400);
+  }
+
+  CosmosResponse _write(String container, CosmosRequest request) {
+    writeAttempts++;
+    if (writeAttempts >= throttleFrom && writeAttempts <= throttleUntil) {
+      throttledResponses++;
+      return CosmosResponse(
+        statusCode: 429,
+        headers: {'x-ms-retry-after-ms': '$retryAfterMs'},
+        body: '{"code":"TooManyRequests","message":"The request rate is too '
+            'large. Please retry after sometime."}',
+      );
+    }
+    final decoded = jsonDecode(request.body ?? '{}');
+    final doc = Map<String, dynamic>.from(decoded as Map);
+    final id = doc['id'] as String;
+    final store = _c(container);
+    final isUpsert = request.headers['x-ms-documentdb-is-upsert'] == 'true';
+    // An atomic create loses to whoever got there first — what the sync lease
+    // relies on.
+    if (!isUpsert && store.containsKey(id)) {
+      return const CosmosResponse(
+        statusCode: 409,
+        body: '{"code":"Conflict","message":"id already exists"}',
+      );
+    }
+    final etag = 'etag-${++_etag}';
+    store[id] = {...doc, '_etag': etag};
+    return CosmosResponse(
+      statusCode: isUpsert ? 200 : 201,
+      headers: {'etag': etag},
+      body: jsonEncode(store[id]),
+    );
+  }
+
+  CosmosResponse _query(String container, CosmosRequest request) {
+    final body = Map<String, dynamic>.from(
+      jsonDecode(request.body ?? '{}') as Map,
+    );
+    final query = body['query'] as String? ?? '';
+    final parameters = <String, Object?>{
+      for (final p in (body['parameters'] as List? ?? const []))
+        (p as Map)['name'] as String: p['value'],
+    };
+    final pkHeader = request.headers['x-ms-documentdb-partitionkey'];
+    final pk = pkHeader == null
+        ? null
+        : (jsonDecode(pkHeader) as List).first as String;
+    var rows = <Map<String, dynamic>>[
+      for (final d in _c(container).values)
+        if (pk == null || d['pk'] == pk) Map<String, dynamic>.from(d),
+    ];
+    if (query.contains('c.classroom = @classroom')) {
+      final want = parameters['@classroom'];
+      rows = [
+        for (final d in rows)
+          if (d['classroom'] == want) d
+      ];
+    }
+    if (query.contains('SELECT c.id, c.pk')) {
+      rows = [
+        for (final d in rows) {'id': d['id'], 'pk': d['pk']},
+      ];
+    }
+    return CosmosResponse(
+      statusCode: 200,
+      body: jsonEncode({'Documents': rows}),
+    );
+  }
+}
+
+/// The *production* shared-store write path over [wire]: a real
+/// [CosmosLinkedStore] on a real [HttpCosmosClient], sharing [governor] exactly
+/// as `bootstrapReconcile` wires them (#196). The retry sleep is collapsed to
+/// nothing so a throttled persist is exercised with no wall-clock waiting.
+CosmosLinkedStore cosmosLinkedStoreOver(
+  ThrottlingCosmosWire wire, {
+  required CosmosThrottleGovernor governor,
+}) =>
+    CosmosLinkedStore(
+      HttpCosmosClient(
+        config: const CosmosConfig(
+          endpoint: 'https://fake.documents.azure.com:443/',
+          database: 'accountmanager',
+        ),
+        transport: wire,
+        tokens: const StaticCosmosTokenProvider('fake-token'),
+        governor: governor,
+        sleep: (_) async {},
+      ),
+      governor: governor,
+    );
 
 // ---------------------------------------------------------------------------
 // The harness: the real State layer over scripted syncers.

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -107,6 +107,7 @@ export 'src/cosmos/cosmos_live_config.dart';
 export 'src/cosmos/cosmos_password_queue_store.dart';
 export 'src/cosmos/cosmos_person_id_resolver.dart';
 export 'src/cosmos/cosmos_linked_store.dart';
+export 'src/cosmos/cosmos_retry.dart';
 export 'src/cosmos/cosmos_settings_store.dart';
 export 'src/cosmos/cosmos_snapshot_store.dart';
 export 'src/cosmos/cosmos_token_provider.dart';

--- a/packages/account_state/lib/src/cosmos/cosmos_client.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_client.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'cosmos_config.dart';
+import 'cosmos_retry.dart';
 import 'cosmos_token_provider.dart';
 import 'cosmos_transport.dart';
 
@@ -140,21 +141,48 @@ abstract interface class CosmosClient {
 /// The wire details (URL layout, partition-key header, upsert/query headers,
 /// continuation paging, status→outcome mapping) live here and are exercised by
 /// the fake-transport unit tests; the adapters above see only [CosmosClient].
+///
+/// **Throttling.** A **429 TooManyRequests** is not surfaced to the caller on
+/// sight: it is Cosmos asking the client to slow down, so the request is retried
+/// up to [CosmosRetryPolicy.maxAttempts] times, waiting at least the server's
+/// `x-ms-retry-after-ms` plus jittered exponential backoff, and every 429 is
+/// reported to the [CosmosThrottleGovernor] so the write fan-out narrows while
+/// the account is under pressure (#196). Only once the attempts are exhausted
+/// does the 429 become a [CosmosException]. The wait is slept through an
+/// injectable seam, so the whole retry path is testable with no wall-clock.
 class HttpCosmosClient implements CosmosClient {
   HttpCosmosClient({
     required CosmosConfig config,
     required CosmosTransport transport,
     required CosmosTokenProvider tokens,
     DateTime Function()? now,
+    CosmosRetryPolicy retry = const CosmosRetryPolicy(),
+    CosmosThrottleGovernor? governor,
+    Future<void> Function(Duration)? sleep,
+    double Function()? jitterRoll,
   })  : _config = config,
         _transport = transport,
         _tokens = tokens,
-        _now = now ?? DateTime.now;
+        _now = now ?? DateTime.now,
+        _retry = retry,
+        _governor = governor ?? CosmosThrottleGovernor(),
+        _sleep = sleep ?? _wallClockSleep,
+        _roll = jitterRoll ?? defaultJitterRoll;
 
   final CosmosConfig _config;
   final CosmosTransport _transport;
   final CosmosTokenProvider _tokens;
   final DateTime Function() _now;
+  final CosmosRetryPolicy _retry;
+  final CosmosThrottleGovernor _governor;
+  final Future<void> Function(Duration) _sleep;
+  final double Function() _roll;
+
+  static Future<void> _wallClockSleep(Duration d) => Future<void>.delayed(d);
+
+  /// The throttling state this client reports 429s to. Shared with the write
+  /// fan-out so it can narrow while the account is throttling (#196).
+  CosmosThrottleGovernor get governor => _governor;
 
   /// The data-plane REST API version. Any recent value works for the operations
   /// used here; pinned so behaviour does not drift under the account.
@@ -317,6 +345,14 @@ class HttpCosmosClient implements CosmosClient {
     return true;
   }
 
+  /// Issues one data-plane request, retrying while Cosmos throttles it (#196).
+  ///
+  /// Every attempt rebuilds the headers, so a retry never replays a stale
+  /// `x-ms-date` or an expired bearer token. A non-429 response (success or any
+  /// other status the callers classify themselves) returns immediately; a 429
+  /// backs off and retries until [CosmosRetryPolicy.maxAttempts] is spent, at
+  /// which point the 429 itself is returned and the caller's `_ensureSuccess`
+  /// turns it into a [CosmosException].
   Future<CosmosResponse> _send(
     String method,
     String path, {
@@ -325,22 +361,39 @@ class HttpCosmosClient implements CosmosClient {
     Map<String, String> extraHeaders = const {},
     String contentType = 'application/json',
   }) async {
-    final token = await _tokens.cosmosAccessToken();
-    final headers = <String, String>{
-      'authorization': _authHeader(token),
-      'x-ms-date': _rfc1123(_now().toUtc()),
-      'x-ms-version': apiVersion,
-      if (body != null) 'Content-Type': contentType,
-      if (partitionKey != null)
-        'x-ms-documentdb-partitionkey': jsonEncode([partitionKey]),
-      ...extraHeaders,
-    };
-    return _transport.send(CosmosRequest(
-      method: method,
-      url: Uri.parse('${_base()}$path'),
-      headers: headers,
-      body: body,
-    ));
+    for (var attempt = 1;; attempt++) {
+      final token = await _tokens.cosmosAccessToken();
+      final headers = <String, String>{
+        'authorization': _authHeader(token),
+        'x-ms-date': _rfc1123(_now().toUtc()),
+        'x-ms-version': apiVersion,
+        if (body != null) 'Content-Type': contentType,
+        if (partitionKey != null)
+          'x-ms-documentdb-partitionkey': jsonEncode([partitionKey]),
+        ...extraHeaders,
+      };
+      final resp = await _transport.send(CosmosRequest(
+        method: method,
+        url: Uri.parse('${_base()}$path'),
+        headers: headers,
+        body: body,
+      ));
+      if (!resp.isThrottled) {
+        _governor.recordSuccess();
+        return resp;
+      }
+      if (attempt >= _retry.maxAttempts) {
+        _governor.recordThrottle(attempt: attempt);
+        return resp;
+      }
+      final wait = _retry.delayFor(
+        attempt: attempt,
+        roll: _roll(),
+        retryAfter: resp.retryAfter,
+      );
+      _governor.recordThrottle(attempt: attempt, wait: wait);
+      await _sleep(wait);
+    }
   }
 
   /// The account endpoint without a trailing slash, so `$base$path` joins

--- a/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:account_core/account_core.dart' as core;
 
 import '../materialize/linked_store.dart';
 import '../materialize/materialized_state.dart';
 import 'cosmos_client.dart';
 import 'cosmos_config.dart';
+import 'cosmos_retry.dart';
 
 /// The [LinkedStore] backed by the Cosmos `linkedAccounts`, `rollups`,
 /// `decisions`, and `syncState` containers (#115, keystone of #112).
@@ -22,16 +25,24 @@ import 'cosmos_config.dart';
 /// mid-flight change); the sync/drift lease (#108) serializes writers so two
 /// rewrites never interleave.
 class CosmosLinkedStore implements LinkedStore {
-  CosmosLinkedStore(this._client);
+  /// [governor] is the shared throttling state (#196): pass the *same* instance
+  /// that was wired into the [CosmosClient], so the fan-out narrows in response
+  /// to the 429s these very writes provoke. Left unset (tests, and any caller
+  /// whose client does not report) the fan-out simply stays at
+  /// [CosmosThrottleGovernor.maxConcurrency].
+  CosmosLinkedStore(this._client, {CosmosThrottleGovernor? governor})
+      : _governor = governor ?? CosmosThrottleGovernor();
 
   final CosmosClient _client;
 
   /// How many per-document upserts/deletes may be in flight at once during a
-  /// [writeMaterialized] container replace. A full account container is ~9.6k
-  /// docs; a bounded fan-out turns thousands of serial round-trips into a write
-  /// that finishes in a fraction of the wall-clock while staying well under the
-  /// throughput that would trip sustained throttling (#168).
-  static const int _writeConcurrency = 24;
+  /// [writeMaterialized] container replace, and how that ceiling reacts to
+  /// throttling. A full account container is ~9.6k docs; a bounded fan-out turns
+  /// thousands of serial round-trips into a write that finishes in a fraction of
+  /// the wall-clock (#168), and narrowing it while the account is throttling
+  /// keeps the write progressing instead of hammering a limit it has already hit
+  /// (#196).
+  final CosmosThrottleGovernor _governor;
 
   /// Emit a progress line every this many upserts (plus one at the end), so a
   /// long write ticks in the operator log rather than looking hung (#168).
@@ -360,13 +371,15 @@ class CosmosLinkedStore implements LinkedStore {
   /// in [container] whose id is not in [freshIds] — the "replace the whole set"
   /// the derived containers need without a container-level truncate.
   ///
-  /// The upserts and deletes run with bounded concurrency ([_writeConcurrency])
-  /// rather than strictly one at a time: a full account container is ~9.6k docs,
-  /// and issuing that many serial round-trips is what made a full sync look hung
-  /// (#168). A bounded fan-out keeps wall-clock low without stampeding the
-  /// account's provisioned throughput into a sustained 429 back-off. When
-  /// [onProgress] and [label] are given, a line is emitted every
-  /// [_progressEvery] upserts (and once at the end) so a long write is visible.
+  /// The upserts and deletes run with bounded concurrency (the [_governor]'s
+  /// ceiling) rather than strictly one at a time: a full account container is
+  /// ~9.6k docs, and issuing that many serial round-trips is what made a full
+  /// sync look hung (#168). The ceiling is not a fixed guess: it narrows on
+  /// every 429 the client reports and widens back as the account keeps up, so a
+  /// real-volume write adapts to the provisioned throughput instead of assuming
+  /// a safe width (#196). When [onProgress] and [label] are given, a line is
+  /// emitted every [_progressEvery] upserts (and once at the end) so a long
+  /// write is visible.
   Future<void> _replaceContainer({
     required String container,
     required Set<String> freshIds,
@@ -412,11 +425,22 @@ class CosmosLinkedStore implements LinkedStore {
     );
   }
 
-  /// Runs [action] over [items] with at most [_writeConcurrency] futures in
-  /// flight at once, calling [onDone] with the running completed count after
-  /// each. A worker-pool (not fixed chunks) keeps the pool full — the slowest
-  /// item in a chunk never idles the rest — and any failure surfaces from the
-  /// awaited [Future.wait] just as the old serial loop would have thrown.
+  /// Runs [action] over [items] with at most [CosmosThrottleGovernor.concurrency]
+  /// futures in flight at once, calling [onDone] with the running completed
+  /// count after each. A worker-pool (not fixed chunks) keeps the pool full —
+  /// the slowest item in a chunk never idles the rest.
+  ///
+  /// The pool is *elastic* (#196): the governor narrows `concurrency` on every
+  /// 429 the client sees, and a worker that finds the pool wider than the
+  /// current ceiling retires (never the last one, so progress is always made);
+  /// as throttling eases and the ceiling widens again, a finishing worker tops
+  /// the pool back up.
+  ///
+  /// A failure is *terminal for the whole pass*: the first error is captured,
+  /// every other worker stops claiming items at its next turn, and only once all
+  /// of them have wound down is the error rethrown. This is what keeps a failed
+  /// persist from leaving unawaited workers firing writes into an account that
+  /// has already been reported as failed — the second consequence in #196.
   Future<void> _runBounded<T>(
     Iterable<T> items,
     Future<void> Function(T) action, {
@@ -426,17 +450,56 @@ class CosmosLinkedStore implements LinkedStore {
     if (list.isEmpty) return;
     var next = 0;
     var done = 0;
+    var active = 0;
+    Object? failure;
+    StackTrace? failureStack;
+    final drained = Completer<void>();
+    late final void Function() spawn;
+
     Future<void> worker() async {
-      while (true) {
-        final i = next++;
-        if (i >= list.length) return;
-        await action(list[i]);
-        onDone?.call(++done);
+      try {
+        while (true) {
+          if (failure != null) return; // a sibling failed: stop claiming work
+          // The governor narrowed the fan-out under throttling; shed a worker,
+          // but never the last one.
+          if (active > _governor.concurrency && active > 1) return;
+          final i = next++;
+          if (i >= list.length) return;
+          await action(list[i]);
+          onDone?.call(++done);
+          // Throttling eased and there is work left: widen back out. The number
+          // of new workers is decided *once* — a spawned worker that finds
+          // nothing to do returns (and decrements `active`) synchronously, so
+          // re-reading `active` in the loop condition would never terminate.
+          final room = _governor.concurrency - active;
+          for (var w = 0; w < room && next < list.length; w++) {
+            spawn();
+          }
+        }
+      } catch (e, st) {
+        failure ??= e;
+        failureStack ??= st;
+      } finally {
+        active--;
+        if (active == 0 && !drained.isCompleted) drained.complete();
       }
     }
 
-    final pool =
-        list.length < _writeConcurrency ? list.length : _writeConcurrency;
-    await Future.wait([for (var w = 0; w < pool; w++) worker()]);
+    spawn = () {
+      active++;
+      unawaited(worker());
+    };
+
+    final pool = list.length < _governor.concurrency
+        ? list.length
+        : _governor.concurrency;
+    for (var w = 0; w < pool; w++) {
+      spawn();
+    }
+    await drained.future;
+    final error = failure;
+    if (error != null) {
+      Error.throwWithStackTrace(error, failureStack ?? StackTrace.current);
+    }
   }
 }

--- a/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
@@ -1,12 +1,69 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:account_core/account_core.dart' as core;
+import 'package:crypto/crypto.dart';
 
 import '../materialize/linked_store.dart';
 import '../materialize/materialized_state.dart';
 import 'cosmos_client.dart';
 import 'cosmos_config.dart';
 import 'cosmos_retry.dart';
+
+/// The field every materialized document (account, group, rollup) carries its
+/// own content hash in, so the next write can tell "identical" from "changed"
+/// without reading the document back (#200).
+///
+/// Written by [CosmosLinkedStore] alongside the document's own fields and read
+/// back by the straggler projection; nothing else interprets it, and the
+/// `fromJson` factories ignore it.
+const String contentHashField = 'contentHash';
+
+/// A stable content hash of one materialized document.
+///
+/// Computed over the **whole** serialized document — every field, nested
+/// candidates and decisions included — rather than a chosen subset, because a
+/// hash that misses a field is worse than no hash at all: the change would be
+/// skipped and an operator's edit would silently never reach the shared store.
+/// The encoding is canonical (map keys sorted at every level), so the hash
+/// depends on the document's *content* and not on the order `toJson` happened
+/// to build its maps in.
+///
+/// [document] must be the freshly serialized document, i.e. *without* a
+/// [contentHashField] of its own — the hash is stamped on afterwards.
+String materializedContentHash(Map<String, dynamic> document) =>
+    sha256.convert(utf8.encode(_canonicalJson(document))).toString();
+
+String _canonicalJson(Object? value) {
+  final out = StringBuffer();
+  _writeCanonical(out, value);
+  return out.toString();
+}
+
+void _writeCanonical(StringBuffer out, Object? value) {
+  if (value is Map) {
+    final entries = value.entries.toList()
+      ..sort((a, b) => a.key.toString().compareTo(b.key.toString()));
+    out.write('{');
+    for (var i = 0; i < entries.length; i++) {
+      if (i > 0) out.write(',');
+      out
+        ..write(jsonEncode(entries[i].key.toString()))
+        ..write(':');
+      _writeCanonical(out, entries[i].value);
+    }
+    out.write('}');
+  } else if (value is List) {
+    out.write('[');
+    for (var i = 0; i < value.length; i++) {
+      if (i > 0) out.write(',');
+      _writeCanonical(out, value[i]);
+    }
+    out.write(']');
+  } else {
+    out.write(jsonEncode(value));
+  }
+}
 
 /// The [LinkedStore] backed by the Cosmos `linkedAccounts`, `rollups`,
 /// `decisions`, and `syncState` containers (#115, keystone of #112).
@@ -19,9 +76,10 @@ import 'cosmos_retry.dart';
 /// never rewritten by the derived-doc replace.
 ///
 /// A rewrite is not a single transaction — Cosmos has no cross-document atomic
-/// write — so [writeMaterialized] upserts the fresh set and then deletes the
-/// documents that are no longer present. A reader that races a rewrite sees a
-/// consistent-enough mix (the generation bump is what #116 uses to detect a
+/// write — so [writeMaterialized] upserts the documents whose content actually
+/// changed (#200) and then deletes the ones that are no longer present. A
+/// reader that races a rewrite sees a consistent-enough mix (the generation
+/// bump — which stays unconditional — is what #116 uses to detect a
 /// mid-flight change); the sync/drift lease (#108) serializes writers so two
 /// rewrites never interleave.
 class CosmosLinkedStore implements LinkedStore {
@@ -119,9 +177,10 @@ class CosmosLinkedStore implements LinkedStore {
       ...(await readSyncState()).systems,
       ...systemSyncs,
     };
-    // Per-account docs: upsert the fresh set, then delete the stragglers no
-    // longer present so a departed account's doc does not linger. This is the
-    // big one (~9.6k docs); its progress is what the operator sees ticking.
+    // Per-account docs: upsert the ones that changed, then delete the
+    // stragglers no longer present so a departed account's doc does not linger.
+    // This is the big one (~9.6k docs); its progress is what the operator sees
+    // ticking.
     await _replaceContainer(
       container: linkedAccountsContainer,
       freshIds: {for (final a in view.accounts) a.id.value},
@@ -132,8 +191,7 @@ class CosmosLinkedStore implements LinkedStore {
       label: 'accounts',
       onProgress: onProgress,
     );
-    // Per-group docs: same wholesale replace, in the single groups partition
-    // (#119).
+    // Per-group docs: same replace, in the single groups partition (#119).
     await _replaceContainer(
       container: linkedGroupsContainer,
       freshIds: {for (final g in view.groups) g.id.value},
@@ -367,15 +425,28 @@ class CosmosLinkedStore implements LinkedStore {
     );
   }
 
-  /// Upserts every document in [docsById], then deletes any document currently
-  /// in [container] whose id is not in [freshIds] — the "replace the whole set"
-  /// the derived containers need without a container-level truncate.
+  /// Brings [container] to exactly [docsById]: upserts the documents whose
+  /// content actually changed and deletes any document currently in [container]
+  /// whose id is not in [freshIds] — the "replace the whole set" the derived
+  /// containers need without a container-level truncate.
+  ///
+  /// **Only what changed is written (#200).** Nearly every document of a
+  /// re-sync is byte-identical to the stored one, and rewriting all ~9.6k of
+  /// them wholesale is what generated the write burst that tripped #196 —
+  /// which the retry/backoff there absorbs but cannot remove. So each fresh
+  /// document carries a [materializedContentHash] in [contentHashField], and
+  /// the upsert is skipped when the stored document already hashes the same.
+  /// The single id/pk/hash projection below answers both questions at once: an
+  /// id the fresh set no longer has is a straggler to delete, and an id whose
+  /// stored hash still matches is a write to skip. The generation bump in
+  /// [writeMaterialized] stays unconditional, so readers still detect the new
+  /// view even when not one document moved.
   ///
   /// The upserts and deletes run with bounded concurrency (the [_governor]'s
-  /// ceiling) rather than strictly one at a time: a full account container is
-  /// ~9.6k docs, and issuing that many serial round-trips is what made a full
-  /// sync look hung (#168). The ceiling is not a fixed guess: it narrows on
-  /// every 429 the client reports and widens back as the account keeps up, so a
+  /// ceiling) rather than strictly one at a time: a first, full write is ~9.6k
+  /// docs, and issuing that many serial round-trips is what made a full sync
+  /// look hung (#168). The ceiling is not a fixed guess: it narrows on every 429
+  /// the client reports and widens back as the account keeps up, so a
   /// real-volume write adapts to the provisioned throughput instead of assuming
   /// a safe width (#196). When [onProgress] and [label] are given, a line is
   /// emitted every [_progressEvery] upserts (and once at the end) so a long
@@ -387,9 +458,49 @@ class CosmosLinkedStore implements LinkedStore {
     String? label,
     void Function(String message)? onProgress,
   }) async {
-    final total = docsById.length;
+    // One projection read, both answers: what to delete and what to skip. Read
+    // *before* the writes — every id this pass writes is in [freshIds], so the
+    // straggler set is the same either way, and doing it first is what makes
+    // the stored hashes available to compare against.
+    final existing = await _client.queryDocuments(
+      container: container,
+      query: 'SELECT c.id, c.pk, c.$contentHashField FROM c',
+    );
+    final storedHashes = <String, String>{};
+    final stragglers = <({String id, String pk})>[];
+    for (final doc in existing) {
+      final id = doc['id'];
+      if (id is! String) continue;
+      if (!freshIds.contains(id)) {
+        stragglers.add((id: id, pk: (doc['pk'] as String?) ?? id));
+        continue;
+      }
+      final hash = doc[contentHashField];
+      // A document stored before #200 carries no hash; it is rewritten once and
+      // hashed from then on.
+      if (hash is String) storedHashes[id] = hash;
+    }
+
+    final writes = <({String pk, Map<String, dynamic> doc})>[];
+    var unchanged = 0;
+    for (final entry in docsById.entries) {
+      final hash = materializedContentHash(entry.value.doc);
+      if (storedHashes[entry.key] == hash) {
+        unchanged++;
+        continue;
+      }
+      writes.add((
+        pk: entry.value.pk,
+        doc: {...entry.value.doc, contentHashField: hash},
+      ));
+    }
+
+    final total = writes.length;
+    if (label != null && onProgress != null && unchanged > 0) {
+      onProgress('Persisting $label: $unchanged unchanged, $total to write…');
+    }
     await _runBounded(
-      docsById.values,
+      writes,
       (entry) => _client.upsertDocument(
         container: container,
         partitionKey: entry.pk,
@@ -403,18 +514,6 @@ class CosmosLinkedStore implements LinkedStore {
               }
             },
     );
-    final existing = await _client.queryDocuments(
-      container: container,
-      query: 'SELECT c.id, c.pk FROM c',
-    );
-    final stragglers = [
-      for (final doc in existing)
-        if (doc['id'] is String && !freshIds.contains(doc['id']))
-          (
-            id: doc['id'] as String,
-            pk: (doc['pk'] as String?) ?? doc['id'] as String,
-          ),
-    ];
     await _runBounded(
       stragglers,
       (s) => _client.deleteDocument(

--- a/packages/account_state/lib/src/cosmos/cosmos_retry.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_retry.dart
@@ -1,0 +1,164 @@
+import 'dart:math';
+
+/// How a throttled (**429 TooManyRequests**) Cosmos request is retried (#196).
+///
+/// A 429 is Cosmos saying "slow down", not "this write is impossible": the
+/// response carries `x-ms-retry-after-ms` telling the client exactly how long to
+/// wait. [delayFor] honours that hint as a *floor* and layers exponential
+/// backoff with jitter on top, so a burst of throttled writes does not
+/// re-converge on the same instant and re-trip the limit.
+///
+/// The policy is a pure value object — no clock, no sleeping — so the whole
+/// backoff curve is unit-testable without wall-clock waits; [HttpCosmosClient]
+/// owns the (injectable) sleep.
+class CosmosRetryPolicy {
+  const CosmosRetryPolicy({
+    this.maxAttempts = 8,
+    this.baseDelay = const Duration(milliseconds: 250),
+    this.maxDelay = const Duration(seconds: 15),
+    this.jitterFraction = 0.5,
+  });
+
+  /// Total attempts for one request, the first included. Once exhausted the 429
+  /// is surfaced to the caller (i.e. as a `CosmosException`), because at that
+  /// point the account really cannot absorb the write.
+  final int maxAttempts;
+
+  /// The backoff for the first retry; it doubles per attempt up to [maxDelay].
+  final Duration baseDelay;
+
+  /// Ceiling for the exponential term. The server's own `retry-after` hint can
+  /// still push the wait beyond this — the server knows better than we do.
+  final Duration maxDelay;
+
+  /// How much jitter is added on top of the computed wait, as a fraction of it.
+  /// `0.5` spreads the retry over `[wait, 1.5 × wait)`.
+  final double jitterFraction;
+
+  /// The wait before retry number [attempt] (1 = after the first failure).
+  ///
+  /// The base wait is the larger of the exponential backoff and the server's
+  /// [retryAfter] hint; [roll] (a `[0,1)` random draw, injected so tests are
+  /// deterministic) then spreads it by up to [jitterFraction] of itself.
+  Duration delayFor({
+    required int attempt,
+    required double roll,
+    Duration? retryAfter,
+  }) {
+    // 2^(attempt-1), with the shift capped so a pathological attempt count can
+    // never overflow the exponent.
+    final shift = attempt <= 1 ? 0 : (attempt - 1).clamp(0, 20);
+    var ms = baseDelay.inMilliseconds * (1 << shift);
+    if (ms > maxDelay.inMilliseconds) ms = maxDelay.inMilliseconds;
+    final hint = retryAfter?.inMilliseconds ?? 0;
+    if (hint > ms) ms = hint;
+    ms += (ms * jitterFraction * roll).round();
+    return Duration(milliseconds: ms);
+  }
+}
+
+/// Shared throttling state for one Cosmos account: the client records every 429
+/// here, and the write fan-out reads [concurrency] to decide how wide to run
+/// (#196).
+///
+/// This is the adaptive half of the 429 fix. Retrying alone absorbs a brief
+/// spike but keeps pushing the same load at an account that is already saying
+/// "too much"; narrowing the fan-out lowers the offered rate until the account
+/// keeps up, then widens back slowly so one transient 429 does not cost the rest
+/// of the persist its speed.
+///
+/// One instance is wired into *both* the [HttpCosmosClient] (which reports) and
+/// the `CosmosLinkedStore` (which reads), so the writer reacts to the throttling
+/// its own requests provoked.
+class CosmosThrottleGovernor {
+  CosmosThrottleGovernor({
+    this.maxConcurrency = 24,
+    this.minConcurrency = 2,
+    this.recoverAfter = 40,
+    this.reportEvery = 100,
+    void Function(String message)? onReport,
+  })  : assert(minConcurrency >= 1),
+        assert(maxConcurrency >= minConcurrency),
+        _report = onReport,
+        _limit = maxConcurrency;
+
+  /// The unthrottled fan-out: how many writes run in parallel when the account
+  /// is keeping up. A full account container is ~9.6k docs, so a serial write is
+  /// not an option (#168).
+  final int maxConcurrency;
+
+  /// The floor the fan-out narrows to under sustained throttling. Never zero —
+  /// a throttled persist must still make progress, just slowly.
+  final int minConcurrency;
+
+  /// How many un-throttled requests must land before the fan-out widens by one.
+  /// Recovery is deliberately far slower than the halving, so the writer settles
+  /// just under the account's real capacity instead of oscillating.
+  final int recoverAfter;
+
+  /// How often a *continuing* throttle burst is re-reported. The first 429 of a
+  /// burst is always reported; after that one line per [reportEvery] events, so
+  /// a heavily throttled persist stays visible without flooding the log.
+  final int reportEvery;
+
+  final void Function(String message)? _report;
+
+  int _limit;
+  int _clean = 0;
+  int _throttles = 0;
+
+  /// How wide the write fan-out may currently run.
+  int get concurrency => _limit;
+
+  /// How many throttled responses have been seen (across all requests).
+  int get throttles => _throttles;
+
+  /// Whether the fan-out is currently narrowed below [maxConcurrency].
+  bool get isNarrowed => _limit < maxConcurrency;
+
+  /// Records a throttled response. [wait] is the backoff about to be slept;
+  /// `null` means the request ran out of attempts and the 429 is being surfaced.
+  void recordThrottle({required int attempt, Duration? wait}) {
+    _throttles++;
+    final wasWide = !isNarrowed;
+    _clean = 0;
+    final halved = _limit ~/ 2;
+    _limit = halved < minConcurrency ? minConcurrency : halved;
+    if (wait == null) {
+      _report?.call(
+        'Cosmos is still throttling after $attempt attempts — giving up on '
+        'this request.',
+      );
+      return;
+    }
+    // Report the start of a burst, then only every [reportEvery]th event.
+    if (wasWide || _throttles % reportEvery == 0) {
+      _report?.call(
+        'Cosmos is throttling (429) — retrying in ${wait.inMilliseconds} ms '
+        'and narrowing the write fan-out to $_limit '
+        '(throttled $_throttles time(s) so far).',
+      );
+    }
+  }
+
+  /// Records a request the account answered without throttling. Widens the
+  /// fan-out by one every [recoverAfter] clean requests.
+  void recordSuccess() {
+    if (!isNarrowed) return;
+    if (++_clean < recoverAfter) return;
+    _clean = 0;
+    _limit++;
+    if (!isNarrowed) {
+      _report?.call(
+        'Cosmos throttling eased — write fan-out back to $_limit.',
+      );
+    }
+  }
+}
+
+/// The default jitter source: a shared [Random] drawn per retry.
+final Random _random = Random();
+
+/// The `[0,1)` draw [CosmosRetryPolicy.delayFor] jitters with. Injectable in
+/// tests so a backoff curve can be asserted exactly.
+double defaultJitterRoll() => _random.nextDouble();

--- a/packages/account_state/lib/src/cosmos/cosmos_transport.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_transport.dart
@@ -52,6 +52,26 @@ class CosmosResponse {
   /// a create races on (#121).
   bool get isPreconditionFailed => statusCode == 412;
 
+  /// `true` when Cosmos rejected the request because the request rate exceeded
+  /// the account's provisioned throughput (**429 TooManyRequests**). This is a
+  /// "slow down", not a "no": the request is retryable after [retryAfter]
+  /// (#196).
+  bool get isThrottled => statusCode == 429;
+
+  /// How long Cosmos asks the client to wait before retrying a [isThrottled]
+  /// request, from `x-ms-retry-after-ms` (milliseconds). Falls back to the
+  /// standard `retry-after` header (seconds) when the Cosmos-specific one is
+  /// absent, and is `null` when neither is present or parseable — the caller
+  /// then uses its own backoff. Header names are case-insensitive on the wire
+  /// (`package:http` lower-cases them), so callers read this rather than the raw
+  /// header.
+  Duration? get retryAfter {
+    final ms = int.tryParse(headers['x-ms-retry-after-ms']?.trim() ?? '');
+    if (ms != null) return Duration(milliseconds: ms);
+    final seconds = int.tryParse(headers['retry-after']?.trim() ?? '');
+    return seconds == null ? null : Duration(seconds: seconds);
+  }
+
   /// The document's current `_etag`, from the `etag` response header Cosmos
   /// returns on a point read or a write. `null` when absent. Header names are
   /// case-insensitive on the wire (`package:http` lower-cases them), so callers

--- a/packages/account_state/pubspec.yaml
+++ b/packages/account_state/pubspec.yaml
@@ -18,6 +18,10 @@ resolution: workspace
 dependencies:
   account_core:
   account_store:
+  # SHA-256 for the per-document content hash the Cosmos materialized-view
+  # write compares against the stored one, so an unchanged document is not
+  # rewritten (#200). Pure Dart (Dart team package), no platform crypto.
+  crypto: ^3.0.0
   http: ^1.2.0
   wisa_api:
   smartschool_api:

--- a/packages/account_state/test/cosmos/cosmos_client_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_client_test.dart
@@ -26,6 +26,27 @@ class _FakeTransport implements CosmosTransport {
 CosmosResponse _ok(Object body) =>
     CosmosResponse(statusCode: 200, body: jsonEncode(body));
 
+/// The 429 Cosmos answers a write burst with once the request rate exceeds the
+/// account's provisioned throughput, carrying its `x-ms-retry-after-ms` hint.
+CosmosResponse _throttled({int? retryAfterMs}) => CosmosResponse(
+      statusCode: 429,
+      headers: {
+        if (retryAfterMs != null) 'x-ms-retry-after-ms': '$retryAfterMs',
+      },
+      body: '{"code":"TooManyRequests","message":"The request rate is too '
+          'large. Please retry after sometime."}',
+    );
+
+/// A token provider handing out a different token per call, so a test can prove
+/// a retry re-reads the (short-lived) bearer token rather than replaying the
+/// first attempt's headers.
+class _CountingTokenProvider implements CosmosTokenProvider {
+  int calls = 0;
+
+  @override
+  Future<String> cosmosAccessToken() async => 'token-${++calls}';
+}
+
 HttpCosmosClient _client(_FakeTransport transport) => HttpCosmosClient(
       config: const CosmosConfig(
         endpoint: 'https://acct.documents.azure.com:443/',
@@ -37,6 +58,32 @@ HttpCosmosClient _client(_FakeTransport transport) => HttpCosmosClient(
       tokens: const StaticCosmosTokenProvider('ab.cd-ef_gh'),
       // Fixed clock so the x-ms-date header is deterministic.
       now: () => DateTime.utc(2026, 7, 4, 10, 4, 38),
+    );
+
+/// A client whose 429 retry loop is fully deterministic and instant: the backoff
+/// is recorded into [slept] instead of being waited out, and the jitter draw is
+/// pinned, so the retry path is asserted without a single wall-clock delay
+/// (#196).
+HttpCosmosClient _retryingClient(
+  _FakeTransport transport, {
+  required List<Duration> slept,
+  CosmosRetryPolicy retry = const CosmosRetryPolicy(),
+  CosmosThrottleGovernor? governor,
+  CosmosTokenProvider? tokens,
+  double roll = 0.0,
+}) =>
+    HttpCosmosClient(
+      config: const CosmosConfig(
+        endpoint: 'https://acct.documents.azure.com:443/',
+        database: 'accountmanager',
+      ),
+      transport: transport,
+      tokens: tokens ?? const StaticCosmosTokenProvider('ab.cd-ef_gh'),
+      now: () => DateTime.utc(2026, 7, 4, 10, 4, 38),
+      retry: retry,
+      governor: governor,
+      sleep: (d) async => slept.add(d),
+      jitterRoll: () => roll,
     );
 
 void main() {
@@ -385,6 +432,301 @@ void main() {
             .having((e) => e.code, 'code', 'Forbidden')
             .having((e) => e.message, 'message', 'no data-plane role')),
       );
+    });
+  });
+
+  group('HttpCosmosClient 429 throttling (#196)', () {
+    test(
+        'a throttled write is retried and succeeds — the 429 never reaches the '
+        'caller', () async {
+      // The bug: a single 429 during the persist burst became a CosmosException
+      // that unwound writeMaterialized and left the shared containers half
+      // written. Cosmos is only asking us to slow down.
+      final transport = _FakeTransport([
+        _throttled(retryAfterMs: 400),
+        _throttled(retryAfterMs: 400),
+        _ok({'id': 'a1', '_etag': 'e9'}),
+      ]);
+      final slept = <Duration>[];
+
+      final outcome =
+          await _retryingClient(transport, slept: slept).upsertDocument(
+        container: 'linkedAccounts',
+        document: const {'id': 'a1'},
+        partitionKey: '1',
+      );
+
+      expect(outcome.applied, isTrue);
+      expect(outcome.etag, 'e9');
+      expect(transport.requests, hasLength(3),
+          reason: 'two throttled attempts, then the write that landed');
+      expect(slept, hasLength(2));
+    });
+
+    test('the wait honours x-ms-retry-after-ms as a floor, jittered beyond it',
+        () async {
+      // Cosmos says exactly how long to wait; the client must not retry sooner.
+      // The jitter (pinned to its maximum draw here) is added on top so a burst
+      // of throttled writes does not re-converge on the same instant.
+      final transport = _FakeTransport([
+        _throttled(retryAfterMs: 800),
+        _ok({'id': 'a1'}),
+      ]);
+      final slept = <Duration>[];
+
+      await _retryingClient(transport, slept: slept, roll: 1.0).upsertDocument(
+        container: 'linkedAccounts',
+        document: const {'id': 'a1'},
+        partitionKey: '1',
+      );
+
+      // The server hint (800 ms) beats the first exponential step (250 ms), and
+      // the default 0.5 jitter fraction at a full draw adds half of it.
+      expect(slept.single, const Duration(milliseconds: 1200));
+    });
+
+    test('with no server hint the backoff grows exponentially, capped',
+        () async {
+      final transport = _FakeTransport([
+        for (var i = 0; i < 6; i++) _throttled(),
+        _ok({'id': 'a1'}),
+      ]);
+      final slept = <Duration>[];
+
+      await _retryingClient(
+        transport,
+        slept: slept,
+        retry: const CosmosRetryPolicy(
+          baseDelay: Duration(milliseconds: 100),
+          maxDelay: Duration(milliseconds: 800),
+        ),
+      ).upsertDocument(
+        container: 'linkedAccounts',
+        document: const {'id': 'a1'},
+        partitionKey: '1',
+      );
+
+      expect(
+          slept.map((d) => d.inMilliseconds), [100, 200, 400, 800, 800, 800]);
+    });
+
+    test(
+        'a request that stays throttled surfaces the 429 once attempts run out',
+        () async {
+      // Bounded, not infinite: if the account genuinely cannot absorb the write,
+      // the operator must still be told rather than the sync hanging forever.
+      final transport = _FakeTransport([
+        for (var i = 0; i < 3; i++) _throttled(retryAfterMs: 100),
+      ]);
+      final slept = <Duration>[];
+
+      await expectLater(
+        _retryingClient(
+          transport,
+          slept: slept,
+          retry: const CosmosRetryPolicy(maxAttempts: 3),
+        ).upsertDocument(
+          container: 'linkedAccounts',
+          document: const {'id': 'a1'},
+          partitionKey: '1',
+        ),
+        throwsA(isA<CosmosException>()
+            .having((e) => e.statusCode, 'statusCode', 429)
+            .having((e) => e.code, 'code', 'TooManyRequests')),
+      );
+      expect(transport.requests, hasLength(3));
+      expect(slept, hasLength(2), reason: 'no sleep after the last attempt');
+    });
+
+    test('a retry rebuilds its headers with a fresh token and date', () async {
+      // A retry can be seconds after the first attempt; replaying the original
+      // x-ms-date / bearer token would eventually be rejected outright.
+      final tokens = _CountingTokenProvider();
+      final transport = _FakeTransport([
+        _throttled(retryAfterMs: 50),
+        _ok({'id': 'a1'}),
+      ]);
+
+      await _retryingClient(transport, slept: [], tokens: tokens)
+          .upsertDocument(
+        container: 'linkedAccounts',
+        document: const {'id': 'a1'},
+        partitionKey: '1',
+      );
+
+      expect(tokens.calls, 2);
+      expect(transport.requests.first.headers['authorization'],
+          isNot(transport.requests.last.headers['authorization']));
+      expect(transport.requests.last.headers['authorization'],
+          contains('token-2'));
+      // …and it is still the same request otherwise.
+      expect(transport.requests.last.body, transport.requests.first.body);
+      expect(
+          transport.requests.last.headers['x-ms-documentdb-is-upsert'], 'true');
+    });
+
+    test('a throttled read is retried too, and a 404 still reads as null',
+        () async {
+      final transport = _FakeTransport([
+        _throttled(retryAfterMs: 50),
+        const CosmosResponse(statusCode: 404),
+      ]);
+
+      final doc = await _retryingClient(transport, slept: []).readDocument(
+        container: 'settings',
+        id: 'settings',
+        partitionKey: 'settings',
+      );
+
+      expect(doc, isNull);
+      expect(transport.requests, hasLength(2));
+    });
+
+    test('throttling narrows the shared write fan-out and reports it once',
+        () async {
+      // The adaptive half of the fix: retrying alone keeps offering the same
+      // load to an account that already said "too much".
+      final reported = <String>[];
+      final governor = CosmosThrottleGovernor(
+        onReport: reported.add,
+        recoverAfter: 2,
+      );
+      final transport = _FakeTransport([
+        _throttled(retryAfterMs: 100),
+        _throttled(retryAfterMs: 100),
+        _ok({'id': 'a1'}),
+      ]);
+
+      await _retryingClient(transport, slept: [], governor: governor)
+          .upsertDocument(
+        container: 'linkedAccounts',
+        document: const {'id': 'a1'},
+        partitionKey: '1',
+      );
+
+      expect(governor.throttles, 2);
+      expect(governor.concurrency, 6,
+          reason: '24 halved twice while the account was throttling');
+      // One line for the burst, not one per 429 (a real burst is thousands).
+      expect(reported, hasLength(1));
+      expect(reported.single, contains('throttling'));
+      expect(reported.single, contains('narrowing the write fan-out to 12'),
+          reason: 'the operator sees the persist slow down, not silence');
+    });
+  });
+
+  group('CosmosRetryPolicy (#196)', () {
+    const policy = CosmosRetryPolicy(
+      baseDelay: Duration(milliseconds: 200),
+      maxDelay: Duration(seconds: 2),
+      jitterFraction: 0.5,
+    );
+
+    test('doubles per attempt and never exceeds maxDelay', () {
+      List<int> curve(double roll) => [
+            for (var a = 1; a <= 6; a++)
+              policy.delayFor(attempt: a, roll: roll).inMilliseconds,
+          ];
+      expect(curve(0.0), [200, 400, 800, 1600, 2000, 2000]);
+    });
+
+    test('jitter only ever adds, bounded by the jitter fraction', () {
+      final base = policy.delayFor(attempt: 3, roll: 0.0).inMilliseconds;
+      final jittered = policy.delayFor(attempt: 3, roll: 1.0).inMilliseconds;
+      expect(base, 800);
+      expect(jittered, 1200);
+      expect(policy.delayFor(attempt: 3, roll: 0.5).inMilliseconds,
+          inInclusiveRange(base, jittered));
+    });
+
+    test("the server's retry-after wins when it is longer than the backoff",
+        () {
+      expect(
+        policy
+            .delayFor(
+              attempt: 1,
+              roll: 0.0,
+              retryAfter: const Duration(seconds: 5),
+            )
+            .inMilliseconds,
+        5000,
+        reason: 'the account knows its own recovery better than we do',
+      );
+      // …but a short hint never shortens our own backoff.
+      expect(
+        policy
+            .delayFor(
+              attempt: 4,
+              roll: 0.0,
+              retryAfter: const Duration(milliseconds: 10),
+            )
+            .inMilliseconds,
+        1600,
+      );
+    });
+  });
+
+  group('CosmosThrottleGovernor (#196)', () {
+    test('halves on throttle down to a floor that still makes progress', () {
+      final g = CosmosThrottleGovernor(maxConcurrency: 24, minConcurrency: 2);
+      expect(g.concurrency, 24);
+      for (var i = 0; i < 10; i++) {
+        g.recordThrottle(attempt: 1, wait: Duration.zero);
+      }
+      expect(g.concurrency, 2, reason: 'never zero — the write must continue');
+      expect(g.isNarrowed, isTrue);
+    });
+
+    test('recovers slowly, one step per run of clean requests', () {
+      final g = CosmosThrottleGovernor(
+        maxConcurrency: 8,
+        minConcurrency: 2,
+        recoverAfter: 3,
+      );
+      g.recordThrottle(attempt: 1, wait: Duration.zero); // 8 → 4
+      expect(g.concurrency, 4);
+
+      for (var i = 0; i < 2; i++) {
+        g.recordSuccess();
+      }
+      expect(g.concurrency, 4,
+          reason: 'a couple of clean writes is not enough');
+      g.recordSuccess();
+      expect(g.concurrency, 5);
+
+      for (var i = 0; i < 9; i++) {
+        g.recordSuccess();
+      }
+      expect(g.concurrency, 8);
+      expect(g.isNarrowed, isFalse);
+      // Widening past the ceiling would re-create the stampede.
+      g.recordSuccess();
+      expect(g.concurrency, 8);
+    });
+
+    test('reports the start of a burst, the recovery, and exhaustion', () {
+      final reported = <String>[];
+      final g = CosmosThrottleGovernor(
+        maxConcurrency: 4,
+        minConcurrency: 2,
+        recoverAfter: 1,
+        onReport: reported.add,
+      );
+
+      g.recordThrottle(attempt: 1, wait: const Duration(milliseconds: 250));
+      g.recordThrottle(attempt: 2, wait: const Duration(milliseconds: 500));
+      expect(reported, hasLength(1), reason: 'one line per burst, not per 429');
+
+      // 2 → 3 is still narrowed (silent); only the return to the full width is
+      // worth a line.
+      g.recordSuccess();
+      expect(reported, hasLength(1));
+      g.recordSuccess();
+      expect(reported, hasLength(2));
+      expect(reported.last, contains('eased'));
+
+      g.recordThrottle(attempt: 8); // out of attempts
+      expect(reported.last, contains('giving up'));
     });
   });
 }

--- a/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
@@ -2,13 +2,31 @@ import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart';
 import 'package:test/test.dart';
 
+/// What a `SELECT c.id, c.pk[, c.contentHash] FROM c` projection returns: the
+/// named fields only, and — as Cosmos does — with a field the stored document
+/// does not carry simply absent rather than null. Shared by the fakes below so
+/// none of them silently hands the store back a whole document.
+Map<String, dynamic> _projection(Map<String, dynamic> doc, String query) => {
+      'id': doc['id'],
+      'pk': doc['pk'],
+      if (query.contains('c.$contentHashField') &&
+          doc.containsKey(contentHashField))
+        contentHashField: doc[contentHashField],
+    };
+
 /// A small in-memory [CosmosClient] covering the query shapes
 /// [CosmosLinkedStore] issues: `SELECT * FROM c`, the classroom filter, and the
-/// `SELECT c.id, c.pk FROM c` id/pk projection — honouring [partitionKey]
-/// scoping via each document's `pk` field.
+/// `SELECT c.id, c.pk, c.contentHash FROM c` projection — honouring
+/// [partitionKey] scoping via each document's `pk` field.
 class _FakeClient implements CosmosClient {
   final Map<String, Map<String, Map<String, dynamic>>> _store = {};
   int deletes = 0;
+
+  /// Upserts per container, so a test can assert what a re-sync actually wrote
+  /// (#200) rather than only what the container ended up holding.
+  final Map<String, int> upserts = {};
+
+  int upsertsTo(String container) => upserts[container] ?? 0;
 
   /// Conditioned upserts rejected as stale (412) — for the concurrency test.
   int staleWrites = 0;
@@ -61,6 +79,7 @@ class _FakeClient implements CosmosClient {
       staleWrites++;
       return const WriteOutcome.stale();
     }
+    upserts[container] = upsertsTo(container) + 1;
     final etag = _nextEtag();
     _c(container)[id] = Map.of(document)..['_etag'] = etag;
     return WriteOutcome.applied(etag);
@@ -91,9 +110,7 @@ class _FakeClient implements CosmosClient {
       ];
     }
     if (query.contains('SELECT c.id, c.pk')) {
-      return [
-        for (final d in rows) {'id': d['id'], 'pk': d['pk']},
-      ];
+      return [for (final d in rows) _projection(d, query)];
     }
     return rows;
   }
@@ -225,9 +242,7 @@ class _ConcurrencyClient implements CosmosClient {
     String? partitionKey,
   }) async {
     if (query.contains('SELECT c.id, c.pk')) {
-      return [
-        for (final d in _c(container).values) {'id': d['id'], 'pk': d['pk']},
-      ];
+      return [for (final d in _c(container).values) _projection(d, query)];
     }
     return [for (final d in _c(container).values) Map<String, dynamic>.from(d)];
   }
@@ -335,9 +350,7 @@ class _AdaptiveClient implements CosmosClient {
     String? partitionKey,
   }) async {
     if (query.contains('SELECT c.id, c.pk')) {
-      return [
-        for (final d in _c(container).values) {'id': d['id'], 'pk': d['pk']},
-      ];
+      return [for (final d in _c(container).values) _projection(d, query)];
     }
     return [for (final d in _c(container).values) Map<String, dynamic>.from(d)];
   }
@@ -769,6 +782,161 @@ void main() {
       await _settle();
       expect(client.upserts, atFailure,
           reason: 'not one more write after the operator was told it failed');
+    });
+
+    test('an unchanged re-sync writes no documents at all (#200)', () async {
+      final client = _FakeClient();
+      final store = CosmosLinkedStore(client);
+      final accounts = [
+        for (var i = 0; i < 50; i++) _account('p$i', classroom: 'c${i % 5}'),
+      ];
+      final groups = [_group('9Z'), _group('8A')];
+
+      await store.writeMaterialized(
+        _view(accounts, groups: groups),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+      final accountWrites = client.upsertsTo(linkedAccountsContainer);
+      final rollupWrites = client.upsertsTo(rollupsContainer);
+      expect(accountWrites, 50, reason: 'the first sync writes the whole set');
+      expect(rollupWrites, greaterThan(0));
+
+      // The identical view again — the everyday case, where nothing about the
+      // three systems moved since the last pass.
+      final progress = <String>[];
+      await store.writeMaterialized(
+        _view(accounts, generation: 2, groups: groups),
+        syncedBy: 'op@school.example',
+        at: _d,
+        onProgress: progress.add,
+      );
+
+      // Not one per-document write: the whole ~4k-doc burst that trips the
+      // serverless account's 429s simply does not happen.
+      expect(client.upsertsTo(linkedAccountsContainer), accountWrites);
+      expect(client.upsertsTo(linkedGroupsContainer), groups.length);
+      expect(client.upsertsTo(rollupsContainer), rollupWrites);
+      expect(client.deletes, 0, reason: 'nothing departed, nothing deleted');
+      // The operator is told the pass was a no-op rather than seeing silence.
+      expect(
+          progress, contains('Persisting accounts: 50 unchanged, 0 to write…'));
+      // …and the view is still whole and still readable.
+      expect(await store.readClassroom(school: '1', classroom: 'c0'),
+          hasLength(10));
+      expect(await store.readGroups(), hasLength(2));
+      // The generation bump is unconditional, so every passive session still
+      // learns there is a new view (#116).
+      expect((await store.readSyncState()).generation, 2);
+    });
+
+    test('a changed document is still written on a re-sync (#200)', () async {
+      // The correctness risk of skipping: a hash computed over too little would
+      // silently drop a real change on the floor.
+      final client = _FakeClient();
+      final store = CosmosLinkedStore(client);
+      final accounts = [
+        for (var i = 0; i < 20; i++) _account('p$i', classroom: '3C'),
+      ];
+
+      await store.writeMaterialized(
+        _view(accounts),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+      final afterFirst = client.upsertsTo(linkedAccountsContainer);
+
+      // One account moved class; everything else is identical.
+      final moved = [
+        _account('p0', classroom: '4A'),
+        for (var i = 1; i < 20; i++) _account('p$i', classroom: '3C'),
+      ];
+      await store.writeMaterialized(
+        _view(moved, generation: 2),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+
+      expect(client.upsertsTo(linkedAccountsContainer), afterFirst + 1,
+          reason: 'exactly the one changed account was rewritten');
+      final threeC = await store.readClassroom(school: '1', classroom: '3C');
+      expect(threeC.map((a) => a.id.value), isNot(contains('p0')));
+      final fourA = await store.readClassroom(school: '1', classroom: '4A');
+      expect(fourA.map((a) => a.id.value), ['p0']);
+    });
+
+    test('a change buried in a nested candidate action is not skipped (#200)',
+        () async {
+      // The hash covers the whole serialized document, so a change anywhere in
+      // it — not just in the top-level fields — still reaches the store.
+      final client = _FakeClient();
+      final store = CosmosLinkedStore(client);
+      MaterializedAccount withSummary(String summary) => MaterializedAccount(
+            id: const core.LinkedAccountId('p0'),
+            school: '1',
+            schoolLabel: 'School 1',
+            gradeYear: '3',
+            classroom: '3C',
+            role: core.PersonRole.student,
+            isStaff: false,
+            confidence: core.LinkConfidence.high,
+            label: 'Jane p0',
+            inWisa: true,
+            inSmartschool: true,
+            inAzure: true,
+            candidates: [
+              CandidateAction(
+                family: 'student',
+                kind: 'MoveToSmartschoolClassGroup',
+                system: core.Origin.smartschool,
+                summary: summary,
+              ),
+            ],
+          );
+
+      await store.writeMaterialized(
+        _view([withSummary('Move to 3C')]),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+      await store.writeMaterialized(
+        _view([withSummary('Move to 4A')], generation: 2),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+
+      expect(client.upsertsTo(linkedAccountsContainer), 2);
+      final stored = await store.readClassroom(school: '1', classroom: '3C');
+      expect(stored.single.candidates.single.summary, 'Move to 4A');
+    });
+
+    test('a document stored before #200 carries no hash and is rewritten once',
+        () async {
+      final client = _FakeClient();
+      final store = CosmosLinkedStore(client);
+      final account = _account('p0');
+      // A pre-#200 document: the same content, stored without a content hash.
+      await client.upsertDocument(
+        container: linkedAccountsContainer,
+        partitionKey: account.school,
+        document: account.toJson(),
+      );
+
+      await store.writeMaterialized(
+        _view([account]),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+      expect(client.upsertsTo(linkedAccountsContainer), 2,
+          reason: 'an unhashed stored doc is rewritten so it gains its hash');
+
+      // …and from then on it is skipped like any other unchanged document.
+      await store.writeMaterialized(
+        _view([account], generation: 2),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+      expect(client.upsertsTo(linkedAccountsContainer), 2);
     });
 
     test('reading before any sync yields the initial generation', () async {

--- a/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
@@ -267,6 +267,193 @@ class _ConcurrencyClient implements CosmosClient {
       true;
 }
 
+/// A [CosmosClient] that stands in for the real client's throttle reporting: it
+/// drives the shared [CosmosThrottleGovernor] on a script (throttle early,
+/// recover later) and records how many upserts were in flight at the moment each
+/// one started — so the write fan-out's *reaction* to throttling is observable
+/// without a Cosmos account (#196).
+class _AdaptiveClient implements CosmosClient {
+  _AdaptiveClient(
+    this.governor, {
+    required this.throttleAt,
+    required this.recoverFrom,
+  });
+
+  final CosmosThrottleGovernor governor;
+
+  /// The 1-based upsert number that reports a 429 (as the client's retry loop
+  /// would after absorbing one).
+  final int throttleAt;
+
+  /// From this upsert on, every write lands cleanly, so the governor's slow
+  /// recovery widens the fan-out again.
+  final int recoverFrom;
+
+  final Map<String, Map<String, Map<String, dynamic>>> _store = {};
+
+  /// In-flight upserts at the start of each upsert, in issue order.
+  final List<int> inFlightAt = [];
+  int _inFlight = 0;
+  int upserts = 0;
+
+  Map<String, Map<String, dynamic>> _c(String name) =>
+      _store.putIfAbsent(name, () => {});
+
+  /// The widest fan-out seen over upserts `[from, to)`.
+  int peakOver(int from, int to) => inFlightAt
+      .sublist(from.clamp(0, inFlightAt.length), to.clamp(0, inFlightAt.length))
+      .fold(0, (a, b) => a > b ? a : b);
+
+  @override
+  Future<WriteOutcome> upsertDocument({
+    required String container,
+    required Map<String, dynamic> document,
+    required String partitionKey,
+    String? ifMatch,
+  }) async {
+    _inFlight++;
+    upserts++;
+    inFlightAt.add(_inFlight);
+    if (upserts == throttleAt) {
+      governor.recordThrottle(attempt: 1, wait: Duration.zero);
+    } else if (upserts >= recoverFrom) {
+      governor.recordSuccess();
+    }
+    // Yield twice so overlapping calls actually interleave before any completes.
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+    _c(container)[document['id'] as String] = Map.of(document);
+    _inFlight--;
+    return const WriteOutcome.applied('etag');
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> queryDocuments({
+    required String container,
+    required String query,
+    Map<String, Object?> parameters = const {},
+    String? partitionKey,
+  }) async {
+    if (query.contains('SELECT c.id, c.pk')) {
+      return [
+        for (final d in _c(container).values) {'id': d['id'], 'pk': d['pk']},
+      ];
+    }
+    return [for (final d in _c(container).values) Map<String, dynamic>.from(d)];
+  }
+
+  @override
+  Future<Map<String, dynamic>?> readDocument({
+    required String container,
+    required String id,
+    required String partitionKey,
+  }) async =>
+      _c(container)[id];
+
+  @override
+  Future<bool> createDocument({
+    required String container,
+    required Map<String, dynamic> document,
+    required String partitionKey,
+  }) async {
+    _c(container)[document['id'] as String] = Map.of(document);
+    return true;
+  }
+
+  @override
+  Future<void> deleteDocument({
+    required String container,
+    required String id,
+    required String partitionKey,
+  }) async {
+    _c(container).remove(id);
+  }
+
+  @override
+  Future<bool> ensureContainer({
+    required String container,
+    required String partitionKeyPath,
+  }) async =>
+      true;
+}
+
+/// A [CosmosClient] whose upsert throws once — the terminal failure a persist
+/// hits when Cosmos has run out of retry attempts. Counts every upsert so a test
+/// can prove the sibling workers stopped instead of running on unawaited (#196).
+class _FailingClient implements CosmosClient {
+  _FailingClient({required this.failAfter});
+
+  final int failAfter;
+  int upserts = 0;
+  bool thrown = false;
+
+  @override
+  Future<WriteOutcome> upsertDocument({
+    required String container,
+    required Map<String, dynamic> document,
+    required String partitionKey,
+    String? ifMatch,
+  }) async {
+    upserts++;
+    await Future<void>.delayed(Duration.zero);
+    if (!thrown && upserts >= failAfter) {
+      thrown = true;
+      throw const CosmosException(
+        429,
+        '{"code":"TooManyRequests","message":"The request rate is too large."}',
+      );
+    }
+    return const WriteOutcome.applied('etag');
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> queryDocuments({
+    required String container,
+    required String query,
+    Map<String, Object?> parameters = const {},
+    String? partitionKey,
+  }) async =>
+      const [];
+
+  @override
+  Future<Map<String, dynamic>?> readDocument({
+    required String container,
+    required String id,
+    required String partitionKey,
+  }) async =>
+      null;
+
+  @override
+  Future<bool> createDocument({
+    required String container,
+    required Map<String, dynamic> document,
+    required String partitionKey,
+  }) async =>
+      true;
+
+  @override
+  Future<void> deleteDocument({
+    required String container,
+    required String id,
+    required String partitionKey,
+  }) async {}
+
+  @override
+  Future<bool> ensureContainer({
+    required String container,
+    required String partitionKeyPath,
+  }) async =>
+      true;
+}
+
+/// Lets every pending microtask/timer-zero callback run, so a test can prove
+/// nothing *further* happens after an awaited call returned.
+Future<void> _settle() async {
+  for (var i = 0; i < 20; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
 final DateTime _d = DateTime.utc(2026, 7, 1);
 
 MaterializedAccount _account(String id,
@@ -503,6 +690,85 @@ void main() {
 
       // The whole set round-trips despite the batching.
       expect((await store.readRollups()).isNotEmpty, isTrue);
+    });
+
+    test(
+        'the write fan-out narrows while Cosmos throttles and widens again as '
+        'it eases (#196)', () async {
+      // #168 fixed the fan-out at 24 on the assumption that stayed "well under
+      // the throughput that would trip sustained throttling". At real volume it
+      // does not, so the width has to follow the account instead of guessing it.
+      final governor = CosmosThrottleGovernor(
+        maxConcurrency: 16,
+        minConcurrency: 2,
+        recoverAfter: 5,
+      );
+      // The account absorbs the opening writes, then throttles — the shape of
+      // the real run, where the burst only exceeds the RU/s budget once it is
+      // properly under way.
+      final client = _AdaptiveClient(
+        governor,
+        throttleAt: 30,
+        recoverFrom: 150,
+      );
+      final store = CosmosLinkedStore(client, governor: governor);
+      final accounts = [
+        for (var i = 0; i < 600; i++) _account('p$i', classroom: 'c${i % 30}'),
+      ];
+
+      await store.writeMaterialized(
+        _view(accounts),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+
+      // It started wide…
+      expect(client.peakOver(0, 20), greaterThan(8),
+          reason: 'an unthrottled account gets the full fan-out');
+      // …then the 429 halved the ceiling and the extra workers retired, so the
+      // throttled stretch never runs wider than the narrowed ceiling.
+      expect(client.peakOver(60, 140), lessThanOrEqualTo(8),
+          reason: 'the writer stops pushing the load the account rejected');
+      // …and once the writes land cleanly again the pool refills.
+      expect(client.peakOver(300, 600), greaterThan(8),
+          reason: 'one transient 429 must not cost the rest of the persist its '
+              'speed');
+      expect(governor.concurrency, 16);
+      // The whole set still round-trips despite the narrowing.
+      expect(client.upserts, greaterThanOrEqualTo(600));
+      expect((await store.readClassroom(school: '1', classroom: 'c0')),
+          isNotEmpty);
+    });
+
+    test(
+        'a terminal write failure stops the sibling workers instead of letting '
+        'them run on (#196)', () async {
+      // The second consequence in the bug report: Future.wait rejected on the
+      // first error while 23 other workers kept firing upserts into the very
+      // account that had just been reported as failed.
+      final client = _FailingClient(failAfter: 40);
+      final store = CosmosLinkedStore(client);
+      final accounts = [
+        for (var i = 0; i < 4000; i++) _account('p$i', classroom: 'c${i % 30}'),
+      ];
+
+      await expectLater(
+        store.writeMaterialized(
+          _view(accounts),
+          syncedBy: 'op@school.example',
+          at: _d,
+        ),
+        throwsA(isA<CosmosException>()
+            .having((e) => e.statusCode, 'statusCode', 429)),
+      );
+
+      // The error surfaced only once every worker had wound down…
+      final atFailure = client.upserts;
+      expect(atFailure, lessThan(4000),
+          reason: 'the pass aborts rather than writing the whole set anyway');
+      await _settle();
+      expect(client.upserts, atFailure,
+          reason: 'not one more write after the operator was told it failed');
     });
 
     test('reading before any sync yields the initial generation', () async {


### PR DESCRIPTION
Two related fixes to the Cosmos materialized-state write path: #196 makes the persist survive throttling, #200 removes most of the pressure that caused it.

## #196 — 429 aborts the linked-view persist

Nothing in the Cosmos layer classified **429 TooManyRequests**. Every throttled write became a plain `CosmosException` that escaped `_runBounded`'s `Future.wait`, unwound `writeMaterialized`, and left the shared containers holding this sync's accounts next to the previous sync's groups and rollups — while the sibling workers kept firing upserts, unawaited, into the same throttled account.

- `CosmosResponse` gains `isThrottled` and `retryAfter` (reads `x-ms-retry-after-ms`).
- `HttpCosmosClient` retries throttled requests a bounded number of times, honouring the server's `retry-after` and adding exponential backoff with jitter beyond it; `CosmosException` is raised only once attempts are exhausted. Sleep and jitter are injected, so no test wall-clock sleeps.
- A shared `CosmosThrottleGovernor` halves the write fan-out under sustained throttling and recovers it slowly, replacing the fixed concurrency of 24.
- The worker pool in `CosmosLinkedStore` is now elastic and cancelling: a terminal failure stops the remaining workers instead of letting them run on.
- Throttling is reported as progress through `bootstrapReconcile`, so a slow persist reads as slow rather than hung.

## #200 — stop rewriting every document every sync

#196 absorbs the burst; this removes it. `_replaceContainer` was upserting ~4k byte-identical account documents on every sync. The Cosmos account is provisioned **serverless** (`EnableServerless`), so raising RU/s is not an available answer — lowering the offered write volume is.

- Each materialized document is stamped with a SHA-256 `contentHash` over the whole canonically-encoded document.
- The straggler-delete projection becomes `SELECT c.id, c.pk, c.contentHash FROM c` — one query now yields both the delete set and the skip set.
- Upserts whose stored hash matches are skipped; the generation bump stays unconditional so readers still detect the new view.
- The log reports `N unchanged, M to write`.

`account_state` gains a direct `crypto` dependency (no lockfile change).

## Test plan

Both commits pass the full local gates independently.

- `dart format --set-exit-if-changed` — clean (283 files)
- `dart analyze` + `flutter analyze` — clean across the workspace
- `account_state` unit tests — **313 pass** (~6 live-only skipped)
- `account_manager` widget/unit tests — **251 pass**
- `account_manager/integration_test/app_launch_test.dart` on `-d windows` — **43 pass**, including new scenarios for both issues

Fails-without-fix proven for both:

- **#196** — with retry disabled, 8 unit tests fail and the new integration scenario fails on "Could not persist".
- **#200** — with the old write path temporarily restored, 3 of the 4 new unit tests fail on upsert counts (50→100, 21→40, 2→3) and the new integration test fails.

Live Cosmos tests remain manual/opt-in; nothing live was added to CI.

Closes #196
Closes #200
