### PR TITLE
Batch: Smartschool import rules, virtual WISA schools, school labels, class-group scoping (#202-#205)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1947,6 +1947,71 @@ void main() {
   });
 
   testWidgets(
+      'the Settings view marks a WISA school virtual end-to-end, and the mark '
+      'survives a "Scholen ophalen" refresh (#203)',
+      (WidgetTester tester) async {
+    // The real app composition over the in-memory settings seams. One school is
+    // known (managed, code-less) and a refresh is wired, so the whole operator
+    // flow runs: mark virtual → refresh the list → save.
+    useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
+      WisaSchool(id: 99, name: 'Virtuele school SMA', description: 'ismav'),
+    ]);
+    final settings = SettingsHarness(
+      initial: const AppSettings(
+        wisa: WisaConnection(server: 'db.school.example', port: '1433'),
+        wisaSchools: [WisaSchoolProfile(schoolId: 99, ours: true)],
+      ),
+      secrets: {passwordRef: 'stored-pw'},
+      fetchWisaSchools: fetcher.call,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+    await openSettingsTab(tester, 'settings-tab-wisa');
+
+    // The school renders with its own virtual toggle, off, next to the managed
+    // one — in the real, laid-out three-column grid with the real fonts.
+    final virtualBox =
+        find.byKey(const ValueKey('settings-wisa-school-99-virtual'));
+    await tester.ensureVisible(virtualBox);
+    await tester.pumpAndSettle();
+    expect(tester.widget<CheckboxListTile>(virtualBox).value, isFalse);
+
+    // Mark it virtual, then refresh the school list: the mark must survive the
+    // merge that backfills the code.
+    await tester.tap(virtualBox);
+    await tester.pumpAndSettle();
+    final refresh = find.byKey(const ValueKey('settings-wisa-fetch-schools'));
+    await tester.ensureVisible(refresh);
+    await tester.tap(refresh);
+    await tester.pumpAndSettle();
+    expect(find.text('ismav'), findsOneWidget);
+    expect(tester.widget<CheckboxListTile>(virtualBox).value, isTrue);
+
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    // The virtual mark landed in the settings document, alongside (not instead
+    // of) the managed mark — this is what the sync reads to pick the virtual
+    // work date for this school.
+    final saved = await settings.store.load();
+    expect(saved.wisaSchools.single.schoolId, 99);
+    expect(saved.wisaSchools.single.virtual, isTrue);
+    expect(saved.wisaSchools.single.ours, isTrue);
+    expect(saved.virtualWisaSchoolIds, {99});
+  });
+
+  testWidgets(
       'the Settings view fetches the WISA school list and persists the picked '
       'selection end-to-end, no id typed by hand (#142)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -994,6 +994,50 @@ void main() {
   });
 
   testWidgets(
+      'the Klasgroepen drill-down proposes only classes of the schools we '
+      'manage end-to-end, never a sibling school\'s (#205)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. WISA hands this session class
+    // groups from two schools — the sibling school's `1A` and `9Z` first, our
+    // own `1A` last — and only school 1 is managed. Every one of them used to
+    // be offered as "Voeg deze klas toe aan Smartschool", and the sibling `1A`
+    // even shadowed ours, so the proposal described the wrong school's class.
+    useTallWindow(tester);
+    final harness = foreignClassGroupHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+
+    // Our own populated class is the only proposal on the list…
+    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
+    expect(find.text('1A'), findsOneWidget);
+    expect(find.text('Voeg deze klas toe aan Smartschool'), findsOneWidget);
+    // …and no class of the school we do not manage is anywhere near it.
+    expect(find.text('9Z'), findsNothing,
+        reason: 'creating another school\'s class is never ours to propose');
+
+    // The surviving proposal describes *our* 1A, not the sibling class that
+    // shares its name.
+    await tester.tap(find.byKey(const ValueKey('entry-group-1A')));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Onze eerste klas'), findsOneWidget);
+    expect(find.textContaining('Klas van een andere school'), findsNothing);
+  });
+
+  testWidgets(
       'the Actions view splits Personeel and Leerlingen into tabs end-to-end: '
       'staff drill in one tab, students in the other (#179)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -957,6 +957,43 @@ void main() {
   });
 
   testWidgets(
+      'the Actions drill-down names a school by name and code end-to-end, '
+      'never "School <id>" (#204)', (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. This session's WISA snapshot
+    // carries no schools at all, so the school's identity can only come from
+    // the operator's persisted Settings profile — exactly the case that used to
+    // bake `School 25` into every materialized node. The drill-down must name
+    // the school the way Instellingen → WISA does.
+    useTallWindow(tester);
+    final harness = namedSchoolHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(find.text('School 25'), findsNothing,
+        reason: 'the numeric id is the last resort, not the rendering (#204)');
+    final node = find.text('Instituut Sancta Maria-A (ISMAA)');
+    expect(node, findsOneWidget);
+
+    // It is the real school node, not a stray label: it drills down to the
+    // student's class.
+    await tester.tap(node);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    expect(find.text('3C'), findsWidgets);
+  });
+
+  testWidgets(
       'the Actions view splits Personeel and Leerlingen into tabs end-to-end: '
       'staff drill in one tab, students in the other (#179)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -37,6 +37,8 @@ import 'package:account_state/account_state.dart'
         signalRRecordSeparator;
 import 'package:azure_api/azure_api.dart'
     show AzureCredentials, StaticAuthProvider;
+import 'package:smartschool_api/smartschool_api.dart'
+    show SmartschoolConnector, SmartschoolMethod, SmartschoolSoapTransport;
 import 'package:wisa_api/wisa_api.dart' show WisaSchool;
 import 'package:flutter/gestures.dart' show PointerDeviceKind, kSecondaryButton;
 import 'package:flutter/material.dart';
@@ -82,6 +84,29 @@ void main() {
   /// across Algemeen / Wisa / Smartschool / Azure tabs).
   Future<void> openSettingsTab(WidgetTester tester, String tabKey) async {
     await tester.tap(find.byKey(ValueKey(tabKey)));
+    await tester.pumpAndSettle();
+  }
+
+  /// Authors one Smartschool import rule the way the operator does (#202): the
+  /// **Toevoegen** menu, the rule type keyed [kind], then the group-name prompt.
+  Future<void> addSmartschoolRule(
+    WidgetTester tester,
+    String kind,
+    String groupName,
+  ) async {
+    final add = find.byKey(const ValueKey('settings-ss-rule-add'));
+    await tester.ensureVisible(add);
+    await tester.pumpAndSettle();
+    await tester.tap(add);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(ValueKey('settings-ss-rule-add-$kind')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-ss-rule-name')),
+      groupName,
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('settings-ss-rule-confirm')));
     await tester.pumpAndSettle();
   }
 
@@ -2423,6 +2448,73 @@ void main() {
     expect(copied.single, onScreen[1]);
     expect(copied.single, isNot(contains('\n')));
   });
+
+  testWidgets(
+      'the Settings view authors the two Smartschool import rules end-to-end, '
+      "and the saved rules prune the next pull's group tree (#202)",
+      (WidgetTester tester) async {
+    // The real app composition over the in-memory settings seams — real fonts,
+    // real navigation, real layout. Until now the Smartschool tab rendered its
+    // rules under a section literally headed "Importregels (alleen-lezen)" with
+    // no way to create one, so in practice there were no rules at all and the
+    // whole group tree — organisational subtrees included — came in on every
+    // pull. Drive the editor the way the operator does, then hand the *saved*
+    // rules to the production connector exactly as bootstrapReconcile does
+    // (`ssConnector.sync(rules: settings.smartschoolRules)`).
+    useTallWindow(tester);
+    final settings = SettingsHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+    await openSettingsTab(tester, 'settings-tab-smartschool');
+
+    // The section is an editor now, not a read-only list.
+    expect(find.text('Importregels'), findsOneWidget);
+    expect(find.textContaining('alleen-lezen'), findsNothing);
+    expect(
+        find.byKey(const ValueKey('settings-ss-rules-empty')), findsOneWidget);
+
+    // Author one rule of each type, then save the document.
+    await addSmartschoolRule(tester, 'discardGroup', 'Organisatie');
+    await addSmartschoolRule(tester, 'noSubgroups', 'Klassen');
+    expect(find.textContaining('Smartschool-groep negeren: Organisatie'),
+        findsOneWidget);
+    expect(find.textContaining('Geen subgroepen: Klassen'), findsOneWidget);
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    // They landed in the settings document on the codec's existing wire shape.
+    final saved = await settings.store.load();
+    expect(saved.toJson()['smartschoolRules'], <Map<String, dynamic>>[
+      {'type': 'discardSmartschoolGroup', 'groupName': 'Organisatie'},
+      {'type': 'noSmartschoolSubgroups', 'groupName': 'Klassen'},
+    ]);
+
+    // …and the next pull really is pruned by them: the production connector,
+    // over a scripted SOAP wire, handed nothing but what Settings persisted.
+    final wire = _GroupTreeSoap();
+    final snapshot = await SmartschoolConnector.fromParts(
+      site: 'school',
+      accessCode: 'ac',
+      transport: wire,
+    ).sync(rules: saved.smartschoolRules);
+
+    // "Organisatie" and its subtree are gone; "Klassen" survives without its
+    // children. Only the root and Klassen remain.
+    expect(snapshot.groups.map((g) => g.id.value).toList(),
+        <String>['SCH', 'KLA']);
+    // And the pruning happened before the account reads, so the connector never
+    // even asked Smartschool about the removed groups.
+    expect(wire.accountCodes, <String>['SCH', 'KLA']);
+  });
 }
 
 /// A broker scripted per test — a fake WAM broker so no live tenant is touched.
