### PR TITLE
Batch: school-name backfill, virtual class groups, flattened Acties tree (#207, #209, #210)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -205,8 +205,6 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(ActionsScreen), findsOneWidget);
     expect(find.text('Overzicht'), findsOneWidget);
-    await tester.tap(find.text('School 1'));
-    await tester.pumpAndSettle();
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
     await tester.ensureVisible(find.text('3C'));
@@ -783,12 +781,11 @@ void main() {
     await tester.pumpAndSettle();
 
     // The departed account is browsed on the Actions tab, under the
-    // "Niet toegewezen" → "Overig" → "Zonder klas" bucket.
+    // "Niet toegewezen" → "Zonder klas" bucket (#210 dropped the always-empty
+    // grade level between them).
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Niet toegewezen'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Jaar Overig'));
     await tester.pumpAndSettle();
     await tester.ensureVisible(find.text('Zonder klas'));
     await tester.tap(find.text('Zonder klas'));
@@ -868,8 +865,6 @@ void main() {
         reason: 'a school we do not manage never appears in Actions (#178)');
     await tester.tap(find.text('Niet toegewezen'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Jaar Overig'));
-    await tester.pumpAndSettle();
     await tester.ensureVisible(find.text('Zonder klas'));
     await tester.tap(find.text('Zonder klas'));
     await tester.pumpAndSettle();
@@ -927,12 +922,13 @@ void main() {
   });
 
   testWidgets(
-      'marking that same school as managed in Settings surfaces it in the '
-      'Actions drill-down end-to-end (#178)', (WidgetTester tester) async {
-    // The very same school-2 student, but now school 2 is one of ours: it must
-    // appear as a school node and the student sits under it. Proves the managed
-    // set from Settings — not the snapshot MarkAsOurs flags — drives which
-    // schools show.
+      'marking that same school as managed in Settings surfaces its students in '
+      'the Actions drill-down end-to-end (#178)', (WidgetTester tester) async {
+    // The very same school-2 student, but now school 2 is one of ours: their
+    // class must be browsable instead of sitting in the leaver bucket. Proves
+    // the managed set from Settings — not the snapshot MarkAsOurs flags —
+    // drives which students show. The school itself is no longer a node (#210),
+    // so the proof is that the student's own class is reachable.
     useTallWindow(tester);
     final harness = managedSchoolsHarness(ourSchoolIds: const {1, 2});
     await tester.pumpWidget(AccountManagerApp(
@@ -948,23 +944,33 @@ void main() {
 
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
-    expect(find.text('School 2'), findsOneWidget,
-        reason: 'managing school 2 surfaces it in Actions (#178)');
-    await tester.tap(find.text('School 2'));
-    await tester.pumpAndSettle();
+    expect(find.text('Niet toegewezen'), findsNothing,
+        reason: 'managing school 2 takes its student out of the leaver bucket');
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
     expect(find.text('3C'), findsWidgets);
+    // The class the student reached still carries school 2's partition, which
+    // is what the per-class read targets.
+    expect(
+      harness.controller
+          .studentChildrenOf(harness.controller.studentRollups.single)
+          .single
+          .school,
+      '2',
+    );
   });
 
   testWidgets(
-      'the Actions drill-down names a school by name and code end-to-end, '
-      'never "School <id>" (#204)', (WidgetTester tester) async {
+      'the materialized view names a school by name and code end-to-end, never '
+      '"School <id>", while the drill-down shows no school at all (#204/#210)',
+      (WidgetTester tester) async {
     // The real app, real fonts, real navigation. This session's WISA snapshot
     // carries no schools at all, so the school's identity can only come from
     // the operator's persisted Settings profile — exactly the case that used to
-    // bake `School 25` into every materialized node. The drill-down must name
-    // the school the way Instellingen → WISA does.
+    // bake `School 25` into every materialized node. #210 took the school level
+    // out of the drill-down, so that label now lives only in the shared
+    // documents (which Cosmos partitions by school and Settings names) — it must
+    // still be the "Instellingen → WISA" identity there, and nowhere on screen.
     useTallWindow(tester);
     final harness = namedSchoolHarness();
     await tester.pumpWidget(AccountManagerApp(
@@ -982,27 +988,29 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('School 25'), findsNothing,
         reason: 'the numeric id is the last resort, not the rendering (#204)');
-    final node = find.text('Instituut Sancta Maria-A (ISMAA)');
-    expect(node, findsOneWidget);
+    expect(find.text('Instituut Sancta Maria-A (ISMAA)'), findsNothing,
+        reason: 'no school node survives in the student tree (#210)');
 
-    // It is the real school node, not a stray label: it drills down to the
-    // student's class.
-    await tester.tap(node);
-    await tester.pumpAndSettle();
+    // The stored school rollup — what the counters and the Cosmos documents are
+    // keyed and labelled by — still carries the full identity.
+    expect(harness.controller.schoolRollups.single.label,
+        'Instituut Sancta Maria-A (ISMAA)');
+
+    // And the year drills straight to the student's class.
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
     expect(find.text('3C'), findsWidgets);
   });
 
   testWidgets(
-      'a settings document written before #208 drills down as '
+      'a settings document written before #208 materializes as '
       '"Instituut Sancta Maria-A (ISMAA)", not inside out',
       (WidgetTester tester) async {
     // The stored document has the long name under `code` and the short code
     // under `name` — the layout every profile persisted before the fix carries.
     // Read back through the real `AppSettings.fromJson`, the migration must put
-    // each half right so the drill-down reads the way #204 specified instead of
-    // "ISMAA (Instituut Sancta Maria-A)".
+    // each half right so the materialized school reads the way #204 specified
+    // instead of "ISMAA (Instituut Sancta Maria-A)".
     useTallWindow(tester);
     final migrated = AppSettings.fromJson(<String, dynamic>{
       'wisaSchools': <Map<String, dynamic>>[
@@ -1035,10 +1043,16 @@ void main() {
 
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
+    // The label lives in the shared documents now that #210 took the school
+    // level out of the tree — it must be neither inverted nor the bare id, and
+    // it must not resurface as a node on screen.
+    expect(harness.controller.schoolRollups.single.label,
+        'Instituut Sancta Maria-A (ISMAA)');
     expect(find.text('ISMAA (Instituut Sancta Maria-A)'), findsNothing,
         reason: 'the inverted rendering #208 fixed must not come back');
     expect(find.text('School 25'), findsNothing);
-    expect(find.text('Instituut Sancta Maria-A (ISMAA)'), findsOneWidget);
+    expect(find.text('Instituut Sancta Maria-A (ISMAA)'), findsNothing,
+        reason: 'no school node survives in the student tree (#210)');
   });
 
   testWidgets(
@@ -1129,17 +1143,69 @@ void main() {
     // class-group records moved nobody.
     await tester.tap(find.byKey(const ValueKey('actions-groups-back')));
     await tester.pumpAndSettle();
-    final schoolNode = find.byKey(const ValueKey('rollup-school-school|99'));
-    await tester.ensureVisible(schoolNode);
-    await tester.tap(schoolNode);
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('rollup-grade-grade|99|1')));
+    // The merged first year spans both managed schools (#210), so the virtual
+    // school's 1V sits beside our own 1A under it.
+    final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
+    await tester.ensureVisible(yearNode);
+    await tester.tap(yearNode);
     await tester.pumpAndSettle();
     final classNode = find.byKey(const ValueKey('rollup-class-class|99|1|1V'));
     await tester.ensureVisible(classNode);
     await tester.tap(classNode);
     await tester.pumpAndSettle();
     expect(find.text('Jane Doe'), findsWidgets);
+  });
+
+  testWidgets(
+      'the Acties drill-down opens on grade-years merged across the managed '
+      'schools end-to-end, with no school level to guess at (#210)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. Two managed schools whose
+    // years overlap: school 1 holds 1A and 3C, school 2 holds 1B and the
+    // non-numeric OKAN. The WISA school split is administrative — operators
+    // treat both as one school — so the overview must open on the years, and a
+    // class must be findable by name without first guessing its school.
+    useTallWindow(tester);
+    final harness = twoSchoolHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(find.text('Jaar 1'), findsOneWidget);
+    expect(find.text('Jaar 3'), findsOneWidget);
+    expect(find.text('School 1'), findsNothing);
+    expect(find.text('School 2'), findsNothing);
+    // The synthetic non-numeric bucket is renamed rather than read as the
+    // nonsensical "Jaar Overig" next to the real years.
+    expect(find.text('Overige klassen'), findsOneWidget);
+    expect(find.text('Jaar Overig'), findsNothing);
+
+    // The merged first year carries both schools' first-year classes and their
+    // combined account count.
+    expect(harness.controller.studentRollups.first.accountCount, 2);
+    await tester.tap(find.text('Jaar 1'));
+    await tester.pumpAndSettle();
+    expect(find.text('1A'), findsOneWidget);
+    expect(find.text('1B'), findsOneWidget);
+
+    // Opening the school-2 class still targets school 2's own partition — the
+    // flattening is presentation only, the documents stay partitioned by school.
+    await tester.ensureVisible(find.text('1B'));
+    await tester.tap(find.text('1B'));
+    await tester.pumpAndSettle();
+    expect(harness.controller.selectedClassroom?.school, '2');
+    expect(harness.controller.classroomAccounts, hasLength(1));
+    expect(
+        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
   });
 
   testWidgets(
@@ -1173,10 +1239,9 @@ void main() {
         find.byKey(const ValueKey('actions-tab-leerlingen')), findsOneWidget);
     expect(find.byKey(const ValueKey('actions-tab-personeel')), findsOneWidget);
 
-    // Default Leerlingen tab: the student school node drills; the staff node
-    // does not appear here.
-    expect(
-        find.byKey(const ValueKey('rollup-school-school|1')), findsOneWidget);
+    // Default Leerlingen tab: the merged grade-year node drills (#210); the
+    // staff node does not appear here.
+    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
     expect(
         find.byKey(const ValueKey('rollup-school-school|staff')), findsNothing);
 
@@ -1184,7 +1249,7 @@ void main() {
     // is preserved within the tab, showing only staff.
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-school-school|1')), findsNothing);
+    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsNothing);
     final staffSchool =
         find.byKey(const ValueKey('rollup-school-school|staff'));
     expect(staffSchool, findsOneWidget);
@@ -1410,8 +1475,6 @@ void main() {
     // Browse the student on the Actions tab, drilling into her class (3C).
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('School 1'));
-    await tester.pumpAndSettle();
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
     await tester.ensureVisible(find.text('3C'));
@@ -1460,8 +1523,6 @@ void main() {
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Niet toegewezen'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Jaar Overig'));
     await tester.pumpAndSettle();
     await tester.ensureVisible(find.text('Zonder klas'));
     await tester.tap(find.text('Zonder klas'));
@@ -1586,16 +1647,17 @@ void main() {
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
     expect(find.text('Overzicht'), findsOneWidget);
-    expect(find.text('School 1'), findsOneWidget);
+    // The stored view projects to the same school-less tree a syncing session
+    // renders (#210).
+    expect(find.text('Jaar 3'), findsOneWidget);
+    expect(find.text('School 1'), findsNothing);
     expect(resumed.wisaSyncs, 0);
     expect(resumed.ssSyncs, 0);
     expect(resumed.azSyncs, 0);
     expect(resumed.controller.linked, isNull,
         reason: 'link() is never called in a passive session');
 
-    // Drill down: school → grade-year → classroom.
-    await tester.tap(find.text('School 1'));
-    await tester.pumpAndSettle();
+    // Drill down: grade-year → classroom.
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('3C'));
@@ -1896,8 +1958,6 @@ void main() {
     expect(resumed.controller.syncState.generation, 2,
         reason: 'the app caught up from the decoded wire signal alone');
     // Drill down to prove the refreshed rollups reached the UI: 3D now exists.
-    await tester.tap(find.text('School 1'));
-    await tester.pumpAndSettle();
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
     expect(find.text('3D'), findsOneWidget);
@@ -1977,8 +2037,6 @@ void main() {
 
     // Browse the create on the Actions tab, in the student's class.
     await tester.tap(find.text('Actions'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('School 1'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2357,6 +2357,103 @@ void main() {
   });
 
   testWidgets(
+      'a sync names the WISA-scholen grid end-to-end — no Scholen ophalen, no '
+      'Opslaan (#207)', (WidgetTester tester) async {
+    // The reported journey in the real app: the operator opens Instellingen →
+    // WISA and sees "School 25", because the stored document predates the
+    // profile's `code`/`name` fields and the grid consults no snapshot. One
+    // ordinary sync must be enough to fix that — the pull already loads every
+    // school. Both bootstraps share the one settings document, exactly as the
+    // real app's two Cosmos-backed stores do.
+    useTallWindow(tester);
+    final settings = SettingsHarness(
+      initial: AppSettings.fromJson(<String, dynamic>{
+        'wisa': const WisaConnection(server: 'db.school.example', port: '1433')
+            .toJson(),
+        // The legacy shape: a school id and a managed flag, nothing else.
+        'wisaSchools': <Map<String, dynamic>>[
+          <String, dynamic>{'schoolId': 25, 'ours': true},
+        ],
+      }),
+      // No fetcher is wired, so "Scholen ophalen" cannot run at all — whatever
+      // names the grid must have arrived without it.
+    );
+    final reconcile = ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(schoolId: 25)],
+        // Verbatim rows 11-12 of the redacted-from-live SMAGetInst fixture,
+        // through the real parser, so the halves are whatever WISA really says.
+        schools: <WisaSchool>[
+          parseSchoolRow('25,Instituut Sancta Maria-A,ISMAA'),
+          parseSchoolRow('27,Instituut Sancta Maria-B,ISMAB'),
+        ],
+      ),
+      smartschool: ssSnap(
+          groups: const [], accounts: [ssAccount()], memberships: const []),
+      azure: azSnap(users: [azUser()]),
+      ourSchoolIds: const {25},
+      settingsStore: settings.store,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: reconcile.bootstrap,
+      settingsBootstrap: settings.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // Before any sync: the bug, in the real grid.
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    final tile = find.byKey(const ValueKey('settings-wisa-school-25-ours'));
+    await tester.ensureVisible(tile);
+    await tester.pumpAndSettle();
+    String titleOf(Finder f) =>
+        (tester.widget<CheckboxListTile>(f).title! as Text).data!;
+    expect(titleOf(tile), 'School 25');
+    expect(tester.widget<CheckboxListTile>(tile).subtitle, isNull);
+    expect(
+      tester
+          .widget<OutlinedButton>(
+              find.byKey(const ValueKey('settings-wisa-fetch-schools')))
+          .onPressed,
+      isNull,
+      reason: 'no fetcher is wired: the names cannot come from this button',
+    );
+
+    // One ordinary sync on the Reconcile view.
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // Back to Settings and re-read the document — no Opslaan was ever pressed.
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-reload')));
+    await tester.tap(find.byKey(const ValueKey('settings-reload')));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(tile);
+    await tester.pumpAndSettle();
+    expect(titleOf(tile), 'Instituut Sancta Maria-A');
+    expect((tester.widget<CheckboxListTile>(tile).subtitle! as Text).data,
+        'ISMAA');
+    expect(find.text('School 25'), findsNothing);
+
+    // The repair landed in the document itself — and touched only the two
+    // derived halves: the managed mark is still the operator's, and the sync
+    // did not add the sibling school the pull also carried.
+    final saved = await settings.store.load();
+    expect(saved.wisaSchools.single.schoolId, 25);
+    expect(saved.wisaSchools.single.name, 'Instituut Sancta Maria-A');
+    expect(saved.wisaSchools.single.code, 'ISMAA');
+    expect(saved.wisaSchools.single.ours, isTrue);
+    expect(saved.wisaSchools.single.virtual, isFalse);
+  });
+
+  testWidgets(
       'the Settings/Algemeen werkdatum controls read clearly end-to-end: '
       'renamed virtual label + right-aligned switch instruction (#141)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1086,6 +1086,63 @@ void main() {
   });
 
   testWidgets(
+      'the Klasgroepen drill-down carries no class of a virtual school '
+      'end-to-end, while its students keep their place (#209)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. School 99 is the operator's
+    // "Virtuele school", ticked *both* beheerd and virtueel — which is why the
+    // managed-school filter of #205 never kept it out. Its classes used to
+    // reach the Klasgroepen list as an applyable "create this class in
+    // Smartschool" proposal (1V) and an empty-class notice (9V): rows nobody
+    // will ever act on, each one an invitation to create a defunct class.
+    useTallWindow(tester);
+    final harness = virtualClassGroupHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+
+    // Only our own class is on the list; neither virtual class is anywhere.
+    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
+    expect(find.byKey(const ValueKey('entry-group-1A')), findsOneWidget);
+    expect(find.byKey(const ValueKey('entry-group-1V')), findsNothing,
+        reason: 'creating a virtual school\'s class is never worth proposing');
+    expect(find.byKey(const ValueKey('entry-group-9V')), findsNothing,
+        reason: 'the empty-class notice for a virtual class is pure clutter');
+    expect(find.textContaining('Virtuele klas'), findsNothing);
+    expect(find.textContaining('Lege virtuele klas'), findsNothing);
+
+    // Back out of Klasgroepen: the virtual school's student is still imported
+    // and still sits in the class their own WISA record names — dropping the
+    // class-group records moved nobody.
+    await tester.tap(find.byKey(const ValueKey('actions-groups-back')));
+    await tester.pumpAndSettle();
+    final schoolNode = find.byKey(const ValueKey('rollup-school-school|99'));
+    await tester.ensureVisible(schoolNode);
+    await tester.tap(schoolNode);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('rollup-grade-grade|99|1')));
+    await tester.pumpAndSettle();
+    final classNode = find.byKey(const ValueKey('rollup-class-class|99|1|1V'));
+    await tester.ensureVisible(classNode);
+    await tester.tap(classNode);
+    await tester.pumpAndSettle();
+    expect(find.text('Jane Doe'), findsWidgets);
+  });
+
+  testWidgets(
       'the Actions view splits Personeel and Leerlingen into tabs end-to-end: '
       'staff drill in one tab, students in the other (#179)',
       (WidgetTester tester) async {

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -453,6 +453,10 @@ Future<ReconcileServices> bootstrapReconcile({
     // drill-down, so it reads "Instituut Sancta Maria-A (ISMAA)" exactly as the
     // Settings grid does rather than "School 25" (#204).
     schoolProfiles: settings.wisaSchools,
+    // …and every sync writes the names it pulled back into that same document
+    // (#207), so a profile stored before the two halves existed stops rendering
+    // as "School 25" in the Settings grid, which consults no snapshot.
+    settingsStore: store,
     publisher: signalPublisher,
     subscriber: signalSubscriber,
     clock: now,

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -274,6 +274,7 @@ class ReconcileController extends ChangeNotifier {
     required this.store,
     this.syncedBy = '',
     this.schoolProfiles = const <WisaSchoolProfile>[],
+    this.settingsStore,
     this.publisher,
     this.subscriber,
     this.persistTimeout = const Duration(minutes: 10),
@@ -308,6 +309,20 @@ class ReconcileController extends ChangeNotifier {
   /// filled the WISA-scholen grid in, which is when the label falls back to the
   /// snapshot and finally to `School <id>`.
   final List<WisaSchoolProfile> schoolProfiles;
+
+  /// Where [schoolProfiles] is persisted, so a WISA pull can repair the stored
+  /// profiles from the school list it just loaded (#207).
+  ///
+  /// Documents written before `code`/`name` existed on a profile (#171/#194)
+  /// carry a school id and an `ours` flag and nothing else, and the Settings
+  /// grid — which consults no snapshot — then renders them as `School 25`
+  /// forever, because the only writer of the two halves used to be the
+  /// **Scholen ophalen** button followed by **Opslaan**. Every sync already
+  /// pulls the full school list, so it can fill them in silently instead;
+  /// [_backfillSchoolProfiles] does, touching only those two fields. Null when
+  /// no store is wired (the in-memory harnesses), which simply skips the
+  /// repair.
+  final SettingsStore? settingsStore;
 
   /// Publishes a [ChangeSignal] when this session takes/releases the sync lease
   /// or writes a new view generation, so other operators are nudged in real time
@@ -1001,6 +1016,11 @@ class ReconcileController extends ChangeNotifier {
         'WISA sync done: ${fresh.students.length} students, '
         '${fresh.staff.length} staff, ${fresh.classGroups.length} classes.',
       );
+      // Repair the operator's stored school profiles from this pull (#207).
+      // Runs before the unchanged-since-last-sync shortcut below, so a session
+      // that has nothing to reconcile still heals a settings document whose
+      // schools have no names.
+      await _backfillSchoolProfiles(fresh.schools);
 
       if (previous != null &&
           _linked != null &&
@@ -1464,6 +1484,49 @@ class ReconcileController extends ChangeNotifier {
         profiles: schoolProfiles,
         schools: app.wisa.snapshot?.schools ?? const <wapi.WisaSchool>[],
       );
+
+  /// Writes the school names and codes this WISA pull carries back into the
+  /// stored profiles (#207), so the Settings grid names every school it lists
+  /// without the operator having to press **Scholen ophalen** and **Opslaan**.
+  ///
+  /// Strictly a repair of the two derived halves: no profile is added, removed
+  /// or reordered, and `ours` / `virtual` / `prefix` are never rewritten — the
+  /// operator's curation of *which* schools are listed and managed stays a
+  /// Settings-only decision. The document is re-read immediately before the
+  /// write so a change another operator saved during this pass is not clobbered
+  /// by this session's startup copy, and nothing is written when the pull adds
+  /// nothing new.
+  ///
+  /// A failing settings store must never fail the sync: the pull itself
+  /// succeeded and the labels are correct in memory (the drill-down merges the
+  /// snapshot), so the problem is logged and the pass continues.
+  Future<void> _backfillSchoolProfiles(List<wapi.WisaSchool> schools) async {
+    final store = settingsStore;
+    if (store == null || schools.isEmpty) return;
+    try {
+      final stored = await store.load();
+      final repaired = mergeWisaSchoolProfiles(
+        profiles: stored.wisaSchools,
+        schools: schools,
+      );
+      final healed = <int>[
+        for (var i = 0; i < repaired.length; i++)
+          if (repaired[i] != stored.wisaSchools[i]) repaired[i].schoolId,
+      ];
+      if (healed.isEmpty) return;
+      await store.save(stored.copyWith(wisaSchools: repaired));
+      log.addMessage(
+        core.Origin.wisa,
+        'Updated the name and code of ${healed.length} WISA school(s) in the '
+        'settings (id ${healed.join(', ')}).',
+      );
+    } on Object catch (e) {
+      log.addError(
+        core.Origin.wisa,
+        'Could not update the WISA school names in the settings: $e',
+      );
+    }
+  }
 
   void _begin(ReconcilePhase phase) {
     _phase = phase;

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -876,7 +876,10 @@ class ReconcileController extends ChangeNotifier {
   /// true after any session has synced, even without a pull this session.
   bool get hasOverview => _rollups.isNotEmpty;
 
-  /// The school-level rollups, alphabetical — the top of the drill-down.
+  /// The school-level rollups, alphabetical — the stored per-school aggregates.
+  /// They no longer render as nodes in the student drill-down (#210 flattened
+  /// that to grade-years), but they are what the per-category summaries and the
+  /// passive-session badge counts are summed from, so they stay materialized.
   List<Rollup> get schoolRollups {
     final schools = [
       for (final r in _rollups)
@@ -884,14 +887,6 @@ class ReconcileController extends ChangeNotifier {
     ]..sort((a, b) => a.label.compareTo(b.label));
     return schools;
   }
-
-  /// The student-school rollups — every school-level rollup **except** the
-  /// synthetic staff bucket — sorted alphabetically. The drill-down roots of the
-  /// Leerlingen tab (#179), which shows only the student action family.
-  List<Rollup> get studentSchoolRollups => [
-        for (final r in schoolRollups)
-          if (r.school != staffPartition) r,
-      ];
 
   /// The single synthetic staff ("Personeel") school rollup, or `null` when no
   /// staff account has been materialized — the drill-down root of the Personeel
@@ -903,8 +898,118 @@ class ReconcileController extends ChangeNotifier {
     return null;
   }
 
+  /// The synthetic "Niet toegewezen" school rollup — accounts with no class of
+  /// ours (a leaver, or a student of a school we do not manage who still owns
+  /// one of our accounts, #178) — or `null` when the bucket is empty.
+  Rollup? get unassignedRollup {
+    for (final r in _rollups) {
+      if (r.level == RollupLevel.school && r.school == unassignedPartition) {
+        return r;
+      }
+    }
+    return null;
+  }
+
+  /// The top-level nodes of the **student** drill-down (#210): one merged
+  /// grade-year node per year across *every* managed school, then the
+  /// "Niet toegewezen" bucket.
+  ///
+  /// The WISA school split is administrative, not operational — everyone running
+  /// this software treats the managed schools as one school — so the school level
+  /// carries no decision and is flattened away here. This is a **view**
+  /// projection: the stored rollups keep their school → grade-year → classroom
+  /// shape, which matters twice over. `school` is the Cosmos partition key of the
+  /// per-account documents, so a classroom node must keep its real school for
+  /// [openClassroom] to read exactly one partition; and [totalPendingCount],
+  /// [staffPendingCount], [studentPendingCount], [schoolRollups] and the
+  /// per-category summaries all aggregate over [RollupLevel.school], so a passive
+  /// session's badges keep reading from data that is still there.
+  ///
+  /// Ordering is pinned: Jaar 1 … Jaar 7 numerically, then the non-numeric years
+  /// ([gradeNodeLabel] renders those as "Overige klassen" — `OKAN` and friends
+  /// bucket into the materializer's synthetic `Overig`), then
+  /// "Niet toegewezen". The Klasgroepen node is appended by the screen, below
+  /// these.
+  List<Rollup> get studentRollups {
+    final tallies = <String, _GradeTally>{};
+    for (final r in _rollups) {
+      if (r.level != RollupLevel.gradeYear) continue;
+      if (r.school == staffPartition || r.school == unassignedPartition) {
+        continue;
+      }
+      (tallies[r.gradeYear] ??= _GradeTally())
+          .add(accounts: r.accountCount, pending: r.pendingCount);
+    }
+    final grades = <Rollup>[
+      for (final entry in tallies.entries)
+        Rollup(
+          level: RollupLevel.gradeYear,
+          key: _mergedGradeKey(entry.key),
+          parentKey: null,
+          // Merged across schools, so this node belongs to no single partition;
+          // only the classroom nodes beneath it carry a real one.
+          school: '',
+          label: gradeNodeLabel(entry.key),
+          gradeYear: entry.key,
+          classroom: '',
+          accountCount: entry.value.accounts,
+          pendingCount: entry.value.pending,
+        ),
+    ]..sort(_byGradeYear);
+    final unassigned = unassignedRollup;
+    return <Rollup>[...grades, if (unassigned != null) unassigned];
+  }
+
+  /// The classroom nodes under one [studentRollups] node (#210).
+  ///
+  /// A merged grade-year node collects that year's classrooms from **every**
+  /// managed school; "Niet toegewezen" skips its always-synthetic grade level and
+  /// lists its classrooms ("Zonder klas") directly. Every node returned is a real
+  /// stored classroom rollup, so it still carries the [Rollup.school] partition
+  /// [openClassroom] reads.
+  List<Rollup> studentChildrenOf(Rollup node) {
+    final bool unassigned = node.school == unassignedPartition;
+    final children = <Rollup>[
+      for (final r in _rollups)
+        if (r.level == RollupLevel.classroom &&
+            r.school != staffPartition &&
+            (unassigned
+                ? r.school == unassignedPartition
+                : r.school != unassignedPartition &&
+                    r.gradeYear == node.gradeYear))
+          r,
+    ]..sort((a, b) => a.label.compareTo(b.label));
+    return children;
+  }
+
+  /// The synthetic node key of the merged grade-year [gradeYear] — distinct from
+  /// any stored rollup key, which is always school-scoped (#210).
+  static String _mergedGradeKey(String gradeYear) => 'grades|$gradeYear';
+
+  /// How a grade-year node is named: `Jaar 3` for a real year, and
+  /// "Overige klassen" for the materializer's synthetic non-numeric bucket
+  /// (`OKAN` and friends), which as a top-level node would otherwise read as the
+  /// nonsensical "Jaar Overig" (#210).
+  static String gradeNodeLabel(String gradeYear) =>
+      int.tryParse(gradeYear) == null ? _otherGradesLabel : 'Jaar $gradeYear';
+
+  static const String _otherGradesLabel = 'Overige klassen';
+
+  /// Pins the top-level order: numeric years ascending, then the non-numeric
+  /// ones by label, so the accordion never reshuffles between syncs.
+  static int _byGradeYear(Rollup a, Rollup b) {
+    final na = int.tryParse(a.gradeYear);
+    final nb = int.tryParse(b.gradeYear);
+    if (na != null && nb != null) return na.compareTo(nb);
+    if (na != null) return -1;
+    if (nb != null) return 1;
+    return a.label.compareTo(b.label);
+  }
+
   /// The rollup nodes directly under [parentKey] (grade-years of a school, or
-  /// classrooms of a grade-year), alphabetical.
+  /// classrooms of a grade-year), alphabetical. The stored parent/child shape —
+  /// what the Personeel tab drills; the student tree flattens it away through
+  /// [studentRollups] / [studentChildrenOf] (#210).
   List<Rollup> childrenOf(String parentKey) {
     final children = [
       for (final r in _rollups)
@@ -1736,5 +1841,18 @@ class ReconcileController extends ChangeNotifier {
   static String? _nonEmpty(String s) {
     final trimmed = s.trim();
     return trimmed.isEmpty ? null : trimmed;
+  }
+}
+
+/// Accumulator for one merged grade-year node of
+/// [ReconcileController.studentRollups] (#210): the summed account and pending
+/// counts of that year across every managed school.
+class _GradeTally {
+  int accounts = 0;
+  int pending = 0;
+
+  void add({required int accounts, required int pending}) {
+    this.accounts += accounts;
+    this.pending += pending;
   }
 }

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:account_actions/account_actions.dart' as actions;
 import 'package:account_state/account_state.dart'
-    show MaterializedAccount, MaterializedGroup, Rollup;
+    show MaterializedAccount, MaterializedGroup, Rollup, RollupLevel;
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
@@ -14,10 +14,12 @@ import '../reconcile/reconcile_controller.dart';
 /// Reconcile screen so a September changeover's hundreds/thousands of tiles no
 /// longer render inline on one very long page.
 ///
-/// Instead of one flat list, actions are browsed through the school →
-/// grade-year → classroom rollup drill-down (#119): the tree loads only the
-/// aggregate counts, and one classroom's actions are lazily loaded (via
-/// `LinkedStore.readClassroom`) and built only when the operator drills into it.
+/// Instead of one flat list, actions are browsed through the rollup drill-down
+/// (#119) — grade-year → classroom for students since #210 dropped the
+/// administrative school level, school → grade-year → classroom for staff: the
+/// tree loads only the aggregate counts, and one classroom's actions are lazily
+/// loaded (via `LinkedStore.readClassroom`) and built only when the operator
+/// drills into it.
 /// The per-class list itself renders through a lazy [SliverList] so only the
 /// on-screen tiles build. The global "Dry-run all" / "Apply all" act on every
 /// pending entry across all classes.
@@ -283,21 +285,34 @@ class _ActionsBodyState extends State<_ActionsBody>
       slivers.addAll(_groupSlivers(context));
     } else if (controller.hasOverview) {
       // Partition the drill-down by family: the Personeel tab shows only the
-      // synthetic staff school node; the Leerlingen tab shows the student
-      // schools plus the class-groups node (class groups are student-oriented).
+      // synthetic staff school node (school → grade → classroom, unchanged); the
+      // Leerlingen tab opens straight on the merged grade-years plus the
+      // class-groups node (class groups are student-oriented).
       final staffRollup = controller.staffSchoolRollup;
       slivers.add(_section(staffTab
           ? _DrillDownSection(
               controller: controller,
-              schools: <Rollup>[if (staffRollup != null) staffRollup],
+              roots: <Rollup>[if (staffRollup != null) staffRollup],
               groups: null,
               emptyLabel: 'Geen openstaande personeelsacties.',
+              childrenOf: (root) => <Widget>[
+                for (final grade in controller.childrenOf(root.key))
+                  _GradeNode(controller: controller, grade: grade),
+              ],
             )
           : _DrillDownSection(
               controller: controller,
-              schools: controller.studentSchoolRollups,
+              roots: controller.studentRollups,
               groups: controller.groupRollup,
               emptyLabel: 'Nog geen gematerialiseerd overzicht.',
+              childrenOf: (root) => <Widget>[
+                for (final classroom in controller.studentChildrenOf(root))
+                  _ClassroomTile(
+                    controller: controller,
+                    classroom: classroom,
+                    indent: PlinkSpacing.s5,
+                  ),
+              ],
             )));
     } else {
       slivers.add(_section(_EmptyState(controller: controller)));
@@ -667,25 +682,46 @@ Future<void> _confirmAndApply(
   if (confirmed ?? false) await apply();
 }
 
-/// The materialized overview (#115/#119): the school → grade-year → classroom
-/// drill-down driven by the stored rollups, so it renders from the shared state
-/// even in a passive session that never pulled or re-linked. Tapping a classroom
-/// (or the Klasgroepen node) lazily loads just that node's actions (#154).
+/// The stable widget key of one rollup node, by level — so a test (and the
+/// element tree) names a node the same way wherever it is rendered.
+String _rollupNodeKey(Rollup r) => switch (r.level) {
+      RollupLevel.school => 'rollup-school-${r.key}',
+      RollupLevel.gradeYear => 'rollup-grade-${r.key}',
+      RollupLevel.classroom => 'rollup-class-${r.key}',
+      RollupLevel.groups => 'rollup-groups',
+    };
+
+/// The materialized overview (#115/#119): the drill-down driven by the stored
+/// rollups, so it renders from the shared state even in a passive session that
+/// never pulled or re-linked. Tapping a classroom (or the Klasgroepen node)
+/// lazily loads just that node's actions (#154).
+///
+/// The tree is two levels deep on the Leerlingen tab (#210): merged grade-year →
+/// classroom, with no school node — the WISA school split is administrative, so
+/// drilling through it never presented a choice. The Personeel tab keeps its
+/// stored school → grade-year → classroom shape; both are driven from the very
+/// same rollups, only projected differently by [childrenOf].
 class _DrillDownSection extends StatelessWidget {
   const _DrillDownSection({
     required this.controller,
-    required this.schools,
+    required this.roots,
     required this.groups,
     required this.emptyLabel,
+    required this.childrenOf,
   });
 
   final ReconcileController controller;
 
-  /// The school-level rollup roots to render — student schools for the
-  /// Leerlingen tab, the single staff node for the Personeel tab (#179).
-  final List<Rollup> schools;
+  /// The top-level accordion nodes: the merged grade-years plus
+  /// "Niet toegewezen" on the Leerlingen tab, the single staff school node on
+  /// the Personeel tab (#179/#210).
+  final List<Rollup> roots;
 
-  /// The "Klasgroepen" rollup node to append below [schools], or `null` when
+  /// Builds the expanded children of one root — classroom tiles under a merged
+  /// grade-year, the nested grade nodes under the staff school.
+  final List<Widget> Function(Rollup root) childrenOf;
+
+  /// The "Klasgroepen" rollup node to append below [roots], or `null` when
   /// this tab carries no group family (the Personeel tab).
   final Rollup? groups;
 
@@ -721,10 +757,10 @@ class _DrillDownSection extends StatelessWidget {
           Text(freshness, style: text.bodySmall),
         ],
         const SizedBox(height: PlinkSpacing.s3),
-        if (schools.isEmpty && groupsNode == null)
+        if (roots.isEmpty && groupsNode == null)
           Text(emptyLabel, style: text.bodyMedium)
         else ...<Widget>[
-          for (final school in schools)
+          for (final root in roots)
             Container(
               margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
               decoration: BoxDecoration(
@@ -733,15 +769,12 @@ class _DrillDownSection extends StatelessWidget {
                     const BorderRadius.all(Radius.circular(PlinkRadius.base)),
               ),
               child: ExpansionTile(
-                key: ValueKey('rollup-school-${school.key}'),
+                key: ValueKey(_rollupNodeKey(root)),
                 shape: const Border(),
                 collapsedShape: const Border(),
-                title: Text(school.label, style: text.bodyLarge),
-                trailing: _PendingBadge(count: school.pendingCount),
-                children: <Widget>[
-                  for (final grade in controller.childrenOf(school.key))
-                    _GradeNode(controller: controller, grade: grade),
-                ],
+                title: Text(root.label, style: text.bodyLarge),
+                trailing: _PendingBadge(count: root.pendingCount),
+                children: childrenOf(root),
               ),
             ),
           if (groupsNode != null)
@@ -767,6 +800,10 @@ class _DrillDownSection extends StatelessWidget {
   }
 }
 
+/// A nested grade-year node inside a school node — the middle level of the
+/// Personeel tab's stored tree, which #210 left as it was. The student tree has
+/// no school to nest under, so its grade-years are [_DrillDownSection] roots and
+/// carry their "Jaar N" label from [ReconcileController.gradeNodeLabel] instead.
 class _GradeNode extends StatelessWidget {
   const _GradeNode({required this.controller, required this.grade});
 
@@ -777,7 +814,7 @@ class _GradeNode extends StatelessWidget {
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     return ExpansionTile(
-      key: ValueKey('rollup-grade-${grade.key}'),
+      key: ValueKey(_rollupNodeKey(grade)),
       shape: const Border(),
       collapsedShape: const Border(),
       tilePadding: const EdgeInsets.only(left: PlinkSpacing.s5, right: 16),
@@ -785,17 +822,42 @@ class _GradeNode extends StatelessWidget {
       trailing: _PendingBadge(count: grade.pendingCount),
       children: <Widget>[
         for (final classroom in controller.childrenOf(grade.key))
-          ListTile(
-            key: ValueKey('rollup-class-${classroom.key}'),
-            contentPadding:
-                const EdgeInsets.only(left: PlinkSpacing.s6, right: 16),
-            title: Text(classroom.label, style: text.bodyMedium),
-            subtitle: Text('${classroom.accountCount} account(s)',
-                style: text.bodySmall),
-            trailing: _PendingBadge(count: classroom.pendingCount),
-            onTap: () => controller.openClassroom(classroom),
+          _ClassroomTile(
+            controller: controller,
+            classroom: classroom,
+            indent: PlinkSpacing.s6,
           ),
       ],
+    );
+  }
+}
+
+/// A leaf classroom node: tapping it opens that class's accounts, which reads
+/// exactly one Cosmos partition ([Rollup.school]). Indented to whatever depth the
+/// enclosing tree puts it at — one level under a merged grade-year on the
+/// Leerlingen tab, two under school → grade-year on the Personeel tab.
+class _ClassroomTile extends StatelessWidget {
+  const _ClassroomTile({
+    required this.controller,
+    required this.classroom,
+    required this.indent,
+  });
+
+  final ReconcileController controller;
+  final Rollup classroom;
+  final double indent;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    return ListTile(
+      key: ValueKey(_rollupNodeKey(classroom)),
+      contentPadding: EdgeInsets.only(left: indent, right: 16),
+      title: Text(classroom.label, style: text.bodyMedium),
+      subtitle:
+          Text('${classroom.accountCount} account(s)', style: text.bodySmall),
+      trailing: _PendingBadge(count: classroom.pendingCount),
+      onTap: () => controller.openClassroom(classroom),
     );
   }
 }

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -308,9 +308,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
   /// fetched id+name records into [_wisaSchools], updating each name, adding any
   /// genuinely new school (unmanaged by default), and preserving the `ours` and
   /// `virtual` marks on schools already known. Prefers a freshly typed password;
-  /// otherwise resolves the stored secret. Failures surface as a toast. The
-  /// merged list is dirty until saved, so the enriched names persist and no
-  /// re-fetch is needed.
+  /// otherwise resolves the stored secret. Failures surface as a toast.
+  ///
+  /// The merged list stays **dirty until Opslaan**, deliberately (#207): a fetch
+  /// adds schools to the operator's curated list, and the working copy it merges
+  /// into may already hold unsaved `ours`/`virtual` edits — persisting behind
+  /// their back would commit those too and take away the reload escape hatch.
+  /// What used to make that a trap was that the names arrived here and nowhere
+  /// else; every sync now writes the two derived halves back into the document
+  /// on its own, so the grid names its schools whether or not this button was
+  /// ever pressed.
   Future<void> _fetchWisaSchools() async {
     final services = _services;
     final fetcher = services?.fetchWisaSchools;
@@ -347,26 +354,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
   /// neither managed nor virtual. Order is stable by school id so the grid does
   /// not jump.
   ///
-  /// Both halves come straight across: the connector already untangled WISA's
-  /// inverted `NAME`/`DESCRIPTION` columns, so `WisaSchool.name` is the long
-  /// name and `WisaSchool.code` the short code (#208).
-  List<WisaSchoolProfile> _mergeFetchedSchools(List<WisaSchool> fetched) {
-    final byId = <int, WisaSchoolProfile>{
-      for (final p in _wisaSchools) p.schoolId: p,
-    };
-    for (final s in fetched) {
-      final existing = byId[s.id];
-      byId[s.id] = existing == null
-          ? WisaSchoolProfile(schoolId: s.id, code: s.code, name: s.name)
-          : existing.copyWith(
-              code: s.code.isEmpty ? existing.code : s.code,
-              name: s.name.isEmpty ? existing.name : s.name,
-            );
-    }
-    final merged = byId.values.toList()
-      ..sort((a, b) => a.schoolId.compareTo(b.schoolId));
-    return merged;
-  }
+  /// The merge rule itself lives in [mergeWisaSchoolProfiles], shared with the
+  /// repair every sync runs against the stored profiles (#207), so the button
+  /// and the silent backfill can never disagree about what a pull may overwrite.
+  List<WisaSchoolProfile> _mergeFetchedSchools(List<WisaSchool> fetched) =>
+      mergeWisaSchoolProfiles(
+        profiles: _wisaSchools,
+        schools: fetched,
+        addUnknown: true,
+      )..sort((a, b) => a.schoolId.compareTo(b.schoolId));
 
   /// Assembles an [AppSettings] from the form, preserving the loaded document's
   /// secret refs and its (read-only) WISA import rules.

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -17,6 +17,34 @@ class _ThrowingPublisher implements SignalPublisher {
       throw StateError('signalr down');
 }
 
+/// An [InMemorySettingsStore] that counts its writes — so a test can prove the
+/// sync-time school backfill (#207) writes only when it has something to fix.
+class _RecordingSettingsStore extends InMemorySettingsStore {
+  _RecordingSettingsStore(super.initial);
+
+  int saves = 0;
+
+  @override
+  Future<void> save(AppSettings settings) {
+    saves++;
+    return super.save(settings);
+  }
+}
+
+/// A settings store whose every read throws — models the store being down while
+/// a sync tries to repair the school profiles (#207).
+class _ThrowingSettingsStore implements SettingsStore {
+  const _ThrowingSettingsStore(this.error);
+
+  final String error;
+
+  @override
+  Future<AppSettings> load() async => throw StateError(error);
+
+  @override
+  Future<void> save(AppSettings settings) async {}
+}
+
 void main() {
   group('first sync', () {
     test('pulls all three systems and derives the linked view + actions',
@@ -199,6 +227,104 @@ void main() {
       expect(h.azSyncs, 2);
       expect(h.wisaSyncs, 1, reason: 'drift check does not re-pull WISA');
       expect(h.controller.linked, isNotNull);
+    });
+  });
+
+  group('settings school-profile backfill (#207)', () {
+    // The reported settings document: entries written before a profile had a
+    // `code`/`name` at all (#171/#194), so the Settings grid — the one view
+    // that consults no snapshot — rendered "School 25" until the operator
+    // pressed Scholen ophalen *and* Opslaan. Every sync already pulls the whole
+    // school list, so it repairs them.
+    const legacy = AppSettings(
+      wisaSchools: <WisaSchoolProfile>[
+        WisaSchoolProfile(schoolId: 25, ours: true),
+        WisaSchoolProfile(schoolId: 27, virtual: true),
+      ],
+    );
+    const pulled = <wapi.WisaSchool>[
+      wapi.WisaSchool(id: 25, name: 'Instituut Sancta Maria-A', code: 'ISMAA'),
+      wapi.WisaSchool(id: 27, name: 'Instituut Sancta Maria-B', code: 'ISMAB'),
+    ];
+
+    test('a sync fills the pulled names and codes into the stored profiles',
+        () async {
+      final settings = InMemorySettingsStore(legacy);
+      final h = ReconcileHarness(
+        wisa: wisaSnap(schools: pulled),
+        settingsStore: settings,
+      );
+
+      await h.controller.sync();
+
+      final saved = await settings.load();
+      expect(
+        saved.wisaSchools.map((p) => p.name),
+        ['Instituut Sancta Maria-A', 'Instituut Sancta Maria-B'],
+      );
+      expect(saved.wisaSchools.map((p) => p.code), ['ISMAA', 'ISMAB']);
+      expect(saved.wisaSchools.first.ours, isTrue,
+          reason: 'the managed mark is the operator\'s, never rewritten');
+      expect(saved.wisaSchools.last.virtual, isTrue);
+      expect(h.log.entries.where((e) => e.isError), isEmpty);
+    });
+
+    test('the unchanged-WISA shortcut still repairs the document', () async {
+      // The repair runs before the smart-diff early return, so an operator
+      // whose group has nothing to reconcile still gets named schools.
+      final settings = InMemorySettingsStore(legacy);
+      final h = ReconcileHarness(
+        wisa: wisaSnap(schools: pulled),
+        settingsStore: settings,
+      );
+      await h.controller.sync();
+      // Model the pre-fix document coming back (another operator saved over it)
+      // and re-sync with identical WISA content.
+      await settings.save(legacy);
+
+      await h.controller.sync();
+
+      expect(h.controller.noChangesNeeded, isTrue);
+      final saved = await settings.load();
+      expect(saved.wisaSchools.first.name, 'Instituut Sancta Maria-A');
+    });
+
+    test('nothing is written when every profile is already named', () async {
+      final settings = _RecordingSettingsStore(const AppSettings(
+        wisaSchools: <WisaSchoolProfile>[
+          WisaSchoolProfile(
+            schoolId: 25,
+            code: 'ISMAA',
+            name: 'Instituut Sancta Maria-A',
+            ours: true,
+          ),
+        ],
+      ));
+      final h = ReconcileHarness(
+        wisa: wisaSnap(schools: pulled),
+        settingsStore: settings,
+      );
+
+      await h.controller.sync();
+
+      expect(settings.saves, 0,
+          reason: 'a sync must not rewrite the settings document for nothing');
+    });
+
+    test('a failing settings store is logged, never fails the sync', () async {
+      final h = ReconcileHarness(
+        wisa: wisaSnap(schools: pulled),
+        settingsStore: const _ThrowingSettingsStore('cosmos 503'),
+      );
+
+      await h.controller.sync();
+
+      expect(h.controller.error, isNull);
+      expect(h.controller.linked, isNotNull);
+      expect(
+        h.log.entries.where((e) => e.isError).map((e) => e.message),
+        contains(contains('cosmos 503')),
+      );
     });
   });
 

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -758,6 +758,133 @@ void main() {
     });
   });
 
+  group('school-less student drill-down (#210)', () {
+    test(
+        'the top level is the grade-years merged across every managed school, '
+        'with combined counts and no school node', () async {
+      final h = twoSchoolHarness();
+      await h.controller.sync();
+
+      // School 1 holds 1A + 3C, school 2 holds 1B + OKAN. The overview merges
+      // the years: one "Jaar 1" spanning both schools' first years.
+      expect(
+        h.controller.studentRollups.map((r) => r.label),
+        <String>['Jaar 1', 'Jaar 3', 'Overige klassen'],
+        reason: 'ordering is pinned: years ascending, then the non-numeric one',
+      );
+      final jaar1 = h.controller.studentRollups.first;
+      expect(jaar1.accountCount, 2, reason: "school 1's 1A plus school 2's 1B");
+      expect(jaar1.pendingCount, greaterThan(0));
+
+      // The school level is gone from the view — and never had a node label of
+      // its own to fall back on.
+      expect(
+        h.controller.studentRollups.map((r) => r.level),
+        everyElement(isNot(RollupLevel.school)),
+      );
+      expect(h.controller.studentRollups.map((r) => r.label),
+          isNot(contains('School 1')));
+
+      // …but the stored rollups keep it, so the aggregates that count by
+      // RollupLevel.school (the badges, the category summaries) still have data.
+      expect(h.controller.schoolRollups.map((r) => r.label),
+          containsAll(<String>['School 1', 'School 2']));
+      expect(h.controller.studentSummary.total, 4);
+    });
+
+    test(
+        'a merged year lists both schools\' classrooms, each keeping its own '
+        'partition so the drill-down still reads one partition', () async {
+      final h = twoSchoolHarness();
+      await h.controller.sync();
+
+      final jaar1 =
+          h.controller.studentRollups.firstWhere((r) => r.label == 'Jaar 1');
+      final classes = h.controller.studentChildrenOf(jaar1);
+      expect(classes.map((r) => r.label), <String>['1A', '1B']);
+      // The partition key of each class is its real school — what
+      // `readClassroom(partitionKey: school)` targets.
+      expect(classes.map((r) => r.school), <String>['1', '2']);
+
+      // Opening one reads exactly that school's partition.
+      await h.controller.openClassroom(classes.last);
+      expect(h.controller.classroomAccounts, hasLength(1));
+      expect(h.controller.classroomAccounts!.single.school, '2');
+    });
+
+    test('a non-numeric class group is never labelled "Jaar Overig"', () async {
+      final h = twoSchoolHarness();
+      await h.controller.sync();
+
+      final other = h.controller.studentRollups.last;
+      expect(other.label, 'Overige klassen');
+      expect(other.gradeYear, 'Overig');
+      expect(
+        h.controller.studentChildrenOf(other).map((r) => r.label),
+        <String>['OKAN'],
+      );
+    });
+
+    test('"Niet toegewezen" expands straight to its classrooms', () async {
+      // Three WISA-departed accounts: all land in the unassigned bucket, whose
+      // grade level is always the synthetic "Overig" and carries no decision.
+      final h = manyDepartedHarness(count: 3);
+      await h.controller.sync();
+
+      final roots = h.controller.studentRollups;
+      expect(roots.map((r) => r.label), <String>['Niet toegewezen'],
+          reason: 'no year node for a bucket that has no real year');
+      final children = h.controller.studentChildrenOf(roots.single);
+      expect(children.map((r) => r.label), <String>['Zonder klas']);
+      expect(children.single.level, RollupLevel.classroom,
+          reason: 'the always-empty grade level is skipped');
+      expect(children.single.accountCount, 3);
+    });
+
+    test(
+        'a passive session projects the same tree from the stored view, with '
+        'its badges and header count untouched', () async {
+      final snapshots = InMemorySnapshotStore();
+      final linkedStore = InMemoryLinkedStore();
+      final s1 = twoSchoolHarness();
+      // Materialize through a first session, then read it back passively.
+      final active = ReconcileHarness(
+        store: snapshots,
+        linkedStore: linkedStore,
+        wisa: s1.wisaResult,
+        smartschool: s1.ssResult,
+        azure: s1.azResult,
+        ourSchoolIds: const {1, 2},
+      );
+      await active.controller.sync();
+
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      await s2.controller.loadOverview();
+
+      expect(s2.controller.linked, isNull, reason: 'passive: never linked');
+      expect(
+        s2.controller.studentRollups.map((r) => r.label),
+        active.controller.studentRollups.map((r) => r.label),
+      );
+      expect(
+        s2.controller.studentRollups.map((r) => r.accountCount),
+        active.controller.studentRollups.map((r) => r.accountCount),
+      );
+      // The counters read from RollupLevel.school rollups, which the view
+      // projection deliberately left in the store.
+      expect(
+          s2.controller.totalPendingCount, active.controller.totalPendingCount);
+      expect(s2.controller.studentPendingCount,
+          active.controller.studentPendingCount);
+      expect(
+          s2.controller.staffPendingCount, active.controller.staffPendingCount);
+      expect(s2.controller.totalPendingCount, greaterThan(0));
+    });
+  });
+
   group('materialized group actions (#119)', () {
     test('a sync materializes group docs + a group rollup', () async {
       // The fixture's two Smartschool-only classes (2B, 3C) raise the

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -449,6 +449,32 @@ ReconcileHarness managedSchoolsHarness({required Set<int> ourSchoolIds}) =>
       ourSchoolIds: ourSchoolIds,
     );
 
+/// A harness for the school-less Actions drill-down (#210). Two managed schools
+/// (1 and 2) each hold students, and their years overlap: school 1 has `1A` and
+/// `3C`, school 2 has `1B` and the non-numeric `OKAN`. So a correct overview
+/// shows one **merged** "Jaar 1" holding both schools' first years with combined
+/// counts, a "Jaar 3", and a single non-numeric bucket — and no school node
+/// anywhere, while each classroom keeps the school partition its accounts are
+/// stored under.
+ReconcileHarness twoSchoolHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(wisaId: '1', classGroup: '1A'),
+          wisaStudent(wisaId: '2', classGroup: '3C'),
+          wisaStudent(wisaId: '3', classGroup: '1B', schoolId: 2),
+          wisaStudent(wisaId: '4', classGroup: 'OKAN', schoolId: 2),
+        ],
+        schools: [wisaSchool(1), wisaSchool(2)],
+      ),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+      ourSchoolIds: const {1, 2},
+    );
+
 /// A harness for the managed-school class-group scope (#205). WISA hands the
 /// session class groups from two schools, and the sibling school's arrive
 /// *first* in the pull: `1A` and `9Z` of school 2 (which we do not manage),

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -926,6 +926,7 @@ class ReconcileHarness {
     this.syncedBy = 'operator@school.example',
     Set<int>? ourSchoolIds,
     List<WisaSchoolProfile> schoolProfiles = const <WisaSchoolProfile>[],
+    this.settingsStore,
   })  : wisaResult = (wisa ?? wisaSnap()),
         ssResult = (smartschool ?? ssSnap()),
         azResult = (azure ?? azSnap()),
@@ -1044,8 +1045,10 @@ class ReconcileHarness {
       store: controllerStore ?? this.linkedStore,
       syncedBy: syncedBy,
       // The operator's curated WISA schools from Settings, which name every
-      // school in the Actions drill-down (#204).
+      // school in the Actions drill-down (#204), and the document they live in
+      // so a pull can fill their names back in (#207).
       schoolProfiles: schoolProfiles,
+      settingsStore: settingsStore,
       publisher: publisher ?? signalHub?.publisher(),
       subscriber: subscriber ?? signalHub?.subscriber(),
       persistTimeout: persistTimeout ?? const Duration(minutes: 10),
@@ -1071,6 +1074,13 @@ class ReconcileHarness {
   /// The shared cold-snapshot store, when this harness models the persistence
   /// wiring (#107). `null` for the plain in-memory scenarios.
   final SnapshotStore? store;
+
+  /// The settings document this session's pulls repair the WISA school profiles
+  /// in (#207). Share the one [InMemorySettingsStore] with a `SettingsHarness`
+  /// to model what the real app does — both bootstraps read and write the same
+  /// Cosmos document — so a test can sync and then open Settings on the result.
+  /// `null` for the scenarios that do not care about settings persistence.
+  final SettingsStore? settingsStore;
 
   /// The shared realtime fan-out (#116): when set, this session's controller
   /// publishes change signals to it and subscribes for others'. Share one hub

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -139,9 +139,17 @@ wapi.WisaStudent wisaStudent({
     );
 
 /// A WISA school, optionally flagged [ours] (the managed-school signal the
-/// linker joins student `schoolId` against, #133/#134).
-wapi.WisaSchool wisaSchool(int id, {bool ours = false}) =>
-    wapi.WisaSchool(id: id, name: 'School $id', code: '', isOurs: ours);
+/// linker joins student `schoolId` against, #133/#134) and/or [virtual] (the
+/// flag `markVirtualSchools` stamps before the pull, whose class groups the
+/// linker refuses to seed, #209).
+wapi.WisaSchool wisaSchool(int id, {bool ours = false, bool virtual = false}) =>
+    wapi.WisaSchool(
+      id: id,
+      name: 'School $id',
+      code: '',
+      isOurs: ours,
+      isVirtual: virtual,
+    );
 
 /// A WISA class group. [name] is the `fullName` the linker matches on;
 /// [schoolId] decides whether the class belongs to a school we manage — a
@@ -484,6 +492,57 @@ ReconcileHarness foreignClassGroupHarness() => ReconcileHarness(
       ),
       azure: azSnap(users: const []),
       ourSchoolIds: const {1},
+    );
+
+/// A harness for the virtual-school class-group exclusion (#209). Two managed
+/// schools: our own school 1, and school 99 — the "Virtuele school" — which the
+/// operator marks **both** beheerd and virtueel, exactly as the real config
+/// does. That is why the #205 ownership filter alone never kept its classes out.
+///
+/// The virtual school contributes a populated class (`1V`, holding its own
+/// student) and an empty one (`9V`), so before the fix the Klasgroepen list
+/// carried an applyable "create this class in Smartschool" proposal *and* the
+/// empty-class notice for classes nobody will ever use. Our own `1A` is
+/// populated and must survive untouched, and the virtual school's student must
+/// keep flowing and stay placed by their own `classGroup` string.
+ReconcileHarness virtualClassGroupHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(wisaId: '1', classGroup: '1A'),
+          wisaStudent(wisaId: '2', classGroup: '1V', schoolId: 99),
+        ],
+        schools: [
+          wisaSchool(1, ours: true),
+          wisaSchool(99, ours: true, virtual: true),
+        ],
+        classGroups: [
+          wisaClassGroup(
+            '1V',
+            description: 'Virtuele klas',
+            schoolCode: '999',
+            schoolId: 99,
+          ),
+          wisaClassGroup(
+            '9V',
+            description: 'Lege virtuele klas',
+            schoolCode: '999',
+            schoolId: 99,
+          ),
+          wisaClassGroup(
+            '1A',
+            description: 'Onze eerste klas',
+            schoolCode: '111',
+            schoolId: 1,
+          ),
+        ],
+      ),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+      ourSchoolIds: const {1, 99},
     );
 
 /// A harness for the school-label drill-down (#204). One student enrolled in

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -16,16 +16,15 @@ void _useTallWindow(WidgetTester tester) {
   addTearDown(tester.view.reset);
 }
 
-/// Drills school → grade → classroom in the rollup tree.
+/// Drills a Leerlingen top-level node — a merged "Jaar N" or the
+/// "Niet toegewezen" bucket — straight into one of its classrooms. #210 dropped
+/// the school level, so exactly one accordion sits above the class.
 Future<void> _drill(
   WidgetTester tester, {
-  required String school,
-  required String grade,
+  required String node,
   required String classroom,
 }) async {
-  await tester.tap(find.text(school));
-  await tester.pumpAndSettle();
-  await tester.tap(find.text('Jaar $grade'));
+  await tester.tap(find.text(node));
   await tester.pumpAndSettle();
   await tester.ensureVisible(find.text(classroom));
   await tester.tap(find.text(classroom));
@@ -54,17 +53,19 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    // The rollup tree is the browser; the flat list is gone. No classroom is
-    // loaded until the operator drills into one.
+    // The rollup tree is the browser; the flat list is gone. The top of it is
+    // the grade-year, never the school (#210). No classroom is loaded until the
+    // operator drills into one.
     expect(find.text('Overzicht'), findsOneWidget);
-    expect(find.text('School 1'), findsOneWidget);
+    expect(find.text('Jaar 3'), findsOneWidget);
+    expect(find.text('School 1'), findsNothing);
     expect(harness.controller.selectedClassroom, isNull);
     expect(harness.controller.classroomAccounts, isNull);
     expect(find.byKey(const ValueKey('actions-classroom-back')), findsNothing);
 
     // Drill in: only the 3C classroom's accounts load (via readClassroom), and
     // that class's pending action tile builds.
-    await _drill(tester, school: 'School 1', grade: '3', classroom: '3C');
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
     expect(harness.controller.selectedClassroom?.classroom, '3C');
     expect(harness.controller.classroomAccounts, hasLength(1));
     expect(
@@ -74,7 +75,7 @@ void main() {
     // Back to the overview tree.
     await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
     await tester.pumpAndSettle();
-    expect(find.text('School 1'), findsOneWidget);
+    expect(find.text('Jaar 3'), findsOneWidget);
   });
 
   testWidgets(
@@ -123,8 +124,8 @@ void main() {
 
   /// A WISA-departed scenario: [count] Smartschool-only active accounts (no
   /// WISA, no Azure), each raising the mutually-exclusive unregister/delete
-  /// choice (#110). They land in the "Niet toegewezen" → "Overig" → "Zonder
-  /// klas" bucket.
+  /// choice (#110). They land in the "Niet toegewezen" → "Zonder klas" bucket
+  /// (#210 collapsed its always-synthetic grade level away).
   ReconcileHarness departedHarness({int count = 1}) => ReconcileHarness(
         wisa: wisaSnap(students: const []),
         smartschool: ssSnap(
@@ -152,8 +153,7 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await _drill(tester,
-        school: 'Niet toegewezen', grade: 'Overig', classroom: 'Zonder klas');
+    await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
 
     final entry = harness.controller.pendingEntries
         .firstWhere((e) => e.family == 'student');
@@ -198,8 +198,7 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await _drill(tester,
-        school: 'Niet toegewezen', grade: 'Overig', classroom: 'Zonder klas');
+    await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
 
     expect(
         find.textContaining('accounts in the same situation'), findsOneWidget);
@@ -229,8 +228,7 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await _drill(tester,
-        school: 'Niet toegewezen', grade: 'Overig', classroom: 'Zonder klas');
+    await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
 
     // All 2000 sit in this one class, each one pending entry.
     expect(harness.controller.classroomPendingEntries, hasLength(2000));
@@ -259,6 +257,42 @@ void main() {
     expect(find.byKey(lastKey), findsOneWidget);
     expect(find.byKey(firstKey), findsNothing,
         reason: 'the first tile unloaded once scrolled far off-screen');
+  });
+
+  // --- School-less student drill-down (#210) -------------------------------
+
+  testWidgets(
+      'the Leerlingen overview opens on grade-years merged across the managed '
+      'schools, with no school level anywhere (#210)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = twoSchoolHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The years are the accordion, in a pinned order; neither school is a node.
+    expect(find.text('Jaar 1'), findsOneWidget);
+    expect(find.text('Jaar 3'), findsOneWidget);
+    expect(find.text('School 1'), findsNothing);
+    expect(find.text('School 2'), findsNothing);
+    // The synthetic non-numeric bucket never renders as "Jaar Overig".
+    expect(find.text('Overige klassen'), findsOneWidget);
+    expect(find.text('Jaar Overig'), findsNothing);
+
+    // "Jaar 1" holds both schools' first years side by side…
+    await tester.tap(find.text('Jaar 1'));
+    await tester.pumpAndSettle();
+    expect(find.text('1A'), findsOneWidget);
+    expect(find.text('1B'), findsOneWidget);
+
+    // …and opening one still targets that class's own school partition.
+    await tester.ensureVisible(find.text('1B'));
+    await tester.tap(find.text('1B'));
+    await tester.pumpAndSettle();
+    expect(harness.controller.selectedClassroom?.classroom, '1B');
+    expect(harness.controller.selectedClassroom?.school, '2');
+    expect(harness.controller.classroomAccounts, hasLength(1));
   });
 
   // --- Personeel / Leerlingen family tabs (#179) ---------------------------
@@ -292,21 +326,20 @@ void main() {
       harness.controller.totalPendingCount,
     );
 
-    // Default tab = Leerlingen: the student school node is a drill root and the
-    // class-groups node shows; the staff ("Personeel") school node does not.
-    expect(
-        find.byKey(const ValueKey('rollup-school-school|1')), findsOneWidget);
+    // Default tab = Leerlingen: the merged grade-year is the drill root (#210)
+    // and the class-groups node shows; the staff ("Personeel") node does not.
+    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
     expect(find.byKey(const ValueKey('rollup-groups')), findsWidgets);
     expect(
         find.byKey(const ValueKey('rollup-school-school|staff')), findsNothing);
 
-    // Switch to Personeel: the staff node appears and the student school /
+    // Switch to Personeel: the staff node appears and the student grade /
     // class-groups nodes are gone — each tab shows only its own family.
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('rollup-school-school|staff')),
         findsOneWidget);
-    expect(find.byKey(const ValueKey('rollup-school-school|1')), findsNothing);
+    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsNothing);
     expect(find.byKey(const ValueKey('rollup-groups')), findsNothing);
   });
 
@@ -322,7 +355,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Drill into a student class on the Leerlingen tab.
-    await _drill(tester, school: 'School 1', grade: '3', classroom: '3C');
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
     expect(harness.controller.selectedClassroom?.classroom, '3C');
     expect(
         find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
@@ -353,7 +386,7 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await _drill(tester, school: 'School 1', grade: '3', classroom: '3C');
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
     // Both accounts show unfiltered; the Leerlingen tab has no search box.
     expect(find.text('Jane Doe'), findsOneWidget);
     expect(find.text('Kees Bakker'), findsOneWidget);
@@ -488,7 +521,7 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await _drill(tester, school: 'School 1', grade: '3', classroom: '3C');
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
     expect(find.text('Wijzig het adres in Smartschool'), findsWidgets);
 
     final entry = harness.controller.pendingEntries
@@ -522,13 +555,16 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Overzicht'), findsOneWidget);
-    expect(find.text('School 1'), findsOneWidget);
+    // The stored view projects to the same school-less tree the syncing
+    // session rendered (#210).
+    expect(find.text('Jaar 3'), findsOneWidget);
+    expect(find.text('School 1'), findsNothing);
     expect(s2.controller.linked, isNull,
         reason: 'link() is never called in a passive session');
     // Nothing loaded until the operator drills in.
     expect(s2.controller.classroomAccounts, isNull);
 
-    await _drill(tester, school: 'School 1', grade: '3', classroom: '3C');
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
 
     // Only the 3C class was read; the read-only account tile renders.
     expect(s2.controller.classroomAccounts, hasLength(1));

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -57,6 +57,14 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 /// keys, only how each is classified ([WisaPresence]); for **groups** it is a
 /// filter (#205), because a class of a school we do not manage has no business
 /// reaching the action engine at all (see [_linkGroups]).
+///
+/// A second group-only filter composes with it: the class groups of a school
+/// flagged [wapi.WisaSchool.isVirtual] are skipped too (#209). A virtual school
+/// is typically *also* marked managed, so ownership alone never excluded it. The
+/// virtual set is always derived from the snapshot's own schools —
+/// `markVirtualSchools` stamps the flag before the pull, so the snapshot is
+/// authoritative here — and it never touches students or staff, who keep flowing
+/// from virtual schools exactly as before.
 LinkedSnapshot link(
   wapi.WisaSnapshot wisaSnapshot,
   ss.SmartschoolSnapshot smartschoolSnapshot,
@@ -70,6 +78,14 @@ LinkedSnapshot link(
         for (final school in wisaSnapshot.schools)
           if (school.isOurs) school.id,
       };
+
+  // The virtual schools (#209). Unlike ownership there is no caller override:
+  // the flag is stamped onto the school list before the pull, and `sync()`
+  // stores that list on the snapshot, so the snapshot is the single source.
+  final virtualSchoolIds = <int>{
+    for (final school in wisaSnapshot.schools)
+      if (school.isVirtual) school.id,
+  };
 
   // Build the student and staff records first, in that order, so the two
   // populations' duplicate-mail warnings accumulate student-then-staff exactly
@@ -123,6 +139,7 @@ LinkedSnapshot link(
     smartschoolSnapshot,
     azureSnapshot,
     effectiveOurSchoolIds,
+    virtualSchoolIds,
   );
 
   return LinkedSnapshot.fromRecords(
@@ -394,11 +411,23 @@ List<_StaffRecord> _buildStaffRecords(
 /// an empty [ourSchoolIds] means ownership is unconfigured and every school is
 /// treated as ours (see [_isOurWisaSchool]).
 ///
+/// The class groups of a **virtual** school ([virtualSchoolIds], #209) are
+/// skipped on top of that: a class group seeds a record only when its school is
+/// *ours **and** not virtual* (see [_seedsClassGroups]). Ownership alone never
+/// excluded them — the operator's virtual school is normally marked managed as
+/// well — so their (always empty) classes reached the engine as
+/// [CreateInSmartschool] notices, cluttering the Klasgroepen list and inviting
+/// the creation of defunct classes in Smartschool. The exclusion is deliberately
+/// *only* about class groups: the students and staff of a virtual school are
+/// untouched here and keep linking exactly as before.
+///
 /// A consequence, decided deliberately: an official Smartschool class whose
-/// only WISA counterpart is a class of a school we do not manage now becomes a
-/// Smartschool orphan record (#52) rather than linking to a class we have no
-/// business managing. The action engine then treats it as the orphan it is
-/// instead of silently considering it in sync.
+/// only WISA counterpart is a class of a school we do not manage — or of a
+/// virtual school — now becomes a Smartschool orphan record (#52) rather than
+/// linking to a class we have no business managing. The action engine then
+/// treats it as the orphan it is instead of silently considering it in sync;
+/// the orphan action is the informational `DoNotImportFromSmartschool`, which
+/// cannot be applied, so nothing is ever deleted automatically.
 ///
 /// Only `official` Smartschool groups are considered (legacy
 /// `AddSmartschoolChildGroups` walked the "Leerlingen" subtree and linked only
@@ -421,6 +450,7 @@ List<LinkedGroup> _linkGroups(
   ss.SmartschoolSnapshot smartschoolSnapshot,
   az.AzureSnapshot azureSnapshot,
   Set<int> ourSchoolIds,
+  Set<int> virtualSchoolIds,
 ) {
   final records = <_GroupRecord>[];
   // Normalized fullName/name/displayName -> the record indexed under it.
@@ -429,13 +459,16 @@ List<LinkedGroup> _linkGroups(
   // 1. Seed one record per distinct WISA class group, in snapshot order, keyed
   //    by its `fullName`. Class groups of schools we do not manage are skipped
   //    outright (#205) — the shared WISA credentials pull every group school,
-  //    and a sibling school's class must never reach the action engine. The
-  //    filter runs *before* the dedupe so a foreign class can no longer occupy
-  //    the name key of one of ours. Duplicate fullNames among our own classes
-  //    still collapse to the first record so the output is a deterministic
-  //    function of the input order (INV-20).
+  //    and a sibling school's class must never reach the action engine — and so
+  //    are those of a virtual school (#209), whose classes are a dead concept.
+  //    The filter runs *before* the dedupe so an excluded class can no longer
+  //    occupy the name key of one of ours. Duplicate fullNames among our own
+  //    classes still collapse to the first record so the output is a
+  //    deterministic function of the input order (INV-20).
   for (final group in wisaSnapshot.classGroups) {
-    if (!_isOurWisaSchool(group.schoolId, ourSchoolIds)) continue;
+    if (!_seedsClassGroups(group.schoolId, ourSchoolIds, virtualSchoolIds)) {
+      continue;
+    }
     final key = _norm(group.fullName);
     if (key == null || byName.containsKey(key)) continue;
     final rec = _GroupRecord(wisa: group);
@@ -615,6 +648,22 @@ WisaPresence _presence(Set<int> wisaSchoolIds, Set<int> ourSchoolIds) {
 /// school counts as ours and group linking keeps its pre-#205 behaviour.
 bool _isOurWisaSchool(int schoolId, Set<int> ourSchoolIds) =>
     ourSchoolIds.isEmpty || ourSchoolIds.contains(schoolId);
+
+/// Whether a WISA class group of [schoolId] may seed a linked group record:
+/// the school must be one we manage (#205) **and** not one marked virtual
+/// (#209). The two exclusions compose rather than replace each other — a
+/// virtual school is normally marked managed too, so ownership alone let its
+/// classes through, and the "ownership unconfigured ⇒ everything is ours"
+/// fallback in [_isOurWisaSchool] still holds with the virtual exclusion
+/// layered on top. Applies to class groups only; students and staff of a
+/// virtual school are unaffected.
+bool _seedsClassGroups(
+  int schoolId,
+  Set<int> ourSchoolIds,
+  Set<int> virtualSchoolIds,
+) =>
+    _isOurWisaSchool(schoolId, ourSchoolIds) &&
+    !virtualSchoolIds.contains(schoolId);
 
 /// Whether an Azure user's [companyName] marks it as one of the school's own
 /// (a current or former student). Trimmed + case-insensitive.

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -498,6 +498,125 @@ void main() {
     });
   });
 
+  group('link — class groups of a virtual school are never imported (#209)',
+      () {
+    /// Links [classGroups] (and optionally [students]) with the schools list
+    /// carrying the virtual/ours flags the linker derives its two group filters
+    /// from. [ourSchoolIds] pins the managed set the Settings path supplies.
+    LinkedSnapshot linkVirtual(
+      List<wapi.WisaClassGroup> classGroups, {
+      List<wapi.WisaSchool> schools = const [],
+      Set<int>? ourSchoolIds,
+      List<wapi.WisaStudent> students = const [],
+      List<Group> ssGroups = const [],
+    }) =>
+        link(
+          wisaSnap(students, classGroups: classGroups, schools: schools),
+          ssSnap(const [], groups: ssGroups),
+          azSnap(const []),
+          SeqResolver(),
+          schoolPrefix: _prefix,
+          ourSchoolIds: ourSchoolIds,
+        );
+
+    test('a class of a virtual school raises no record, even when managed', () {
+      // The real config: the virtual school is ticked "beheerd" too, so the
+      // #205 ownership filter passes it straight through. Only the virtual
+      // exclusion keeps its classes out.
+      final snapshot = linkVirtual(
+        [wisaClassGroup('1V', schoolId: 99)],
+        schools: [wisaSchool(99, ours: true, virtual: true)],
+        ourSchoolIds: const {1, 99},
+      );
+
+      expect(snapshot.groups, isEmpty);
+    });
+
+    test('a class of a managed, non-virtual school is unaffected', () {
+      final snapshot = linkVirtual(
+        [
+          wisaClassGroup('3B', schoolCode: '111', schoolId: 1),
+          wisaClassGroup('1V', schoolId: 99),
+        ],
+        schools: [wisaSchool(1, ours: true), wisaSchool(99, virtual: true)],
+        ourSchoolIds: const {1, 99},
+      );
+
+      expect([for (final g in snapshot.groups) g.wisa!.name], ['3B']);
+      expect(snapshot.groups.single.wisa!.instituteNumber, '111');
+    });
+
+    test('the virtual exclusion applies on top of the #205 ours fallback', () {
+      // Ownership unconfigured ⇒ every school is ours (the pre-#205 fallback),
+      // but a virtual school's classes are still dropped.
+      final snapshot = linkVirtual(
+        [
+          wisaClassGroup('5A', schoolId: 1),
+          wisaClassGroup('1V', schoolId: 99),
+        ],
+        schools: [wisaSchool(1), wisaSchool(99, virtual: true)],
+      );
+
+      expect([for (final g in snapshot.groups) g.wisa!.name], ['5A']);
+    });
+
+    test('a virtual class arriving first no longer shadows ours', () {
+      // The name key is claimed at the seed, so a same-named virtual class used
+      // to occupy it and the surviving proposal described the virtual school.
+      final snapshot = linkVirtual(
+        [
+          wisaClassGroup('1A', schoolCode: '999', schoolId: 99),
+          wisaClassGroup('1A', schoolCode: '111', schoolId: 1),
+        ],
+        schools: [
+          wisaSchool(1, ours: true),
+          wisaSchool(99, ours: true, virtual: true)
+        ],
+        ourSchoolIds: const {1, 99},
+      );
+
+      expect(snapshot.groups, hasLength(1));
+      expect(snapshot.groups.single.wisa!.instituteNumber, '111');
+    });
+
+    test('students of a virtual school still link, and stay ours', () {
+      // The virtual work date exists precisely so these people come back; only
+      // the class-group records are in scope. Placement reads the student's own
+      // `classGroup` string, so dropping the records moves nobody.
+      final snapshot = linkVirtual(
+        [wisaClassGroup('1V', schoolId: 99)],
+        schools: [
+          wisaSchool(1, ours: true),
+          wisaSchool(99, ours: true, virtual: true)
+        ],
+        ourSchoolIds: const {1, 99},
+        students: [wisaStudent('W9', schoolId: 99)],
+      );
+
+      expect(snapshot.groups, isEmpty);
+      final a = snapshot.accounts.single;
+      expect(a.wisa, isNotNull);
+      expect(a.wisaSchoolIds, {99});
+      expect(a.wisaPresence, WisaPresence.ours);
+    });
+
+    test(
+        'a Smartschool class whose only WISA counterpart is virtual becomes an '
+        'orphan', () {
+      final snapshot = linkVirtual(
+        [wisaClassGroup('1V', schoolId: 99)],
+        schools: [wisaSchool(99, ours: true, virtual: true)],
+        ourSchoolIds: const {99},
+        ssGroups: [ssGroup('1V')],
+      );
+
+      final g = snapshot.groups.single;
+      expect(g.wisa, isNull);
+      expect(g.smartschool, isNotNull);
+      expect(g.confidence, LinkConfidence.medium);
+    });
+  });
+
   group('link — staff scenarios', () {
     test('fully linked across three systems → high confidence', () {
       // Staff bridge Smartschool by `code` (≡ accountId) and Azure by `wisaId`

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -41,9 +41,17 @@ wapi.WisaStudent wisaStudent(String wisaId, {int schoolId = 1}) =>
     );
 
 /// A WISA school, optionally flagged [ours] (the `MarkAsOurs` import-rule
-/// outcome the linker derives the managed-school set from, #133/#134).
-wapi.WisaSchool wisaSchool(int id, {bool ours = false}) =>
-    wapi.WisaSchool(id: id, name: 'S$id', code: '', isOurs: ours);
+/// outcome the linker derives the managed-school set from, #133/#134) and/or
+/// [virtual] (the `MarkAsVirtual` / settings flag whose class groups the linker
+/// refuses to seed, #209).
+wapi.WisaSchool wisaSchool(int id, {bool ours = false, bool virtual = false}) =>
+    wapi.WisaSchool(
+      id: id,
+      name: 'S$id',
+      code: '',
+      isOurs: ours,
+      isVirtual: virtual,
+    );
 
 /// A Smartschool **student** account. [accountId] holds the WISA id by
 /// convention; [mail] is the Azure-UPN bridge.

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -99,6 +99,7 @@ export 'src/settings/import_rule_codec.dart';
 export 'src/settings/secret_provider.dart';
 export 'src/settings/settings_store.dart';
 export 'src/settings/wisa_school_label.dart';
+export 'src/settings/wisa_school_merge.dart';
 export 'src/settings/wisa_school_profile.dart';
 export 'src/settings/work_date.dart';
 export 'src/cosmos/cosmos_client.dart';

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -220,7 +220,7 @@ List<Rollup> buildRollups(List<MaterializedAccount> accounts) {
 
 const String _staffSchool = staffPartition;
 const String _staffLabel = 'Personeel';
-const String _unassignedSchool = 'unassigned';
+const String _unassignedSchool = unassignedPartition;
 const String _unassignedLabel = 'Niet toegewezen';
 const String _noGrade = 'Overig';
 const String _noClassroom = 'Zonder klas';

--- a/packages/account_state/lib/src/materialize/materialized_state.dart
+++ b/packages/account_state/lib/src/materialize/materialized_state.dart
@@ -321,6 +321,14 @@ const String groupsPartition = 'groups';
 /// student-school rollups when it sums the per-category totals (#163).
 const String staffPartition = 'staff';
 
+/// The synthetic partition (and rollup school) every account with no class *of
+/// ours* lands in — a student who left, or one who only exists in a school we do
+/// not manage but still owns one of our accounts (#178). Exposed so the Actions
+/// drill-down can tell this bucket apart from a real school when it flattens the
+/// student tree to grade-years (#210): "Niet toegewezen" stays a top-level node
+/// of its own instead of merging into a year.
+const String unassignedPartition = 'unassigned';
+
 /// One linked **class group** as a stored document (#119).
 ///
 /// The group-family counterpart of [MaterializedAccount]: where a per-account

--- a/packages/account_state/lib/src/settings/wisa_school_merge.dart
+++ b/packages/account_state/lib/src/settings/wisa_school_merge.dart
@@ -1,0 +1,75 @@
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+import 'wisa_school_profile.dart';
+
+// How a freshly pulled WISA school list is folded into the persisted school
+// profiles — the one place that knows the rule (#207).
+//
+// Two callers merge the same two things and must not drift apart:
+//
+// - **Scholen ophalen** in Settings, which refreshes the grid and may add a
+//   school the operator has never seen ([addUnknown]);
+// - every **sync**, which repairs the stored profiles from the school list the
+//   pull already loaded, so the grid never renders `School 25` again just
+//   because the document predates the `code`/`name` fields (#171/#194).
+//
+// The rule itself is per half rather than per school, exactly as
+// `wisaSchoolLabels` merges a snapshot over the stored profiles: the pull
+// refreshes whichever of the two halves it actually carries and never blanks
+// out the other.
+
+/// Merges the freshly pulled [schools] into the persisted [profiles], filling
+/// in each profile's `code` and `name` from the school with its id.
+///
+/// **Only those two halves are touched.** `ours`, `virtual` and `prefix` are
+/// operator decisions and are carried through untouched — a repair must never
+/// silently un-manage a school. A pulled half that is empty leaves the stored
+/// one alone, so a partial pull cannot blank a known name.
+///
+/// By default the merge is strictly a repair: no entry is added and none is
+/// removed, and the order of [profiles] is preserved, so a sync can run it
+/// against the settings document without the grid growing or reordering behind
+/// the operator's back. With [addUnknown] — what the **Scholen ophalen** button
+/// does — a pulled school that has no profile yet is appended as neither
+/// managed nor virtual.
+///
+/// Both halves come straight across: `parseSchoolRow` untangles WISA's inverted
+/// `NAME`/`DESCRIPTION` columns at the connector edge, so `WisaSchool.name` is
+/// the long name and `WisaSchool.code` the short code (#208).
+List<WisaSchoolProfile> mergeWisaSchoolProfiles({
+  required Iterable<WisaSchoolProfile> profiles,
+  required Iterable<wapi.WisaSchool> schools,
+  bool addUnknown = false,
+}) {
+  final byId = <int, wapi.WisaSchool>{for (final s in schools) s.id: s};
+  final merged = <WisaSchoolProfile>[
+    for (final p in profiles) _enriched(p, byId[p.schoolId]),
+  ];
+  if (!addUnknown) return merged;
+
+  final known = <int>{for (final p in profiles) p.schoolId};
+  for (final s in schools) {
+    if (known.add(s.id)) {
+      merged.add(WisaSchoolProfile(
+        schoolId: s.id,
+        code: s.code.trim(),
+        name: s.name.trim(),
+      ));
+    }
+  }
+  return merged;
+}
+
+/// [profile] with whichever halves [school] actually carries filled in, and
+/// every operator-owned field left as it was.
+WisaSchoolProfile _enriched(
+    WisaSchoolProfile profile, wapi.WisaSchool? school) {
+  if (school == null) return profile;
+  final String code = school.code.trim();
+  final String name = school.name.trim();
+  if (code.isEmpty && name.isEmpty) return profile;
+  return profile.copyWith(
+    code: code.isEmpty ? profile.code : code,
+    name: name.isEmpty ? profile.name : name,
+  );
+}

--- a/packages/account_state/test/linked_state_test.dart
+++ b/packages/account_state/test/linked_state_test.dart
@@ -119,13 +119,14 @@ wapi.WisaClassGroup _wClass(
 wapi.WisaSnapshot _wSnap({
   List<wapi.WisaStudent> students = const [],
   List<wapi.WisaClassGroup> classGroups = const [],
+  List<wapi.WisaSchool> schools = const [],
 }) =>
     wapi.WisaSnapshot(
       fetchedAt: _d,
       students: students,
       staff: const [],
       classGroups: classGroups,
-      schools: const [],
+      schools: schools,
     );
 
 ss.SmartschoolSnapshot _sSnap({
@@ -516,6 +517,113 @@ void main() {
 
       final action = state.groupActions.whereType<AddToSmartschool>().single;
       expect(action.target.wisa!.instituteNumber, '111');
+    });
+  });
+
+  group('group actions skip the classes of a virtual school (#209)', () {
+    /// Recomputes over [classGroups] + [students] with the snapshot carrying
+    /// [schools] — where the virtual flag lives — and the managed set pinned to
+    /// [ourSchoolIds], the Settings-derived path the app wires.
+    LinkedState recompute({
+      required List<wapi.WisaClassGroup> classGroups,
+      required List<wapi.WisaStudent> students,
+      List<wapi.WisaSchool> schools = const [],
+      Set<int>? ourSchoolIds,
+    }) =>
+        LinkedState.recompute(
+          wisa: _wSnap(
+            students: students,
+            classGroups: classGroups,
+            schools: schools,
+          ),
+          smartschool: _sSnap(),
+          azure: _aSnap(),
+          resolver: _SeqResolver(),
+          studentConfig: _studentConfig,
+          staffConfig: _staffConfig,
+          classTree: const SmartschoolClassTree(grades: ['G1', 'G2', 'G3']),
+          ourSchoolIds: ourSchoolIds,
+        );
+
+    test('an empty class of a virtual school raises no group action at all',
+        () {
+      // The virtual school is marked managed as well — the operator's real
+      // config — so before #209 this surfaced as a CreateInSmartschool notice
+      // in the Klasgroepen list.
+      final state = recompute(
+        classGroups: [_wClass('1V', adminCode: 'v1', schoolId: 99)],
+        students: const [],
+        schools: [
+          const wapi.WisaSchool(
+            id: 99,
+            name: 'Virtuele school',
+            code: 'ISMV',
+            isOurs: true,
+            isVirtual: true,
+          ),
+        ],
+        ourSchoolIds: const {1, 99},
+      );
+
+      expect(state.snapshot.groups, isEmpty);
+      expect(state.groupActions, isEmpty,
+          reason: 'a virtual class is never ours to create downstream');
+    });
+
+    test('a student of the virtual school is still placed by their classGroup',
+        () {
+      // Placement reads WisaStudent.classGroup, not the class-group records, so
+      // dropping those records must move nobody.
+      final state = recompute(
+        classGroups: [_wClass('1V', adminCode: 'v1', schoolId: 99)],
+        students: [_wStudent(wisaId: '9', classGroup: '1V', schoolId: 99)],
+        schools: [
+          const wapi.WisaSchool(
+            id: 99,
+            name: 'Virtuele school',
+            code: 'ISMV',
+            isOurs: true,
+            isVirtual: true,
+          ),
+        ],
+        ourSchoolIds: const {1, 99},
+      );
+
+      expect(state.snapshot.groups, isEmpty);
+      final account = state.snapshot.accounts.single;
+      expect(account.wisa, isNotNull);
+      expect(account.wisaPresence, core.WisaPresence.ours);
+
+      // The drill-down still buckets them under their own class.
+      final view = materialize(state, generation: 1);
+      final placed = view.accounts.single;
+      expect(placed.school, '99');
+      expect(placed.classroom, '1V',
+          reason: 'the student keeps the class their own WISA record names');
+    });
+
+    test('a class of a managed, non-virtual school still raises its action',
+        () {
+      final state = recompute(
+        classGroups: [
+          _wClass('1A', adminCode: 'a1', schoolId: 1),
+          _wClass('1V', adminCode: 'v1', schoolId: 99),
+        ],
+        students: [_wStudent(wisaId: '1', classGroup: '1A')],
+        schools: [
+          const wapi.WisaSchool(id: 1, name: 'Onze school', code: 'ISM'),
+          const wapi.WisaSchool(
+            id: 99,
+            name: 'Virtuele school',
+            code: 'ISMV',
+            isVirtual: true,
+          ),
+        ],
+        ourSchoolIds: const {1, 99},
+      );
+
+      final action = state.groupActions.whereType<AddToSmartschool>().single;
+      expect(action.target.wisa!.name, '1A');
     });
   });
 

--- a/packages/account_state/test/wisa_school_merge_test.dart
+++ b/packages/account_state/test/wisa_school_merge_test.dart
@@ -1,0 +1,118 @@
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+/// A snapshot school, with each half on the field that claims it (#208).
+WisaSchool _school(int id, {String code = '', String name = ''}) =>
+    WisaSchool(id: id, name: name, code: code);
+
+void main() {
+  group('mergeWisaSchoolProfiles', () {
+    test('fills both halves into a profile stored with neither (#207)', () {
+      // The reported document: three entries carrying only `schoolId` + `ours`,
+      // which the Settings grid rendered as "School 25" forever.
+      final repaired = mergeWisaSchoolProfiles(
+        profiles: const [WisaSchoolProfile(schoolId: 25, ours: true)],
+        schools: [
+          _school(25, code: 'ISMAA', name: 'Instituut Sancta Maria-A'),
+        ],
+      );
+
+      expect(repaired.single.name, 'Instituut Sancta Maria-A');
+      expect(repaired.single.code, 'ISMAA');
+      expect(repaired.single.nameLabel, 'Instituut Sancta Maria-A');
+      expect(repaired.single.label, 'Instituut Sancta Maria-A (ISMAA)');
+    });
+
+    test('never rewrites the operator-owned fields', () {
+      // `ours`, `virtual` and `prefix` are Settings decisions; a pull that
+      // repairs the two derived halves must leave every one of them alone.
+      final repaired = mergeWisaSchoolProfiles(
+        profiles: const [
+          WisaSchoolProfile(
+            schoolId: 7,
+            ours: true,
+            virtual: true,
+            prefix: 'SP',
+          ),
+        ],
+        schools: [_school(7, code: 'SP7', name: 'Sint-Pieter')],
+      );
+
+      expect(repaired.single.ours, isTrue);
+      expect(repaired.single.virtual, isTrue);
+      expect(repaired.single.prefix, 'SP');
+    });
+
+    test('a half the pull does not carry leaves the stored one standing', () {
+      final repaired = mergeWisaSchoolProfiles(
+        profiles: const [
+          WisaSchoolProfile(schoolId: 7, code: 'SP', name: 'Sint-Pieter'),
+        ],
+        schools: [_school(7, name: 'Sint-Pieter (nieuwe naam)')],
+      );
+
+      expect(repaired.single.code, 'SP', reason: 'not blanked by the pull');
+      expect(repaired.single.name, 'Sint-Pieter (nieuwe naam)',
+          reason: 'a WISA-side rename does reach the stored profile');
+    });
+
+    test('adds and removes nothing by default, and keeps the order', () {
+      // The repair a sync runs: the operator curated this list, so the grid may
+      // not grow, shrink or reorder behind their back.
+      final repaired = mergeWisaSchoolProfiles(
+        profiles: const [
+          WisaSchoolProfile(schoolId: 31, ours: true),
+          WisaSchoolProfile(schoolId: 25, ours: true),
+        ],
+        schools: [
+          _school(25, code: 'ISMAA', name: 'Instituut Sancta Maria-A'),
+          _school(27, code: 'ISMAB', name: 'Instituut Sancta Maria-B'),
+        ],
+      );
+
+      expect(repaired.map((p) => p.schoolId), [31, 25]);
+      expect(repaired.first.name, isEmpty,
+          reason: 'school 31 is in no pull, so nothing to fill in');
+      expect(repaired.last.name, 'Instituut Sancta Maria-A');
+    });
+
+    test('addUnknown appends the schools the list does not have yet', () {
+      // What "Scholen ophalen" does: the refresh may introduce a school the
+      // operator has never seen, unmanaged and non-virtual until they say so.
+      final merged = mergeWisaSchoolProfiles(
+        profiles: const [WisaSchoolProfile(schoolId: 25, ours: true)],
+        schools: [
+          _school(25, code: 'ISMAA', name: 'Instituut Sancta Maria-A'),
+          _school(27, code: 'ISMAB', name: 'Instituut Sancta Maria-B'),
+        ],
+        addUnknown: true,
+      );
+
+      expect(merged.map((p) => p.schoolId), [25, 27]);
+      expect(merged.last.name, 'Instituut Sancta Maria-B');
+      expect(merged.last.code, 'ISMAB');
+      expect(merged.last.ours, isFalse);
+      expect(merged.last.virtual, isFalse);
+      expect(merged.first.ours, isTrue, reason: 'the managed mark survives');
+    });
+
+    test('a pulled half that is only whitespace is not stored', () {
+      final repaired = mergeWisaSchoolProfiles(
+        profiles: const [WisaSchoolProfile(schoolId: 7, name: 'Sint-Pieter')],
+        schools: [_school(7, code: '   ')],
+      );
+
+      expect(repaired.single.code, isEmpty);
+      expect(repaired.single.name, 'Sint-Pieter');
+    });
+
+    test('an empty pull changes nothing', () {
+      const stored = [WisaSchoolProfile(schoolId: 25, ours: true)];
+      expect(
+        mergeWisaSchoolProfiles(profiles: stored, schools: const []),
+        stored,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Three issues, one commit each, in dependency order. All three build on #208
(merged separately in #211), which made `WisaSchool.name` / `.code` mean what they
say.

- **#207 — fill the WISA school names into the stored profiles at sync.** The
  operator's settings document held profiles in the legacy `{schoolId, ours}`
  shape with empty `code`/`name`, so the WISA-scholen grid read `School 25` /
  `School 27` / `School 31` on open; only **Scholen ophalen** followed by
  **Opslaan** repaired it, and nothing else ever did. Every WISA sync now backfills
  those two halves into the stored profiles through a new shared
  `mergeWisaSchoolProfiles` helper: per-half fill (an empty pulled half never
  blanks a stored one), `ours` / `virtual` / `prefix` never rewritten, order
  preserved, and by default nothing added or removed — `addUnknown: true` is the
  extra step the **Scholen ophalen** button needs, so the button and the silent
  backfill cannot drift. The write re-reads the document immediately beforehand so
  it cannot clobber a concurrent save, writes only on an actual change, and logs
  rather than failing the sync if the store is down.

  The issue's alternative — have the grid fall back to the live snapshot — was
  rejected as unreachable: Settings bootstraps independently of the reconcile
  stack by design, so it can repair a config too broken to stand the connectors
  up. A fetch also still requires **Opslaan**, deliberately: it merges into a
  working copy that may already hold unsaved `ours` / `virtual` toggles, so
  auto-saving would commit those too and remove the reload escape hatch. What made
  that a trap was names arriving *only* there, and the sync backfill removes it.

- **#209 — stop importing the class groups of a virtual WISA school.** #205's
  filter did not cover this: a virtual school is typically *also* marked managed
  (`ISMV` is ticked as beheerd), so its classes sailed straight through. A class
  group now seeds a record only when its school is ours **and** not virtual, with
  the virtual ids derived from `wisaSnapshot.schools` alongside the existing
  `isOurs` derivation. The filter runs before the name dedupe, so a virtual class
  can no longer occupy the name key of one of ours, and #205's "ownership
  unconfigured ⇒ everything is ours" fallback is preserved.

  Implemented at the linker rather than the connector, for a correctness reason
  beyond the issue's own: `PlacementResolver` reads `wisa.classGroups` to compute
  `_subGroupClassNames`, which decides whether a student's target class name is
  `1V` or `1V <subgroup>`. Dropping records at the connector would change that
  input; filtering at the linker leaves it — and the smart-diff baseline —
  byte-identical. Students and staff of virtual schools are untouched and still
  pulled with the virtual work date.

  **Orphan check, asked for explicitly on the issue:** a Smartschool class whose
  only WISA counterpart is now filtered out becomes a `wisa: null` orphan, which
  raises `DoNotImportFromSmartschool` — informational only (`canApply == false`,
  `apply()` throws). It reads "Deze klas bestaat in Smartschool maar niet in WISA.
  Verwijder ze manueel als ze niet meer nodig is." No deletion is proposed and none
  can be applied. Pinned by a unit test.

- **#210 — drop the school level from the Acties drill-down.** Grade-years are now
  the top-level accordion, merged across managed schools with combined counts;
  `Niet toegewezen` expands straight to `Zonder klas`; `Personeel` and
  `Klasgroepen` are unchanged. Flattened in `ReconcileController`'s view getters
  (`studentRollups` / `studentChildrenOf`) with the materialized and stored
  rollups left alone — so classroom nodes keep their real `school` and
  `readClassroom(partitionKey: school)` still hits exactly one Cosmos partition,
  and every `RollupLevel.school` aggregate still feeds the tab badges and header
  count in passive sessions. Verified end to end: opening school 2's `1B` from a
  merged `Jaar 1` reports `selectedClassroom.school == '2'`.

  The synthetic non-numeric grade bucket renders as **`Overige klassen`** rather
  than the nonsensical "Jaar Overig"; the `Jaar ` prefix moved out of the widget
  into `gradeNodeLabel` so that decision lives in one place. Top-level order is
  pinned: numeric years ascending, then `Overige klassen`, `Niet toegewezen`,
  `Klasgroepen`. Same-named classes in two schools are deliberately *not* merged —
  merging would break the single-partition read — though the linker already
  collapses them, so it stays theoretical.

  Two integration tests (#204, #208) asserted the school *label* inside the Acties
  tree, which no longer exists there; they were retargeted to assert it on the
  stored school rollup — what Cosmos partitions by and what Settings names —
  plus `findsNothing` on screen. #208's Settings-grid label coverage already lives
  in its own e2e test.

## Test plan

Per-commit results, as run locally by each issue's worker:

- [x] **#207** — `dart format --set-exit-if-changed .` clean (287 files);
      `dart analyze` clean; `dart test packages/*/test` 936 pass / 11 skipped;
      `flutter test` 274 pass; `flutter test integration_test/app_launch_test.dart
      -d windows` 50 pass including the new #207 e2e. Fail-without-fix proven for
      both new layers: with the backfill call commented out, 3 of the 4 new
      controller tests and the #207 integration test fail.
- [x] **#209** — format clean (287 files); `flutter analyze` "No issues found!";
      937 package unit tests pass; 274 widget tests pass; bounded integration:
      "Klasgroepen drill-down" 2/2 (#205 + new #209) and "Actions drill-down" 3/3.
      Fail-without-fix proven by stashing `link.dart`: 6/6 new linker tests and the
      new #209 e2e fail, green again after restore.
- [x] **#210** — format clean; `dart analyze --fatal-infos --fatal-warnings`
      clean; 945 package unit tests pass (11 skipped, live-only); 280 widget tests
      pass (5 new controller tests + 1 new Actions widget test); 52 Windows
      integration tests pass in `app_launch_test.dart` (1 new #210 e2e), run
      individually.

Closes #207
Closes #209
Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
