### PR TITLE
fix(wisa): store the school long name and short code on the fields that claim them (#208)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -34,12 +34,13 @@ import 'package:account_state/account_state.dart'
         StaticSignalRTokenProvider,
         WisaConnection,
         WisaSchoolProfile,
+        WisaSchoolProfileLabel,
         signalRRecordSeparator;
 import 'package:azure_api/azure_api.dart'
     show AzureCredentials, StaticAuthProvider;
 import 'package:smartschool_api/smartschool_api.dart'
     show SmartschoolConnector, SmartschoolMethod, SmartschoolSoapTransport;
-import 'package:wisa_api/wisa_api.dart' show WisaSchool;
+import 'package:wisa_api/wisa_api.dart' show WisaSchool, parseSchoolRow;
 import 'package:flutter/gestures.dart' show PointerDeviceKind, kSecondaryButton;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -991,6 +992,53 @@ void main() {
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
     expect(find.text('3C'), findsWidgets);
+  });
+
+  testWidgets(
+      'a settings document written before #208 drills down as '
+      '"Instituut Sancta Maria-A (ISMAA)", not inside out',
+      (WidgetTester tester) async {
+    // The stored document has the long name under `code` and the short code
+    // under `name` — the layout every profile persisted before the fix carries.
+    // Read back through the real `AppSettings.fromJson`, the migration must put
+    // each half right so the drill-down reads the way #204 specified instead of
+    // "ISMAA (Instituut Sancta Maria-A)".
+    useTallWindow(tester);
+    final migrated = AppSettings.fromJson(<String, dynamic>{
+      'wisaSchools': <Map<String, dynamic>>[
+        <String, dynamic>{
+          'schoolId': 25,
+          'code': 'Instituut Sancta Maria-A',
+          'name': 'ISMAA',
+          'ours': true,
+        },
+      ],
+    });
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(students: [wisaStudent(schoolId: 25)], schools: const []),
+      smartschool: ssSnap(
+          groups: const [], accounts: [ssAccount()], memberships: const []),
+      azure: azSnap(users: [azUser()]),
+      ourSchoolIds: const {25},
+      schoolProfiles: migrated.wisaSchools,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(find.text('ISMAA (Instituut Sancta Maria-A)'), findsNothing,
+        reason: 'the inverted rendering #208 fixed must not come back');
+    expect(find.text('School 25'), findsNothing);
+    expect(find.text('Instituut Sancta Maria-A (ISMAA)'), findsOneWidget);
   });
 
   testWidgets(
@@ -2037,7 +2085,7 @@ void main() {
     useTallWindow(tester);
     const passwordRef = SecretRef('wisa.password');
     final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
-      WisaSchool(id: 99, name: 'Virtuele school SMA', description: 'ismav'),
+      WisaSchool(id: 99, name: 'Virtuele school SMA', code: 'ismav'),
     ]);
     final settings = SettingsHarness(
       initial: const AppSettings(
@@ -2103,8 +2151,8 @@ void main() {
     useTallWindow(tester);
     const passwordRef = SecretRef('wisa.password');
     final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
-      WisaSchool(id: 3, name: 'Sint-Jan', description: 'SJ'),
-      WisaSchool(id: 7, name: 'Sint-Pieter', description: 'SP'),
+      WisaSchool(id: 3, name: 'Sint-Jan', code: 'SJ'),
+      WisaSchool(id: 7, name: 'Sint-Pieter', code: 'SP'),
     ]);
     final settings = SettingsHarness(
       initial: const AppSettings(
@@ -2163,9 +2211,9 @@ void main() {
     // no code); the fetch backfills the code and the grid must lead with it.
     useTallWindow(tester);
     const passwordRef = SecretRef('wisa.password');
-    // `SMAGetInst`'s CSV NAME column (the short code) lands on `description`.
+    // `SMAGetInst`'s CSV DESCRIPTION column (the short code) lands on `code`.
     final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
-      WisaSchool(id: 7, name: 'Sint-Pieter', description: 'ismab'),
+      WisaSchool(id: 7, name: 'Sint-Pieter', code: 'ismab'),
     ]);
     final settings = SettingsHarness(
       initial: const AppSettings(
@@ -2200,8 +2248,8 @@ void main() {
         findsOneWidget);
     expect(find.text('School 7'), findsNothing);
 
-    // Fetch: the code takes the lead and the long name drops to the subtitle,
-    // so the id no longer shows at all.
+    // Fetch: the code fills the second line in place of the id, so the id no
+    // longer shows at all.
     final button = find.byKey(const ValueKey('settings-wisa-fetch-schools'));
     await tester.ensureVisible(button);
     await tester.tap(button);
@@ -2219,6 +2267,93 @@ void main() {
     final saved = await settings.store.load();
     expect(saved.wisaSchools.single.code, 'ismab');
     expect(saved.wisaSchools.single.ours, isTrue);
+  });
+
+  testWidgets(
+      'the Settings grid names a school parsed from the real SMAGetInst CSV '
+      'end-to-end — long name on top, short code beneath (#208)',
+      (WidgetTester tester) async {
+    // The whole path, with no hand-built `WisaSchool` anywhere: real CSV rows →
+    // the real `parseSchoolRow` → the real fetch/merge → the real grid, in the
+    // real app with real fonts and layout. A fixture that agrees with the bug
+    // cannot hide here, because the halves come from the CSV itself.
+    useTallWindow(tester);
+    const passwordRef = SecretRef('wisa.password');
+    // Verbatim rows 11-12 of packages/wisa_api/test/fixtures/sma_get_inst.csv,
+    // itself redacted from a live WISA pull. Columns: ID,NAME,DESCRIPTION.
+    final fetcher = FakeWisaSchoolFetcher(<WisaSchool>[
+      parseSchoolRow('25,Instituut Sancta Maria-A,ISMAA'),
+      parseSchoolRow('27,Instituut Sancta Maria-B,ISMAB'),
+    ]);
+    // A settings document persisted before #208, read back through the real
+    // load path: it stored the long name under `code` and the code under
+    // `name`, and must render the right way up all the same.
+    final legacy = AppSettings.fromJson(<String, dynamic>{
+      'wisa': const WisaConnection(server: 'db.school.example', port: '1433')
+          .toJson(),
+      'wisaSchools': <Map<String, dynamic>>[
+        <String, dynamic>{
+          'schoolId': 25,
+          'code': 'Instituut Sancta Maria-A',
+          'name': 'ISMAA',
+          'ours': true,
+        },
+      ],
+    });
+    final settings = SettingsHarness(
+      initial: legacy,
+      secrets: {passwordRef: 'stored-pw'},
+      fetchWisaSchools: fetcher.call,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-wisa');
+
+    // Which line is which, not merely which strings are present: the title is
+    // the long name and the subtitle the short code.
+    final tile = find.byKey(const ValueKey('settings-wisa-school-25-ours'));
+    await tester.ensureVisible(tile);
+    await tester.pumpAndSettle();
+    String titleOf(Finder f) =>
+        (tester.widget<CheckboxListTile>(f).title! as Text).data!;
+    String subtitleOf(Finder f) =>
+        (tester.widget<CheckboxListTile>(f).subtitle! as Text).data!;
+    expect(titleOf(tile), 'Instituut Sancta Maria-A');
+    expect(subtitleOf(tile), 'ISMAA');
+    expect(find.text('School 25'), findsNothing);
+
+    // A fetch off the real CSV rows reaches the same rendering, and adds the
+    // sibling school the same way up.
+    final button = find.byKey(const ValueKey('settings-wisa-fetch-schools'));
+    await tester.ensureVisible(button);
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+    expect(titleOf(tile), 'Instituut Sancta Maria-A');
+    expect(subtitleOf(tile), 'ISMAA');
+    final sibling = find.byKey(const ValueKey('settings-wisa-school-27-ours'));
+    await tester.ensureVisible(sibling);
+    await tester.pumpAndSettle();
+    expect(titleOf(sibling), 'Instituut Sancta Maria-B');
+    expect(subtitleOf(sibling), 'ISMAB');
+
+    // Saving writes the halves onto the fields that claim them, so the next
+    // load needs no migration.
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    final saved = await settings.store.load();
+    final ismaa = saved.wisaSchools.firstWhere((p) => p.schoolId == 25);
+    expect(ismaa.code, 'ISMAA');
+    expect(ismaa.name, 'Instituut Sancta Maria-A');
+    expect(ismaa.ours, isTrue, reason: 'the managed mark survived the merge');
+    expect(ismaa.label, 'Instituut Sancta Maria-A (ISMAA)');
   });
 
   testWidgets(

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -347,9 +347,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   /// neither managed nor virtual. Order is stable by school id so the grid does
   /// not jump.
   ///
-  /// The short code (`ismaa`, `ismab`, …) rides on `WisaSchool.description`, not
-  /// `.name` — `SMAGetInst`'s CSV is `ID,NAME,DESCRIPTION` and the connector
-  /// preserves the legacy swap of the last two columns (#194).
+  /// Both halves come straight across: the connector already untangled WISA's
+  /// inverted `NAME`/`DESCRIPTION` columns, so `WisaSchool.name` is the long
+  /// name and `WisaSchool.code` the short code (#208).
   List<WisaSchoolProfile> _mergeFetchedSchools(List<WisaSchool> fetched) {
     final byId = <int, WisaSchoolProfile>{
       for (final p in _wisaSchools) p.schoolId: p,
@@ -357,9 +357,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
     for (final s in fetched) {
       final existing = byId[s.id];
       byId[s.id] = existing == null
-          ? WisaSchoolProfile(schoolId: s.id, code: s.description, name: s.name)
+          ? WisaSchoolProfile(schoolId: s.id, code: s.code, name: s.name)
           : existing.copyWith(
-              code: s.description.isEmpty ? existing.code : s.description,
+              code: s.code.isEmpty ? existing.code : s.code,
               name: s.name.isEmpty ? existing.name : s.name,
             );
     }
@@ -1346,11 +1346,11 @@ class _WisaSchoolsEditor extends StatelessWidget {
   }
 }
 
-/// A single cell in the known-WISA-school grid (#171): the school's WISA code
-/// (`ismaa`, `ismab`, …) — the identifier operators actually use — with the long
-/// name beneath it, plus an inline checkbox marking whether we manage it and a
-/// second, quieter one marking it *virtual* (#203). Both are keyed by school id
-/// so a test can flip a specific school's flag.
+/// A single cell in the known-WISA-school grid (#171): the school's long name
+/// with its short WISA code (`ISMAA`, `ISMAB`, …) beneath it, plus an inline
+/// checkbox marking whether we manage it and a second, quieter one marking it
+/// *virtual* (#203). Both are keyed by school id so a test can flip a specific
+/// school's flag.
 ///
 /// The two marks are deliberately unequal in weight. `ours` scopes the linker;
 /// `virtual` changes **which work date the school is pulled with**, so a school
@@ -1359,8 +1359,8 @@ class _WisaSchoolsEditor extends StatelessWidget {
 /// than as a second equal-looking checkbox.
 ///
 /// The numeric id is strictly a fallback and never appears twice (#194): the
-/// title degrades code → name → `School <id>`, and the subtitle shows whichever
-/// of name / `id: <id>` the title has not already used — nothing at all when the
+/// title degrades name → code → `School <id>`, and the subtitle shows whichever
+/// of code / `id: <id>` the title has not already used — nothing at all when the
 /// title is already the id.
 class _SchoolCell extends StatelessWidget {
   const _SchoolCell({
@@ -1381,10 +1381,13 @@ class _SchoolCell extends StatelessWidget {
     final String name = profile.name;
     // The lead label comes from the shared school-label helper the Actions
     // drill-down also names schools with, so the two views can never disagree
-    // about which half of the pair is the code (#204).
-    final String title = profile.codeLabel;
+    // about which half of the pair is the code (#204). The grid leads with the
+    // long name and puts the code beneath, which is what it always rendered —
+    // before #208 it got there by leading with a `code` field that in fact held
+    // the long name.
+    final String title = profile.nameLabel;
     final String? subtitle = code.isNotEmpty && name.isNotEmpty
-        ? name
+        ? code
         : (code.isEmpty && name.isEmpty ? null : 'id: ${profile.schoolId}');
 
     return Column(

--- a/account_manager/test/reconcile/reconcile_bootstrap_test.dart
+++ b/account_manager/test/reconcile/reconcile_bootstrap_test.dart
@@ -402,9 +402,8 @@ void main() {
 
   group('markVirtualSchools', () {
     const schools = <WisaSchool>[
-      WisaSchool(
-          id: 25, name: 'Instituut Sancta Maria-A', description: 'ISMAA'),
-      WisaSchool(id: 99, name: 'Virtuele school SMA', description: 'ISMAV'),
+      WisaSchool(id: 25, name: 'Instituut Sancta Maria-A', code: 'ISMAA'),
+      WisaSchool(id: 99, name: 'Virtuele school SMA', code: 'ISMAV'),
     ];
 
     test('flags exactly the schools the operator marked virtual (#203)', () {
@@ -426,14 +425,14 @@ void main() {
     });
 
     test('never un-flags a school an import rule already marked (#203)', () {
-      // MarkAsVirtual runs first and matches by name; settings marks by id.
+      // MarkAsVirtual runs first and matches by code; settings marks by id.
       // The settings pass is additive, so a legacy rule keeps working even
       // when the school is not in the settings list.
       const ruled = <WisaSchool>[
         WisaSchool(
             id: 25,
             name: 'Instituut Sancta Maria-A',
-            description: 'ISMAA',
+            code: 'ISMAA',
             isVirtual: true),
       ];
       expect(markVirtualSchools(ruled, const <int>{}).single.isVirtual, isTrue);

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -512,7 +512,7 @@ void main() {
             wapi.WisaSchool(
               id: 25,
               name: 'Instituut Sancta Maria-A',
-              description: 'ISMAA',
+              code: 'ISMAA',
               isOurs: true,
             ),
           ],

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -141,7 +141,7 @@ wapi.WisaStudent wisaStudent({
 /// A WISA school, optionally flagged [ours] (the managed-school signal the
 /// linker joins student `schoolId` against, #133/#134).
 wapi.WisaSchool wisaSchool(int id, {bool ours = false}) =>
-    wapi.WisaSchool(id: id, name: 'School $id', description: '', isOurs: ours);
+    wapi.WisaSchool(id: id, name: 'School $id', code: '', isOurs: ours);
 
 /// A WISA class group. [name] is the `fullName` the linker matches on;
 /// [schoolId] decides whether the class belongs to a school we manage — a

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -417,7 +417,7 @@ void main() {
     _useTallWindow(tester);
     const passwordRef = SecretRef('wisa.password');
     final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
-      WisaSchool(id: 99, name: 'Virtuele school SMA', description: 'ismav'),
+      WisaSchool(id: 99, name: 'Virtuele school SMA', code: 'ismav'),
     ]);
     // Marked virtual on a previous run, stored without a code.
     final harness = SettingsHarness(
@@ -458,7 +458,7 @@ void main() {
     _useTallWindow(tester);
     const passwordRef = SecretRef('wisa.password');
     final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
-      WisaSchool(id: 3, name: 'Sint-Jan', description: 'SJ'),
+      WisaSchool(id: 3, name: 'Sint-Jan', code: 'SJ'),
     ]);
     final harness = SettingsHarness(
       initial: const AppSettings(
@@ -576,10 +576,10 @@ void main() {
       (WidgetTester tester) async {
     _useTallWindow(tester);
     const passwordRef = SecretRef('wisa.password');
-    // `SMAGetInst` puts the short code in the CSV NAME column, which the
-    // connector maps onto `WisaSchool.description` (the legacy swap).
+    // `SMAGetInst` puts the short code in the CSV DESCRIPTION column, which the
+    // connector untangles onto `WisaSchool.code` (#208).
     final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
-      WisaSchool(id: 7, name: 'Sint-Pieter', description: 'ismab'),
+      WisaSchool(id: 7, name: 'Sint-Pieter', code: 'ismab'),
     ]);
     // Stored before #194: managed, named, but with no code.
     final harness = SettingsHarness(
@@ -602,7 +602,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('settings-wisa-fetch-schools')));
     await tester.pumpAndSettle();
 
-    // The code now leads the cell and the managed mark survived the merge.
+    // The code now sits under the name and the managed mark survived the merge.
     expect(find.text('ismab'), findsOneWidget);
     expect(find.text('Sint-Pieter'), findsOneWidget);
     expect(
@@ -668,8 +668,8 @@ void main() {
     _useTallWindow(tester);
     const passwordRef = SecretRef('wisa.password');
     final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
-      WisaSchool(id: 3, name: 'Sint-Jan', description: 'SJ'),
-      WisaSchool(id: 7, name: 'Sint-Pieter', description: 'SP'),
+      WisaSchool(id: 3, name: 'Sint-Jan', code: 'SJ'),
+      WisaSchool(id: 7, name: 'Sint-Pieter', code: 'SP'),
     ]);
     final harness = SettingsHarness(
       initial: const AppSettings(
@@ -729,7 +729,7 @@ void main() {
     _useTallWindow(tester);
     const passwordRef = SecretRef('wisa.password');
     final fetcher = FakeWisaSchoolFetcher(const <WisaSchool>[
-      WisaSchool(id: 7, name: 'Sint-Pieter', description: 'SP'),
+      WisaSchool(id: 7, name: 'Sint-Pieter', code: 'SP'),
     ]);
     // Id 7 is already managed from a previous run, but stored without a name.
     final harness = SettingsHarness(

--- a/account_manager/test/settings/wisa_school_fetcher_test.dart
+++ b/account_manager/test/settings/wisa_school_fetcher_test.dart
@@ -36,13 +36,16 @@ class _FakeTransport implements WisaSoapTransport {
 
 void main() {
   group('fetchWisaSchoolsLive', () {
-    test('issues SMAGetInst and returns the parsed id + name list', () async {
-      // ID,NAME,DESCRIPTION — the connector maps DESCRIPTION → name (legacy
-      // quirk preserved), so column 3 is the display name.
+    test('issues SMAGetInst and returns the parsed id + name + code list',
+        () async {
+      // ID,NAME,DESCRIPTION, filled the way WISA really fills it (see the
+      // redacted fixture packages/wisa_api/test/fixtures/sma_get_inst.csv):
+      // column 2 is the long name, column 3 the short code. The connector
+      // untangles them onto `name` / `code` (#208).
       final transport = _FakeTransport(
         'ID,NAME,DESCRIPTION\n'
-        '3,SJ,Sint-Jan\n'
-        '7,SP,Sint-Pieter\n',
+        '3,Sint-Jan,SJ\n'
+        '7,Sint-Pieter,SP\n',
       );
       final schools = await fetchWisaSchoolsLive(
         const WisaConnection(server: 'db.school.example', port: '1433'),
@@ -54,6 +57,7 @@ void main() {
       expect(transport.envelopes.single, contains(WisaQuery.getSchools));
       expect(schools.map((s) => s.id), [3, 7]);
       expect(schools.map((s) => s.name), ['Sint-Jan', 'Sint-Pieter']);
+      expect(schools.map((s) => s.code), ['SJ', 'SP']);
     });
 
     test('throws WisaSchoolFetchException when the server is missing',

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -43,7 +43,7 @@ wapi.WisaStudent wisaStudent(String wisaId, {int schoolId = 1}) =>
 /// A WISA school, optionally flagged [ours] (the `MarkAsOurs` import-rule
 /// outcome the linker derives the managed-school set from, #133/#134).
 wapi.WisaSchool wisaSchool(int id, {bool ours = false}) =>
-    wapi.WisaSchool(id: id, name: 'S$id', description: '', isOurs: ours);
+    wapi.WisaSchool(id: id, name: 'S$id', code: '', isOurs: ours);
 
 /// A Smartschool **student** account. [accountId] holds the WISA id by
 /// convention; [mail] is the Azure-UPN bridge.

--- a/packages/account_state/lib/src/settings/wisa_school_label.dart
+++ b/packages/account_state/lib/src/settings/wisa_school_label.dart
@@ -5,12 +5,10 @@ import 'wisa_school_profile.dart';
 // How a WISA school is named for a human — the one place that knows it (#204).
 //
 // A school has two halves: the long descriptive name ("Instituut Sancta
-// Maria-A") and the short code operators use day to day (`ISMAA`). Which half
-// sits on which field is the trap: `SMAGetInst`'s CSV columns are
-// `ID,NAME,DESCRIPTION` and the connector preserves the legacy swap of the last
-// two, so the **code** rides on `WisaSchool.description` and the **long name**
-// on `WisaSchool.name` (see `wisa_school.dart`). `WisaSchoolProfile` has already
-// untangled that: its `code` is the short one, its `name` the long one.
+// Maria-A") and the short code operators use day to day (`ISMAA`). Both
+// `WisaSchool` and `WisaSchoolProfile` now name those halves honestly — `name`
+// is the long one, `code` the short one — because `parseSchoolRow` untangles
+// WISA's inverted `NAME`/`DESCRIPTION` columns at the connector edge (#208).
 //
 // Every view that names a school routes through here — the Settings grid, the
 // Actions drill-down, and the label baked into the materialized documents — so
@@ -35,20 +33,22 @@ String wisaSchoolLabel({
   return 'School $schoolId';
 }
 
-/// The short lead label for one school: the [code] when known, else the long
-/// [name], else `School <id>`.
+/// The lead label for one school: the long [name] when known, else the short
+/// [code], else `School <id>`.
 ///
-/// What the Settings grid leads each cell with (#194), where the long name is
-/// the second line rather than a parenthetical.
-String wisaSchoolCodeLabel({
+/// What the Settings grid leads each cell with, with the short code as the
+/// second line rather than a parenthetical (#194, corrected in #208 — the grid
+/// always *showed* the long name first; before the fix it got there by leading
+/// with a `code` field that actually held the long name).
+String wisaSchoolNameLabel({
   required int schoolId,
   String code = '',
   String name = '',
 }) {
-  final String c = code.trim();
-  if (c.isNotEmpty) return c;
   final String n = name.trim();
   if (n.isNotEmpty) return n;
+  final String c = code.trim();
+  if (c.isNotEmpty) return c;
   return 'School $schoolId';
 }
 
@@ -77,7 +77,7 @@ Map<int, String> wisaSchoolLabels({
   // The live pull wins where it has something to say — a WISA-side rename must
   // show this session, not only after the operator re-fetches in Settings.
   for (final s in schools) {
-    put(s.id, s.description, s.name);
+    put(s.id, s.code, s.name);
   }
 
   return <int, String>{
@@ -97,8 +97,8 @@ extension WisaSchoolProfileLabel on WisaSchoolProfile {
   String get label =>
       wisaSchoolLabel(schoolId: schoolId, code: code, name: name);
 
-  /// The short lead label the Settings grid puts at the top of this school's
-  /// cell, with the long name beneath it.
-  String get codeLabel =>
-      wisaSchoolCodeLabel(schoolId: schoolId, code: code, name: name);
+  /// The lead label the Settings grid puts at the top of this school's cell,
+  /// with the short code beneath it.
+  String get nameLabel =>
+      wisaSchoolNameLabel(schoolId: schoolId, code: code, name: name);
 }

--- a/packages/account_state/lib/src/settings/wisa_school_profile.dart
+++ b/packages/account_state/lib/src/settings/wisa_school_profile.dart
@@ -9,7 +9,8 @@
 /// operator-editable ownership record keyed by school *id* that survives in the
 /// settings blob.
 ///
-/// The shape (`{ schoolId, code, name, ours, virtual, prefix }`) is the
+/// The shape (`{ schemaVersion, schoolId, code, name, ours, virtual, prefix }`)
+/// is the
 /// per-WISA-school ownership link #112/#113 called for, so the settings document
 /// is not reshaped twice. This slice only carries the data — no action reads it
 /// yet (#134 is slice 2).
@@ -26,19 +27,17 @@ class WisaSchoolProfile {
   /// The WISA school id (`WisaSchool.id`) this ownership entry is keyed by.
   final int schoolId;
 
-  /// The short WISA school code (`ismaa`, `ismab`, …) — how the schools are
-  /// identified day to day, and what the settings editor leads each cell with
-  /// (#194). It arrives on `WisaSchool.description`, not `.name`: the
-  /// `SMAGetInst` CSV columns are `ID,NAME,DESCRIPTION` and the connector
-  /// preserves the legacy swap of the last two. Empty for profiles stored
-  /// before the code was persisted — the editor falls back to the [name] and
-  /// a later fetch fills the code in.
+  /// The short WISA school code (`ISMAA`, `ISMAB`, …) — how the schools are
+  /// identified day to day, and what the settings editor shows beneath the
+  /// [name] (#194). It arrives on `WisaSchool.code` (#208). Empty for profiles
+  /// stored before the code was persisted — the editor falls back to the [name]
+  /// and a later fetch fills the code in.
   final String code;
 
-  /// The WISA school name (`WisaSchool.name`), the long descriptive name shown
-  /// beneath the [code]. Empty for profiles stored before the name was
-  /// persisted (#171) — the editor falls back to `School <id>` and a later
-  /// fetch fills the name in.
+  /// The long descriptive WISA school name (`WisaSchool.name`), which the
+  /// settings editor leads each cell with. Empty for profiles stored before
+  /// the name was persisted (#171) — the editor falls back to the [code], then
+  /// to `School <id>`, and a later fetch fills the name in.
   final String name;
 
   /// Whether we manage this school. A student found only in schools where this
@@ -75,7 +74,17 @@ class WisaSchoolProfile {
         prefix: prefix ?? this.prefix,
       );
 
+  /// The layout version [toJson] writes, and the marker [fromJson] migrates on.
+  ///
+  /// `1` (or, in practice, its absence) is every profile persisted before #208:
+  /// those were filled from a `WisaSchool` whose halves were swapped, so their
+  /// `code` holds the long name and their `name` the short code. `2` is the
+  /// honest layout. Bump this — and extend [fromJson]'s ladder — if the shape
+  /// ever changes again.
+  static const int schemaVersion = 2;
+
   Map<String, dynamic> toJson() => {
+        'schemaVersion': schemaVersion,
         'schoolId': schoolId,
         'code': code,
         'name': name,
@@ -84,15 +93,27 @@ class WisaSchoolProfile {
         'prefix': prefix,
       };
 
-  factory WisaSchoolProfile.fromJson(Map<String, dynamic> json) =>
-      WisaSchoolProfile(
-        schoolId: json['schoolId'] as int,
-        code: (json['code'] as String?) ?? '',
-        name: (json['name'] as String?) ?? '',
-        ours: (json['ours'] as bool?) ?? false,
-        virtual: (json['virtual'] as bool?) ?? false,
-        prefix: (json['prefix'] as String?) ?? '',
-      );
+  /// Reads a persisted profile, migrating the pre-#208 layout on the way in.
+  ///
+  /// A document with no `schemaVersion` was written when `code` held the long
+  /// name and `name` the short code, so its two halves are swapped back here.
+  /// The alternative — waiting for the next WISA fetch to re-derive both — was
+  /// rejected: a passive session may never fetch, and it would leave every
+  /// stored profile rendering inside out until someone did.
+  factory WisaSchoolProfile.fromJson(Map<String, dynamic> json) {
+    final int version = (json['schemaVersion'] as int?) ?? 1;
+    final String storedCode = (json['code'] as String?) ?? '';
+    final String storedName = (json['name'] as String?) ?? '';
+    final bool swapped = version < 2;
+    return WisaSchoolProfile(
+      schoolId: json['schoolId'] as int,
+      code: swapped ? storedName : storedCode,
+      name: swapped ? storedCode : storedName,
+      ours: (json['ours'] as bool?) ?? false,
+      virtual: (json['virtual'] as bool?) ?? false,
+      prefix: (json['prefix'] as String?) ?? '',
+    );
+  }
 
   @override
   bool operator ==(Object other) =>

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -509,7 +509,7 @@ void main() {
           staff: const [],
           classGroups: const [],
           schools: const [
-            wapi.WisaSchool(id: 1, name: 'One', description: '', isOurs: true),
+            wapi.WisaSchool(id: 1, name: 'One', code: '', isOurs: true),
           ],
         ),
         smartschool: ss.SmartschoolSnapshot(

--- a/packages/account_state/test/settings_store_test.dart
+++ b/packages/account_state/test/settings_store_test.dart
@@ -137,14 +137,63 @@ void main() {
 
     test(
         'a school profile predating the persisted code loads with an empty '
-        'code (#194)', () {
+        'name (#194)', () {
+      // A pre-#194 document has only the one half, and it was filled from the
+      // swapped `WisaSchool` of the day — so what sits under `name` is really
+      // the short code, and the #208 migration moves it to `code`.
       final settings = AppSettings.fromJson({
         'wisaSchools': [
-          {'schoolId': 42, 'name': 'Sint-Jan', 'ours': true, 'prefix': ''},
+          {'schoolId': 42, 'name': 'ISMAA', 'ours': true, 'prefix': ''},
         ],
       });
-      expect(settings.wisaSchools.single.code, isEmpty);
-      expect(settings.wisaSchools.single.name, 'Sint-Jan');
+      expect(settings.wisaSchools.single.code, 'ISMAA');
+      expect(settings.wisaSchools.single.name, isEmpty);
+    });
+
+    test(
+        'a settings document written before #208 loads with its code and name '
+        'unswapped', () {
+      // The pre-#208 layout: `code` held the long name and `name` the short
+      // code. The absent `schemaVersion` is the marker that says so.
+      final settings = AppSettings.fromJson({
+        'wisaSchools': [
+          {
+            'schoolId': 25,
+            'code': 'Instituut Sancta Maria-A',
+            'name': 'ISMAA',
+            'ours': true,
+            'virtual': false,
+            'prefix': '',
+          },
+        ],
+      });
+      final migrated = settings.wisaSchools.single;
+      expect(migrated.code, 'ISMAA');
+      expect(migrated.name, 'Instituut Sancta Maria-A');
+      expect(migrated.ours, isTrue);
+      // And it renders the way #204 specified, not inside out.
+      expect(migrated.label, 'Instituut Sancta Maria-A (ISMAA)');
+      expect(migrated.nameLabel, 'Instituut Sancta Maria-A');
+    });
+
+    test('a migrated profile is rewritten in the current layout, once', () {
+      // Saving after a migration must not swap the halves a second time.
+      final once = AppSettings.fromJson({
+        'wisaSchools': [
+          {
+            'schoolId': 25,
+            'code': 'Instituut Sancta Maria-A',
+            'name': 'ISMAA',
+          },
+        ],
+      });
+      final twice = AppSettings.fromJson(once.toJson());
+      expect(twice.wisaSchools, once.wisaSchools);
+      expect(twice.wisaSchools.single.code, 'ISMAA');
+      expect(
+        (once.toJson()['wisaSchools'] as List).single,
+        containsPair('schemaVersion', 2),
+      );
     });
 
     test('copyWith preserves and can replace the school code (#194)', () {
@@ -203,12 +252,14 @@ void main() {
     test(
         'a settings document written before the virtual flag loads with every '
         'school non-virtual (#203)', () {
+      // Pre-#203 is also pre-#208, so this document carries the swapped halves
+      // and comes back through the migration.
       final settings = AppSettings.fromJson({
         'wisaSchools': [
           {
             'schoolId': 42,
-            'code': 'ismaa',
-            'name': 'Sint-Jan',
+            'code': 'Sint-Jan',
+            'name': 'ISMAA',
             'ours': true,
             'prefix': '',
           },
@@ -216,6 +267,8 @@ void main() {
       });
       expect(settings.wisaSchools.single.virtual, isFalse);
       expect(settings.virtualWisaSchoolIds, isEmpty);
+      expect(settings.wisaSchools.single.code, 'ISMAA');
+      expect(settings.wisaSchools.single.name, 'Sint-Jan');
     });
 
     test('copyWith preserves and can replace the virtual flag (#203)', () {

--- a/packages/account_state/test/wisa_school_label_test.dart
+++ b/packages/account_state/test/wisa_school_label_test.dart
@@ -1,11 +1,30 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:account_state/account_state.dart';
 import 'package:test/test.dart';
 import 'package:wisa_api/wisa_api.dart';
 
-/// The `SMAGetInst` column swap in fixture form: the short code arrives on
-/// [WisaSchool.description] and the long name on [WisaSchool.name].
+/// A snapshot school, with each half on the field that claims it (#208).
 WisaSchool _school(int id, {String code = '', String name = ''}) =>
-    WisaSchool(id: id, name: name, description: code);
+    WisaSchool(id: id, name: name, code: code);
+
+/// The redacted-from-live `SMAGetInst` fixture, resolved whether `dart test`
+/// runs from this package or from the workspace root (CI does the latter).
+String _readSchoolFixture() {
+  const rel = 'test/fixtures/sma_get_inst.csv';
+  final candidates = <String>[
+    Uri.base.resolve('../wisa_api/$rel').toFilePath(),
+    Uri.base.resolve('packages/wisa_api/$rel').toFilePath(),
+    '../wisa_api/$rel',
+    'packages/wisa_api/$rel',
+  ];
+  for (final p in candidates) {
+    final f = File(p);
+    if (f.existsSync()) return f.readAsStringSync();
+  }
+  throw FileSystemException('fixture not found', candidates.join(', '));
+}
 
 void main() {
   group('wisaSchoolLabel', () {
@@ -34,21 +53,21 @@ void main() {
     });
   });
 
-  group('wisaSchoolCodeLabel', () {
-    test('leads with the code, then the name, then the id', () {
+  group('wisaSchoolNameLabel', () {
+    test('leads with the long name, then the code, then the id', () {
       expect(
-        wisaSchoolCodeLabel(
+        wisaSchoolNameLabel(
           schoolId: 25,
           code: 'ISMAA',
           name: 'Instituut Sancta Maria-A',
         ),
-        'ISMAA',
-      );
-      expect(
-        wisaSchoolCodeLabel(schoolId: 25, name: 'Instituut Sancta Maria-A'),
         'Instituut Sancta Maria-A',
       );
-      expect(wisaSchoolCodeLabel(schoolId: 25), 'School 25');
+      expect(
+        wisaSchoolNameLabel(schoolId: 25, code: 'ISMAA'),
+        'ISMAA',
+      );
+      expect(wisaSchoolNameLabel(schoolId: 25), 'School 25');
     });
   });
 
@@ -60,14 +79,14 @@ void main() {
         name: 'Instituut Sancta Maria-A',
       );
       expect(profile.label, 'Instituut Sancta Maria-A (ISMAA)');
-      expect(profile.codeLabel, 'ISMAA');
+      expect(profile.nameLabel, 'Instituut Sancta Maria-A');
     });
 
     test('a profile stored before the code/name were persisted keeps the id',
         () {
       const profile = WisaSchoolProfile(schoolId: 25);
       expect(profile.label, 'School 25');
-      expect(profile.codeLabel, 'School 25');
+      expect(profile.nameLabel, 'School 25');
     });
   });
 
@@ -93,7 +112,7 @@ void main() {
       );
     });
 
-    test('takes the code off description and the name off name', () {
+    test('takes the code off code and the name off name', () {
       expect(
         wisaSchoolLabels(schools: [
           _school(25, code: 'ISMAA', name: 'Instituut Sancta Maria-A'),
@@ -146,6 +165,54 @@ void main() {
         ),
         {25: 'ISMAA', 30: 'Sancta Maria-B'},
       );
+    });
+  });
+
+  // The convention pinned by *real* data rather than by hand-built fixtures
+  // that can quietly agree with a bug (#208). Every step is production code:
+  // the redacted-from-live CSV → `parseSchoolRow` → `wisaSchoolLabels`.
+  group('from the redacted SMAGetInst fixture to a rendered label', () {
+    final rows = const LineSplitter()
+        .convert(_readSchoolFixture())
+        .where((l) => l.trim().isNotEmpty)
+        .skip(1) // the ID,NAME,DESCRIPTION header
+        .toList();
+    final schools = [for (final r in rows) parseSchoolRow(r)];
+
+    test('the fixture is the shape this test relies on', () {
+      expect(rows, contains('25,Instituut Sancta Maria-A,ISMAA'));
+    });
+
+    test('parses the long name onto name and the short code onto code', () {
+      final ismaa = schools.firstWhere((s) => s.id == 25);
+      expect(ismaa.name, 'Instituut Sancta Maria-A');
+      expect(ismaa.code, 'ISMAA');
+    });
+
+    test('renders the long name first with the short code in parentheses', () {
+      final labels = wisaSchoolLabels(schools: schools);
+      expect(labels[25], 'Instituut Sancta Maria-A (ISMAA)');
+      expect(labels[27], 'Instituut Sancta Maria-B (ISMAB)');
+      // The inverse — what the drill-down read before the fix — must be gone.
+      expect(labels[25], isNot('ISMAA (Instituut Sancta Maria-A)'));
+    });
+
+    test('a code-only fixture row degrades to the code, not to School <id>',
+        () {
+      // Row 2 of the fixture is `0,,?`: no long name, only a placeholder code.
+      final labels = wisaSchoolLabels(schools: schools);
+      expect(labels[0], '?');
+    });
+
+    test('the grid leads each fixture school with its long name', () {
+      final ismaa = schools.firstWhere((s) => s.id == 25);
+      final profile = WisaSchoolProfile(
+        schoolId: ismaa.id,
+        code: ismaa.code,
+        name: ismaa.name,
+      );
+      expect(profile.nameLabel, 'Instituut Sancta Maria-A');
+      expect(profile.label, 'Instituut Sancta Maria-A (ISMAA)');
     });
   });
 }

--- a/packages/account_state/test/wisa_snapshot_diff_test.dart
+++ b/packages/account_state/test/wisa_snapshot_diff_test.dart
@@ -55,8 +55,8 @@ WisaClassGroup _classGroup({String name = '3A'}) => WisaClassGroup(
 
 WisaSchool _school({int id = 1, bool isVirtual = false}) => WisaSchool(
       id: id,
-      name: 'SMA',
-      description: 'Sint-Michiel',
+      name: 'Sint-Michiel',
+      code: 'SMA',
       isVirtual: isVirtual,
     );
 

--- a/packages/wisa_api/lib/src/connector.dart
+++ b/packages/wisa_api/lib/src/connector.dart
@@ -201,7 +201,9 @@ class WisaConnector {
     }
     _log?.addMessage(
       core.Origin.wisa,
-      'Loading classgroups from ${school.name} succeeded.',
+      // The short code, as the sync log has always named a school — before
+      // #208 that half simply sat on `school.name`.
+      'Loading classgroups from ${school.code} succeeded.',
     );
     return groups;
   }
@@ -228,7 +230,7 @@ class WisaConnector {
     }
     _log?.addMessage(
       core.Origin.wisa,
-      'Loading ${students.length} students from ${school.name} succeeded.',
+      'Loading ${students.length} students from ${school.code} succeeded.',
     );
     return students;
   }
@@ -255,7 +257,7 @@ class WisaConnector {
     }
     _log?.addMessage(
       core.Origin.wisa,
-      'Loading ${staff.length} staff members from ${school.name} succeeded.',
+      'Loading ${staff.length} staff members from ${school.code} succeeded.',
     );
     return staff;
   }

--- a/packages/wisa_api/lib/src/csv/row_parsers.dart
+++ b/packages/wisa_api/lib/src/csv/row_parsers.dart
@@ -165,9 +165,13 @@ WisaClassGroup parseClassGroupRow(String line, {required int schoolId}) {
   }
 }
 
-/// Parses a `SMAGetInst` row into a [WisaSchool]. Preserves the legacy
-/// quirk: column 1 (`NAME`) becomes the school's `description` and column
-/// 2 (`DESCRIPTION`) becomes its `name`.
+/// Parses a `SMAGetInst` row into a [WisaSchool].
+///
+/// WISA fills the two text columns the other way round from what it calls
+/// them: column 1 (`NAME`) holds the **long** name and column 2
+/// (`DESCRIPTION`) the **short** code. This is the one place that untangles
+/// that, so [WisaSchool.name] and [WisaSchool.code] each hold the half their
+/// name says they do (#208).
 WisaSchool parseSchoolRow(String line) {
   try {
     final f = splitCsvLine(line);
@@ -183,8 +187,8 @@ WisaSchool parseSchoolRow(String line) {
     }
     return WisaSchool(
       id: id,
-      description: f[1].trim(),
-      name: f[2].trim(),
+      name: f[1].trim(),
+      code: f[2].trim(),
     );
   } on CsvRowParseException {
     rethrow;

--- a/packages/wisa_api/lib/src/models/wisa_school.dart
+++ b/packages/wisa_api/lib/src/models/wisa_school.dart
@@ -1,9 +1,13 @@
 /// A WISA school ("instelling") record.
 ///
 /// Source: legacy `legacy-wpf/AccountApi/Wisa/School.cs`. The CSV columns
-/// from the `SMAGetInst` query are `ID,NAME,DESCRIPTION` — note that the
-/// legacy code maps column 1 (the WISA "NAME" column) to `Description` and
-/// column 2 (the WISA "DESCRIPTION" column) to `Name`, which we preserve.
+/// from the `SMAGetInst` query are `ID,NAME,DESCRIPTION`, and WISA fills them
+/// the other way round from what they are called: column `NAME` carries the
+/// **long** name ("Instituut Sancta Maria-A") and column `DESCRIPTION` the
+/// **short** code (`ISMAA`). The legacy C# preserved that inversion in its
+/// field names; we do not (#208). Here [name] is always the long name and
+/// [code] always the short code, so no reader has to remember a swap —
+/// `parseSchoolRow` is the single place that untangles the CSV.
 ///
 /// [isVirtual] is set at snapshot construction time by the
 /// `MarkAsVirtual` import rule; it tells the connector that this school
@@ -17,15 +21,22 @@
 /// entirely; this slice only carries the flag — it changes no action yet.
 class WisaSchool {
   final int id;
+
+  /// The long, human-readable school name ("Instituut Sancta Maria-A").
+  /// Parsed from the `SMAGetInst` CSV's `NAME` column.
   final String name;
-  final String description;
+
+  /// The short code operators use day to day (`ISMAA`). Parsed from the
+  /// `SMAGetInst` CSV's `DESCRIPTION` column, and what the school-marking
+  /// import rules (`MarkAsOurs`, `MarkAsVirtual`) match on.
+  final String code;
   final bool isVirtual;
   final bool isOurs;
 
   const WisaSchool({
     required this.id,
     required this.name,
-    required this.description,
+    required this.code,
     this.isVirtual = false,
     this.isOurs = false,
   });
@@ -35,23 +46,33 @@ class WisaSchool {
   Map<String, dynamic> toJson() => {
         'id': id,
         'name': name,
-        'description': description,
+        'code': code,
         'isVirtual': isVirtual,
         'isOurs': isOurs,
       };
 
-  factory WisaSchool.fromJson(Map<String, dynamic> json) => WisaSchool(
-        id: json['id'] as int,
-        name: json['name'] as String,
-        description: json['description'] as String,
-        isVirtual: (json['isVirtual'] as bool?) ?? false,
-        isOurs: (json['isOurs'] as bool?) ?? false,
-      );
+  /// Reads a snapshot school, migrating documents written before #208.
+  ///
+  /// Those carry the halves under the inverted legacy keys — `name` held the
+  /// short code and `description` the long name — so a document with no `code`
+  /// key is read back swapped. Nothing else distinguishes the two shapes, and
+  /// the `code` key is written unconditionally, so the test is exact rather
+  /// than a guess about the values.
+  factory WisaSchool.fromJson(Map<String, dynamic> json) {
+    final legacy = !json.containsKey('code') && json.containsKey('description');
+    return WisaSchool(
+      id: json['id'] as int,
+      name: (legacy ? json['description'] : json['name']) as String,
+      code: (legacy ? json['name'] : json['code']) as String,
+      isVirtual: (json['isVirtual'] as bool?) ?? false,
+      isOurs: (json['isOurs'] as bool?) ?? false,
+    );
+  }
 
   WisaSchool copyWith({bool? isVirtual, bool? isOurs}) => WisaSchool(
         id: id,
         name: name,
-        description: description,
+        code: code,
         isVirtual: isVirtual ?? this.isVirtual,
         isOurs: isOurs ?? this.isOurs,
       );
@@ -62,14 +83,14 @@ class WisaSchool {
       other is WisaSchool &&
           id == other.id &&
           name == other.name &&
-          description == other.description &&
+          code == other.code &&
           isVirtual == other.isVirtual &&
           isOurs == other.isOurs;
 
   @override
-  int get hashCode => Object.hash(id, name, description, isVirtual, isOurs);
+  int get hashCode => Object.hash(id, name, code, isVirtual, isOurs);
 
   @override
-  String toString() =>
-      'WisaSchool(id: $id, name: $name, isVirtual: $isVirtual, isOurs: $isOurs)';
+  String toString() => 'WisaSchool(id: $id, name: $name, code: $code, '
+      'isVirtual: $isVirtual, isOurs: $isOurs)';
 }

--- a/packages/wisa_api/lib/src/rules/import_rules.dart
+++ b/packages/wisa_api/lib/src/rules/import_rules.dart
@@ -52,27 +52,30 @@ class ReplaceInstitute extends WisaImportRule {
       matches(g) ? g.copyWith(schoolCode: replacement) : g;
 }
 
-/// Flags schools whose [WisaSchool.name] equals [schoolCode] as virtual.
+/// Flags schools whose [WisaSchool.code] equals [schoolCode] as virtual.
 /// The connector then syncs those schools with the virtual workdate
 /// instead of the real one. Mirrors legacy `MarkAsVirtual`
 /// (`RuleAction.WorkDate`).
+///
+/// Matches on the **short code** (`ISMV`), as it always did — before #208 that
+/// half was misfiled on `WisaSchool.name`, so this read `s.name`.
 class MarkAsVirtual extends WisaImportRule {
   final String schoolCode;
   const MarkAsVirtual(this.schoolCode);
 
-  bool matches(WisaSchool s) => s.name == schoolCode;
+  bool matches(WisaSchool s) => s.code == schoolCode;
 }
 
-/// Flags schools whose [WisaSchool.name] equals [schoolCode] as *ours*
+/// Flags schools whose [WisaSchool.code] equals [schoolCode] as *ours*
 /// (managed). Group-wide leave detection (#113) uses the flag to tell a
 /// student gone from *our* school but still in the group from one gone from
 /// the whole group. Mirrors [MarkAsVirtual] — a snapshot-time school marker
-/// keyed by the WISA school name.
+/// keyed by the short WISA school code.
 class MarkAsOurs extends WisaImportRule {
   final String schoolCode;
   const MarkAsOurs(this.schoolCode);
 
-  bool matches(WisaSchool s) => s.name == schoolCode;
+  bool matches(WisaSchool s) => s.code == schoolCode;
 }
 
 /// Applies all rules in [rules] to [groups], in order. Returns a new list;

--- a/packages/wisa_api/lib/wisa_api.dart
+++ b/packages/wisa_api/lib/wisa_api.dart
@@ -12,6 +12,10 @@ library;
 export 'src/config/live_config.dart' show WisaLiveConfig;
 export 'src/connector.dart' show WisaConnector, WisaQuery;
 export 'src/csv/csv_parser.dart' show CsvHeaderMismatch, CsvRowParseException;
+// The canonical `SMAGetInst` row decoder — the one place that untangles WISA's
+// inverted NAME/DESCRIPTION columns. Exported so the convention can be pinned
+// against the real CSV from outside this package (#208).
+export 'src/csv/row_parsers.dart' show parseSchoolRow;
 export 'src/models/wisa_class_group.dart';
 export 'src/models/wisa_school.dart';
 export 'src/models/wisa_staff.dart';

--- a/packages/wisa_api/test/connector_test.dart
+++ b/packages/wisa_api/test/connector_test.dart
@@ -107,10 +107,15 @@ void main() {
       expect(schools, isNotEmpty);
       expect(schools.every((s) => !s.isVirtual), isTrue);
       // The redacted fixture preserves the legacy edge case of a "?"
-      // placeholder school at id 0.
-      expect(schools.any((s) => s.id == 0 && s.name == '?'), isTrue);
-      // ISMAA (id 25) is the primary active school in the fixture.
-      expect(schools.any((s) => s.id == 25), isTrue);
+      // placeholder school at id 0 — a row with no long name, only a code.
+      expect(schools.any((s) => s.id == 0 && s.name == '' && s.code == '?'),
+          isTrue);
+      // ISMAA (id 25) is the primary active school in the fixture. Its two
+      // halves land on the fields that claim them: the long name on `name`,
+      // the short code on `code` (#208).
+      final ismaa = schools.firstWhere((s) => s.id == 25);
+      expect(ismaa.name, 'Instituut Sancta Maria-A');
+      expect(ismaa.code, 'ISMAA');
     });
   });
 

--- a/packages/wisa_api/test/csv/row_parsers_test.dart
+++ b/packages/wisa_api/test/csv/row_parsers_test.dart
@@ -226,13 +226,15 @@ void main() {
   });
 
   group('parseSchoolRow', () {
-    test('parses a typical row, swapping NAME and DESCRIPTION', () {
-      // CSV columns: ID,NAME,DESCRIPTION
-      // Legacy maps column 1 -> description, column 2 -> name.
-      final s = parseSchoolRow('25,SMA,Sint-Maria-Aalst');
+    test('untangles WISA\'s inverted NAME / DESCRIPTION columns (#208)', () {
+      // CSV columns are ID,NAME,DESCRIPTION, but WISA fills them the other way
+      // round: NAME carries the long name, DESCRIPTION the short code. This is
+      // the exact shape of row 11 of the redacted live fixture
+      // (test/fixtures/sma_get_inst.csv).
+      final s = parseSchoolRow('25,Instituut Sancta Maria-A,ISMAA');
       expect(s.id, 25);
-      expect(s.description, 'SMA');
-      expect(s.name, 'Sint-Maria-Aalst');
+      expect(s.name, 'Instituut Sancta Maria-A');
+      expect(s.code, 'ISMAA');
       expect(s.isVirtual, isFalse);
     });
 

--- a/packages/wisa_api/test/fixtures/README.md
+++ b/packages/wisa_api/test/fixtures/README.md
@@ -36,7 +36,7 @@ dart run packages/wisa_api/tool/redact_fixtures.dart
 
 | File                  | Query        | Header                                                                                                          |
 | --------------------- | ------------ | --------------------------------------------------------------------------------------------------------------- |
-| `sma_get_inst.csv`    | `SMAGetInst` | `ID,NAME,DESCRIPTION` (note: legacy swaps NAME and DESCRIPTION on the model)                                    |
+| `sma_get_inst.csv`    | `SMAGetInst` | `ID,NAME,DESCRIPTION` (WISA inverts these: `NAME` is the long name, `DESCRIPTION` the short code — `parseSchoolRow` untangles it onto `WisaSchool.name` / `.code`, #208) |
 | `sma_sync_lln.csv`    | `SmaSyncLln` | `KLAS,KLASGROEP,NAAM,VOORNAAM,ROEPNAAM,GEBOORTEDATUM,WISAID,STAMBOEKNUMMER,GESLACHT,RIJKSREGISTERNR,GEBOORTEPLAATS,NATIONALITEIT,STRAAT,STRAATNR,BUSNR,POSTCODE,WOONPLAATS,KLASWIJZIGING` |
 | `sma_sync_per.csv`    | `SmaSyncPer` | `CODE,WISAID,FAMILIENAAM,VOORNAAM`                                                                              |
 | `sync_klas.csv`       | `SyncKlas`   | `KLAS,KLASGROEP,OMSCHRIJVING,ADMINGROEP,INSTELLINGSNUMMER`                                                      |

--- a/packages/wisa_api/test/models/models_equality_test.dart
+++ b/packages/wisa_api/test/models/models_equality_test.dart
@@ -102,12 +102,12 @@ void main() {
 
   group('WisaSchool', () {
     test('equality based on all fields including isVirtual', () {
-      const a = WisaSchool(id: 1, name: 'SMA', description: 'X');
-      const b = WisaSchool(id: 1, name: 'SMA', description: 'X');
+      const a = WisaSchool(id: 1, name: 'Sint-Maria', code: 'SMA');
+      const b = WisaSchool(id: 1, name: 'Sint-Maria', code: 'SMA');
       const c = WisaSchool(
         id: 1,
-        name: 'SMA',
-        description: 'X',
+        name: 'Sint-Maria',
+        code: 'SMA',
         isVirtual: true,
       );
       expect(a, b);
@@ -116,17 +116,17 @@ void main() {
     });
 
     test('copyWith flips isVirtual', () {
-      const a = WisaSchool(id: 1, name: 'SMA', description: 'X');
+      const a = WisaSchool(id: 1, name: 'Sint-Maria', code: 'SMA');
       expect(a.copyWith(isVirtual: true).isVirtual, isTrue);
       expect(a.copyWith().isVirtual, isFalse);
     });
 
     test('isOurs participates in equality and copyWith and round-trips', () {
-      const a = WisaSchool(id: 1, name: 'SMA', description: 'X');
+      const a = WisaSchool(id: 1, name: 'Sint-Maria', code: 'SMA');
       const managed = WisaSchool(
         id: 1,
-        name: 'SMA',
-        description: 'X',
+        name: 'Sint-Maria',
+        code: 'SMA',
         isOurs: true,
       );
       expect(a, isNot(managed));
@@ -135,17 +135,35 @@ void main() {
       expect(WisaSchool.fromJson(managed.toJson()), managed);
       // Old snapshots without the key default to not-ours.
       expect(
-        WisaSchool.fromJson(const {'id': 1, 'name': 'SMA', 'description': 'X'})
-            .isOurs,
+        WisaSchool.fromJson(
+            const {'id': 1, 'name': 'Sint-Maria', 'code': 'SMA'}).isOurs,
         isFalse,
       );
     });
 
-    test('toString includes id, name, and virtual flag', () {
-      const a = WisaSchool(id: 1, name: 'SMA', description: 'X');
+    test('a pre-#208 snapshot document reads back with its halves unswapped',
+        () {
+      // Documents written before #208 carry the long name under `description`
+      // and the short code under `name`. The absent `code` key is the marker.
+      const legacy = <String, dynamic>{
+        'id': 25,
+        'name': 'ISMAA',
+        'description': 'Instituut Sancta Maria-A',
+        'isVirtual': false,
+        'isOurs': true,
+      };
+      final migrated = WisaSchool.fromJson(legacy);
+      expect(migrated.name, 'Instituut Sancta Maria-A');
+      expect(migrated.code, 'ISMAA');
+      expect(migrated.isOurs, isTrue);
+    });
+
+    test('toString includes id, name, code, and virtual flag', () {
+      const a = WisaSchool(id: 1, name: 'Sint-Maria', code: 'SMA');
       final s = a.toString();
       expect(s, contains('id: 1'));
-      expect(s, contains('SMA'));
+      expect(s, contains('name: Sint-Maria'));
+      expect(s, contains('code: SMA'));
       expect(s, contains('isVirtual'));
     });
   });

--- a/packages/wisa_api/test/rules/import_rules_test.dart
+++ b/packages/wisa_api/test/rules/import_rules_test.dart
@@ -77,22 +77,30 @@ void main() {
   });
 
   group('MarkAsVirtual', () {
-    test('flips isVirtual on matching school name', () {
+    test('flips isVirtual on the matching short school code', () {
+      // The rule keys off the short code, never the long name (#208).
       const schools = [
-        WisaSchool(id: 1, name: 'SMA', description: 'Sint Maria'),
-        WisaSchool(id: 2, name: 'SDK', description: 'Sint Dimphna'),
+        WisaSchool(id: 1, name: 'Sint Maria', code: 'SMA'),
+        WisaSchool(id: 2, name: 'Sint Dimphna', code: 'SDK'),
       ];
       final out = applyRulesToSchools(schools, const [MarkAsVirtual('SMA')]);
       expect(out[0].isVirtual, isTrue);
       expect(out[1].isVirtual, isFalse);
     });
+
+    test('does not match on the long school name', () {
+      const schools = [WisaSchool(id: 1, name: 'Sint Maria', code: 'SMA')];
+      final out =
+          applyRulesToSchools(schools, const [MarkAsVirtual('Sint Maria')]);
+      expect(out.single.isVirtual, isFalse);
+    });
   });
 
   group('MarkAsOurs', () {
-    test('flips isOurs on matching school name only', () {
+    test('flips isOurs on the matching short school code only', () {
       const schools = [
-        WisaSchool(id: 1, name: 'SMA', description: 'Sint Maria'),
-        WisaSchool(id: 2, name: 'SDK', description: 'Sint Dimphna'),
+        WisaSchool(id: 1, name: 'Sint Maria', code: 'SMA'),
+        WisaSchool(id: 2, name: 'Sint Dimphna', code: 'SDK'),
       ];
       final out = applyRulesToSchools(schools, const [MarkAsOurs('SMA')]);
       expect(out[0].isOurs, isTrue);
@@ -101,8 +109,15 @@ void main() {
       expect(out[0].isVirtual, isFalse);
     });
 
+    test('does not match on the long school name', () {
+      const schools = [WisaSchool(id: 1, name: 'Sint Maria', code: 'SMA')];
+      final out =
+          applyRulesToSchools(schools, const [MarkAsOurs('Sint Maria')]);
+      expect(out.single.isOurs, isFalse);
+    });
+
     test('MarkAsVirtual and MarkAsOurs flag independently on one school', () {
-      const schools = [WisaSchool(id: 1, name: 'SMA', description: 'X')];
+      const schools = [WisaSchool(id: 1, name: 'Sint Maria', code: 'SMA')];
       final out = applyRulesToSchools(
         schools,
         const [MarkAsVirtual('SMA'), MarkAsOurs('SMA')],

--- a/packages/wisa_api/test/snapshot_test.dart
+++ b/packages/wisa_api/test/snapshot_test.dart
@@ -10,7 +10,7 @@ void main() {
       students: const [],
       staff: const [],
       classGroups: const [],
-      schools: const [WisaSchool(id: 1, name: 'SMA', description: 'X')],
+      schools: const [WisaSchool(id: 1, name: 'Sint-Maria', code: 'SMA')],
     );
 
     test('origin is Origin.wisa', () {
@@ -37,7 +37,7 @@ void main() {
 
     test('input list is copied (later mutation does not leak in)', () {
       final mutableSchools = [
-        const WisaSchool(id: 1, name: 'SMA', description: 'X'),
+        const WisaSchool(id: 1, name: 'Sint-Maria', code: 'SMA'),
       ];
       final snap = WisaSnapshot(
         fetchedAt: fetchedAt,
@@ -76,7 +76,7 @@ void main() {
           ),
         ],
         schools: const [
-          WisaSchool(id: 1, name: 'SMA', description: 'X', isVirtual: true),
+          WisaSchool(id: 1, name: 'Sint-Maria', code: 'SMA', isVirtual: true),
         ],
       );
 

--- a/packages/wisa_api/tool/redact_fixtures.dart
+++ b/packages/wisa_api/tool/redact_fixtures.dart
@@ -73,9 +73,9 @@ void _writeSchools(Directory inDir, Directory outDir) {
   final buf = StringBuffer('ID,NAME,DESCRIPTION\n');
   for (final s in schools) {
     final id = s['ID'] as int;
-    // Legacy quirk: WISA's CSV column "NAME" holds the long description,
-    // and "DESCRIPTION" holds the short code (see SchoolManager.cs and
-    // parseSchoolRow). Emit accordingly. School names/descriptions are
+    // WISA quirk: its CSV column "NAME" holds the long name, and
+    // "DESCRIPTION" holds the short code (see SchoolManager.cs and
+    // parseSchoolRow, which untangles it). Emit accordingly. School names are
     // public info (institutional names), not PII — keep verbatim, but
     // strip non-ASCII for encoding-safe fixtures.
     final long = _csvField(_toAscii((s['Description'] as String?) ?? ''));


### PR DESCRIPTION
## Summary

WISA's `SMAGetInst` CSV carries the long name in its `NAME` column and the short
code in `DESCRIPTION`. `parseSchoolRow` preserved that inversion onto the model,
so `WisaSchool.description` held the long name and `.name` held the code — and
every consumer inherited it. `WisaSchoolProfile.code` ended up holding the long
name and `.name` the code, and the shared label helper composed
`ISMAA (Instituut Sancta Maria-A)` instead of `Instituut Sancta Maria-A (ISMAA)`.

- **The parser is now the single place that untangles the columns.**
  `WisaSchool.description` is renamed to `WisaSchool.code`, so `name` is always
  the long name and `code` always the short one. `_mergeFetchedSchools` and
  `wisaSchoolLabels` needed no logic change once the parser told the truth — only
  their doc comments were wrong.
- **`MarkAsVirtual` / `MarkAsOurs` now match on `s.code`.** They always keyed off
  the short code, which merely used to sit on `name`; without this they would have
  silently started matching long names.
- **The Settings grid keeps the pixels it has today** — long name on the first
  line, short code beneath — by leading with a renamed `nameLabel` /
  `wisaSchoolNameLabel` instead of `codeLabel`, which used to lead with a `code`
  field that actually held the long name. The Acties drill-down now reads
  `Instituut Sancta Maria-A (ISMAA)`.
- **Migration is on load, via a new `WisaSchoolProfile.schemaVersion`:** absent/1
  means the pre-fix swapped layout and the two halves are swapped back on read; 2
  is written from now on. `WisaSchool.fromJson` uses an absent `code` key as the
  equivalent marker for cold snapshots. On-load migration was chosen over
  re-deriving from the next fetch because a passive session may never fetch and
  would otherwise render every stored school inside out until one did.
- **Every hand-built `WisaSchool` fixture was re-based** on what `parseSchoolRow`
  actually produces. One was not cosmetic: `wisa_school_fetcher_test.dart` fed the
  connector a CSV written backwards (`3,SJ,Sint-Jan`) and asserted against it, so
  it went red under the fix and was corrected to real WISA column order rather
  than papered over. `parseSchoolRow` is now exported from
  `package:wisa_api/wisa_api.dart` so the convention can be pinned from outside
  the package.

## Test plan

- [x] `dart test packages/*/test` — 929 pass / 11 skipped (opt-in live)
- [x] `flutter test` (account_manager) — 270 pass
- [x] `flutter test integration_test/app_launch_test.dart -d windows` — 49 pass
      (47 existing + 2 new, including a real-CSV-to-rendered-label test that pins
      the convention against `sma_get_inst.csv` rather than a hand-built fixture)
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `dart analyze` clean
- [x] Fail-without-fix proven by two targeted mutations: reverting the parser swap
      reds 6 tests including the real-CSV-to-label ones; disabling the profile
      migration reds 4 settings-store tests.

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)