@@ -2507,4 +2599,62 @@ class _FakeSignalRSocket implements SignalRSocket {
   void serverSend(String frame) {
     if (!_incoming.isClosed) _incoming.add(frame);
   }
+}
+
+/// A scripted Smartschool SOAP wire for the import-rule end-to-end (#202):
+/// answers `getAllGroupsAndClasses` with a small base64 group tree and reports
+/// "no direct accounts" (code 19) for every group, recording the group codes the
+/// connector asked about so the test can see the pruned ones were never read.
+class _GroupTreeSoap implements SmartschoolSoapTransport {
+  /// The group codes `getAllAccountsExtended` was called for, in walk order.
+  final List<String> accountCodes = <String>[];
+
+  static const String _tree = '<groups>'
+      '<group><name>School</name><type>G</type><code>SCH</code>'
+      '<visible>1</visible><children>'
+      '<group><name>Organisatie</name><type>G</type><code>ORG</code>'
+      '<visible>1</visible><children>'
+      '<group><name>Verborgen</name><type>G</type><code>HID</code>'
+      '<visible>1</visible></group>'
+      '</children></group>'
+      '<group><name>Klassen</name><type>G</type><code>KLA</code>'
+      '<visible>1</visible><children>'
+      '<group><name>1A</name><type>K</type><code>C1A</code>'
+      '<visible>1</visible></group>'
+      '</children></group>'
+      '</children></group></groups>';
+
+  @override
+  Future<String> send({
+    required Uri endpoint,
+    required String soapAction,
+    required String envelope,
+  }) async {
+    // The SOAPAction is `<namespace>#<method>`.
+    final String method = soapAction.split('#').last;
+    if (method == SmartschoolMethod.getAllGroupsAndClasses) {
+      return _wrap(
+        method,
+        base64.encode(utf8.encode(_tree)),
+        'xsd:base64Binary',
+      );
+    }
+    if (method == SmartschoolMethod.getAllAccountsExtended) {
+      accountCodes.add(
+        RegExp(r'<code[^>]*>([^<]*)</code>').firstMatch(envelope)?.group(1) ??
+            '',
+      );
+      return _wrap(method, '19', 'xsd:int'); // Smartschool: no direct accounts.
+    }
+    return _wrap(method, '0', 'xsd:int');
+  }
+
+  String _wrap(String method, String value, String type) =>
+      '<?xml version="1.0" encoding="utf-8"?>'
+      '<soap:Envelope '
+      'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" '
+      'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+      '<soap:Body><${method}Response>'
+      '<return xsi:type="$type">$value</return>'
+      '</${method}Response></soap:Body></soap:Envelope>';
 }

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -343,9 +343,10 @@ Future<ReconcileServices> bootstrapReconcile({
       system: core.Origin.wisa,
       initial: wisaSeed,
       // Schools are re-read per sync so a WISA-side school change is picked
-      // up; MarkAsVirtual rules are applied to them before the row pulls, the
-      // other rules at snapshot construction. Rules are read live from the
-      // shared holder so a DontImportFromWisa apply affects the re-sync (#72).
+      // up; MarkAsVirtual rules and the operator's per-school virtual marks
+      // (#203) are applied to them before the row pulls, the other rules at
+      // snapshot construction. Rules are read live from the shared holder so a
+      // DontImportFromWisa apply affects the re-sync (#72).
       // The pull is wrapped so each fresh snapshot is persisted (#107).
       syncer: persistingSyncer<wapi.WisaSnapshot>(
         system: core.Origin.wisa,
@@ -354,9 +355,12 @@ Future<ReconcileServices> bootstrapReconcile({
         payloadOf: (s) => s.toJson(),
         onError: (e) => logSnapshotIssue(core.Origin.wisa, e),
         inner: (_) async {
-          final schools = wapi.WisaConnector.applySchoolRules(
-            await wisaConnector.loadSchools(),
-            wisaRules.rules,
+          final schools = markVirtualSchools(
+            wapi.WisaConnector.applySchoolRules(
+              await wisaConnector.loadSchools(),
+              wisaRules.rules,
+            ),
+            settings.virtualWisaSchoolIds,
           );
           final at = now();
           return wisaConnector.sync(
@@ -494,6 +498,28 @@ String smartschoolSiteFrom(String uri) {
   if (host.isNotEmpty) return host.split('.').first;
   return trimmed;
 }
+
+/// Flags the operator's virtual WISA schools on a freshly loaded school list.
+///
+/// The virtual marks live in the settings document keyed by school **id**
+/// ([AppSettings.virtualWisaSchoolIds], #203), while the snapshot-time
+/// `MarkAsVirtual` import rule matches by school **name**. Setting
+/// `WisaSchool.isVirtual` straight from settings mirrors how `ourSchoolIds`
+/// bypasses `MarkAsOurs`: the operator-editable record is authoritative and no
+/// rule has to be synthesised for it.
+///
+/// The pass is additive — a school the rules already flagged stays flagged even
+/// when it is not in [virtualIds] — so wiring settings in can never silently
+/// un-virtualise a school an existing `MarkAsVirtual` rule covers. Returns a new
+/// list; the input is not mutated.
+List<wapi.WisaSchool> markVirtualSchools(
+  Iterable<wapi.WisaSchool> schools,
+  Set<int> virtualIds,
+) =>
+    <wapi.WisaSchool>[
+      for (final s in schools)
+        virtualIds.contains(s.id) ? s.copyWith(isVirtual: true) : s,
+    ];
 
 String _firstNonEmpty(String preferred, String fallback) =>
     preferred.trim().isNotEmpty ? preferred.trim() : fallback;

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -449,6 +449,10 @@ Future<ReconcileServices> bootstrapReconcile({
     log: logBuffer,
     store: linked,
     syncedBy: syncedBy,
+    // The operator's curated school list names every school in the Actions
+    // drill-down, so it reads "Instituut Sancta Maria-A (ISMAA)" exactly as the
+    // Settings grid does rather than "School 25" (#204).
+    schoolProfiles: settings.wisaSchools,
     publisher: signalPublisher,
     subscriber: signalSubscriber,
     clock: now,

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -273,6 +273,7 @@ class ReconcileController extends ChangeNotifier {
     required this.log,
     required this.store,
     this.syncedBy = '',
+    this.schoolProfiles = const <WisaSchoolProfile>[],
     this.publisher,
     this.subscriber,
     this.persistTimeout = const Duration(minutes: 10),
@@ -298,6 +299,15 @@ class ReconcileController extends ChangeNotifier {
 
   /// The operator (UPN) whose session writes the materialized view.
   final String syncedBy;
+
+  /// The operator-curated WISA schools from the settings document
+  /// (AppSettings.wisaSchools), each carrying the school's short code and long
+  /// name. They are what [_schoolLabels] names a school with, so the Actions
+  /// drill-down identifies schools exactly as the Settings grid does even in a
+  /// session that has not pulled WISA yet (#204). Empty until an operator has
+  /// filled the WISA-scholen grid in, which is when the label falls back to the
+  /// snapshot and finally to `School <id>`.
+  final List<WisaSchoolProfile> schoolProfiles;
 
   /// Publishes a [ChangeSignal] when this session takes/releases the sync lease
   /// or writes a new view generation, so other operators are nudged in real time
@@ -1443,12 +1453,17 @@ class ReconcileController extends ChangeNotifier {
     }
   }
 
-  /// The WISA school-id → name map for the materializer's school labels, from
-  /// the current WISA snapshot's schools list (empty before the first pull).
-  Map<int, String> _schoolLabels() => {
-        for (final s in app.wisa.snapshot?.schools ?? const <wapi.WisaSchool>[])
-          s.id: s.name,
-      };
+  /// The WISA school-id → label map the materializer bakes into its documents.
+  ///
+  /// Built from the persisted [schoolProfiles] merged with the current WISA
+  /// snapshot's schools (empty before the first pull), so a school reads as
+  /// `Instituut Sancta Maria-A (ISMAA)` — the same identity the Settings grid
+  /// shows — instead of degrading to `School <id>` whenever the session's
+  /// snapshot happens to carry no schools (#204).
+  Map<int, String> _schoolLabels() => wisaSchoolLabels(
+        profiles: schoolProfiles,
+        schools: app.wisa.snapshot?.schools ?? const <wapi.WisaSchool>[],
+      );
 
   void _begin(ReconcilePhase phase) {
     _phase = phase;

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -26,8 +26,12 @@ import '../settings/settings_bootstrap.dart';
 ///   store into the form, so a settings change another operator made (or the
 ///   operator's own save) can be pulled back without relaunching.
 ///
-/// Import rules are shown read-only for now (accumulated by `DontImportFromWisa`
-/// applies during reconcile); editing them is a later slice.
+/// The **Smartschool** import rules are authored here (#202): add / edit /
+/// remove the two rules the legacy app offers (`DiscardSmartschoolGroup`,
+/// `NoSmartschoolSubgroups`), persisted through the existing rule codec and
+/// applied by the connector on the next Smartschool pull. The **WISA** rules
+/// stay read-only (they are accumulated by `DontImportFromWisa` applies during
+/// reconcile); editing those is a later slice.
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key, required this.bootstrap});
 
@@ -78,6 +82,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
     SmartschoolConnection.yearCount,
     (_) => TextEditingController(),
   );
+
+  // The Smartschool import rules (#202): a mutable working copy the rule editor
+  // edits in place and `_collect` commits on save, mirroring how the WISA school
+  // list below is handled. Empty means the whole Smartschool group tree is
+  // imported — which is what every install did while nothing could author one.
+  List<SmartschoolImportRule> _ssRules = const <SmartschoolImportRule>[];
 
   // Azure profile.
   final _azClientId = TextEditingController();
@@ -201,6 +211,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _years[i].text =
           i < s.smartschool.years.length ? s.smartschool.years[i] : '';
     }
+    _ssRules = List<SmartschoolImportRule>.of(s.smartschoolRules);
 
     _azClientId.text = s.azure.clientId;
     _azTenantId.text = s.azure.tenantId;
@@ -214,6 +225,57 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void _toggleSchoolOurs(int index, bool ours) {
     toggle(
         () => _wisaSchools[index] = _wisaSchools[index].copyWith(ours: ours));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Smartschool import rules (#202)
+  // ---------------------------------------------------------------------------
+
+  /// Prompts for a group name and appends a new rule of [kind]. Cancelling the
+  /// prompt leaves the list untouched.
+  Future<void> _addSmartschoolRule(_SmartschoolRuleKind kind) async {
+    final name = await _promptRuleGroupName(kind: kind);
+    if (name == null || !mounted) return;
+    toggle(() => _ssRules = <SmartschoolImportRule>[..._ssRules, kind(name)]);
+  }
+
+  /// Re-prompts for the group name of the rule at [index], keeping its kind.
+  Future<void> _editSmartschoolRule(int index) async {
+    final rule = _ssRules[index];
+    final kind = _SmartschoolRuleKind.of(rule);
+    final name = await _promptRuleGroupName(
+      kind: kind,
+      initial: _smartschoolRuleGroupName(rule),
+    );
+    if (name == null || !mounted) return;
+    toggle(() {
+      _ssRules = List<SmartschoolImportRule>.of(_ssRules)..[index] = kind(name);
+    });
+  }
+
+  /// Drops the rule at [index] from the working list.
+  void _removeSmartschoolRule(int index) {
+    toggle(() {
+      _ssRules = List<SmartschoolImportRule>.of(_ssRules)..removeAt(index);
+    });
+  }
+
+  /// Asks for the Smartschool group name a rule applies to. Returns the trimmed
+  /// name, or `null` when the operator cancels.
+  ///
+  /// Free text rather than a picker on purpose: this view's seams are the
+  /// settings store, the vault and the WISA school fetcher — there is no
+  /// Smartschool snapshot here to pick from — and a rule has to be authorable
+  /// *before* the first pull, which is exactly the state a fresh install is in.
+  /// It also matches the legacy dialog.
+  Future<String?> _promptRuleGroupName({
+    required _SmartschoolRuleKind kind,
+    String initial = '',
+  }) {
+    return showDialog<String>(
+      context: context,
+      builder: (_) => _RuleGroupNameDialog(kind: kind, initial: initial),
+    );
   }
 
   /// Whether the persisted WISA connection is complete enough to fetch the
@@ -297,7 +359,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   /// Assembles an [AppSettings] from the form, preserving the loaded document's
-  /// secret refs and (read-only) import rules.
+  /// secret refs and its (read-only) WISA import rules.
   AppSettings _collect(AppSettings base) {
     return base.copyWith(
       schoolPrefix: _schoolPrefix.text.trim(),
@@ -328,6 +390,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         tenantId: _azTenantId.text.trim(),
         domain: _azDomain.text.trim(),
       ),
+      smartschoolRules: List<SmartschoolImportRule>.of(_ssRules),
       wisaSchools: List<WisaSchoolProfile>.of(_wisaSchools),
     );
   }
@@ -648,7 +711,7 @@ class _SettingsForm extends StatelessWidget {
   }
 
   /// Smartschool connector config: connection, credentials, grade/year
-  /// vocabulary, and the Smartschool import rules (read-only).
+  /// vocabulary, and the Smartschool import-rule editor (#202).
   Widget _smartschoolTab() {
     return _tab('settings-tab-smartschool-body', <Widget>[
       _Section(
@@ -708,12 +771,9 @@ class _SettingsForm extends StatelessWidget {
         ],
       ),
       _Section(
-        title: 'Importregels (alleen-lezen)',
+        title: 'Importregels',
         children: <Widget>[
-          _RulesList(
-            emptyKey: const ValueKey('settings-ss-rules-empty'),
-            smartschoolRules: settings.smartschoolRules,
-          ),
+          _SmartschoolRulesEditor(state: state),
         ],
       ),
     ]);
@@ -907,14 +967,12 @@ class _RulesList extends StatelessWidget {
   const _RulesList({
     required this.emptyKey,
     this.wisaRules = const <WisaImportRule>[],
-    this.smartschoolRules = const <SmartschoolImportRule>[],
   });
 
   /// Key stamped on the "no rules yet" placeholder, so each connector tab's
   /// empty state is addressable on its own.
   final Key emptyKey;
   final List<WisaImportRule> wisaRules;
-  final List<SmartschoolImportRule> smartschoolRules;
 
   static String _describeWisa(WisaImportRule rule) => switch (rule) {
         DontImportClass(:final className) =>
@@ -927,19 +985,11 @@ class _RulesList extends StatelessWidget {
         MarkAsOurs(:final schoolCode) => 'Markeer als beheerd: $schoolCode',
       };
 
-  static String _describeSmartschool(SmartschoolImportRule rule) =>
-      switch (rule) {
-        DiscardSmartschoolGroup(:final groupName) =>
-          'Smartschool-groep negeren: $groupName',
-        NoSmartschoolSubgroups(:final groupName) =>
-          'Geen subgroepen: $groupName',
-      };
-
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     final ColorScheme colors = Theme.of(context).colorScheme;
-    if (wisaRules.isEmpty && smartschoolRules.isEmpty) {
+    if (wisaRules.isEmpty) {
       return Text(
         'Nog geen importregels verzameld.',
         key: emptyKey,
@@ -954,11 +1004,230 @@ class _RulesList extends StatelessWidget {
             padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
             child: Text('• ${_describeWisa(r)}', style: text.bodyMedium),
           ),
-        for (final r in smartschoolRules)
-          Padding(
-            padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
-            child: Text('• ${_describeSmartschool(r)}', style: text.bodyMedium),
+      ],
+    );
+  }
+}
+
+/// How one Smartschool import rule reads in the settings list.
+String _describeSmartschoolRule(SmartschoolImportRule rule) => switch (rule) {
+      DiscardSmartschoolGroup(:final groupName) =>
+        'Smartschool-groep negeren: $groupName',
+      NoSmartschoolSubgroups(:final groupName) => 'Geen subgroepen: $groupName',
+    };
+
+/// The Smartschool group name a rule applies to. The sealed base type carries
+/// no shared field, so a switch over the two cases is where they meet.
+String _smartschoolRuleGroupName(SmartschoolImportRule rule) => switch (rule) {
+      DiscardSmartschoolGroup(:final groupName) => groupName,
+      NoSmartschoolSubgroups(:final groupName) => groupName,
+    };
+
+/// The two Smartschool import rules an operator can author (#202), carrying the
+/// Dutch labels the legacy `ImportRuleSelectDialog` offered. Calling a kind
+/// builds its rule for a group name — which is all that separates them.
+enum _SmartschoolRuleKind {
+  discardGroup(
+    'Negeer groep',
+    'De groep en alles eronder wordt niet ingelezen.',
+  ),
+  noSubgroups(
+    'Negeer subgroepen',
+    'De groep wordt ingelezen, maar zonder haar subgroepen.',
+  );
+
+  const _SmartschoolRuleKind(this.label, this.explanation);
+
+  /// The menu / dialog label, matching legacy.
+  final String label;
+
+  /// One line telling the operator what the rule does to the import.
+  final String explanation;
+
+  SmartschoolImportRule call(String groupName) => switch (this) {
+        _SmartschoolRuleKind.discardGroup => DiscardSmartschoolGroup(groupName),
+        _SmartschoolRuleKind.noSubgroups => NoSmartschoolSubgroups(groupName),
+      };
+
+  static _SmartschoolRuleKind of(SmartschoolImportRule rule) => switch (rule) {
+        DiscardSmartschoolGroup() => _SmartschoolRuleKind.discardGroup,
+        NoSmartschoolSubgroups() => _SmartschoolRuleKind.noSubgroups,
+      };
+}
+
+/// Editor for the Smartschool import rules (#202).
+///
+/// The app could already *carry* the two rules, but nothing could *create*
+/// them — so in practice there were none, and the whole Smartschool group tree
+/// (organisational subtrees included) was imported on every pull. This is the
+/// authoring surface: the configured rules, each editable and removable inline,
+/// plus a **Toevoegen** menu offering the two rule types. Edits live in the
+/// screen's working copy and persist with the rest of the document on
+/// **Opslaan**, through the existing `encodeSmartschoolRule` codec.
+class _SmartschoolRulesEditor extends StatelessWidget {
+  const _SmartschoolRulesEditor({required this.state});
+
+  final _SettingsScreenState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final rules = state._ssRules;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          'Regels snoeien de Smartschool-groepenboom bij het inlezen. Ze '
+          'gelden vanaf de volgende synchronisatie.',
+          style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+        ),
+        const SizedBox(height: PlinkSpacing.s3),
+        if (rules.isEmpty)
+          Text(
+            'Nog geen importregels ingesteld.',
+            key: const ValueKey('settings-ss-rules-empty'),
+            style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+          )
+        else
+          for (var i = 0; i < rules.length; i++)
+            _RuleRow(state: state, index: i, rule: rules[i]),
+        const SizedBox(height: PlinkSpacing.s4),
+        MenuAnchor(
+          menuChildren: <Widget>[
+            for (final kind in _SmartschoolRuleKind.values)
+              MenuItemButton(
+                key: ValueKey('settings-ss-rule-add-${kind.name}'),
+                onPressed: () => state._addSmartschoolRule(kind),
+                child: Text(kind.label),
+              ),
+          ],
+          builder: (_, MenuController menu, __) => OutlinedButton.icon(
+            key: const ValueKey('settings-ss-rule-add'),
+            onPressed: () => menu.isOpen ? menu.close() : menu.open(),
+            icon: const Icon(Icons.add),
+            label: const Text('Toevoegen'),
           ),
+        ),
+      ],
+    );
+  }
+}
+
+/// One configured Smartschool rule: its description plus the edit and remove
+/// affordances. Keyed by position so a widget/integration test can drive a
+/// specific row.
+class _RuleRow extends StatelessWidget {
+  const _RuleRow({
+    required this.state,
+    required this.index,
+    required this.rule,
+  });
+
+  final _SettingsScreenState state;
+  final int index;
+  final SmartschoolImportRule rule;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Text(
+              _describeSmartschoolRule(rule),
+              key: ValueKey('settings-ss-rule-$index'),
+              style: text.bodyMedium,
+            ),
+          ),
+          IconButton(
+            key: ValueKey('settings-ss-rule-$index-edit'),
+            tooltip: 'Bewerken',
+            icon: const Icon(Icons.edit_outlined),
+            onPressed: () => state._editSmartschoolRule(index),
+          ),
+          IconButton(
+            key: ValueKey('settings-ss-rule-$index-remove'),
+            tooltip: 'Verwijderen',
+            icon: const Icon(Icons.delete_outline),
+            onPressed: () => state._removeSmartschoolRule(index),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Prompts for the Smartschool group name a rule applies to, popping the
+/// trimmed name (or nothing when cancelled). A blank name is refused: a rule
+/// without a group matches nothing and would silently do no work.
+class _RuleGroupNameDialog extends StatefulWidget {
+  const _RuleGroupNameDialog({required this.kind, required this.initial});
+
+  final _SmartschoolRuleKind kind;
+  final String initial;
+
+  @override
+  State<_RuleGroupNameDialog> createState() => _RuleGroupNameDialogState();
+}
+
+class _RuleGroupNameDialogState extends State<_RuleGroupNameDialog> {
+  late final TextEditingController _name =
+      TextEditingController(text: widget.initial);
+
+  @override
+  void dispose() {
+    _name.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final value = _name.text.trim();
+    if (value.isEmpty) return;
+    Navigator.of(context).pop(value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    return AlertDialog(
+      key: const ValueKey('settings-ss-rule-dialog'),
+      title: Text(widget.kind.label),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(widget.kind.explanation, style: text.bodyMedium),
+          const SizedBox(height: PlinkSpacing.s3),
+          TextField(
+            key: const ValueKey('settings-ss-rule-name'),
+            controller: _name,
+            autofocus: true,
+            onSubmitted: (_) => _submit(),
+            decoration: const InputDecoration(
+              labelText: 'Groepsnaam',
+              hintText: 'Naam zoals ze in Smartschool staat',
+              border: OutlineInputBorder(),
+            ),
+          ),
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          key: const ValueKey('settings-ss-rule-cancel'),
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Annuleren'),
+        ),
+        ValueListenableBuilder<TextEditingValue>(
+          valueListenable: _name,
+          builder: (_, TextEditingValue value, __) => FilledButton(
+            key: const ValueKey('settings-ss-rule-confirm'),
+            onPressed: value.text.trim().isEmpty ? null : _submit,
+            child: const Text('Bewaren'),
+          ),
+        ),
       ],
     );
   }

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -1379,9 +1379,10 @@ class _SchoolCell extends StatelessWidget {
     final ColorScheme colors = Theme.of(context).colorScheme;
     final String code = profile.code;
     final String name = profile.name;
-    final String title = code.isNotEmpty
-        ? code
-        : (name.isNotEmpty ? name : 'School ${profile.schoolId}');
+    // The lead label comes from the shared school-label helper the Actions
+    // drill-down also names schools with, so the two views can never disagree
+    // about which half of the pair is the code (#204).
+    final String title = profile.codeLabel;
     final String? subtitle = code.isNotEmpty && name.isNotEmpty
         ? name
         : (code.isEmpty && name.isEmpty ? null : 'id: ${profile.schoolId}');

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -227,6 +227,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
         () => _wisaSchools[index] = _wisaSchools[index].copyWith(ours: ours));
   }
 
+  /// Flips the `virtual` flag on the profile at [index] (#203). Independent of
+  /// `ours`: a virtual school is pulled with the separate virtual work date,
+  /// whether or not we manage it.
+  void _toggleSchoolVirtual(int index, bool virtual) {
+    toggle(() =>
+        _wisaSchools[index] = _wisaSchools[index].copyWith(virtual: virtual));
+  }
+
   // ---------------------------------------------------------------------------
   // Smartschool import rules (#202)
   // ---------------------------------------------------------------------------
@@ -298,10 +306,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
   /// Refreshes the known-WISA-school list from the API (#171). "Scholen ophalen"
   /// is a *refresh* now, not the primary way to build the list: it merges the
   /// fetched id+name records into [_wisaSchools], updating each name, adding any
-  /// genuinely new school (unmanaged by default), and preserving the `ours` mark
-  /// on schools already known. Prefers a freshly typed password; otherwise
-  /// resolves the stored secret. Failures surface as a toast. The merged list is
-  /// dirty until saved, so the enriched names persist and no re-fetch is needed.
+  /// genuinely new school (unmanaged by default), and preserving the `ours` and
+  /// `virtual` marks on schools already known. Prefers a freshly typed password;
+  /// otherwise resolves the stored secret. Failures surface as a toast. The
+  /// merged list is dirty until saved, so the enriched names persist and no
+  /// re-fetch is needed.
   Future<void> _fetchWisaSchools() async {
     final services = _services;
     final fetcher = services?.fetchWisaSchools;
@@ -332,10 +341,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   /// Merges the [fetched] WISA schools (id + code + name) into the current known
-  /// list: keeps every already-known school (preserving its `ours`/`prefix`,
-  /// refreshing its code and name when the fetch supplies them) and appends any
-  /// fetched school not yet known as unmanaged. Order is stable by school id so
-  /// the grid does not jump.
+  /// list: keeps every already-known school (preserving its
+  /// `ours`/`virtual`/`prefix` marks, refreshing its code and name when the
+  /// fetch supplies them) and appends any fetched school not yet known as
+  /// neither managed nor virtual. Order is stable by school id so the grid does
+  /// not jump.
   ///
   /// The short code (`ismaa`, `ismab`, …) rides on `WisaSchool.description`, not
   /// `.name` — `SMAGetInst`'s CSV is `ID,NAME,DESCRIPTION` and the connector
@@ -1258,11 +1268,13 @@ class _WisaSchoolsEditor extends StatelessWidget {
       children: <Widget>[
         // The known-school list is the primary surface; the fetch is a refresh
         // (#171): mark which schools we manage inline, and only re-fetch when a
-        // genuinely new school appears.
+        // genuinely new school appears. The virtual mark (#203) rides along in
+        // the same cell — it decides which work date the school is pulled with.
         Text(
-          'De bekende WISA-scholen. Markeer welke we beheren. Gebruik '
-          '"Scholen ophalen" om de lijst te vernieuwen als er een nieuwe '
-          'school bijkomt.',
+          'De bekende WISA-scholen. Markeer welke we beheren. Vink '
+          '"virtueel" aan voor scholen die met de virtuele werkdatum '
+          'opgehaald moeten worden. Gebruik "Scholen ophalen" om de lijst te '
+          'vernieuwen als er een nieuwe school bijkomt.',
           style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
         ),
         const SizedBox(height: PlinkSpacing.s3),
@@ -1312,7 +1324,7 @@ class _WisaSchoolsEditor extends StatelessWidget {
 
   /// Lays the known schools out as rows of [_columns] cells, padding the final
   /// row with empty slots so the grid columns stay aligned. Each cell toggles
-  /// its school's managed (`ours`) flag inline.
+  /// its school's managed (`ours`) and virtual flags inline.
   List<Widget> _schoolRows(List<WisaSchoolProfile> schools) {
     final rows = <Widget>[];
     for (var start = 0; start < schools.length; start += _columns) {
@@ -1336,8 +1348,15 @@ class _WisaSchoolsEditor extends StatelessWidget {
 
 /// A single cell in the known-WISA-school grid (#171): the school's WISA code
 /// (`ismaa`, `ismab`, …) — the identifier operators actually use — with the long
-/// name beneath it, plus an inline checkbox marking whether we manage it. Keyed
-/// by school id so a test can flip a specific school's managed flag.
+/// name beneath it, plus an inline checkbox marking whether we manage it and a
+/// second, quieter one marking it *virtual* (#203). Both are keyed by school id
+/// so a test can flip a specific school's flag.
+///
+/// The two marks are deliberately unequal in weight. `ours` scopes the linker;
+/// `virtual` changes **which work date the school is pulled with**, so a school
+/// wrongly marked virtual comes back against the wrong date and can read as a
+/// mass leave. It therefore sits on its own indented, small-type line rather
+/// than as a second equal-looking checkbox.
 ///
 /// The numeric id is strictly a fallback and never appears twice (#194): the
 /// title degrades code → name → `School <id>`, and the subtitle shows whichever
@@ -1356,6 +1375,8 @@ class _SchoolCell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
     final String code = profile.code;
     final String name = profile.name;
     final String title = code.isNotEmpty
@@ -1365,21 +1386,45 @@ class _SchoolCell extends StatelessWidget {
         ? name
         : (code.isEmpty && name.isEmpty ? null : 'id: ${profile.schoolId}');
 
-    return CheckboxListTile(
-      key: ValueKey('settings-wisa-school-${profile.schoolId}-ours'),
-      contentPadding: EdgeInsets.zero,
-      controlAffinity: ListTileControlAffinity.leading,
-      dense: true,
-      title: Text(
-        title,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      ),
-      subtitle: subtitle == null
-          ? null
-          : Text(subtitle, maxLines: 1, overflow: TextOverflow.ellipsis),
-      value: profile.ours,
-      onChanged: (v) => state._toggleSchoolOurs(index, v ?? false),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        CheckboxListTile(
+          key: ValueKey('settings-wisa-school-${profile.schoolId}-ours'),
+          contentPadding: EdgeInsets.zero,
+          controlAffinity: ListTileControlAffinity.leading,
+          dense: true,
+          title: Text(
+            title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          subtitle: subtitle == null
+              ? null
+              : Text(subtitle, maxLines: 1, overflow: TextOverflow.ellipsis),
+          value: profile.ours,
+          onChanged: (v) => state._toggleSchoolOurs(index, v ?? false),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(left: PlinkSpacing.s3),
+          child: CheckboxListTile(
+            key: ValueKey('settings-wisa-school-${profile.schoolId}-virtual'),
+            contentPadding: EdgeInsets.zero,
+            controlAffinity: ListTileControlAffinity.leading,
+            dense: true,
+            visualDensity: VisualDensity.compact,
+            title: Text(
+              'virtueel',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+            ),
+            value: profile.virtual,
+            onChanged: (v) => state._toggleSchoolVirtual(index, v ?? false),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/account_manager/test/reconcile/reconcile_bootstrap_test.dart
+++ b/account_manager/test/reconcile/reconcile_bootstrap_test.dart
@@ -4,6 +4,7 @@ import 'package:account_manager/src/auth/sign_in_session.dart';
 import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
 import 'package:account_state/account_state.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:wisa_api/wisa_api.dart' show WisaSchool;
 
 import '../auth/fake_broker.dart';
 
@@ -396,6 +397,53 @@ void main() {
       ));
       expect(tree.grades, isNotEmpty);
       expect(tree.years, isEmpty);
+    });
+  });
+
+  group('markVirtualSchools', () {
+    const schools = <WisaSchool>[
+      WisaSchool(
+          id: 25, name: 'Instituut Sancta Maria-A', description: 'ISMAA'),
+      WisaSchool(id: 99, name: 'Virtuele school SMA', description: 'ISMAV'),
+    ];
+
+    test('flags exactly the schools the operator marked virtual (#203)', () {
+      final marked = markVirtualSchools(schools, {99});
+      expect(marked.firstWhere((s) => s.id == 99).isVirtual, isTrue);
+      expect(marked.firstWhere((s) => s.id == 25).isVirtual, isFalse);
+      // Nothing else about the school is touched.
+      expect(marked.firstWhere((s) => s.id == 99).name, 'Virtuele school SMA');
+      expect(marked.length, schools.length);
+    });
+
+    test('an empty virtual set leaves every school alone (#203)', () {
+      expect(markVirtualSchools(schools, const <int>{}), schools);
+    });
+
+    test('an id we do not know is simply ignored (#203)', () {
+      final marked = markVirtualSchools(schools, {12345});
+      expect(marked.every((s) => !s.isVirtual), isTrue);
+    });
+
+    test('never un-flags a school an import rule already marked (#203)', () {
+      // MarkAsVirtual runs first and matches by name; settings marks by id.
+      // The settings pass is additive, so a legacy rule keeps working even
+      // when the school is not in the settings list.
+      const ruled = <WisaSchool>[
+        WisaSchool(
+            id: 25,
+            name: 'Instituut Sancta Maria-A',
+            description: 'ISMAA',
+            isVirtual: true),
+      ];
+      expect(markVirtualSchools(ruled, const <int>{}).single.isVirtual, isTrue);
+      expect(markVirtualSchools(ruled, {25}).single.isVirtual, isTrue);
+    });
+
+    test('does not mutate the input list (#203)', () {
+      final input = List<WisaSchool>.of(schools);
+      markVirtualSchools(input, {25, 99});
+      expect(input.every((s) => !s.isVirtual), isTrue);
     });
   });
 }

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:account_manager/src/reconcile/reconcile_controller.dart';
 import 'package:account_state/account_state.dart';
 import 'package:azure_api/azure_api.dart' as az;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:wisa_api/wisa_api.dart' as wapi;
 
 import 'reconcile_fakes.dart';
 
@@ -475,6 +476,54 @@ void main() {
 
       expect(h.controller.hasOverview, isTrue);
       expect(h.controller.syncState.generation, 1);
+    });
+
+    test(
+        'school rollups are labelled from the persisted Settings profiles, '
+        'not the school id (#204)', () async {
+      // The regression: the label map was built solely from the WISA snapshot's
+      // schools, so a session whose snapshot carries none (a cold seed written
+      // before schools were serialized) baked `School 25` into every document.
+      final h = namedSchoolHarness();
+
+      await h.controller.sync();
+
+      final rollups = await h.linkedStore.readRollups();
+      final school = rollups.singleWhere((r) => r.level == RollupLevel.school);
+      expect(school.label, 'Instituut Sancta Maria-A (ISMAA)');
+      expect(school.label, isNot('School 25'));
+
+      // The same label is baked into the per-account documents the drill-down
+      // reads back, so a passive session sees it too.
+      final accounts = await h.linkedStore.readClassroom(
+        school: school.school,
+        classroom: '3C',
+      );
+      expect(accounts.single.schoolLabel, 'Instituut Sancta Maria-A (ISMAA)');
+    });
+
+    test('a live WISA pull labels schools it carries itself (#204)', () async {
+      // No Settings profile at all: the pulled school list still names the
+      // school by its own two halves rather than by its id.
+      final h = ReconcileHarness(
+        wisa: wisaSnap(
+          students: [wisaStudent(schoolId: 25)],
+          schools: const [
+            wapi.WisaSchool(
+              id: 25,
+              name: 'Instituut Sancta Maria-A',
+              description: 'ISMAA',
+              isOurs: true,
+            ),
+          ],
+        ),
+      );
+
+      await h.controller.sync();
+
+      final rollups = await h.linkedStore.readRollups();
+      final school = rollups.singleWhere((r) => r.level == RollupLevel.school);
+      expect(school.label, 'Instituut Sancta Maria-A (ISMAA)');
     });
 
     test('re-sync bumps the generation again', () async {

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -143,6 +143,26 @@ wapi.WisaStudent wisaStudent({
 wapi.WisaSchool wisaSchool(int id, {bool ours = false}) =>
     wapi.WisaSchool(id: id, name: 'School $id', description: '', isOurs: ours);
 
+/// A WISA class group. [name] is the `fullName` the linker matches on;
+/// [schoolId] decides whether the class belongs to a school we manage — a
+/// sibling school's class must never reach the action engine (#205).
+wapi.WisaClassGroup wisaClassGroup(
+  String name, {
+  String groupName = '00',
+  String description = '',
+  String adminCode = '',
+  String schoolCode = '123',
+  int schoolId = 1,
+}) =>
+    wapi.WisaClassGroup(
+      name: name,
+      groupName: groupName,
+      description: description,
+      adminCode: adminCode,
+      schoolCode: schoolCode,
+      schoolId: schoolId,
+    );
+
 /// A WISA staff record — the personeel counterpart of [wisaStudent]. A staff
 /// member present only in WISA (no Smartschool / Azure counterpart) links as a
 /// [core.LinkedStaff] and materializes into the synthetic "Personeel" school
@@ -227,12 +247,13 @@ wapi.WisaSnapshot wisaSnap({
   List<wapi.WisaStudent>? students,
   List<wapi.WisaStaff> staff = const [],
   List<wapi.WisaSchool> schools = const [],
+  List<wapi.WisaClassGroup> classGroups = const [],
 }) =>
     wapi.WisaSnapshot(
       fetchedAt: fetchedAt ?? kFixtureDate,
       students: students ?? [wisaStudent()],
       staff: staff,
-      classGroups: const [],
+      classGroups: classGroups,
       schools: schools,
     );
 
@@ -418,6 +439,51 @@ ReconcileHarness managedSchoolsHarness({required Set<int> ourSchoolIds}) =>
       ),
       azure: azSnap(users: [azUser()]),
       ourSchoolIds: ourSchoolIds,
+    );
+
+/// A harness for the managed-school class-group scope (#205). WISA hands the
+/// session class groups from two schools, and the sibling school's arrive
+/// *first* in the pull: `1A` and `9Z` of school 2 (which we do not manage),
+/// then our own `1A` of school 1. Each class holds a student, so before the fix
+/// every one of them raised `AddToSmartschool` — a proposal to create another
+/// school's class in *our* Smartschool — and the sibling `1A` even shadowed
+/// ours, so the proposal described the wrong school's class. Only school 1 is
+/// managed, from the persisted Settings set.
+ReconcileHarness foreignClassGroupHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(wisaId: '1', classGroup: '1A'),
+          wisaStudent(wisaId: '2', classGroup: '9Z', schoolId: 2),
+        ],
+        schools: [wisaSchool(1), wisaSchool(2)],
+        classGroups: [
+          wisaClassGroup(
+            '1A',
+            description: 'Klas van een andere school',
+            schoolCode: '222',
+            schoolId: 2,
+          ),
+          wisaClassGroup(
+            '9Z',
+            description: 'Ook van een andere school',
+            schoolCode: '222',
+            schoolId: 2,
+          ),
+          wisaClassGroup(
+            '1A',
+            description: 'Onze eerste klas',
+            schoolCode: '111',
+            schoolId: 1,
+          ),
+        ],
+      ),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+      ourSchoolIds: const {1},
     );
 
 /// A harness for the school-label drill-down (#204). One student enrolled in

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -420,6 +420,35 @@ ReconcileHarness managedSchoolsHarness({required Set<int> ourSchoolIds}) =>
       ourSchoolIds: ourSchoolIds,
     );
 
+/// A harness for the school-label drill-down (#204). One student enrolled in
+/// school 25 and fully present in *our* Smartschool + Azure, in a session whose
+/// WISA snapshot carries **no** schools at all — the cold-snapshot case that
+/// made every school node degrade to `School 25`. The school's identity comes
+/// solely from the operator's persisted Settings profile (short code + long
+/// name), so the Actions drill-down must still name it exactly as the Settings
+/// grid does.
+ReconcileHarness namedSchoolHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(schoolId: 25)],
+        schools: const [],
+      ),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: [ssAccount()],
+        memberships: const [],
+      ),
+      azure: azSnap(users: [azUser()]),
+      ourSchoolIds: const {25},
+      schoolProfiles: const [
+        WisaSchoolProfile(
+          schoolId: 25,
+          code: 'ISMAA',
+          name: 'Instituut Sancta Maria-A',
+          ours: true,
+        ),
+      ],
+    );
+
 // ---------------------------------------------------------------------------
 // Passive-session materialized-view fixtures for the Actions filter tests
 // (#187): hand-built account docs so one classroom can hold a controlled mix of
@@ -830,6 +859,7 @@ class ReconcileHarness {
     this.azureGate,
     this.syncedBy = 'operator@school.example',
     Set<int>? ourSchoolIds,
+    List<WisaSchoolProfile> schoolProfiles = const <WisaSchoolProfile>[],
   })  : wisaResult = (wisa ?? wisaSnap()),
         ssResult = (smartschool ?? ssSnap()),
         azResult = (azure ?? azSnap()),
@@ -947,6 +977,9 @@ class ReconcileHarness {
       log: log,
       store: controllerStore ?? this.linkedStore,
       syncedBy: syncedBy,
+      // The operator's curated WISA schools from Settings, which name every
+      // school in the Actions drill-down (#204).
+      schoolProfiles: schoolProfiles,
       publisher: publisher ?? signalHub?.publisher(),
       subscriber: subscriber ?? signalHub?.subscriber(),
       persistTimeout: persistTimeout ?? const Duration(minutes: 10),

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -539,6 +539,35 @@ void main() {
   });
 
   testWidgets(
+      'the Klasgroepen drill-down proposes only classes of the schools we '
+      'manage, and describes ours rather than the sibling class that shares '
+      'its name (#205)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = foreignClassGroupHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+
+    // Our own populated class is the one and only proposal…
+    expect(find.text('1A'), findsOneWidget);
+    expect(find.text('Voeg deze klas toe aan Smartschool'), findsOneWidget);
+    // …and the sibling school's class is never offered: applying it would
+    // create another school's class in our Smartschool.
+    expect(find.text('9Z'), findsNothing);
+
+    // Expanding it shows *our* class's data — the sibling `1A` used to arrive
+    // first and shadow ours, so the proposal described the wrong class.
+    await tester.tap(find.byKey(const ValueKey('entry-group-1A')));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Onze eerste klas'), findsOneWidget);
+    expect(find.textContaining('Klas van een andere school'), findsNothing);
+  });
+
+  testWidgets(
       'a passive session surfaces the Klasgroepen node and opens the group '
       'detail (#119/#154)', (WidgetTester tester) async {
     final snapshots = InMemorySnapshotStore();

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:account_manager/src/screens/settings_screen.dart';
 import 'package:account_state/account_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:smartschool_api/smartschool_api.dart';
 import 'package:wisa_api/wisa_api.dart';
 
 import 'settings_fakes.dart';
@@ -20,6 +21,29 @@ void _useTallWindow(WidgetTester tester) {
 /// split across Algemeen / Wisa / Smartschool / Azure tabs).
 Future<void> _openTab(WidgetTester tester, String tabKey) async {
   await tester.tap(find.byKey(ValueKey(tabKey)));
+  await tester.pumpAndSettle();
+}
+
+/// Authors one Smartschool import rule through the editor (#202): opens the
+/// **Toevoegen** menu, picks the rule type keyed [kind], types [groupName] into
+/// the prompt and confirms — exactly what the operator does.
+Future<void> _addSmartschoolRule(
+  WidgetTester tester,
+  String kind,
+  String groupName,
+) async {
+  final add = find.byKey(const ValueKey('settings-ss-rule-add'));
+  await tester.ensureVisible(add);
+  await tester.tap(add);
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(ValueKey('settings-ss-rule-add-$kind')));
+  await tester.pumpAndSettle();
+  await tester.enterText(
+    find.byKey(const ValueKey('settings-ss-rule-name')),
+    groupName,
+  );
+  await tester.pump();
+  await tester.tap(find.byKey(const ValueKey('settings-ss-rule-confirm')));
   await tester.pumpAndSettle();
 }
 
@@ -690,5 +714,211 @@ void main() {
     final instrRight = tester.getTopRight(instruction).dx;
     expect(switchLeft - instrRight, lessThan(instrCenter - tileLeft),
         reason: 'the instruction hugs the switch, away from the field label');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Smartschool import-rule editor (#202)
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+      'the Smartschool import rules are an editor now, not an "alleen-lezen" '
+      'list (#202)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-smartschool');
+    expect(find.text('Importregels'), findsOneWidget);
+    expect(find.textContaining('alleen-lezen'), findsNothing);
+    // Nothing configured yet, and the add affordance is there to change that.
+    expect(
+        find.byKey(const ValueKey('settings-ss-rules-empty')), findsOneWidget);
+    expect(find.byKey(const ValueKey('settings-ss-rule-add')), findsOneWidget);
+  });
+
+  testWidgets('Toevoegen offers exactly the two legacy rule types (#202)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-smartschool');
+    await tester.tap(find.byKey(const ValueKey('settings-ss-rule-add')));
+    await tester.pumpAndSettle();
+
+    // The Dutch labels the legacy ImportRuleSelectDialog offered.
+    expect(find.text('Negeer groep'), findsOneWidget);
+    expect(find.text('Negeer subgroepen'), findsOneWidget);
+  });
+
+  testWidgets(
+      'authoring both rule types round-trips through the existing codec (#202)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-smartschool');
+    await _addSmartschoolRule(tester, 'discardGroup', 'Organisatie');
+    await _addSmartschoolRule(tester, 'noSubgroups', 'Klassen');
+
+    // Both render in the list before the save.
+    expect(find.textContaining('Smartschool-groep negeren: Organisatie'),
+        findsOneWidget);
+    expect(find.textContaining('Geen subgroepen: Klassen'), findsOneWidget);
+    expect(find.byKey(const ValueKey('settings-ss-rules-empty')), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.smartschoolRules, hasLength(2));
+    expect(
+      (saved.smartschoolRules[0] as DiscardSmartschoolGroup).groupName,
+      'Organisatie',
+    );
+    expect(
+      (saved.smartschoolRules[1] as NoSmartschoolSubgroups).groupName,
+      'Klassen',
+    );
+    // …on the wire shape the codec already defined — no new tags (#202).
+    expect(saved.toJson()['smartschoolRules'], <Map<String, dynamic>>[
+      {'type': 'discardSmartschoolGroup', 'groupName': 'Organisatie'},
+      {'type': 'noSmartschoolSubgroups', 'groupName': 'Klassen'},
+    ]);
+  });
+
+  testWidgets('editing a rule rewrites its group name, keeping its type (#202)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: AppSettings(
+        smartschoolRules: <SmartschoolImportRule>[
+          const DiscardSmartschoolGroup('Oude naam'),
+        ],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-smartschool');
+    expect(find.textContaining('Smartschool-groep negeren: Oude naam'),
+        findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('settings-ss-rule-0-edit')));
+    await tester.pumpAndSettle();
+    // The prompt opens on the current name, so fixing a typo is a correction
+    // rather than a re-entry.
+    expect(find.text('Oude naam'), findsOneWidget);
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-ss-rule-name')),
+      'Nieuwe naam',
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('settings-ss-rule-confirm')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    final rule = saved.smartschoolRules.single;
+    expect(rule, isA<DiscardSmartschoolGroup>());
+    expect((rule as DiscardSmartschoolGroup).groupName, 'Nieuwe naam');
+  });
+
+  testWidgets('removing a rule drops it from the saved document (#202)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: AppSettings(
+        smartschoolRules: <SmartschoolImportRule>[
+          const DiscardSmartschoolGroup('Organisatie'),
+          const NoSmartschoolSubgroups('Klassen'),
+        ],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-smartschool');
+    await tester.tap(find.byKey(const ValueKey('settings-ss-rule-1-remove')));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Geen subgroepen: Klassen'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.smartschoolRules, hasLength(1));
+    expect(
+      (saved.smartschoolRules.single as DiscardSmartschoolGroup).groupName,
+      'Organisatie',
+    );
+  });
+
+  testWidgets('a rule cannot be saved without a group name (#202)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-smartschool');
+    await tester.tap(find.byKey(const ValueKey('settings-ss-rule-add')));
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(const ValueKey('settings-ss-rule-add-discardGroup')));
+    await tester.pumpAndSettle();
+
+    FilledButton confirm() => tester.widget<FilledButton>(
+          find.byKey(const ValueKey('settings-ss-rule-confirm')),
+        );
+    // Empty, then blank-only: a rule with no group name matches nothing, so it
+    // is refused rather than silently doing no work.
+    expect(confirm().onPressed, isNull);
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-ss-rule-name')),
+      '   ',
+    );
+    await tester.pump();
+    expect(confirm().onPressed, isNull);
+
+    // A real name arms it; cancelling still leaves the list untouched.
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-ss-rule-name')),
+      'Organisatie',
+    );
+    await tester.pump();
+    expect(confirm().onPressed, isNotNull);
+    await tester.tap(find.byKey(const ValueKey('settings-ss-rule-cancel')));
+    await tester.pumpAndSettle();
+    expect(
+        find.byKey(const ValueKey('settings-ss-rules-empty')), findsOneWidget);
+  });
+
+  testWidgets('the WISA rule list stays read-only (#202)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: AppSettings(
+        wisaRules: <WisaImportRule>[const DontImportClass('OKAN')],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    expect(find.text('Importregels (alleen-lezen)'), findsOneWidget);
+    expect(find.byKey(const ValueKey('settings-ss-rule-add')), findsNothing);
   });
 }

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -337,6 +337,153 @@ void main() {
     expect(saved.wisaSchools.single.ours, isTrue);
   });
 
+  testWidgets(
+      'each school cell carries a virtual toggle, independent of the managed '
+      'one, and marking it round-trips to the store (#203)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // One school is managed but not virtual, the other virtual but unmanaged —
+    // the two marks are separate facts about the same school.
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisaSchools: [
+          WisaSchoolProfile(schoolId: 42, name: 'Sint-Jan', ours: true),
+          WisaSchoolProfile(
+              schoolId: 99, name: 'Virtuele school SMA', virtual: true),
+        ],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    final virtual42 =
+        find.byKey(const ValueKey('settings-wisa-school-42-virtual'));
+    final virtual99 =
+        find.byKey(const ValueKey('settings-wisa-school-99-virtual'));
+    expect(virtual42, findsOneWidget);
+    expect(virtual99, findsOneWidget);
+    // Managed ≠ virtual, in both directions.
+    expect(tester.widget<CheckboxListTile>(virtual42).value, isFalse);
+    expect(tester.widget<CheckboxListTile>(virtual99).value, isTrue);
+    expect(
+        tester
+            .widget<CheckboxListTile>(
+                find.byKey(const ValueKey('settings-wisa-school-99-ours')))
+            .value,
+        isFalse);
+
+    // Mark the managed school virtual too and save.
+    await tester.tap(virtual42);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.virtualWisaSchoolIds, {42, 99});
+    // Flipping "virtueel" left the managed marks exactly as they were.
+    expect(saved.managedWisaSchoolIds, {42});
+  });
+
+  testWidgets('clearing the virtual mark round-trips to the store (#203)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisaSchools: [
+          WisaSchoolProfile(schoolId: 42, name: 'Sint-Jan', virtual: true),
+        ],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    await tester
+        .tap(find.byKey(const ValueKey('settings-wisa-school-42-virtual')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.wisaSchools.single.virtual, isFalse);
+    expect(saved.virtualWisaSchoolIds, isEmpty);
+  });
+
+  testWidgets('a refetch preserves the virtual mark (#203)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
+      WisaSchool(id: 99, name: 'Virtuele school SMA', description: 'ismav'),
+    ]);
+    // Marked virtual on a previous run, stored without a code.
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisa: WisaConnection(server: 'db.school.example', port: '1433'),
+        wisaSchools: [WisaSchoolProfile(schoolId: 99, virtual: true)],
+      ),
+      secrets: {passwordRef: 'stored-pw'},
+      fetchWisaSchools: fetcher.call,
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-fetch-schools')));
+    await tester.pumpAndSettle();
+
+    // "Scholen ophalen" backfilled the code and kept the virtual mark ticked.
+    expect(find.text('ismav'), findsOneWidget);
+    expect(
+        tester
+            .widget<CheckboxListTile>(
+                find.byKey(const ValueKey('settings-wisa-school-99-virtual')))
+            .value,
+        isTrue);
+
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.wisaSchools.single.code, 'ismav');
+    expect(saved.wisaSchools.single.virtual, isTrue);
+  });
+
+  testWidgets('a freshly fetched school is not virtual until marked (#203)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
+      WisaSchool(id: 3, name: 'Sint-Jan', description: 'SJ'),
+    ]);
+    final harness = SettingsHarness(
+      initial: const AppSettings(
+        wisa: WisaConnection(server: 'db.school.example', port: '1433'),
+      ),
+      secrets: {passwordRef: 'stored-pw'},
+      fetchWisaSchools: fetcher.call,
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-fetch-schools')));
+    await tester.pumpAndSettle();
+
+    expect(
+        tester
+            .widget<CheckboxListTile>(
+                find.byKey(const ValueKey('settings-wisa-school-3-virtual')))
+            .value,
+        isFalse,
+        reason: 'a new school pulls with the ordinary work date until marked');
+  });
+
   testWidgets('a profile stored without a name falls back to "School <id>"',
       (WidgetTester tester) async {
     _useTallWindow(tester);

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -52,9 +52,11 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 /// one who is genuinely present here. When null, it is derived from the
 /// snapshot's own `WisaSchool.isOurs` flags (the `MarkAsOurs` import rule). When
 /// that derived set is also empty — ownership unconfigured — every WISA-present
-/// student is treated as ours, preserving the pre-#134 behaviour. Membership
-/// never changes which records exist or their identity keys, only how each is
-/// classified ([WisaPresence]).
+/// student is treated as ours, preserving the pre-#134 behaviour. For students
+/// and staff, membership never changes which records exist or their identity
+/// keys, only how each is classified ([WisaPresence]); for **groups** it is a
+/// filter (#205), because a class of a school we do not manage has no business
+/// reaching the action engine at all (see [_linkGroups]).
 LinkedSnapshot link(
   wapi.WisaSnapshot wisaSnapshot,
   ss.SmartschoolSnapshot smartschoolSnapshot,
@@ -116,7 +118,12 @@ LinkedSnapshot link(
       ),
   ];
 
-  final groups = _linkGroups(wisaSnapshot, smartschoolSnapshot, azureSnapshot);
+  final groups = _linkGroups(
+    wisaSnapshot,
+    smartschoolSnapshot,
+    azureSnapshot,
+    effectiveOurSchoolIds,
+  );
 
   return LinkedSnapshot.fromRecords(
     accounts: accounts,
@@ -377,6 +384,22 @@ List<_StaffRecord> _buildStaffRecords(
 /// is kept for a former student. This lets the action engine raise a delete
 /// action for a class that vanished from WISA but still exists downstream.
 ///
+/// Only class groups of the schools we manage ([ourSchoolIds]) seed records
+/// (#205). The shared WISA credentials pull every group-visible school, so
+/// without this every sibling school's class was linked and offered as
+/// `AddToSmartschool` — a proposal to create another school's class in *our*
+/// Smartschool. Skipping them at the seed also fixes the quieter half of the
+/// bug: records are keyed by normalized name and collapse to the first seen, so
+/// a foreign `1A` arriving first used to shadow our own `1A`. As with students,
+/// an empty [ourSchoolIds] means ownership is unconfigured and every school is
+/// treated as ours (see [_isOurWisaSchool]).
+///
+/// A consequence, decided deliberately: an official Smartschool class whose
+/// only WISA counterpart is a class of a school we do not manage now becomes a
+/// Smartschool orphan record (#52) rather than linking to a class we have no
+/// business managing. The action engine then treats it as the orphan it is
+/// instead of silently considering it in sync.
+///
 /// Only `official` Smartschool groups are considered (legacy
 /// `AddSmartschoolChildGroups` walked the "Leerlingen" subtree and linked only
 /// official classes); organisational sub-groups never match or seed orphans.
@@ -397,15 +420,22 @@ List<LinkedGroup> _linkGroups(
   wapi.WisaSnapshot wisaSnapshot,
   ss.SmartschoolSnapshot smartschoolSnapshot,
   az.AzureSnapshot azureSnapshot,
+  Set<int> ourSchoolIds,
 ) {
   final records = <_GroupRecord>[];
   // Normalized fullName/name/displayName -> the record indexed under it.
   final byName = <String, _GroupRecord>{};
 
   // 1. Seed one record per distinct WISA class group, in snapshot order, keyed
-  //    by its `fullName`. Duplicate fullNames collapse to the first record so
-  //    the output is a deterministic function of the input order (INV-20).
+  //    by its `fullName`. Class groups of schools we do not manage are skipped
+  //    outright (#205) — the shared WISA credentials pull every group school,
+  //    and a sibling school's class must never reach the action engine. The
+  //    filter runs *before* the dedupe so a foreign class can no longer occupy
+  //    the name key of one of ours. Duplicate fullNames among our own classes
+  //    still collapse to the first record so the output is a deterministic
+  //    function of the input order (INV-20).
   for (final group in wisaSnapshot.classGroups) {
+    if (!_isOurWisaSchool(group.schoolId, ourSchoolIds)) continue;
     final key = _norm(group.fullName);
     if (key == null || byName.containsKey(key)) continue;
     final rec = _GroupRecord(wisa: group);
@@ -578,6 +608,13 @@ WisaPresence _presence(Set<int> wisaSchoolIds, Set<int> ourSchoolIds) {
       ? WisaPresence.ours
       : WisaPresence.groupOnly;
 }
+
+/// Whether a WISA class group's [schoolId] belongs to a school we manage
+/// ([ourSchoolIds], #205). Mirrors the fallback [_presence] applies to
+/// students: an empty [ourSchoolIds] means ownership is unconfigured, so every
+/// school counts as ours and group linking keeps its pre-#205 behaviour.
+bool _isOurWisaSchool(int schoolId, Set<int> ourSchoolIds) =>
+    ourSchoolIds.isEmpty || ourSchoolIds.contains(schoolId);
 
 /// Whether an Azure user's [companyName] marks it as one of the school's own
 /// (a current or former student). Trimmed + case-insensitive.

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -401,6 +401,103 @@ void main() {
     });
   });
 
+  group('link — class groups are scoped to the schools we manage (#205)', () {
+    /// Links [classGroups] alone (no people), with the managed-school set
+    /// pinned by [ourSchoolIds] (the Settings path) or derived from [schools].
+    LinkedSnapshot linkClasses(
+      List<wapi.WisaClassGroup> classGroups, {
+      Set<int>? ourSchoolIds,
+      List<wapi.WisaSchool> schools = const [],
+      List<Group> ssGroups = const [],
+    }) =>
+        link(
+          wisaSnap(const [], classGroups: classGroups, schools: schools),
+          ssSnap(const [], groups: ssGroups),
+          azSnap(const []),
+          SeqResolver(),
+          schoolPrefix: _prefix,
+          ourSchoolIds: ourSchoolIds,
+        );
+
+    test('a class of a school we do not manage is not linked at all', () {
+      final snapshot = linkClasses(
+        [wisaClassGroup('9Z', schoolId: 2)],
+        ourSchoolIds: const {1},
+      );
+
+      // No record ⇒ no group candidate for the action engine to raise.
+      expect(snapshot.groups, isEmpty);
+    });
+
+    test('a class of a school we manage still links', () {
+      final snapshot = linkClasses(
+        [wisaClassGroup('3B', schoolCode: '111', schoolId: 1)],
+        ourSchoolIds: const {1},
+      );
+
+      final g = snapshot.groups.single;
+      expect(g.wisa!.name, '3B');
+      expect(g.wisa!.instituteNumber, '111');
+      expect(g.smartschool, isNull);
+      expect(g.confidence, LinkConfidence.medium);
+    });
+
+    test('a foreign class sharing a name does not shadow ours', () {
+      // The sibling school's 5A arrives first: before #205 it seeded the name
+      // key and *our* 5A was dropped as a duplicate, so the class proposed to
+      // Smartschool carried the wrong school's institute number.
+      final snapshot = linkClasses(
+        [
+          wisaClassGroup('5A', schoolCode: '222', schoolId: 2),
+          wisaClassGroup('5A', schoolCode: '111', schoolId: 1),
+        ],
+        ourSchoolIds: const {1},
+      );
+
+      expect(snapshot.groups, hasLength(1));
+      expect(snapshot.groups.single.wisa!.instituteNumber, '111');
+    });
+
+    test('the managed set falls back to WisaSchool.isOurs when unset', () {
+      final snapshot = linkClasses(
+        [
+          wisaClassGroup('5A', schoolId: 1),
+          wisaClassGroup('9Z', schoolId: 2),
+        ],
+        schools: [wisaSchool(1, ours: true), wisaSchool(2)],
+      );
+
+      expect([for (final g in snapshot.groups) g.wisa!.name], ['5A']);
+    });
+
+    test('ownership unconfigured → every class still links', () {
+      // No explicit set and no isOurs flags anywhere: the pre-#205 behaviour is
+      // preserved for a group that has not marked its schools yet.
+      final snapshot = linkClasses([
+        wisaClassGroup('5A', schoolId: 1),
+        wisaClassGroup('9Z', schoolId: 2),
+      ]);
+
+      expect([for (final g in snapshot.groups) g.wisa!.name], ['5A', '9Z']);
+    });
+
+    test(
+        'a Smartschool class matching only a foreign WISA class becomes an '
+        'orphan rather than a link', () {
+      final snapshot = linkClasses(
+        [wisaClassGroup('9Z', schoolId: 2)],
+        ourSchoolIds: const {1},
+        ssGroups: [ssGroup('9Z')],
+      );
+
+      final g = snapshot.groups.single;
+      expect(g.wisa, isNull,
+          reason: 'linking it would treat a class we do not manage as in sync');
+      expect(g.smartschool, isNotNull);
+      expect(g.confidence, LinkConfidence.medium);
+    });
+  });
+
   group('link — staff scenarios', () {
     test('fully linked across three systems → high confidence', () {
       // Staff bridge Smartschool by `code` (≡ accountId) and Azure by `wisaId`

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -140,12 +140,14 @@ az.AzureUser azureUser({
 /// A WISA class group. [name] + [groupName] form the `fullName` the linker
 /// matches on; `groupName == '00'` (the default) means "no subgroup", so
 /// `fullName == name`. [schoolCode] becomes the linked group's institute
-/// number.
+/// number. [schoolId] selects which group school the class belongs to — the
+/// managed-school join that decides whether the class is linked at all (#205).
 wapi.WisaClassGroup wisaClassGroup(
   String name, {
   String groupName = '00',
   String schoolCode = '123',
   String adminCode = '',
+  int schoolId = 1,
 }) =>
     wapi.WisaClassGroup(
       name: name,
@@ -153,7 +155,7 @@ wapi.WisaClassGroup wisaClassGroup(
       description: '',
       adminCode: adminCode,
       schoolCode: schoolCode,
-      schoolId: 1,
+      schoolId: schoolId,
     );
 
 /// A Smartschool class group as a [core.Group]. Matched to WISA by [name];

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -98,6 +98,7 @@ export 'src/settings/connection.dart';
 export 'src/settings/import_rule_codec.dart';
 export 'src/settings/secret_provider.dart';
 export 'src/settings/settings_store.dart';
+export 'src/settings/wisa_school_label.dart';
 export 'src/settings/wisa_school_profile.dart';
 export 'src/settings/work_date.dart';
 export 'src/cosmos/cosmos_client.dart';

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -4,6 +4,7 @@ import 'package:smartschool_api/smartschool_api.dart' as ss;
 import 'package:wisa_api/wisa_api.dart' as wapi;
 
 import '../link/linked_state.dart';
+import '../settings/wisa_school_label.dart';
 import 'materialized_state.dart';
 
 /// Turns a transient [LinkedState] into the persistable [MaterializedView]
@@ -19,10 +20,12 @@ import 'materialized_state.dart';
 /// in the drill-down beside the school tree (#119). The account, staff, and
 /// group families — everything the drill-down renders — are covered.
 ///
-/// [schoolLabels] maps a WISA school id to its human name (from the WISA
-/// snapshot's schools list); a student's school partition falls back to the id
-/// when no label is known. [generation] is stamped onto the view for the store
-/// to write.
+/// [schoolLabels] maps a WISA school id to its human label — the long name
+/// with its short code, built by [wisaSchoolLabels] from the operator's
+/// persisted school profiles merged with the WISA snapshot's schools list. A
+/// student's school partition falls back to `School <id>` only for an id that
+/// matches no known school (#204). [generation] is stamped onto the view for
+/// the store to write.
 MaterializedView materialize(
   LinkedState linked, {
   required int generation,
@@ -252,7 +255,8 @@ _Placement _placeAccount(
     final school = wisa.schoolId.toString();
     return _Placement(
       school: school,
-      schoolLabel: schoolLabels[wisa.schoolId] ?? 'School ${wisa.schoolId}',
+      schoolLabel: schoolLabels[wisa.schoolId] ??
+          wisaSchoolLabel(schoolId: wisa.schoolId),
       gradeYear: gradeYearOf(wisa.classGroup),
       classroom: wisa.classGroup.trim().isEmpty
           ? _noClassroom

--- a/packages/account_state/lib/src/settings/app_settings.dart
+++ b/packages/account_state/lib/src/settings/app_settings.dart
@@ -82,6 +82,16 @@ class AppSettings {
           if (p.ours) p.schoolId,
       };
 
+  /// The set of WISA school ids the operator marked *virtual* — the
+  /// `virtual`-flagged entries of [wisaSchools] (#203). A sync flags exactly
+  /// these schools, so the connector pulls them with the
+  /// [WisaConnection.virtualWorkDate] instead of the ordinary work date; empty
+  /// means no school is virtual and every school pulls with the ordinary one.
+  Set<int> get virtualWisaSchoolIds => <int>{
+        for (final p in wisaSchools)
+          if (p.virtual) p.schoolId,
+      };
+
   /// Returns a copy with the given fields replaced.
   AppSettings copyWith({
     String? schoolPrefix,

--- a/packages/account_state/lib/src/settings/wisa_school_label.dart
+++ b/packages/account_state/lib/src/settings/wisa_school_label.dart
@@ -1,0 +1,104 @@
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+import 'wisa_school_profile.dart';
+
+// How a WISA school is named for a human — the one place that knows it (#204).
+//
+// A school has two halves: the long descriptive name ("Instituut Sancta
+// Maria-A") and the short code operators use day to day (`ISMAA`). Which half
+// sits on which field is the trap: `SMAGetInst`'s CSV columns are
+// `ID,NAME,DESCRIPTION` and the connector preserves the legacy swap of the last
+// two, so the **code** rides on `WisaSchool.description` and the **long name**
+// on `WisaSchool.name` (see `wisa_school.dart`). `WisaSchoolProfile` has already
+// untangled that: its `code` is the short one, its `name` the long one.
+//
+// Every view that names a school routes through here — the Settings grid, the
+// Actions drill-down, and the label baked into the materialized documents — so
+// the two can never drift into showing different halves of the same pair.
+
+/// The full single-line label for one school: `"<naam> (<code>)"`, degrading to
+/// whichever half is known and finally to `School <id>` when neither is.
+///
+/// [code] is the short code (`ISMAA`), [name] the long name ("Instituut Sancta
+/// Maria-A"). The `School <id>` form is the **last resort** for an id that
+/// matches no known school — never the normal rendering.
+String wisaSchoolLabel({
+  required int schoolId,
+  String code = '',
+  String name = '',
+}) {
+  final String c = code.trim();
+  final String n = name.trim();
+  if (n.isNotEmpty && c.isNotEmpty) return '$n ($c)';
+  if (n.isNotEmpty) return n;
+  if (c.isNotEmpty) return c;
+  return 'School $schoolId';
+}
+
+/// The short lead label for one school: the [code] when known, else the long
+/// [name], else `School <id>`.
+///
+/// What the Settings grid leads each cell with (#194), where the long name is
+/// the second line rather than a parenthetical.
+String wisaSchoolCodeLabel({
+  required int schoolId,
+  String code = '',
+  String name = '',
+}) {
+  final String c = code.trim();
+  if (c.isNotEmpty) return c;
+  final String n = name.trim();
+  if (n.isNotEmpty) return n;
+  return 'School $schoolId';
+}
+
+/// The school-id → display-label map the materializer bakes into its documents.
+///
+/// Merges the operator-curated [profiles] persisted in the settings document
+/// (available without any WISA pull, so a passive session labels schools too)
+/// with the live snapshot [schools] of the session's WISA pull. The merge is
+/// per half rather than per school: a fresh pull refreshes whichever of the two
+/// halves it actually carries and never blanks the other one out of a stored
+/// profile — the same rule the Settings grid merges a fetch with.
+Map<int, String> wisaSchoolLabels({
+  Iterable<WisaSchoolProfile> profiles = const <WisaSchoolProfile>[],
+  Iterable<wapi.WisaSchool> schools = const <wapi.WisaSchool>[],
+}) {
+  final codes = <int, String>{};
+  final names = <int, String>{};
+  void put(int id, String code, String name) {
+    if (code.trim().isNotEmpty) codes[id] = code.trim();
+    if (name.trim().isNotEmpty) names[id] = name.trim();
+  }
+
+  for (final p in profiles) {
+    put(p.schoolId, p.code, p.name);
+  }
+  // The live pull wins where it has something to say — a WISA-side rename must
+  // show this session, not only after the operator re-fetches in Settings.
+  for (final s in schools) {
+    put(s.id, s.description, s.name);
+  }
+
+  return <int, String>{
+    for (final id in <int>{...codes.keys, ...names.keys})
+      id: wisaSchoolLabel(
+        schoolId: id,
+        code: codes[id] ?? '',
+        name: names[id] ?? '',
+      ),
+  };
+}
+
+/// The display labels of one persisted school profile.
+extension WisaSchoolProfileLabel on WisaSchoolProfile {
+  /// The full single-line label — `"<naam> (<code>)"` — as the Actions
+  /// drill-down names this school.
+  String get label =>
+      wisaSchoolLabel(schoolId: schoolId, code: code, name: name);
+
+  /// The short lead label the Settings grid puts at the top of this school's
+  /// cell, with the long name beneath it.
+  String get codeLabel =>
+      wisaSchoolCodeLabel(schoolId: schoolId, code: code, name: name);
+}

--- a/packages/account_state/lib/src/settings/wisa_school_profile.dart
+++ b/packages/account_state/lib/src/settings/wisa_school_profile.dart
@@ -9,16 +9,17 @@
 /// operator-editable ownership record keyed by school *id* that survives in the
 /// settings blob.
 ///
-/// The shape (`{ schoolId, code, name, ours, prefix }`) is the per-WISA-school
-/// ownership link #112/#113 called for, so the settings document is not reshaped
-/// twice. This slice only carries the data — no action reads it yet (#134 is
-/// slice 2).
+/// The shape (`{ schoolId, code, name, ours, virtual, prefix }`) is the
+/// per-WISA-school ownership link #112/#113 called for, so the settings document
+/// is not reshaped twice. This slice only carries the data — no action reads it
+/// yet (#134 is slice 2).
 class WisaSchoolProfile {
   const WisaSchoolProfile({
     required this.schoolId,
     this.code = '',
     this.name = '',
     this.ours = false,
+    this.virtual = false,
     this.prefix = '',
   });
 
@@ -44,6 +45,14 @@ class WisaSchoolProfile {
   /// is `false` (group-visible siblings) has left *our* schools.
   final bool ours;
 
+  /// Whether this school is a *virtual* school, i.e. one WISA must be queried
+  /// with [AppSettings.wisa]'s separate virtual workdate instead of the ordinary
+  /// one (#203). The persistent, id-keyed counterpart of the snapshot-time
+  /// `MarkAsVirtual` import rule, exactly as [ours] is for `MarkAsOurs`.
+  /// Defaults to `false`, so a settings document written before this field
+  /// existed loads with every school non-virtual.
+  final bool virtual;
+
   /// Per-school Azure-orphan scoping prefix. Empty means "inherit the global
   /// [AppSettings.schoolPrefix]" — a per-school override to grow into (#113),
   /// not yet consulted by the linker.
@@ -54,6 +63,7 @@ class WisaSchoolProfile {
     String? code,
     String? name,
     bool? ours,
+    bool? virtual,
     String? prefix,
   }) =>
       WisaSchoolProfile(
@@ -61,6 +71,7 @@ class WisaSchoolProfile {
         code: code ?? this.code,
         name: name ?? this.name,
         ours: ours ?? this.ours,
+        virtual: virtual ?? this.virtual,
         prefix: prefix ?? this.prefix,
       );
 
@@ -69,6 +80,7 @@ class WisaSchoolProfile {
         'code': code,
         'name': name,
         'ours': ours,
+        'virtual': virtual,
         'prefix': prefix,
       };
 
@@ -78,6 +90,7 @@ class WisaSchoolProfile {
         code: (json['code'] as String?) ?? '',
         name: (json['name'] as String?) ?? '',
         ours: (json['ours'] as bool?) ?? false,
+        virtual: (json['virtual'] as bool?) ?? false,
         prefix: (json['prefix'] as String?) ?? '',
       );
 
@@ -89,13 +102,14 @@ class WisaSchoolProfile {
           code == other.code &&
           name == other.name &&
           ours == other.ours &&
+          virtual == other.virtual &&
           prefix == other.prefix;
 
   @override
-  int get hashCode => Object.hash(schoolId, code, name, ours, prefix);
+  int get hashCode => Object.hash(schoolId, code, name, ours, virtual, prefix);
 
   @override
   String toString() =>
       'WisaSchoolProfile(schoolId: $schoolId, code: $code, name: $name, '
-      'ours: $ours, prefix: $prefix)';
+      'ours: $ours, virtual: $virtual, prefix: $prefix)';
 }

--- a/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
@@ -470,11 +470,11 @@ Future<void> _settle() async {
 final DateTime _d = DateTime.utc(2026, 7, 1);
 
 MaterializedAccount _account(String id,
-        {String school = '1', String classroom = '3C'}) =>
+        {String school = '1', String classroom = '3C', String? schoolLabel}) =>
     MaterializedAccount(
       id: core.LinkedAccountId(id),
       school: school,
-      schoolLabel: 'School $school',
+      schoolLabel: schoolLabel ?? 'School $school',
       gradeYear: '3',
       classroom: classroom,
       role: core.PersonRole.student,
@@ -863,6 +863,43 @@ void main() {
       expect(threeC.map((a) => a.id.value), isNot(contains('p0')));
       final fourA = await store.readClassroom(school: '1', classroom: '4A');
       expect(fourA.map((a) => a.id.value), ['p0']);
+    });
+
+    test('a renamed school label reaches the store on a re-sync (#204/#200)',
+        () async {
+      // The school label is baked into every account document and into the
+      // school rollup, so a better label only becomes visible if the
+      // changed-document-only write (#200) actually rewrites them. The hash
+      // covers the whole document, so it does — this pins that down.
+      final client = _FakeClient();
+      final store = CosmosLinkedStore(client);
+      List<MaterializedAccount> withLabel(String label) => [
+            for (var i = 0; i < 5; i++) _account('p$i', schoolLabel: label),
+          ];
+
+      await store.writeMaterialized(
+        _view(withLabel('School 1')),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+      final afterFirst = client.upsertsTo(linkedAccountsContainer);
+      final rollupsAfterFirst = client.upsertsTo(rollupsContainer);
+
+      await store.writeMaterialized(
+        _view(withLabel('Instituut Sancta Maria-A (ISMAA)'), generation: 2),
+        syncedBy: 'op@school.example',
+        at: _d,
+      );
+
+      expect(client.upsertsTo(linkedAccountsContainer), afterFirst + 5,
+          reason: 'every account carries the changed label');
+      expect(client.upsertsTo(rollupsContainer), greaterThan(rollupsAfterFirst),
+          reason: 'the school rollup the drill-down renders is rewritten too');
+      final stored = await store.readClassroom(school: '1', classroom: '3C');
+      expect(stored.first.schoolLabel, 'Instituut Sancta Maria-A (ISMAA)');
+      final school = (await store.readRollups())
+          .firstWhere((r) => r.level == RollupLevel.school);
+      expect(school.label, 'Instituut Sancta Maria-A (ISMAA)');
     });
 
     test('a change buried in a nested candidate action is not skipped (#200)',

--- a/packages/account_state/test/linked_state_test.dart
+++ b/packages/account_state/test/linked_state_test.dart
@@ -20,6 +20,7 @@ wapi.WisaStudent _wStudent({
   required String wisaId,
   String classGroup = '',
   String classSubGroup = '',
+  int schoolId = 1,
 }) =>
     wapi.WisaStudent(
       wisaId: core.WisaId(wisaId),
@@ -36,7 +37,7 @@ wapi.WisaStudent _wStudent({
       nationality: '',
       address: _addr,
       classChange: _d,
-      schoolId: 1,
+      schoolId: schoolId,
     );
 
 ss.SmartschoolAccount _ssAccount({
@@ -104,6 +105,7 @@ wapi.WisaClassGroup _wClass(
   String groupName = '00',
   String adminCode = '',
   String schoolCode = '123',
+  int schoolId = 1,
 }) =>
     wapi.WisaClassGroup(
       name: name,
@@ -111,7 +113,7 @@ wapi.WisaClassGroup _wClass(
       description: '',
       adminCode: adminCode,
       schoolCode: schoolCode,
-      schoolId: 1,
+      schoolId: schoolId,
     );
 
 wapi.WisaSnapshot _wSnap({
@@ -453,6 +455,67 @@ void main() {
         unwired.whereType<MoveToSmartschoolClassGroup>(),
         isEmpty,
       );
+    });
+  });
+
+  group('group actions are scoped to the schools we manage (#205)', () {
+    /// Recomputes over [classGroups] + [students] with the managed-school set
+    /// pinned to [ourSchoolIds] — the Settings-derived path the app wires.
+    LinkedState recompute({
+      required List<wapi.WisaClassGroup> classGroups,
+      required List<wapi.WisaStudent> students,
+      Set<int>? ourSchoolIds,
+    }) =>
+        LinkedState.recompute(
+          wisa: _wSnap(students: students, classGroups: classGroups),
+          smartschool: _sSnap(),
+          azure: _aSnap(),
+          resolver: _SeqResolver(),
+          studentConfig: _studentConfig,
+          staffConfig: _staffConfig,
+          classTree: const SmartschoolClassTree(grades: ['G1', 'G2', 'G3']),
+          ourSchoolIds: ourSchoolIds,
+        );
+
+    test(
+        'a populated class of a school we manage still raises AddToSmartschool',
+        () {
+      final state = recompute(
+        classGroups: [_wClass('1A', adminCode: 'a1', schoolId: 1)],
+        students: [_wStudent(wisaId: '1', classGroup: '1A')],
+        ourSchoolIds: const {1},
+      );
+
+      expect(state.groupActions.whereType<AddToSmartschool>(), hasLength(1));
+    });
+
+    test('a populated class of a school we do not manage raises nothing', () {
+      final state = recompute(
+        classGroups: [_wClass('9Z', adminCode: 'z1', schoolId: 2)],
+        students: [_wStudent(wisaId: '2', classGroup: '9Z', schoolId: 2)],
+        ourSchoolIds: const {1},
+      );
+
+      expect(state.snapshot.groups, isEmpty);
+      expect(state.groupActions, isEmpty,
+          reason: 'we have no business creating another school\'s class');
+    });
+
+    test('a foreign class sharing a name does not shadow ours in the action',
+        () {
+      // The sibling school's 1A arrives first; the action must still describe
+      // *our* 1A (institute number 111), not the one we do not manage.
+      final state = recompute(
+        classGroups: [
+          _wClass('1A', adminCode: 'a2', schoolCode: '222', schoolId: 2),
+          _wClass('1A', adminCode: 'a1', schoolCode: '111', schoolId: 1),
+        ],
+        students: [_wStudent(wisaId: '1', classGroup: '1A')],
+        ourSchoolIds: const {1},
+      );
+
+      final action = state.groupActions.whereType<AddToSmartschool>().single;
+      expect(action.target.wisa!.instituteNumber, '111');
     });
   });
 

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -265,6 +265,34 @@ void main() {
       expect(view.accounts.single.schoolLabel, 'GBS Centrum');
     });
 
+    test('a school-id label reaches the school rollup too (#204)', () {
+      // What the Actions drill-down actually renders is the rollup's label, so
+      // the pair has to survive the aggregation, not just the account doc.
+      final view = materialize(
+        _movePendingLinked(),
+        generation: 1,
+        schoolLabels: wisaSchoolLabels(profiles: const [
+          WisaSchoolProfile(
+            schoolId: 1,
+            code: 'ISMAA',
+            name: 'Instituut Sancta Maria-A',
+          ),
+        ]),
+      );
+      final school =
+          view.rollups.firstWhere((r) => r.level == RollupLevel.school);
+      expect(school.label, 'Instituut Sancta Maria-A (ISMAA)');
+    });
+
+    test('School <id> is the last resort for an unlabelled school', () {
+      final view = materialize(
+        _movePendingLinked(),
+        generation: 1,
+        schoolLabels: const {99: 'Ergens anders'},
+      );
+      expect(view.accounts.single.schoolLabel, 'School 1');
+    });
+
     test('an Azure-only leaver lands in the unassigned bucket', () {
       final linked = LinkedState.recompute(
         wisa: wapi.WisaSnapshot(

--- a/packages/account_state/test/settings_store_test.dart
+++ b/packages/account_state/test/settings_store_test.dart
@@ -167,6 +167,64 @@ void main() {
       expect(const AppSettings().managedWisaSchoolIds, isEmpty);
     });
 
+    test('the per-school virtual mark round-trips through JSON (#203)', () {
+      const original = AppSettings(
+        wisaSchools: [
+          WisaSchoolProfile(
+              schoolId: 10,
+              code: 'ismav',
+              name: 'Virtuele school SMA',
+              virtual: true),
+          WisaSchoolProfile(schoolId: 20, name: 'Sint-Pieter', ours: true),
+        ],
+      );
+      final restored = AppSettings.fromJson(original.toJson());
+      expect(restored.wisaSchools, original.wisaSchools);
+      expect(restored.wisaSchools.first.virtual, isTrue);
+      expect(restored.wisaSchools.last.virtual, isFalse);
+    });
+
+    test('virtualWisaSchoolIds is the set of virtual-flagged school ids (#203)',
+        () {
+      const settings = AppSettings(
+        wisaSchools: [
+          WisaSchoolProfile(schoolId: 10, name: 'A', virtual: true),
+          WisaSchoolProfile(schoolId: 20, name: 'B', ours: true),
+          WisaSchoolProfile(schoolId: 30, name: 'C', ours: true, virtual: true),
+        ],
+      );
+      expect(settings.virtualWisaSchoolIds, {10, 30});
+      // The two marks are independent: managing a school says nothing about
+      // which work date it is pulled with.
+      expect(settings.managedWisaSchoolIds, {20, 30});
+      expect(const AppSettings().virtualWisaSchoolIds, isEmpty);
+    });
+
+    test(
+        'a settings document written before the virtual flag loads with every '
+        'school non-virtual (#203)', () {
+      final settings = AppSettings.fromJson({
+        'wisaSchools': [
+          {
+            'schoolId': 42,
+            'code': 'ismaa',
+            'name': 'Sint-Jan',
+            'ours': true,
+            'prefix': '',
+          },
+        ],
+      });
+      expect(settings.wisaSchools.single.virtual, isFalse);
+      expect(settings.virtualWisaSchoolIds, isEmpty);
+    });
+
+    test('copyWith preserves and can replace the virtual flag (#203)', () {
+      const profile =
+          WisaSchoolProfile(schoolId: 10, code: 'ismaa', virtual: true);
+      expect(profile.copyWith(ours: true).virtual, isTrue);
+      expect(profile.copyWith(virtual: false).virtual, isFalse);
+    });
+
     test(
         'a school profile predating the persisted name loads with an empty '
         'name (#171)', () {

--- a/packages/account_state/test/wisa_school_label_test.dart
+++ b/packages/account_state/test/wisa_school_label_test.dart
@@ -1,0 +1,151 @@
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+/// The `SMAGetInst` column swap in fixture form: the short code arrives on
+/// [WisaSchool.description] and the long name on [WisaSchool.name].
+WisaSchool _school(int id, {String code = '', String name = ''}) =>
+    WisaSchool(id: id, name: name, description: code);
+
+void main() {
+  group('wisaSchoolLabel', () {
+    test('pairs the long name with the short code', () {
+      expect(
+        wisaSchoolLabel(
+          schoolId: 25,
+          code: 'ISMAA',
+          name: 'Instituut Sancta Maria-A',
+        ),
+        'Instituut Sancta Maria-A (ISMAA)',
+      );
+    });
+
+    test('degrades to whichever half is known', () {
+      expect(
+        wisaSchoolLabel(schoolId: 25, name: 'Instituut Sancta Maria-A'),
+        'Instituut Sancta Maria-A',
+      );
+      expect(wisaSchoolLabel(schoolId: 25, code: 'ISMAA'), 'ISMAA');
+    });
+
+    test('falls back to the id only when neither half is known', () {
+      expect(wisaSchoolLabel(schoolId: 25), 'School 25');
+      expect(wisaSchoolLabel(schoolId: 25, code: '  ', name: ' '), 'School 25');
+    });
+  });
+
+  group('wisaSchoolCodeLabel', () {
+    test('leads with the code, then the name, then the id', () {
+      expect(
+        wisaSchoolCodeLabel(
+          schoolId: 25,
+          code: 'ISMAA',
+          name: 'Instituut Sancta Maria-A',
+        ),
+        'ISMAA',
+      );
+      expect(
+        wisaSchoolCodeLabel(schoolId: 25, name: 'Instituut Sancta Maria-A'),
+        'Instituut Sancta Maria-A',
+      );
+      expect(wisaSchoolCodeLabel(schoolId: 25), 'School 25');
+    });
+  });
+
+  group('WisaSchoolProfile labels', () {
+    test('read the same pair the Settings grid renders', () {
+      const profile = WisaSchoolProfile(
+        schoolId: 25,
+        code: 'ISMAA',
+        name: 'Instituut Sancta Maria-A',
+      );
+      expect(profile.label, 'Instituut Sancta Maria-A (ISMAA)');
+      expect(profile.codeLabel, 'ISMAA');
+    });
+
+    test('a profile stored before the code/name were persisted keeps the id',
+        () {
+      const profile = WisaSchoolProfile(schoolId: 25);
+      expect(profile.label, 'School 25');
+      expect(profile.codeLabel, 'School 25');
+    });
+  });
+
+  group('wisaSchoolLabels', () {
+    test('labels every school from the persisted profiles alone (#204)', () {
+      // The cold-snapshot case: the session has pulled no schools, so the
+      // operator's curated Settings list is the only identity available — and
+      // it must still name the school rather than degrade to `School 25`.
+      expect(
+        wisaSchoolLabels(profiles: const [
+          WisaSchoolProfile(
+            schoolId: 25,
+            code: 'ISMAA',
+            name: 'Instituut Sancta Maria-A',
+          ),
+          WisaSchoolProfile(
+              schoolId: 30, code: 'ISMAB', name: 'Sancta Maria-B'),
+        ]),
+        {
+          25: 'Instituut Sancta Maria-A (ISMAA)',
+          30: 'Sancta Maria-B (ISMAB)',
+        },
+      );
+    });
+
+    test('takes the code off description and the name off name', () {
+      expect(
+        wisaSchoolLabels(schools: [
+          _school(25, code: 'ISMAA', name: 'Instituut Sancta Maria-A'),
+        ]),
+        {25: 'Instituut Sancta Maria-A (ISMAA)'},
+      );
+    });
+
+    test('a live pull refreshes a renamed school over the stored profile', () {
+      expect(
+        wisaSchoolLabels(
+          profiles: const [
+            WisaSchoolProfile(schoolId: 25, code: 'ISMAA', name: 'Oude naam'),
+          ],
+          schools: [_school(25, code: 'ISMAA', name: 'Nieuwe naam')],
+        ),
+        {25: 'Nieuwe naam (ISMAA)'},
+      );
+    });
+
+    test('a half the pull does not carry keeps the stored profile value', () {
+      // A snapshot school with an empty code must not blank out the code the
+      // operator already curated — the same per-half merge the Settings grid
+      // applies to a fetch.
+      expect(
+        wisaSchoolLabels(
+          profiles: const [
+            WisaSchoolProfile(
+              schoolId: 25,
+              code: 'ISMAA',
+              name: 'Instituut Sancta Maria-A',
+            ),
+          ],
+          schools: [_school(25, name: 'Instituut Sancta Maria-A')],
+        ),
+        {25: 'Instituut Sancta Maria-A (ISMAA)'},
+      );
+    });
+
+    test('unions the two sources and skips a school neither half names', () {
+      expect(
+        wisaSchoolLabels(
+          profiles: const [
+            WisaSchoolProfile(schoolId: 25, code: 'ISMAA'),
+            // Nothing to say about school 99: no map entry, so the materializer
+            // falls back to `School 99`.
+            WisaSchoolProfile(schoolId: 99),
+          ],
+          schools: [_school(30, name: 'Sancta Maria-B')],
+        ),
+        {25: 'ISMAA', 30: 'Sancta Maria-B'},
+      );
+    });
+  });
+}

--- a/packages/wisa_api/test/connector_test.dart
+++ b/packages/wisa_api/test/connector_test.dart
@@ -200,6 +200,46 @@ void main() {
       expect(werkdates, {'01/09/2025'});
     });
 
+    test(
+        'sends each school its own Werkdatum: the virtual date for virtual '
+        'schools, the ordinary one for the rest (#203)', () async {
+      final t = _FakeTransport(fixtures);
+      final c = buildConnector(t);
+      final schools = await c.loadSchools();
+      // ISMAA is pulled as a virtual school, ISMAB as an ordinary one, in the
+      // same sync — the mixed case the per-school work date exists for.
+      final virtual = schools.firstWhere((s) => s.id == 25);
+      final ordinary = schools.firstWhere((s) => s.id == 27);
+      await c.sync(
+        schools: [virtual.copyWith(isVirtual: true), ordinary],
+        workDate: DateTime(2024, 9, 1),
+        virtualWorkDate: DateTime(2025, 9, 1),
+      );
+
+      String? paramOf(
+        List<({String name, String value})> params,
+        String name,
+      ) {
+        for (final p in params) {
+          if (p.name == name) return p.value;
+        }
+        return null;
+      }
+
+      final bySchool = <String, Set<String>>{};
+      for (final call in t.calls) {
+        final id = paramOf(call.params, 'IS_ID');
+        final wd = paramOf(call.params, 'Werkdatum');
+        if (id == null || wd == null) continue;
+        bySchool.putIfAbsent(id, () => <String>{}).add(wd);
+      }
+      // Every query for the virtual school (classes, students, staff) carried
+      // the virtual date; every query for the ordinary school carried the
+      // ordinary one.
+      expect(bySchool['25'], {'01/09/2025'});
+      expect(bySchool['27'], {'01/09/2024'});
+    });
+
     test('applies ReplaceInstitute to matching class group schoolCodes',
         () async {
       final t = _FakeTransport(fixtures);


### PR DESCRIPTION
## Summary

Four issues, one commit each, in order:

- **#202 — Author Smartschool import rules.** The rule types, codec, and connector
  wiring already existed but nothing could create a rule, so the list was
  permanently empty and the Smartschool group tree was imported whole.
  **Instellingen → Smartschool → Importregels** is now an editor: a *Toevoegen*
  menu offering the two legacy rule types (*Negeer groep* / *Negeer subgroepen*),
  a group-name prompt, and inline edit/remove per rule. Rules ride in a working
  copy (mirroring `_wisaSchools`) and persist through the existing
  `encodeSmartschoolRule` codec — no new wire shape, no `SettingsStore` change.
  The group name is free text: the Settings view has no Smartschool snapshot
  among its seams, and a rule must be authorable before the first pull (as in
  legacy).

- **#203 — Mark WISA schools virtual.** `virtualWorkDate` was settable and the
  connector honoured `WisaSchool.isVirtual`, but `isVirtual` was only ever set by
  a `MarkAsVirtual` rule nothing could create — so the virtual workdate was dead
  configuration. Adds a persisted `WisaSchoolProfile.virtual` field (defaulting
  to `false`, so older settings documents load non-virtual), an
  `AppSettings.virtualWisaSchoolIds` getter, a second per-cell toggle in the
  WISA-scholen grid, and `markVirtualSchools` applied to the loaded school list
  before `wisaConnector.sync`. Sets `isVirtual` directly rather than synthesising
  `MarkAsVirtual` rules — profiles are keyed by school *id* while the rule
  matches by *name* — mirroring how `ourSchoolIds` bypasses `MarkAsOurs`. The
  pass is additive, so an existing rule's school cannot be silently
  un-virtualised.

- **#204 — Name schools by name and code in the drill-down.** The drill-down
  labelled schools `School 25`, `School 30`, … because `_schoolLabels()` mapped
  only `WisaSchool.name` from the live snapshot and ignored the persisted
  profiles that hold both halves. Adds one shared helper
  (`wisaSchoolLabel` / `wisaSchoolCodeLabel` / `wisaSchoolLabels`) that merges
  the persisted `AppSettings.wisaSchools` profiles with the snapshot *per half*,
  so a stored code is never blanked by a pull carrying only the name. The
  Settings grid, the reconcile controller's label map, and the materializer's
  `School <id>` last resort now all go through it, so the two views cannot drift.
  Confirmed en route that the CSV column swap is `description` = short code /
  `name` = long name, and that #200's content-hash write does rewrite both the
  account docs and the school rollup when a label changes (pinned by a store
  test rather than left as a reading).

- **#205 — Scope class-group linking to the schools we manage.** `link()` threaded
  `ourSchoolIds` into the account side but called `_linkGroups` without it, so
  every group-visible school's classes became `AddToSmartschool` candidates —
  proposals to create another school's class in our Smartschool environment.
  `_linkGroups` now takes the effective managed-school set and drops unmanaged
  schools' class groups at the seed, *before* the `fullName` dedupe, which also
  fixes the quieter bug: a sibling school's `1A` arriving first could shadow our
  own `1A`. An empty managed set still means "everything is ours". An official
  Smartschool class matching only a foreign WISA class becomes a Smartschool
  orphan record (#52) rather than linking to a class we do not manage.

## Test plan

Per-commit results, as run locally by each issue's worker:

- [x] **#202** — `dart format --set-exit-if-changed .` clean (283 files);
      `dart analyze --fatal-infos --fatal-warnings` clean; `dart test packages/*/test`
      891 pass / 11 skipped (opt-in live); `flutter test` 258 pass including 7 new
      widget tests; `flutter test integration_test/app_launch_test.dart -d windows`
      44 pass including a new end-to-end that drives the editor, saves, asserts the
      persisted tagged JSON, then feeds the *saved* rules to a production
      `SmartschoolConnector.sync(rules:)` over a scripted SOAP wire and asserts the
      discarded group + subtree vanish and the pruned group's children are never
      fetched.
- [x] **#203** — format clean (283 files); analyzer clean;
      `dart test packages/*/test` 896 pass / 11 skipped; `flutter test` 267 pass;
      integration 45 pass including the new #203 e2e. The 4 new widget tests were
      verified failing (4/4) with the settings-screen change stashed.
- [x] **#204** — format clean (285 files); analyzer clean; 864 package tests pass
      (11 skipped) including 11 new `wisa_school_label_test.dart` cases, 2 new
      materializer label tests, and a new #204/#200 store round-trip test;
      269 widget tests pass including 2 new controller regressions (both proven red
      without the fix: `School 25`, and a code-less `Instituut Sancta Maria-A`);
      46 e2e pass including a new drill-down label test, also proven red on the
      unpatched controller.
- [x] **#205** — format clean (285 files); `flutter analyze` clean;
      `dart test packages/*/test` 919 pass / 11 skipped / 0 fail; `flutter test`
      270 pass / 0 fail; `flutter test integration_test/app_launch_test.dart
      -d windows --plain-name "(#205)"` 1 pass. Fail-without-fix verified by
      stashing `link.dart`: 4/6 new linker cases, 2/3 new `linked_state` cases, the
      new widget case, and the new integration case all fail on unpatched code.

Closes #202
Closes #203
Closes #204
Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
