### PR TITLE
Batch: delta-token recovery, read-only Acties notice, name search, password permission (#213–#217)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1340,12 +1340,15 @@ void main() {
   });
 
   testWidgets(
-      'the Passwords personeel tab defaults its filter to Voornaam and lists '
-      'staff alphabetically end-to-end (#186)', (WidgetTester tester) async {
+      'the Passwords personeel tab searches staff by any part of the name, in '
+      'either order, with no field picker end-to-end (#186/#215)',
+      (WidgetTester tester) async {
     // The real app, real fonts, real window: a "Personeel" group holding three
-    // staff seeded out of alphabetical order across mixed casing. On opening the
-    // personeel tab the filter selector must default to Voornaam and the list
-    // must render sorted by the displayed "Voornaam Naam" name.
+    // staff seeded out of alphabetical order across mixed casing (alice Bravo /
+    // Bob Alpha / Charlie Zulu). The tab used to pair its filter box with a
+    // Naam / Voornaam / Gebruiker dropdown, so a fragment of the wrong half of
+    // the name returned an empty list with no hint why. One box now matches any
+    // part of the full name, and the list still renders alphabetically.
     useTallWindow(tester);
     final harness = ReconcileHarness(ssInitial: staffOrderSnap());
     await tester.pumpWidget(AccountManagerApp(
@@ -1360,14 +1363,48 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('passwords-tab-personeel')));
     await tester.pumpAndSettle();
 
-    // The filter selector renders its default selection: Voornaam.
-    expect(find.text('Voornaam'), findsOneWidget);
+    // One full-width search box; the field picker and its options are gone.
+    final filter = find.byKey(const ValueKey('passwords-staff-filter'));
+    expect(filter, findsOneWidget);
+    expect(find.byKey(const ValueKey('passwords-staff-filter-field')),
+        findsNothing);
+    expect(find.text('Voornaam'), findsNothing);
+    expect(find.text('Gebruiker'), findsNothing);
 
     // The tiles render top-to-bottom in alphabetical order: alice, Bob, Charlie.
     double y(String uid) =>
         tester.getTopLeft(find.byKey(ValueKey('passwords-staff-$uid'))).dy;
     expect(y('alice'), lessThan(y('bob')));
     expect(y('bob'), lessThan(y('charlie')));
+
+    // The focused field's blinking cursor never settles, so pump frames.
+    Future<void> search(String needle) async {
+      await tester.enterText(filter, needle);
+      await tester.pump();
+    }
+
+    // A surname fragment in the other casing — the search the old default
+    // (Voornaam) answered with an empty list.
+    await search('BRAV');
+    expect(find.byKey(const ValueKey('passwords-staff-alice')), findsOneWidget);
+    expect(find.byKey(const ValueKey('passwords-staff-bob')), findsNothing);
+    expect(find.byKey(const ValueKey('passwords-staff-charlie')), findsNothing);
+
+    // Both halves typed surname-first, the order the tile does not display in.
+    await search('bravo alice');
+    expect(find.byKey(const ValueKey('passwords-staff-alice')), findsOneWidget);
+    expect(find.byKey(const ValueKey('passwords-staff-bob')), findsNothing);
+
+    // Parts from two different people match neither.
+    await search('alice zulu');
+    expect(find.byKey(const ValueKey('passwords-staff-alice')), findsNothing);
+    expect(find.byKey(const ValueKey('passwords-staff-charlie')), findsNothing);
+
+    // Clearing the box brings the whole list back, still in order.
+    await search('');
+    expect(y('alice'), lessThan(y('bob')));
+    expect(y('bob'), lessThan(y('charlie')));
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets(

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2897,9 +2897,9 @@ void main() {
   });
 
   testWidgets(
-      'the Actions Personeel classroom filters by name and by the '
-      'only-with-actions toggle end-to-end, combining both (#187)',
-      (WidgetTester tester) async {
+      'the Actions Personeel classroom filters by any part of the name in any '
+      'order and by the only-with-actions toggle end-to-end, combining both '
+      '(#187/#217)', (WidgetTester tester) async {
     // The real app, real fonts, real window over a passive session: three staff
     // seeded into the one synthetic Personeel class — two share the surname
     // "Smit" (one carrying an action, one not) and one has a distinct voornaam.
@@ -2950,8 +2950,35 @@ void main() {
     expect(find.text('Clara Smit'), findsOneWidget);
     expect(find.text('Bram Jansen'), findsNothing);
 
-    // Combine with the only-with-actions toggle: only Anna keeps an action, so
-    // Clara (name-matched but action-free) drops too.
+    // Both halves of one name, typed in the stored order and reversed (#217).
+    // Reversed is the half of the time the operator misremembers which way
+    // round the name is stored; it used to return an empty list, because the
+    // needle was matched as one contiguous substring of "Voornaam Naam".
+    await tester.enterText(
+        find.byKey(const ValueKey('actions-search')), 'anna smit');
+    await tester.pump();
+    expect(find.text('Anna Smit'), findsOneWidget);
+    expect(find.text('Clara Smit'), findsNothing);
+    await tester.enterText(
+        find.byKey(const ValueKey('actions-search')), 'smit anna');
+    await tester.pump();
+    expect(find.text('Anna Smit'), findsOneWidget);
+    expect(find.text('Clara Smit'), findsNothing);
+    expect(find.text('Bram Jansen'), findsNothing);
+
+    // Every part must occur, so parts taken from two different people match
+    // neither — the operator sees the filter-empty line, not both of them.
+    await tester.enterText(
+        find.byKey(const ValueKey('actions-search')), 'anna jansen');
+    await tester.pump();
+    expect(
+        find.text('Geen accounts die aan de filter voldoen.'), findsOneWidget);
+
+    // Back to "Smit", then combine with the only-with-actions toggle: only Anna
+    // keeps an action, so Clara (name-matched but action-free) drops too.
+    await tester.enterText(
+        find.byKey(const ValueKey('actions-search')), 'smit');
+    await tester.pump();
     final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
     await tester.ensureVisible(toggle);
     await tester.tap(toggle);

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1408,6 +1408,65 @@ void main() {
   });
 
   testWidgets(
+      'a refused Office 365 password reset tells the operator which permission '
+      'is missing instead of showing a raw GraphException end-to-end (#216)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real window — and the *production* password
+    // write path (real ConnectorPasswordBackends → real AzureConnector) over a
+    // Graph that answers the way the tenant did: the user lookup succeeds, the
+    // passwordProfile PATCH comes back 403 Authorization_RequestDenied because
+    // the app registration only ever had User.ReadWrite.All. The operator used
+    // to read "Reset mislukt: GraphException(403 (Authorization_RequestDenied))"
+    // and had to go dig in the log panel to learn it was a rights problem.
+    useTallWindow(tester);
+    final denied = PasswordWriteDeniedGraph();
+    final harness =
+        ReconcileHarness(ssInitial: passwordsSnap(), passwordGraph: denied);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Passwords'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-tab-personeel')));
+    await tester.pumpAndSettle();
+
+    // The fixture's staff account (uid anna.smit) is named Jane Doe. Reset the
+    // Office 365 password only, so the whole reset rides on the refused write.
+    await tester.tap(find.byKey(const ValueKey('passwords-staff-anna.smit')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('passwords-staff-reset-o365')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester
+        .tap(find.byKey(const ValueKey('passwords-staff-reset-confirm')));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    // Graph really was asked, and really refused.
+    expect(denied.refusedWrites, hasLength(1));
+
+    // What the operator reads on the screen: who it was for, and the two
+    // directory-side causes — no exception class, no status code.
+    final message = tester.widget<Text>(
+      find.byKey(const ValueKey('passwords-message')),
+    );
+    final String shown = message.data!;
+    expect(shown, contains('Geen rechten'));
+    expect(shown, contains('Jane Doe'));
+    expect(shown, contains('User-PasswordProfile.ReadWrite.All'));
+    expect(shown, isNot(contains('GraphException')));
+    expect(shown, isNot(contains('403')));
+
+    // No sheet is handed over for a password that was never set.
+    expect(harness.passwordWrites, isEmpty);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'the Passwords view prints the queued sheets as a real PDF and opens it '
       'for printing end-to-end (#195)', (WidgetTester tester) async {
     // The real app, real fonts, real window. Printing used to drop browser-

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1765,6 +1765,90 @@ void main() {
   });
 
   testWidgets(
+      'a passive Acties drill-down says it is read-only in both trees, and its '
+      'Synchroniseer turns the very same class interactive end-to-end (#214)',
+      (WidgetTester tester) async {
+    // Session 1 syncs and materializes the shared view; session 2 is the real
+    // app over the same stores and never syncs — the everyday passive session
+    // that opened Acties to look at the pending work. Both drill-downs used to
+    // swap their interactive tiles for static bullet text with no gesture
+    // handler and say nothing about it, which reads as an interactive screen
+    // whose taps stopped working rather than as a view of the shared state.
+    useTallWindow(tester);
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+        .controller
+        .sync();
+
+    final resumed = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: resumed.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(resumed.controller.linked, isNull);
+
+    final readOnly = find.byKey(const ValueKey('actions-read-only'));
+    final pendingTiles = find.byWidgetPredicate((w) =>
+        w.key is ValueKey<String> &&
+        (w.key! as ValueKey<String>).value.startsWith('entry-'));
+    expect(readOnly, findsNothing,
+        reason: 'the browsable overview is not the read-only surface');
+
+    // The Klasgroepen tree: static tiles, and now they say so.
+    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+    expect(readOnly, findsOneWidget);
+    expect(find.text('Alleen-lezen overzicht'), findsOneWidget);
+    expect(pendingTiles, findsNothing);
+    await tester.tap(find.byKey(const ValueKey('actions-groups-back')));
+    await tester.pumpAndSettle();
+
+    // The classroom tree: the same announcement, and the cards themselves carry
+    // the muted lock rather than passing for tappable rows.
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('3C'));
+    await tester.tap(find.text('3C'));
+    await tester.pumpAndSettle();
+    expect(readOnly, findsOneWidget);
+    expect(find.textContaining('nog niet gesynchroniseerd'), findsOneWidget);
+    expect(find.byIcon(Icons.lock_outline), findsWidgets);
+    expect(pendingTiles, findsNothing,
+        reason: 'nothing in this class is actionable — that is the point');
+
+    // Take the offered way out, from the banner itself: WISA is pulled, the
+    // session links, and the freshly persisted view closes the drill-down.
+    final sync = find.byKey(const ValueKey('actions-read-only-sync'));
+    await tester.ensureVisible(sync);
+    await tester.tap(sync);
+    await tester.pumpAndSettle();
+    expect(resumed.wisaSyncs, 1);
+    expect(resumed.controller.linked, isNotNull);
+    expect(readOnly, findsNothing);
+
+    // The very same class is interactive now: real entry tiles, no notice, no
+    // locks — which is what the operator expected the first time round.
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('3C'));
+    await tester.tap(find.text('3C'));
+    await tester.pumpAndSettle();
+    expect(readOnly, findsNothing);
+    expect(find.byIcon(Icons.lock_outline), findsNothing);
+    expect(pendingTiles, findsWidgets);
+  });
+
+  testWidgets(
       'a passive session shows the shared freshness and, while another '
       'operator holds the sync lease, disables Synchronise (#108)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3008,6 +3008,90 @@ void main() {
     // even asked Smartschool about the removed groups.
     expect(wire.accountCodes, <String>['SCH', 'KLA']);
   });
+
+  testWidgets(
+      'a Check for drift whose stored Azure delta token Graph refuses still '
+      'finishes, on a full re-read that leaves a usable token behind (#213)',
+      (WidgetTester tester) async {
+    // The real app over the *production* Azure pull — a real AzureConnector
+    // behind the real azureSyncer — with Graph answering a resume from the
+    // stored token the way it answered the operator:
+    // `400 Request_UnsupportedQuery — DeltaLink older than 30 days is not
+    // supported.` The exception used to propagate out of the connector into
+    // ReconcileController._fail, so the whole pass produced no linked state at
+    // all; and because a failed pass deliberately leaves the stored snapshot
+    // alone, every later pass re-sent the same dead token. Nothing short of
+    // wiping the stored Azure document got the operator out of it.
+    useTallWindow(tester);
+    final azureWire = StaleDeltaTokenGraph();
+    final harness = ReconcileHarness(
+      azureTransport: azureWire,
+      // Last night's snapshot, with the token that has since gone stale.
+      azureInitial: azSnap(
+        fetchedAt: DateTime.now().subtract(const Duration(hours: 15)),
+        deltaToken: 'DEADTOKEN',
+      ),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    // Yesterday's session: WISA + Smartschool pull, the seeded Azure snapshot
+    // is reused untouched (its token is not spent yet).
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(azureWire.resumeTokens, isEmpty);
+
+    // Today: Check for drift, which is what re-reads Azure.
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.pumpAndSettle();
+
+    // The pass finished instead of dying: no inline failure, not busy, and the
+    // overview the operator came for is on screen.
+    expect(harness.controller.error, isNull);
+    expect(harness.controller.busy, isFalse);
+    expect(find.text('Overview'), findsOneWidget);
+
+    // The dead token was tried exactly once and then given up on, and the
+    // fallback was the $filter-scoped bulk read (PAIN-2 holds while recovering).
+    expect(azureWire.resumeTokens, <String>['DEADTOKEN']);
+    expect(azureWire.bulkReads, 1);
+    expect(
+      azureWire.requests
+          .lastWhere((r) => r.url.path.endsWith('/users'))
+          .url
+          .queryParameters[r'$filter'],
+      isNotNull,
+    );
+
+    // The snapshot is complete (not the stale one held over) and carries a
+    // fresh token…
+    expect(harness.app.azure.snapshot?.users.map((u) => u.upn),
+        <String>['jane.doe@student.school.example']);
+    expect(harness.app.azure.snapshot?.deltaToken, 'FRESH-DELTA-TOKEN');
+
+    // …and the operator is told why the full read happened, with the rejected
+    // token's age — the diagnostic that says whether Graph expired a genuinely
+    // old token or the app had stopped advancing it.
+    expect(find.textContaining('Graph rejected the stored delta token'),
+        findsOneWidget);
+    expect(find.textContaining('stored 15h'), findsOneWidget);
+
+    // A second drift check resumes from that fresh token: the recovery restored
+    // incremental syncing rather than condemning the app to full reads.
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.pumpAndSettle();
+    expect(azureWire.resumeTokens, <String>['DEADTOKEN', 'FRESH-DELTA-TOKEN']);
+    expect(azureWire.bulkReads, 1, reason: 'no second full read');
+    expect(harness.controller.error, isNull);
+  });
 }
 
 /// A broker scripted per test — a fake WAM broker so no live tenant is touched.

--- a/account_manager/lib/src/passwords/password_backends.dart
+++ b/account_manager/lib/src/passwords/password_backends.dart
@@ -23,6 +23,12 @@ abstract interface class PasswordBackends {
   /// Resets the Azure / Office 365 password of the user identified by
   /// [mailOrUpn]. Returns `true` when the user was found and updated, `false`
   /// when no such user exists (mirroring the legacy "No account for …" skip).
+  ///
+  /// Throws [az.AzurePasswordPermissionException] when the directory refuses
+  /// the write (#216). That is a permission/role gap the operator can act on,
+  /// not a missing account, so it is signalled rather than folded into `false`:
+  /// the caller names the cause on screen instead of reporting a bare "niet
+  /// gezet".
   Future<bool> setAzurePassword(String mailOrUpn, String password);
 }
 

--- a/account_manager/lib/src/passwords/password_controller.dart
+++ b/account_manager/lib/src/passwords/password_controller.dart
@@ -6,6 +6,7 @@ import 'package:azure_api/azure_api.dart' as az;
 import 'package:flutter/foundation.dart';
 import 'package:smartschool_api/smartschool_api.dart' as ss;
 
+import '../search/name_query.dart';
 import 'password_backends.dart';
 import 'password_export.dart';
 
@@ -542,36 +543,19 @@ class PasswordController extends ChangeNotifier {
   /// Narrows the staff list to the accounts matching the current filter text.
   /// The needle is split on whitespace and every part must match (#215), so an
   /// empty or whitespace-only needle shows everyone.
+  ///
+  /// The matching itself lives in [NameQuery], shared with the Acties Personeel
+  /// search so the two boxes cannot drift apart (#217).
   void _applyStaffFilter() {
-    final parts = _words(_filterText);
-    if (parts.isEmpty) {
+    final query = NameQuery(_filterText);
+    if (query.isEmpty) {
       _filteredStaff = List<ss.SmartschoolAccount>.of(_allStaff);
       return;
     }
     _filteredStaff = <ss.SmartschoolAccount>[
       for (final a in _allStaff)
-        if (_staffMatches(a, parts)) a,
+        if (query.matches('${a.givenName} ${a.surname}')) a,
     ];
-  }
-
-  /// The lower-cased, whitespace-separated words of [text], empties dropped —
-  /// used to normalise both the needle and the name it is matched against.
-  static List<String> _words(String text) => <String>[
-        for (final part in text.toLowerCase().split(RegExp(r'\s+')))
-          if (part.isNotEmpty) part,
-      ];
-
-  /// Whether every part of the needle occurs somewhere in [a]'s full name,
-  /// case-insensitively — the `*namepart*` search that replaced the Naam /
-  /// Voornaam / Gebruiker field picker (#215).
-  ///
-  /// Matching per part rather than on the whole needle is what makes either
-  /// name order work: "jan peeters" finds "Peeters Jan" just as it finds
-  /// "Jan Peeters", so the operator never has to guess which way round the
-  /// name is stored.
-  static bool _staffMatches(ss.SmartschoolAccount a, List<String> parts) {
-    final fullName = _words('${a.givenName} ${a.surname}').join(' ');
-    return parts.every(fullName.contains);
   }
 
   /// Resets the selected staff member's password(s): a fresh Smartschool and/or

--- a/account_manager/lib/src/passwords/password_controller.dart
+++ b/account_manager/lib/src/passwords/password_controller.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart';
+import 'package:azure_api/azure_api.dart' as az;
 import 'package:flutter/foundation.dart';
 import 'package:smartschool_api/smartschool_api.dart' as ss;
 
@@ -219,6 +220,7 @@ class PasswordController extends ChangeNotifier {
   Future<void> generate() async {
     if (_busy || selectedCount == 0) return;
     _setBusy(true);
+    _rightsProblem = null;
     try {
       final entries = await _queue.load();
       final byKey = <String, PasswordEntry>{
@@ -247,15 +249,13 @@ class PasswordController extends ChangeNotifier {
                   'Smartschool-wachtwoord niet gezet voor ${row.username}.');
             }
           } else if (target == PasswordTarget.office365) {
-            final mail = row.account.mail;
-            if (mail.isNotEmpty &&
-                await _backends.setAzurePassword(mail, password)) {
-              azPw = password;
+            final set =
+                await _pushAzurePassword(row.account.mail, row.name, password);
+            if (set != null) {
+              azPw = set;
               pushed++;
             } else {
               failed++;
-              _log?.addError(core.Origin.azure,
-                  'Office 365-wachtwoord niet gezet voor ${row.name}.');
             }
           } else {
             final slot = target.coSlot!;
@@ -282,15 +282,65 @@ class PasswordController extends ChangeNotifier {
 
       await _queue.save(byKey.values.toList());
       await _reloadQueue();
-      _message = failed == 0
-          ? '$pushed wachtwoord(en) gegenereerd en verstuurd.'
-          : '$pushed verstuurd, $failed mislukt — zie het logboek.';
+      final rights = _rightsProblem;
+      _message = rights != null
+          ? '$pushed verstuurd, $failed mislukt — $rights'
+          : failed == 0
+              ? '$pushed wachtwoord(en) gegenereerd en verstuurd.'
+              : '$pushed verstuurd, $failed mislukt — zie het logboek.';
     } on Object catch (e) {
       _message = 'Genereren mislukt: $e';
     } finally {
       _setBusy(false);
     }
   }
+
+  // --- The Office 365 write (shared by both tabs) ----------------------------
+
+  /// The operator-readable diagnosis of a refused Office 365 write, set while a
+  /// generate/reset runs and folded into [message] when it finishes (#216).
+  /// Cleared at the start of each run so a fixed tenant stops reporting it.
+  String? _rightsProblem;
+
+  /// Pushes [password] to Azure for [mail], returning it when the write landed
+  /// and `null` when it did not.
+  ///
+  /// A refused write — Graph `403`, because the sign-in lacks the
+  /// `User-PasswordProfile.ReadWrite.All` permission or the operator holds no
+  /// password-reset role — used to surface as a raw `GraphException` string, or
+  /// as an unexplained "niet gezet". It is recorded as a rights problem naming
+  /// [who] instead (#216). Both tabs push through here, so the class-wide
+  /// generate and the per-staff reset report the same diagnosis, and a refusal
+  /// ends only this one push: the rest of a class batch still runs.
+  Future<String?> _pushAzurePassword(
+    String mail,
+    String who,
+    String password,
+  ) async {
+    try {
+      if (mail.isNotEmpty && await _backends.setAzurePassword(mail, password)) {
+        return password;
+      }
+      _log?.addError(
+        core.Origin.azure,
+        'Office 365-wachtwoord niet gezet voor $who.',
+      );
+    } on az.AzurePasswordPermissionException catch (e) {
+      final problem = _rightsMessage(who);
+      _rightsProblem = problem;
+      _log?.addError(core.Origin.azure, '$problem ($e)');
+    }
+    return null;
+  }
+
+  /// What the operator reads when Azure refuses the write: who it was for, and
+  /// the two directory-side causes worth checking, in the order they bite.
+  static String _rightsMessage(String who) =>
+      'Geen rechten om het Office 365-wachtwoord van $who te resetten — de '
+      'aanmelding mist de Graph-toestemming '
+      '"User-PasswordProfile.ReadWrite.All" (beheerderstoestemming geven en '
+      'opnieuw aanmelden), of je account heeft geen rol die wachtwoorden mag '
+      'resetten (Gebruikersbeheerder).';
 
   void _mergeAccount(
     Map<String, PasswordEntry> byKey,
@@ -536,8 +586,10 @@ class PasswordController extends ChangeNotifier {
     final account = _selectedStaff;
     if (account == null || _busy || (!smartschool && !office365)) return null;
     _setBusy(true);
+    _rightsProblem = null;
     try {
       final shared = _generate();
+      final who = '${account.givenName} ${account.surname}'.trim();
       String? ssPw;
       String? azPw;
       var failed = false;
@@ -553,33 +605,33 @@ class PasswordController extends ChangeNotifier {
       }
       if (office365) {
         final pw = smartschool ? shared : _generate();
-        if (account.mail.isNotEmpty &&
-            await _backends.setAzurePassword(account.mail, pw)) {
-          azPw = pw;
-        } else {
-          failed = true;
-        }
+        azPw = await _pushAzurePassword(account.mail, who, pw);
+        if (azPw == null) failed = true;
       }
 
+      final rights = _rightsProblem;
       if (ssPw == null && azPw == null) {
-        _message = 'Geen wachtwoord gezet — zie het logboek.';
+        _message = rights ?? 'Geen wachtwoord gezet — zie het logboek.';
         return null;
       }
       final path = await _writer(
         '${account.uid}.pdf',
         await staffPasswordPdf(
-          name: '${account.givenName} ${account.surname}'.trim(),
+          name: who,
           username: account.uid,
           mail: account.mail,
           smartschoolPassword: ssPw,
           office365Password: azPw,
         ),
       );
-      _message = _exportMessage(
+      final exported = _exportMessage(
         failed ? 'Deels gezet — sheet' : 'Wachtwoord gezet en sheet',
         path,
         await _tryOpen(path),
       );
+      // A half-successful reset still hands over a sheet, so say both: what was
+      // written, and why the Office 365 half was refused (#216).
+      _message = rights == null ? exported : '$rights $exported';
       return path;
     } on Object catch (e) {
       _message = 'Reset mislukt: $e';

--- a/account_manager/lib/src/passwords/password_controller.dart
+++ b/account_manager/lib/src/passwords/password_controller.dart
@@ -39,9 +39,6 @@ enum PasswordTarget {
       };
 }
 
-/// The fields a staff list can be filtered on (#180, legacy `FilterTypes`).
-enum StaffFilterField { naam, voornaam, gebruikersnaam }
-
 /// One student in the currently-selected class, with its per-target selection.
 class StudentRow {
   StudentRow(this.account);
@@ -452,9 +449,6 @@ class PasswordController extends ChangeNotifier {
 
   String _filterText = '';
   String get filterText => _filterText;
-  // Voornaam (first name) is the more natural default to filter staff by (#186).
-  StaffFilterField _filterField = StaffFilterField.voornaam;
-  StaffFilterField get filterField => _filterField;
 
   ss.SmartschoolAccount? _selectedStaff;
   ss.SmartschoolAccount? get selectedStaff => _selectedStaff;
@@ -490,35 +484,45 @@ class PasswordController extends ChangeNotifier {
     notifyListeners();
   }
 
-  void setStaffFilterField(StaffFilterField field) {
-    _filterField = field;
-    _applyStaffFilter();
-    notifyListeners();
-  }
-
   void selectStaff(ss.SmartschoolAccount account) {
     _selectedStaff = account;
     notifyListeners();
   }
 
+  /// Narrows the staff list to the accounts matching the current filter text.
+  /// The needle is split on whitespace and every part must match (#215), so an
+  /// empty or whitespace-only needle shows everyone.
   void _applyStaffFilter() {
-    final needle = _filterText.toLowerCase();
-    if (needle.isEmpty) {
+    final parts = _words(_filterText);
+    if (parts.isEmpty) {
       _filteredStaff = List<ss.SmartschoolAccount>.of(_allStaff);
       return;
     }
     _filteredStaff = <ss.SmartschoolAccount>[
       for (final a in _allStaff)
-        if (_staffMatches(a, needle)) a,
+        if (_staffMatches(a, parts)) a,
     ];
   }
 
-  bool _staffMatches(ss.SmartschoolAccount a, String needle) =>
-      switch (_filterField) {
-        StaffFilterField.voornaam => a.givenName.toLowerCase().contains(needle),
-        StaffFilterField.naam => a.surname.toLowerCase().contains(needle),
-        StaffFilterField.gebruikersnaam => a.uid.toLowerCase().contains(needle),
-      };
+  /// The lower-cased, whitespace-separated words of [text], empties dropped —
+  /// used to normalise both the needle and the name it is matched against.
+  static List<String> _words(String text) => <String>[
+        for (final part in text.toLowerCase().split(RegExp(r'\s+')))
+          if (part.isNotEmpty) part,
+      ];
+
+  /// Whether every part of the needle occurs somewhere in [a]'s full name,
+  /// case-insensitively — the `*namepart*` search that replaced the Naam /
+  /// Voornaam / Gebruiker field picker (#215).
+  ///
+  /// Matching per part rather than on the whole needle is what makes either
+  /// name order work: "jan peeters" finds "Peeters Jan" just as it finds
+  /// "Jan Peeters", so the operator never has to guess which way round the
+  /// name is stored.
+  static bool _staffMatches(ss.SmartschoolAccount a, List<String> parts) {
+    final fullName = _words('${a.givenName} ${a.surname}').join(' ');
+    return parts.every(fullName.contains);
+  }
 
   /// Resets the selected staff member's password(s): a fresh Smartschool and/or
   /// Office 365 password (when both are requested they share one password, as

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -24,6 +24,10 @@ import '../reconcile/reconcile_controller.dart';
 /// on-screen tiles build. The global "Dry-run all" / "Apply all" act on every
 /// pending entry across all classes.
 ///
+/// A session with no linked view — passive, or one whose pass failed before it
+/// linked — can only show the stored documents, so both drill-downs say so out
+/// loud rather than quietly swapping in static cards (#214).
+///
 /// Shares the one memoized [ReconcileServices] (and so the one
 /// [ReconcileController]) with the Reconcile and Passwords screens, so a sync
 /// run on Reconcile populates the actions shown here.
@@ -327,6 +331,11 @@ class _ActionsBodyState extends State<_ActionsBody>
   /// interactive entry tiles for that class (active session) or the read-only
   /// materialized account docs (passive session) — both through a lazy
   /// [SliverList] so only the on-screen tiles build (#154).
+  ///
+  /// The read-only half announces itself (#214): without a linked view there is
+  /// nothing to choose, dry-run or apply, and the static account cards are
+  /// otherwise indistinguishable from an interactive list whose taps stopped
+  /// working.
   List<Widget> _classroomSlivers(BuildContext context) {
     final classroom = controller.selectedClassroom;
     final slivers = <Widget>[
@@ -340,6 +349,7 @@ class _ActionsBodyState extends State<_ActionsBody>
     if (controller.loadingClassroom) {
       return slivers..add(_section(const LinearProgressIndicator()));
     }
+    slivers.addAll(_readOnlySlivers());
 
     Widget filterBar() => _section(_ClassroomFilterBar(
           onlyWithActions: _onlyWithActions,
@@ -392,9 +402,22 @@ class _ActionsBodyState extends State<_ActionsBody>
   static const String _noMatchLabel =
       'Geen accounts die aan de filter voldoen.';
 
+  /// The read-only announcement shown above either drill-down when this session
+  /// has no linked view to act on (#214) — a passive session that only read the
+  /// shared overview, or one whose sync/drift pass failed before it could link.
+  /// Empty in an active session, where the tiles below are the interactive ones.
+  List<Widget> _readOnlySlivers() {
+    if (controller.linked != null) return const <Widget>[];
+    return <Widget>[
+      _section(_ReadOnlyNotice(controller: controller)),
+      _gap(PlinkSpacing.s3),
+    ];
+  }
+
   /// The drilled-into "Klasgroepen" node (#119): the live interactive group
   /// entries (active) or the read-only materialized group docs (passive),
-  /// through a lazy [SliverList] (#154).
+  /// through a lazy [SliverList] (#154). The read-only half carries the same
+  /// announcement as the classroom drill-down (#214).
   List<Widget> _groupSlivers(BuildContext context) {
     final slivers = <Widget>[
       _section(_DetailHeader(
@@ -407,6 +430,7 @@ class _ActionsBodyState extends State<_ActionsBody>
     if (controller.loadingGroups) {
       return slivers..add(_section(const LinearProgressIndicator()));
     }
+    slivers.addAll(_readOnlySlivers());
     if (controller.linked != null) {
       final rows = _pendingRows(controller.groupPendingSituations);
       if (rows.isEmpty) {
@@ -635,6 +659,95 @@ class _EmptyState extends StatelessWidget {
       'Nog geen gematerialiseerd overzicht. Synchroniseer op het Reconcile-'
       'scherm om openstaande acties per klas te zien.',
       style: text.bodyMedium,
+    );
+  }
+}
+
+/// The read-only announcement above a drill-down whose session has no linked
+/// view (#214).
+///
+/// `ReconcileController.linked` is what the interactive
+/// [_PendingEntryTile] path is built from: the choices, the per-entry dry-run
+/// and apply. Without it the drill-down can only render the stored account /
+/// group documents as static cards — correct, but silently so, which reads as
+/// an interactive list that stopped responding. This says which of the two the
+/// operator is looking at, why, and offers the sync that turns one into the
+/// other.
+///
+/// Two ways to get here, and the operator is told which: a **passive** session
+/// that only read the shared overview (`loadOverview()`, never synced), or one
+/// whose sync/drift pass **failed** before it could link. A failed pass never
+/// discards an existing linked view — `_fail` records the error and returns to
+/// `ready`, leaving `linked` untouched — so the failure wording only ever
+/// appears when this session had nothing linked to begin with.
+class _ReadOnlyNotice extends StatelessWidget {
+  const _ReadOnlyNotice({required this.controller});
+
+  final ReconcileController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final bool failed = controller.error != null;
+    final bool lockedByOther = controller.syncLockedByOther;
+
+    return Container(
+      key: const ValueKey('actions-read-only'),
+      padding: const EdgeInsets.all(PlinkSpacing.s4),
+      decoration: BoxDecoration(
+        border: Border.all(color: colors.primary),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Icon(Icons.visibility_outlined, size: 18, color: colors.primary),
+              const SizedBox(width: PlinkSpacing.s3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text('Alleen-lezen overzicht', style: text.titleSmall),
+                    const SizedBox(height: PlinkSpacing.s1),
+                    Text(
+                      failed
+                          ? 'De laatste sync is mislukt, dus deze sessie heeft '
+                              'geen actuele acties om toe te passen. Hieronder '
+                              'staat het gedeelde overzicht van de vorige sync.'
+                          : 'Deze sessie heeft nog niet gesynchroniseerd, dus '
+                              'deze acties kunnen niet worden toegepast. '
+                              'Hieronder staat het gedeelde overzicht van de '
+                              'laatste sync.',
+                      style: text.bodyMedium,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: PlinkSpacing.s3),
+          FilledButton.icon(
+            key: const ValueKey('actions-read-only-sync'),
+            onPressed:
+                controller.busy || lockedByOther ? null : controller.sync,
+            icon: const Icon(Icons.sync, size: 18),
+            label: const Text('Synchroniseer'),
+          ),
+          // A dead Synchronise needs its reason on screen too — the same
+          // named-holder line the Reconcile screen shows (#108).
+          if (lockedByOther) ...<Widget>[
+            const SizedBox(height: PlinkSpacing.s2),
+            Text(
+              '${controller.syncLockOwner} is aan het synchroniseren…',
+              style: text.bodySmall,
+            ),
+          ],
+        ],
+      ),
     );
   }
 }
@@ -975,6 +1088,12 @@ class _ClassroomFilterBar extends StatelessWidget {
 /// One account's read-only summary in a passive-session classroom drill-down:
 /// the systems it lives in and its candidate action summaries (no live actions
 /// to apply without a sync this session).
+///
+/// Styled as the inert card it is (#214): a muted lock beside the pending
+/// badge, and the candidate lines in the disabled colour, so a card that offers
+/// no choice, dry-run or apply does not sit next to the interactive
+/// [_PendingEntryTile] looking identical to it. [_ReadOnlyNotice] above the
+/// list carries the explanation.
 class _AccountTile extends StatelessWidget {
   const _AccountTile({required this.account});
 
@@ -984,6 +1103,7 @@ class _AccountTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     final Color hairline = Theme.of(context).dividerColor;
+    final Color muted = Theme.of(context).disabledColor;
     final systems = <String>[
       if (account.inWisa) 'WISA',
       if (account.inSmartschool) 'Smartschool',
@@ -1003,6 +1123,8 @@ class _AccountTile extends StatelessWidget {
           Row(
             children: <Widget>[
               Expanded(child: Text(account.label, style: text.bodyLarge)),
+              const _ReadOnlyLock(),
+              const SizedBox(width: PlinkSpacing.s2),
               _PendingBadge(
                   count: account.candidates.where((c) => c.canApply).length),
             ],
@@ -1020,7 +1142,10 @@ class _AccountTile extends StatelessWidget {
           for (final c in account.candidates)
             Padding(
               padding: const EdgeInsets.only(top: PlinkSpacing.s1),
-              child: Text('• ${c.summary}', style: text.bodySmall),
+              child: Text(
+                '• ${c.summary}',
+                style: text.bodySmall?.copyWith(color: muted),
+              ),
             ),
         ],
       ),
@@ -1028,7 +1153,25 @@ class _AccountTile extends StatelessWidget {
   }
 }
 
-/// One class group's read-only summary in a passive-session group drill-down.
+/// The muted lock a read-only card carries where an interactive tile carries
+/// its expand affordance (#214) — the per-row half of the read-only state,
+/// explained once by [_ReadOnlyNotice] at the top of the list.
+class _ReadOnlyLock extends StatelessWidget {
+  const _ReadOnlyLock();
+
+  @override
+  Widget build(BuildContext context) => Tooltip(
+        message: 'Alleen-lezen — synchroniseer om acties toe te passen',
+        child: Icon(
+          Icons.lock_outline,
+          size: 16,
+          color: Theme.of(context).disabledColor,
+        ),
+      );
+}
+
+/// One class group's read-only summary in a passive-session group drill-down,
+/// styled inert exactly as [_AccountTile] is (#214).
 class _GroupTile extends StatelessWidget {
   const _GroupTile({required this.group});
 
@@ -1038,6 +1181,7 @@ class _GroupTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     final Color hairline = Theme.of(context).dividerColor;
+    final Color muted = Theme.of(context).disabledColor;
     final systems = <String>[
       if (group.inWisa) 'WISA',
       if (group.inSmartschool) 'Smartschool',
@@ -1057,6 +1201,8 @@ class _GroupTile extends StatelessWidget {
           Row(
             children: <Widget>[
               Expanded(child: Text(group.label, style: text.bodyLarge)),
+              const _ReadOnlyLock(),
+              const SizedBox(width: PlinkSpacing.s2),
               _PendingBadge(
                   count: group.candidates.where((c) => c.canApply).length),
             ],
@@ -1071,7 +1217,7 @@ class _GroupTile extends StatelessWidget {
               padding: const EdgeInsets.only(top: PlinkSpacing.s1),
               child: Text(
                 c.canApply ? '• ${c.summary}' : '• ${c.summary} (manueel)',
-                style: text.bodySmall,
+                style: text.bodySmall?.copyWith(color: muted),
               ),
             ),
         ],

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -9,6 +9,7 @@ import 'package:plink_design_system/plink_design_system.dart';
 import '../format/timestamps.dart';
 import '../reconcile/reconcile_bootstrap.dart';
 import '../reconcile/reconcile_controller.dart';
+import '../search/name_query.dart';
 
 /// The Actions view (#154): the pending-actions browser, split off the
 /// Reconcile screen so a September changeover's hundreds/thousands of tiles no
@@ -190,16 +191,16 @@ class _ActionsBodyState extends State<_ActionsBody>
   /// carries a name search (#187).
   bool get _staffTab => _tabs.index == _ActionFamilyTab.personeel.index;
 
-  /// The active, normalized search query (empty on any non-Personeel tab).
-  String get _query => _staffTab ? _search.text.trim().toLowerCase() : '';
-
-  /// Whether [label] passes the current name search. A single searchbox matches
-  /// the person's display name ("Voornaam Naam"), so a query on either the
-  /// voornaam or the naam is a substring hit (#187).
-  bool _matchesSearch(String label) {
-    final q = _query;
-    return q.isEmpty || label.toLowerCase().contains(q);
-  }
+  /// The active name search, parsed (empty on any non-Personeel tab, which
+  /// carries no search box).
+  ///
+  /// A single searchbox matches the person's display name ("Voornaam Naam"),
+  /// and since #217 the needle is split on whitespace with every part required
+  /// — the same [NameQuery] the Wachtwoorden → Personeel box uses (#215), so
+  /// the two Personeel searches one tab apart behave identically. Per-part
+  /// matching is what makes either name order work: "peeters jan" finds
+  /// "Jan Peeters", which as one contiguous substring found nobody.
+  NameQuery get _query => NameQuery(_staffTab ? _search.text : '');
 
   /// The passive-session classroom accounts narrowed by the active filters: the
   /// "only with actions" toggle keeps just the accounts with an applyable
@@ -207,9 +208,10 @@ class _ActionsBodyState extends State<_ActionsBody>
   /// the tile badge use), and the name search keeps matching display names.
   List<MaterializedAccount> _filterAccounts(
       List<MaterializedAccount> accounts) {
+    final query = _query;
     return [
       for (final a in accounts)
-        if ((!_onlyWithActions || a.hasPending) && _matchesSearch(a.label)) a,
+        if ((!_onlyWithActions || a.hasPending) && query.matches(a.label)) a,
     ];
   }
 
@@ -220,12 +222,13 @@ class _ActionsBodyState extends State<_ActionsBody>
   List<List<PendingAccountEntry>> _filterSituations(
     List<List<PendingAccountEntry>> situations,
   ) {
-    if (_query.isEmpty) return situations;
+    final query = _query;
+    if (query.isEmpty) return situations;
     final out = <List<PendingAccountEntry>>[];
     for (final subset in situations) {
       final kept = <PendingAccountEntry>[
         for (final e in subset)
-          if (_matchesSearch(e.target)) e,
+          if (query.matches(e.target)) e,
       ];
       if (kept.isNotEmpty) out.add(kept);
     }
@@ -1052,7 +1055,9 @@ class _ClassroomFilterBar extends StatelessWidget {
             decoration: InputDecoration(
               isDense: true,
               prefixIcon: const Icon(Icons.search, size: 18),
-              hintText: 'Zoek op voornaam of naam',
+              // Same wording as the Wachtwoorden → Personeel box, which matches
+              // the same way (#217): any part of the name, in any order.
+              hintText: 'Zoek op naam…',
               border: const OutlineInputBorder(),
               suffixIcon: searchController.text.isEmpty
                   ? null

--- a/account_manager/lib/src/screens/passwords_screen.dart
+++ b/account_manager/lib/src/screens/passwords_screen.dart
@@ -19,9 +19,10 @@ import '../reconcile/reconcile_bootstrap.dart';
 ///   Office 365, CoAccount 1–6). A guarded "Genereer wachtwoorden" pushes a
 ///   fresh password live for each checked target and queues the result for the
 ///   printable student sheet (a real PDF, #195) and the co-account CSV.
-/// - **Personeel**: the "Personeel" group, filterable by name/username; a
-///   per-member reset mints a fresh Smartschool and/or Office 365 password,
-///   pushes it live, and exports a per-staff PDF sheet.
+/// - **Personeel**: the "Personeel" group, searchable by any part of the full
+///   name (#215 — one box, no field picker); a per-member reset mints a fresh
+///   Smartschool and/or Office 365 password, pushes it live, and exports a
+///   per-staff PDF sheet.
 ///
 /// Shares the one memoized [ReconcileServices] with the Reconcile and Actions
 /// screens, so the class/staff tree comes from the same synced Smartschool
@@ -541,44 +542,20 @@ class _PersoneelTab extends StatelessWidget {
           width: 320,
           child: Column(
             children: <Widget>[
+              // One search box over the whole name (#215): the operator types a
+              // fragment and gets the person, rather than first picking which
+              // field to match on and getting an unexplained empty list when
+              // they pick the wrong one.
               Padding(
                 padding: const EdgeInsets.all(PlinkSpacing.s3),
-                child: Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: TextField(
-                        key: const ValueKey('passwords-staff-filter'),
-                        decoration: const InputDecoration(
-                          isDense: true,
-                          prefixIcon: Icon(Icons.search, size: 18),
-                          hintText: 'Filter…',
-                        ),
-                        onChanged: controller.setStaffFilterText,
-                      ),
-                    ),
-                    const SizedBox(width: PlinkSpacing.s2),
-                    DropdownButton<StaffFilterField>(
-                      key: const ValueKey('passwords-staff-filter-field'),
-                      value: controller.filterField,
-                      onChanged: (f) {
-                        if (f != null) controller.setStaffFilterField(f);
-                      },
-                      items: const <DropdownMenuItem<StaffFilterField>>[
-                        DropdownMenuItem(
-                          value: StaffFilterField.naam,
-                          child: Text('Naam'),
-                        ),
-                        DropdownMenuItem(
-                          value: StaffFilterField.voornaam,
-                          child: Text('Voornaam'),
-                        ),
-                        DropdownMenuItem(
-                          value: StaffFilterField.gebruikersnaam,
-                          child: Text('Gebruiker'),
-                        ),
-                      ],
-                    ),
-                  ],
+                child: TextField(
+                  key: const ValueKey('passwords-staff-filter'),
+                  decoration: const InputDecoration(
+                    isDense: true,
+                    prefixIcon: Icon(Icons.search, size: 18),
+                    hintText: 'Zoek op naam…',
+                  ),
+                  onChanged: controller.setStaffFilterText,
                 ),
               ),
               const Divider(height: 1),

--- a/account_manager/lib/src/search/name_query.dart
+++ b/account_manager/lib/src/search/name_query.dart
@@ -1,0 +1,49 @@
+/// A parsed name search needle: whitespace-tolerant, case-insensitive, and
+/// order-independent.
+///
+/// The needle is split on whitespace and **every** part must occur somewhere in
+/// the normalised name. Matching per part rather than on the whole needle is
+/// what makes either name order work: "jan peeters" finds "Peeters Jan" just as
+/// it finds "Jan Peeters", so the operator never has to guess which way round
+/// the name is stored. A search that silently returns nothing for a
+/// correctly-remembered name is worse than no search (#215, #217).
+///
+/// This is shared deliberately. The two Personeel searches — Wachtwoorden →
+/// Personeel (`PasswordController`, #215) and the Acties Personeel drill-down
+/// (`ActionsScreen`, #187/#217) — sit one tab apart and the operator will not
+/// remember which is which, so they must behave identically; one helper is what
+/// keeps them from drifting apart again.
+class NameQuery {
+  /// Parses [text] into the words to match on. An empty or whitespace-only
+  /// needle yields no parts, and so matches everyone.
+  NameQuery(String text) : parts = _words(text);
+
+  /// The lower-cased words of the needle, in the order typed (which does not
+  /// affect matching — every part is looked for independently).
+  final List<String> parts;
+
+  /// Whether the needle carries nothing to match on, so every name passes.
+  /// Callers that can skip filtering entirely use this to keep the original
+  /// list rather than rebuilding it.
+  bool get isEmpty => parts.isEmpty;
+
+  /// Whether every part of the needle occurs somewhere in [name],
+  /// case-insensitively and regardless of the order the parts were typed in.
+  bool matches(String name) {
+    if (parts.isEmpty) return true;
+    // Normalise the haystack the same way as the needle so runs of whitespace,
+    // and a leading/trailing space from an empty voornaam or naam, cannot
+    // decide a match.
+    final haystack = _words(name).join(' ');
+    return parts.every(haystack.contains);
+  }
+
+  /// The lower-cased, whitespace-separated words of [text], empties dropped —
+  /// used to normalise both the needle and the name it is matched against.
+  static List<String> _words(String text) => <String>[
+        for (final part in text.toLowerCase().split(_whitespace))
+          if (part.isNotEmpty) part,
+      ];
+
+  static final RegExp _whitespace = RegExp(r'\s+');
+}

--- a/account_manager/test/auth/sign_in_session_test.dart
+++ b/account_manager/test/auth/sign_in_session_test.dart
@@ -179,6 +179,17 @@ void main() {
       expect(graph.scopes, isNot(contains('offline_access')));
     });
 
+    test('graph carries the passwordProfile write permission (#216)', () {
+      // The broker asks for exactly these scopes, so the permission that
+      // authorises an Office 365 password reset has to travel with them —
+      // `User.ReadWrite.All` alone gets a 403 on the passwordProfile write.
+      expect(
+        graph.scopes,
+        contains(
+            'https://graph.microsoft.com/User-PasswordProfile.ReadWrite.All'),
+      );
+    });
+
     test('cosmos requests the cosmos.azure.com default scope', () {
       expect(AadResource.cosmos.scopes, ['https://cosmos.azure.com/.default']);
     });

--- a/account_manager/test/passwords/password_backends_test.dart
+++ b/account_manager/test/passwords/password_backends_test.dart
@@ -24,11 +24,14 @@ class _RecordingSoap implements ss.SmartschoolSoapTransport {
 }
 
 /// A Graph transport that answers GETs (user lookup) from [userExists] and
-/// records PATCHes (the password reset).
+/// records PATCHes (the password reset). With [denyPatch] the PATCH comes back
+/// the way the tenant answered it in #216: the user is found, the
+/// `passwordProfile` write is refused.
 class _FakeGraph implements az.GraphTransport {
-  _FakeGraph({required this.userExists});
+  _FakeGraph({required this.userExists, this.denyPatch = false});
 
   final bool userExists;
+  final bool denyPatch;
   final List<az.GraphRequest> patches = <az.GraphRequest>[];
 
   @override
@@ -42,6 +45,13 @@ class _FakeGraph implements az.GraphTransport {
           : const az.GraphResponse(statusCode: 404);
     }
     patches.add(request);
+    if (denyPatch) {
+      return const az.GraphResponse(
+        statusCode: 403,
+        body: '{"error":{"code":"Authorization_RequestDenied",'
+            '"message":"Insufficient privileges to complete the operation."}}',
+      );
+    }
     return const az.GraphResponse(statusCode: 204);
   }
 }
@@ -96,6 +106,23 @@ void main() {
       expect(ok, isFalse);
       expect(graph.patches, isEmpty);
       expect(log.errors, isNotEmpty);
+    });
+
+    test(
+        'a refused passwordProfile write surfaces as a permission problem, not '
+        'a bare GraphException (#216)', () async {
+      final graph = _FakeGraph(userExists: true, denyPatch: true);
+      final backends = ConnectorPasswordBackends(azure: _az(graph));
+
+      final error = await backends
+          .setAzurePassword('jane@student.school', 'Sw0rd!')
+          .then<Object?>((_) => null, onError: (Object e) => e);
+
+      // Not folded into `false`: the account exists, the rights do not — the
+      // caller must be able to tell the operator which.
+      expect(error, isA<az.AzurePasswordPermissionException>());
+      expect('$error', contains('User-PasswordProfile.ReadWrite.All'));
+      expect(graph.patches, hasLength(1));
     });
 
     test('a null connector makes the push a no-op that returns false',

--- a/account_manager/test/passwords/password_controller_test.dart
+++ b/account_manager/test/passwords/password_controller_test.dart
@@ -196,6 +196,39 @@ void main() {
       expect(c.message, contains('mislukt'));
     });
 
+    test(
+        'a refused Azure write is reported as a rights problem naming the '
+        'student, and the rest of the batch still runs (#216)', () async {
+      // Graph denies the passwordProfile write. The operator used to read
+      // "Genereren mislukt: GraphException(403 (Authorization_RequestDenied))".
+      backends = RecordingPasswordBackends(denyAzure: {'jane@student.school'});
+      final c = build();
+      final klas = c.childrenOf(c.studentRoot!).single;
+      c.selectClass(klas);
+      final jane = c.rows.firstWhere((r) => r.username == 'jane');
+      final bob = c.rows.firstWhere((r) => r.username == 'bob');
+      c
+        ..toggleRow(jane, PasswordTarget.office365, true)
+        ..toggleRow(jane, PasswordTarget.smartschool, true)
+        ..toggleRow(bob, PasswordTarget.smartschool, true);
+
+      await c.generate();
+
+      expect(c.message, isNot(contains('GraphException')));
+      expect(c.message, contains('Geen rechten'));
+      expect(c.message, contains('Jane Doe'));
+      expect(c.message, contains('User-PasswordProfile.ReadWrite.All'));
+      // The refusal ended one push, not the run: both Smartschool passwords
+      // were still pushed and queued.
+      expect(backends.smartschoolPushes.map((p) => p.$1), ['jane', 'bob']);
+      final entries = await queue.load();
+      expect(entries, hasLength(2));
+      expect(
+        entries.firstWhere((e) => e.accountName == 'jane').azurePassword,
+        isNull,
+      );
+    });
+
     test('generate is a no-op when nothing is selected', () async {
       final c = build();
       c.selectClass(c.childrenOf(c.studentRoot!).single);
@@ -390,6 +423,38 @@ void main() {
       await c.resetStaff(smartschool: true, office365: false);
       expect(backends.smartschoolPushes, hasLength(1));
       expect(backends.azurePushes, isEmpty);
+    });
+
+    test(
+        'a refused Office 365 reset names the staff member and the cause, not '
+        'a raw GraphException (#216)', () async {
+      backends = RecordingPasswordBackends(denyAzure: {'anna@school'});
+      final c = build();
+      c.selectStaff(c.staff.single);
+
+      final path = await c.resetStaff(smartschool: false, office365: true);
+
+      expect(path, isNull, reason: 'nothing was set, so no sheet is written');
+      expect(c.message, isNot(contains('GraphException')));
+      expect(c.message, contains('Geen rechten'));
+      expect(c.message, contains('Jane Doe'));
+      expect(c.message, contains('User-PasswordProfile.ReadWrite.All'));
+      expect(writes, isEmpty);
+    });
+
+    test('a half-refused reset still hands over the sheet and says why (#216)',
+        () async {
+      backends = RecordingPasswordBackends(denyAzure: {'anna@school'});
+      final c = build();
+      c.selectStaff(c.staff.single);
+
+      final path = await c.resetStaff(smartschool: true, office365: true);
+
+      expect(path, isNotNull);
+      expect(backends.smartschoolPushes, hasLength(1));
+      expect(c.message, contains('Geen rechten'));
+      expect(c.message, contains('sheet'));
+      expect(c.message, isNot(contains('GraphException')));
     });
 
     test('reset with no target selected is a no-op', () async {

--- a/account_manager/test/passwords/password_controller_test.dart
+++ b/account_manager/test/passwords/password_controller_test.dart
@@ -297,10 +297,6 @@ void main() {
       expect(c.staff.map((a) => a.uid), ['anna.smit']);
     });
 
-    test('defaults the staff filter field to voornaam (#186)', () {
-      expect(build().filterField, StaffFilterField.voornaam);
-    });
-
     test('orders the staff list alphabetically by name (#186)', () {
       // Three staff seeded out of alphabetical order across mixed casing; the
       // controller must expose them sorted by display name (alice, Bob, Charlie).
@@ -315,13 +311,57 @@ void main() {
       expect(c.staff.map((a) => a.uid), ['alice', 'bob', 'charlie']);
     });
 
-    test('filters staff by username', () {
-      final c = build()
-        ..setStaffFilterField(StaffFilterField.gebruikersnaam)
-        ..setStaffFilterText('anna');
-      expect(c.staff, hasLength(1));
+    /// The Personeel search over three staff whose names differ in case and in
+    /// which half is distinctive: Charlie Zulu, alice Bravo, Bob Alpha.
+    PasswordController buildStaffSearch() => PasswordController(
+          snapshot: staffOrderSnap(),
+          queue: queue,
+          backends: backends,
+          generatePassword: _seqGenerator(),
+          writer: (name, bytes) async => 'C:/exports/$name',
+        );
+
+    test('searches any part of the full name, case-insensitively (#215)', () {
+      final c = buildStaffSearch()..setStaffFilterText('ZUL');
+      expect(c.staff.map((a) => a.uid), ['charlie']);
+      // The given name matches just as well as the surname — no field to pick.
+      c.setStaffFilterText('Bob');
+      expect(c.staff.map((a) => a.uid), ['bob']);
+      // …and a fragment from the middle of a name matches too (*namepart*).
+      c.setStaffFilterText('rav');
+      expect(c.staff.map((a) => a.uid), ['alice']);
       c.setStaffFilterText('zzz');
       expect(c.staff, isEmpty);
+    });
+
+    test('a multi-word needle matches in either name order (#215)', () {
+      final c = buildStaffSearch()..setStaffFilterText('alice bravo');
+      expect(c.staff.map((a) => a.uid), ['alice']);
+      // Reversed — the operator never has to guess which way round the name is
+      // stored.
+      c.setStaffFilterText('bravo alice');
+      expect(c.staff.map((a) => a.uid), ['alice']);
+      // Every part must match: one part from each of two people finds neither.
+      c.setStaffFilterText('alice zulu');
+      expect(c.staff, isEmpty);
+    });
+
+    test('a whitespace-only needle shows every staff member (#215)', () {
+      final c = buildStaffSearch()..setStaffFilterText('zzz');
+      expect(c.staff, isEmpty);
+      c.setStaffFilterText('   ');
+      expect(c.staff, hasLength(3));
+      c.setStaffFilterText('');
+      expect(c.staff, hasLength(3));
+    });
+
+    test('searches the name, not the username (#215)', () {
+      // This staff account is named "Jane Doe" under the username anna.smit:
+      // with the Gebruiker option gone the name is what the box matches.
+      final c = build()..setStaffFilterText('anna.smit');
+      expect(c.staff, isEmpty);
+      c.setStaffFilterText('doe jane');
+      expect(c.staff.map((a) => a.uid), ['anna.smit']);
     });
 
     test('reset both mints one shared password, pushes both, exports a sheet',

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -67,6 +67,94 @@ class RecordingGraph implements az.GraphTransport {
   }
 }
 
+/// A [az.GraphTransport] that answers the way Graph does for a school whose
+/// stored delta token is no longer usable (#213): resuming `/users/delta` from
+/// it comes back
+/// `400 Request_UnsupportedQuery — DeltaLink older than 30 days is not
+/// supported.`, while the full-read path (`$deltatoken=latest` + the
+/// `$filter`-scoped `/users` pull) succeeds and hands back [freshToken].
+///
+/// The users it serves are the harness's own Azure fixture, so a pass that
+/// recovered lands the same linked view as a healthy one.
+class StaleDeltaTokenGraph implements az.GraphTransport {
+  StaleDeltaTokenGraph({
+    this.freshToken = 'FRESH-DELTA-TOKEN',
+    List<az.AzureUser>? users,
+  }) : users = users ?? <az.AzureUser>[azUser()];
+
+  /// The token the recovered full read primes for the next sync.
+  final String freshToken;
+
+  /// What the `$filter`-scoped bulk read returns.
+  final List<az.AzureUser> users;
+
+  final List<az.GraphRequest> requests = <az.GraphRequest>[];
+
+  /// Every delta token Graph was asked to resume from, in order — so a test can
+  /// prove the dead one is not re-sent after the recovery.
+  final List<String> resumeTokens = <String>[];
+
+  /// How many `$filter`-scoped bulk reads ran.
+  int bulkReads = 0;
+
+  @override
+  Future<az.GraphResponse> send(az.GraphRequest request) async {
+    requests.add(request);
+    final String path = request.url.path;
+    if (path.contains('/members') || path.contains('groups')) {
+      return _ok(<String, dynamic>{'value': const <Object>[]});
+    }
+    if (path.contains('users/delta')) {
+      final String? token = request.url.queryParameters[r'$deltatoken'];
+      if (token == 'latest') return _deltaLink();
+      resumeTokens.add(token ?? '');
+      // A token this transport itself handed out is honoured, so a test can
+      // prove the recovery really restored incremental syncing.
+      if (token == freshToken) return _deltaLink();
+      return az.GraphResponse(
+        statusCode: 400,
+        body: jsonEncode(<String, dynamic>{
+          'error': <String, dynamic>{
+            'code': 'Request_UnsupportedQuery',
+            'message': 'DeltaLink older than 30 days is not supported.',
+          },
+        }),
+      );
+    }
+    bulkReads++;
+    return _ok(<String, dynamic>{
+      'value': <Map<String, dynamic>>[
+        for (final az.AzureUser u in users)
+          <String, dynamic>{
+            'id': u.id,
+            'userPrincipalName': u.upn,
+            if (u.employeeId != null) 'employeeId': u.employeeId,
+            'displayName': u.displayName,
+            'givenName': u.givenName,
+            'surname': u.surname,
+            if (u.companyName != null) 'companyName': u.companyName,
+            if (u.department != null) 'department': u.department,
+            'accountEnabled': u.accountEnabled,
+          },
+      ],
+    });
+  }
+
+  /// An empty delta page closed by a deltaLink carrying [freshToken].
+  az.GraphResponse _deltaLink() => _ok(<String, dynamic>{
+        '@odata.deltaLink':
+            'https://graph.microsoft.com/v1.0/users/delta?\$deltatoken='
+                '$freshToken',
+        'value': const <Object>[],
+      });
+
+  static az.GraphResponse _ok(Map<String, dynamic> body) => az.GraphResponse(
+        statusCode: 200,
+        headers: const <String, String>{'content-type': 'application/json'},
+        body: jsonEncode(body),
+      );
+}
+
 /// A recording [PasswordBackends] for the on-demand Passwords screen (#180):
 /// captures every live push a generation/reset would make and reports success,
 /// so the reworked Passwords screen can be driven end-to-end with zero network.
@@ -684,9 +772,14 @@ Future<InMemoryLinkedStore> seededLinkedStore(
   return store;
 }
 
-az.AzureSnapshot azSnap({DateTime? fetchedAt, List<az.AzureUser>? users}) =>
+az.AzureSnapshot azSnap({
+  DateTime? fetchedAt,
+  List<az.AzureUser>? users,
+  String? deltaToken,
+}) =>
     az.AzureSnapshot(
       fetchedAt: fetchedAt ?? kFixtureDate,
+      deltaToken: deltaToken,
       users: users ?? [azUser()],
       groups: const [],
     );
@@ -1008,6 +1101,7 @@ class ReconcileHarness {
     ss.SmartschoolSnapshot? ssInitial,
     az.AzureSnapshot? azureInitial,
     this.azureGate,
+    this.azureTransport,
     this.syncedBy = 'operator@school.example',
     Set<int>? ourSchoolIds,
     List<WisaSchoolProfile> schoolProfiles = const <WisaSchoolProfile>[],
@@ -1032,15 +1126,41 @@ class ReconcileHarness {
       ssSyncs++;
       return ssResult;
     };
-    Syncer<az.AzureSnapshot> azSync = (_) async {
-      azSyncs++;
-      // When a test wires a gate, the Azure pull parks here until released, so
-      // a widget test can hold a sync mid-flight and observe the busy progress
-      // bar the earlier stages have already advanced (#176).
-      final gate = azureGate;
-      if (gate != null) await gate.future;
-      return azResult;
-    };
+    // The Azure pull. By default it is scripted like the other two; wiring an
+    // [azureTransport] swaps in the *production* pull instead — a real
+    // [az.AzureConnector] behind the real [azureSyncer], logging into this
+    // harness's LogBuffer exactly as `bootstrapReconcile` composes them. That
+    // is the only way a test can drive Graph's own answers (a rejected delta
+    // token, #213) through the pass the operator triggers.
+    final azureTransport = this.azureTransport;
+    Syncer<az.AzureSnapshot> azSync;
+    if (azureTransport != null) {
+      final inner = azureSyncer(az.AzureConnector(
+        credentials: az.AzureCredentials(
+          clientId: 'c',
+          tenantId: 't',
+          azureDomain: 'school.example',
+          schoolPrefix: 'GBS',
+        ),
+        authProvider: const az.StaticAuthProvider('token'),
+        transport: azureTransport,
+        log: log,
+      ));
+      azSync = (previous) async {
+        azSyncs++;
+        return inner(previous);
+      };
+    } else {
+      azSync = (_) async {
+        azSyncs++;
+        // When a test wires a gate, the Azure pull parks here until released,
+        // so a widget test can hold a sync mid-flight and observe the busy
+        // progress bar the earlier stages have already advanced (#176).
+        final gate = azureGate;
+        if (gate != null) await gate.future;
+        return azResult;
+      };
+    }
 
     final s = store;
     if (s != null) {
@@ -1181,6 +1301,12 @@ class ReconcileHarness {
   /// it — a seam to freeze a sync mid-pass (WISA + Smartschool already pulled)
   /// so a widget test can observe the busy progress bar (#176).
   final Completer<void>? azureGate;
+
+  /// When set, the Azure pull is the **production** one — a real
+  /// [az.AzureConnector] + [azureSyncer] over this transport — instead of the
+  /// scripted [azResult]. Lets a test answer as Graph does (e.g. rejecting a
+  /// stored delta token, #213) and drive the result through the real pass.
+  final az.GraphTransport? azureTransport;
 
   /// Builds a "second session" seeded from [store] — a fresh controller over
   /// the state another harness already persisted, the way bootstrap seeds each

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -155,6 +155,44 @@ class StaleDeltaTokenGraph implements az.GraphTransport {
       );
 }
 
+/// A [az.GraphTransport] answering the way the tenant answered in #216: the
+/// user lookup succeeds, and the `passwordProfile` PATCH that follows is
+/// refused with `403 Authorization_RequestDenied`, because the app
+/// registration was never granted `User-PasswordProfile.ReadWrite.All` (and
+/// `User.ReadWrite.All` does not authorise that property).
+///
+/// Wire it into [ReconcileHarness.passwordGraph] to drive the **production**
+/// password write path — real `ConnectorPasswordBackends` over a real
+/// [az.AzureConnector] — so a refusal travels from Graph all the way to what
+/// the Passwords screen puts on screen.
+class PasswordWriteDeniedGraph implements az.GraphTransport {
+  final List<az.GraphRequest> requests = <az.GraphRequest>[];
+
+  /// The PATCHes Graph refused.
+  List<az.GraphRequest> get refusedWrites => <az.GraphRequest>[
+        for (final r in requests)
+          if (r.method == 'PATCH') r
+      ];
+
+  @override
+  Future<az.GraphResponse> send(az.GraphRequest request) async {
+    requests.add(request);
+    if (request.method == 'GET') {
+      return const az.GraphResponse(
+        statusCode: 200,
+        headers: <String, String>{'content-type': 'application/json'},
+        body: '{"id":"az-anna","userPrincipalName":"anna@school"}',
+      );
+    }
+    return const az.GraphResponse(
+      statusCode: 403,
+      headers: <String, String>{'content-type': 'application/json'},
+      body: '{"error":{"code":"Authorization_RequestDenied",'
+          '"message":"Insufficient privileges to complete the operation."}}',
+    );
+  }
+}
+
 /// A recording [PasswordBackends] for the on-demand Passwords screen (#180):
 /// captures every live push a generation/reset would make and reports success,
 /// so the reworked Passwords screen can be driven end-to-end with zero network.
@@ -164,6 +202,7 @@ class RecordingPasswordBackends implements PasswordBackends {
   RecordingPasswordBackends({
     this.failSmartschool = const <String>{},
     this.failAzure = const <String>{},
+    this.denyAzure = const <String>{},
   });
 
   /// Smartschool usernames whose push should fail.
@@ -171,6 +210,13 @@ class RecordingPasswordBackends implements PasswordBackends {
 
   /// Azure mails/UPNs whose push should fail (models "no Azure account").
   final Set<String> failAzure;
+
+  /// Azure mails/UPNs the directory *refuses* to write (#216): Graph answers
+  /// `403 Authorization_RequestDenied` because the sign-in lacks
+  /// `User-PasswordProfile.ReadWrite.All` or the operator holds no
+  /// password-reset role. Distinct from [failAzure]: the account exists, the
+  /// rights do not, and the operator must be told which.
+  final Set<String> denyAzure;
 
   /// Every Smartschool push: `(uid, slot, password)`.
   final List<(String, core.AccountType, String)> smartschoolPushes =
@@ -192,6 +238,16 @@ class RecordingPasswordBackends implements PasswordBackends {
 
   @override
   Future<bool> setAzurePassword(String mailOrUpn, String password) async {
+    if (denyAzure.contains(mailOrUpn)) {
+      throw az.AzurePasswordPermissionException(
+        mailOrUpn,
+        const az.GraphException(
+          403,
+          '{"error":{"code":"Authorization_RequestDenied",'
+          '"message":"Insufficient privileges to complete the operation."}}',
+        ),
+      );
+    }
     if (failAzure.contains(mailOrUpn)) return false;
     azurePushes.add((mailOrUpn, password));
     return true;
@@ -1102,6 +1158,7 @@ class ReconcileHarness {
     az.AzureSnapshot? azureInitial,
     this.azureGate,
     this.azureTransport,
+    this.passwordGraph,
     this.syncedBy = 'operator@school.example',
     Set<int>? ourSchoolIds,
     List<WisaSchoolProfile> schoolProfiles = const <WisaSchoolProfile>[],
@@ -1308,6 +1365,37 @@ class ReconcileHarness {
   /// stored delta token, #213) and drive the result through the real pass.
   final az.GraphTransport? azureTransport;
 
+  /// When set, the Passwords screen writes through the **production**
+  /// [ConnectorPasswordBackends] over this transport instead of the recording
+  /// [passwordBackends] — the only way a test can answer as Graph does when it
+  /// refuses a password write (#216) and see what the screen then tells the
+  /// operator.
+  final az.GraphTransport? passwordGraph;
+
+  /// The production write seam built over [passwordGraph], or `null` when no
+  /// test wired one. Built lazily so the harness's log is already assigned.
+  late final PasswordBackends? _livePasswordBackends = passwordGraph == null
+      ? null
+      : ConnectorPasswordBackends(
+          smartschool: ss.SmartschoolConnector.fromParts(
+            site: 'demo',
+            accessCode: 'secret',
+            transport: soap,
+          ),
+          azure: az.AzureConnector(
+            credentials: az.AzureCredentials(
+              clientId: 'c',
+              tenantId: 't',
+              azureDomain: 'school.example',
+              schoolPrefix: 'GBS',
+            ),
+            authProvider: const az.StaticAuthProvider('token'),
+            transport: passwordGraph!,
+            log: log,
+          ),
+          log: log,
+        );
+
   /// Builds a "second session" seeded from [store] — a fresh controller over
   /// the state another harness already persisted, the way bootstrap seeds each
   /// [SystemState] from the store on app open (#107).
@@ -1397,7 +1485,7 @@ class ReconcileHarness {
         controller: controller,
         log: log,
         passwordQueue: passwordQueue,
-        passwordBackends: passwordBackends,
+        passwordBackends: _livePasswordBackends ?? passwordBackends,
         passwordFileWriter: (name, bytes) async {
           passwordWrites.add((name, List<int>.of(bytes)));
           return 'C:/exports/$name';

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -402,8 +402,9 @@ void main() {
   });
 
   testWidgets(
-      'the Personeel classroom search matches on voornaam or naam and combines '
-      'with the only-with-actions toggle (#187)', (WidgetTester tester) async {
+      'the Personeel classroom search matches any part of the name in any '
+      'order and combines with the only-with-actions toggle (#187/#217)',
+      (WidgetTester tester) async {
     _useTallWindow(tester);
     // Three staff in the one synthetic Personeel class: two share the surname
     // "Smit" (one with an action, one without) and one distinct voornaam.
@@ -451,6 +452,29 @@ void main() {
     expect(find.text('Bram Jansen'), findsOneWidget);
     expect(find.text('Anna Smit'), findsNothing);
     expect(find.text('Clara Smit'), findsNothing);
+
+    // Both halves, in the stored order and reversed (#217): either way round
+    // finds the one person. Reversed used to return nothing, because the needle
+    // was matched as one contiguous substring of "Voornaam Naam".
+    await tester.enterText(
+        find.byKey(const ValueKey('actions-search')), 'anna smit');
+    await tester.pump();
+    expect(find.text('Anna Smit'), findsOneWidget);
+    expect(find.text('Clara Smit'), findsNothing);
+    await tester.enterText(
+        find.byKey(const ValueKey('actions-search')), 'smit anna');
+    await tester.pump();
+    expect(find.text('Anna Smit'), findsOneWidget);
+    expect(find.text('Clara Smit'), findsNothing);
+    expect(find.text('Bram Jansen'), findsNothing);
+
+    // Every part must occur: parts taken from two different people match
+    // neither, rather than matching both.
+    await tester.enterText(
+        find.byKey(const ValueKey('actions-search')), 'anna jansen');
+    await tester.pump();
+    expect(
+        find.text('Geen accounts die aan de filter voldoen.'), findsOneWidget);
 
     // Combine the toggle with the search: search "Smit" AND only-with-actions
     // keeps just Anna (Clara matches the name but has no action).

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -541,6 +541,10 @@ void main() {
   testWidgets(
       'a passive session drills into a classroom read-only via readClassroom, '
       'loading only that class (#115/#154)', (WidgetTester tester) async {
+    // Tall, like its siblings: the read-only notice #214 added above the list
+    // costs the first card its place on an 800×600 fold, and this test is about
+    // which class was read, not about where the fold falls.
+    _useTallWindow(tester);
     final snapshots = InMemorySnapshotStore();
     final linkedStore = InMemoryLinkedStore();
     await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
@@ -691,5 +695,150 @@ void main() {
     expect(find.textContaining('Generatie 1 · $dm'), findsOneWidget);
     expect(find.textContaining('Generatie 1 · $hhmm'), findsNothing,
         reason: 'a stamp from a past day is never rendered as bare time');
+  });
+
+  // --- The read-only drill-down state (#214) -------------------------------
+
+  final readOnly = find.byKey(const ValueKey('actions-read-only'));
+  final readOnlySync = find.byKey(const ValueKey('actions-read-only-sync'));
+
+  testWidgets(
+      'a passive classroom drill-down announces itself as read-only, styles '
+      'its cards inert and offers the sync (#214)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // A passive session: the shared documents are there to read, but nothing is
+    // linked, so no choice, dry-run or apply exists for the accounts below.
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The overview itself is browsable as ever — only a drill-down, where the
+    // actions are supposed to be actionable, carries the notice.
+    expect(readOnly, findsNothing);
+
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+    expect(harness.controller.linked, isNull);
+
+    // The state is named instead of silently swapping in static cards.
+    expect(readOnly, findsOneWidget);
+    expect(find.text('Alleen-lezen overzicht'), findsOneWidget);
+    expect(find.textContaining('nog niet gesynchroniseerd'), findsOneWidget);
+
+    // …with the sync affordance right there, and live.
+    expect(tester.widget<FilledButton>(readOnlySync).onPressed, isNotNull);
+
+    // The account card is styled as the inert thing it is, rather than passing
+    // for one of the interactive entry tiles.
+    expect(find.text('Jane Doe'), findsOneWidget);
+    expect(find.byIcon(Icons.lock_outline), findsWidgets);
+    final candidate = tester.widget<Text>(
+      find.text('• Wijzig de klas in Smartschool'),
+    );
+    expect(
+      candidate.style?.color,
+      Theme.of(tester.element(readOnly)).disabledColor,
+      reason: 'a summary nobody can act on is not rendered as live body text',
+    );
+  });
+
+  testWidgets(
+      'the passive Klasgroepen drill-down carries the same read-only '
+      'announcement (#214)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+        .controller
+        .sync();
+
+    final s2 = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: s2.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+
+    expect(s2.controller.linked, isNull);
+    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
+    expect(readOnly, findsOneWidget,
+        reason: 'the group drill-down falls back to the same static tiles');
+    expect(find.byIcon(Icons.lock_outline), findsWidgets);
+  });
+
+  testWidgets(
+      'an active session drills into the same class with no read-only notice — '
+      'those tiles really are interactive (#214)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = ReconcileHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+
+    expect(harness.controller.linked, isNotNull);
+    expect(readOnly, findsNothing);
+    expect(find.byIcon(Icons.lock_outline), findsNothing);
+    expect(find.byKey(const ValueKey('rollup-groups')), findsNothing);
+  });
+
+  testWidgets(
+      'a session whose sync failed is told the sync failed, not that it never '
+      'ran (#214)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // The second reproduction path of #214: the pass died before it could link
+    // (the Azure delta-token failure of #213 was one such), so this session has
+    // an error *and* no linked view. `_fail` leaves any previously linked view
+    // untouched, so this wording is only ever reached when there was none.
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store)
+      ..wisaError = StateError('WISA host unreachable');
+    await harness.controller.sync();
+    expect(harness.controller.error, contains('WISA host unreachable'));
+    expect(harness.controller.linked, isNull);
+
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+
+    expect(readOnly, findsOneWidget);
+    expect(find.textContaining('De laatste sync is mislukt'), findsOneWidget);
+    expect(find.textContaining('nog niet gesynchroniseerd'), findsNothing);
+  });
+
+  testWidgets(
+      "the read-only banner's sync is disabled and named when another operator "
+      'holds the lease (#214/#108)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+        .controller
+        .sync();
+    await linkedStore.acquireLease(owner: 'mieke@school', now: kFixtureDate);
+
+    final s2 = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: s2.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+
+    expect(readOnly, findsOneWidget);
+    expect(tester.widget<FilledButton>(readOnlySync).onPressed, isNull);
+    expect(find.textContaining('mieke@school'), findsOneWidget,
+        reason: 'a dead button needs its reason on screen too');
   });
 }

--- a/account_manager/test/screens/passwords_screen_test.dart
+++ b/account_manager/test/screens/passwords_screen_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:account_core/account_core.dart' as core;
-import 'package:account_manager/src/passwords/password_controller.dart';
 import 'package:account_manager/src/screens/passwords_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -198,11 +197,12 @@ void main() {
   });
 
   testWidgets(
-      'Personeel: filter defaults to Voornaam and the list is alphabetical '
-      '(#186)', (WidgetTester tester) async {
+      'Personeel: the list is alphabetical and the field picker is gone '
+      '(#186/#215)', (WidgetTester tester) async {
     // Three staff seeded out of alphabetical order across mixed casing; the
-    // Personeel tab must default its filter selector to voornaam and render the
-    // list sorted by the displayed "Voornaam Naam" name.
+    // Personeel tab must render the list sorted by the displayed "Voornaam
+    // Naam" name, with a single search box and no Naam/Voornaam/Gebruiker
+    // selector beside it.
     final harness = ReconcileHarness(ssInitial: staffOrderSnap());
     await tester
         .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
@@ -211,10 +211,15 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('passwords-tab-personeel')));
     await tester.pumpAndSettle();
 
-    // The filter selector defaults to voornaam.
-    final dropdown = tester.widget<DropdownButton<StaffFilterField>>(
-        find.byKey(const ValueKey('passwords-staff-filter-field')));
-    expect(dropdown.value, StaffFilterField.voornaam);
+    // One search box, no field picker (#215).
+    expect(
+        find.byKey(const ValueKey('passwords-staff-filter')), findsOneWidget);
+    expect(find.byKey(const ValueKey('passwords-staff-filter-field')),
+        findsNothing);
+    for (final label in const <String>['Naam', 'Voornaam', 'Gebruiker']) {
+      expect(find.text(label), findsNothing,
+          reason: 'the $label option belonged to the dropped field picker');
+    }
 
     // The tiles render top-to-bottom in alphabetical order: alice, Bob, Charlie.
     double y(String uid) =>
@@ -242,5 +247,51 @@ void main() {
     await tester.pump();
     expect(
         find.byKey(const ValueKey('passwords-staff-anna.smit')), findsNothing);
+  });
+
+  testWidgets(
+      'Personeel: one box finds a staff member by any part of the name, in '
+      'either order (#215)', (WidgetTester tester) async {
+    // alice Bravo / Bob Alpha / Charlie Zulu. With the field picker gone the
+    // operator types a fragment and gets the person — a surname fragment, a
+    // given-name fragment and both halves typed the "wrong" way round all land
+    // on the same tile, where picking the wrong field used to return nothing.
+    final harness = ReconcileHarness(ssInitial: staffOrderSnap());
+    await tester
+        .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('passwords-tab-personeel')));
+    await tester.pumpAndSettle();
+
+    final filter = find.byKey(const ValueKey('passwords-staff-filter'));
+    // The focused field's blinking cursor never settles, so pump frames.
+    Future<void> search(String needle) async {
+      await tester.enterText(filter, needle);
+      await tester.pump();
+    }
+
+    // A surname fragment, cased the other way round.
+    await search('BRAV');
+    expect(find.byKey(const ValueKey('passwords-staff-alice')), findsOneWidget);
+    expect(find.byKey(const ValueKey('passwords-staff-bob')), findsNothing);
+    expect(find.byKey(const ValueKey('passwords-staff-charlie')), findsNothing);
+
+    // Both halves, surname first — the order the tile does *not* display in.
+    await search('bravo alice');
+    expect(find.byKey(const ValueKey('passwords-staff-alice')), findsOneWidget);
+    expect(find.byKey(const ValueKey('passwords-staff-bob')), findsNothing);
+
+    // Parts from two different people match neither.
+    await search('alice zulu');
+    expect(find.byKey(const ValueKey('passwords-staff-alice')), findsNothing);
+    expect(find.byKey(const ValueKey('passwords-staff-charlie')), findsNothing);
+
+    // Clearing the box brings everyone back.
+    await search('');
+    expect(find.byKey(const ValueKey('passwords-staff-alice')), findsOneWidget);
+    expect(find.byKey(const ValueKey('passwords-staff-bob')), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('passwords-staff-charlie')), findsOneWidget);
   });
 }

--- a/account_manager/test/search/name_query_test.dart
+++ b/account_manager/test/search/name_query_test.dart
@@ -1,0 +1,67 @@
+import 'package:account_manager/src/search/name_query.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The needle handling behind both Personeel search boxes — Wachtwoorden
+/// (#215) and Acties (#187/#217). Pinned once here so the two screens sharing
+/// it cannot drift apart again.
+void main() {
+  group('NameQuery', () {
+    test('an empty or whitespace-only needle matches everyone', () {
+      for (final text in <String>['', '   ', '\t\n ']) {
+        final query = NameQuery(text);
+        expect(query.isEmpty, isTrue, reason: 'needle ${text.length} spaces');
+        expect(query.matches('Jan Peeters'), isTrue);
+        expect(query.matches(''), isTrue);
+      }
+    });
+
+    test('a single fragment matches either half of the name, any case', () {
+      expect(NameQuery('peeters').matches('Jan Peeters'), isTrue);
+      expect(NameQuery('JAN').matches('Jan Peeters'), isTrue);
+      expect(NameQuery('jan').matches('Jan Peeters'), isTrue);
+    });
+
+    test('a fragment matches mid-word, not just at a word boundary', () {
+      expect(NameQuery('eter').matches('Jan Peeters'), isTrue);
+      expect(NameQuery('an pe').matches('Jan Peeters'), isTrue);
+    });
+
+    test('a non-occurring fragment matches nothing', () {
+      expect(NameQuery('zzz').matches('Jan Peeters'), isFalse);
+    });
+
+    test('both halves match in the stored order', () {
+      expect(NameQuery('jan peeters').matches('Jan Peeters'), isTrue);
+    });
+
+    test('both halves match reversed — the point of #217', () {
+      // "peeters jan" is the order the operator remembers the name in half the
+      // time; as one contiguous substring it found nobody.
+      expect(NameQuery('peeters jan').matches('Jan Peeters'), isTrue);
+      expect(NameQuery('Smit Anna').matches('Anna Smit'), isTrue);
+    });
+
+    test('every part must occur — parts from two people match neither', () {
+      expect(NameQuery('jan smit').matches('Jan Peeters'), isFalse);
+      expect(NameQuery('jan smit').matches('Anna Smit'), isFalse);
+    });
+
+    test('runs of whitespace in the needle collapse', () {
+      expect(NameQuery('  peeters    jan  ').matches('Jan Peeters'), isTrue);
+      expect(NameQuery('peeters\tjan').matches('Jan Peeters'), isTrue);
+    });
+
+    test('the name is normalised too, so padding cannot decide a match', () {
+      // A missing voornaam or surname leaves the composed "Voornaam Naam" with
+      // a stray space; it must not break a two-part needle or create a match.
+      expect(NameQuery('peeters').matches('  Peeters'), isTrue);
+      expect(NameQuery('jan peeters').matches('Jan   Peeters'), isTrue);
+      expect(NameQuery('jan peeters').matches(' Peeters '), isFalse);
+    });
+
+    test('parts exposes the typed words, lower-cased and trimmed', () {
+      expect(NameQuery(' Peeters   JAN ').parts, <String>['peeters', 'jan']);
+      expect(NameQuery('   ').parts, isEmpty);
+    });
+  });
+}

--- a/packages/azure_api/CHANGELOG.md
+++ b/packages/azure_api/CHANGELOG.md
@@ -13,6 +13,11 @@ Initial Microsoft Graph connector for Azure AD / Office 365 (issue #22).
 - `UserManager`: filtered/$select read, `/users/delta`, and user CRUD
   (`getUser`, `createUser`, `updateUser`, `deleteUser`) mirroring the legacy
   `UserManager.cs` surface.
+- Password writes request `User-PasswordProfile.ReadWrite.All` (the least
+  privileged permission for the `passwordProfile` property; requires admin
+  consent), and a refused write surfaces as
+  `AzurePasswordPermissionException` naming the missing permission/role
+  instead of a bare `GraphException` (#216).
 - `GroupManager`: prefixed group list and membership add/remove, with `$batch`
   coalescing for multi-write membership operations.
 - Record-and-replay fixture tests over a swappable Graph transport; opt-in,

--- a/packages/azure_api/README.md
+++ b/packages/azure_api/README.md
@@ -26,6 +26,26 @@ The legacy connector downloads roughly **6000** tenant users to keep the
 `userPrincipalName`, `employeeId`, `displayName`, `givenName`, `surname`,
 `companyName`, `department`, `accountEnabled`.
 
+### Delta-token lifetime (#213)
+
+Graph refuses a delta link older than 30 days. Two rules keep that from ever
+becoming a dead end:
+
+- **The token on a snapshot is always minted during that snapshot's own sync** —
+  from that pass's delta walk, or from `latestDeltaToken()` on a full read. A
+  delta walk that ends without an `@odata.deltaLink` yields *no* token rather
+  than re-shipping the one it was handed, so a token can never silently stop
+  advancing and age out while every sync still reports success. The cost is one
+  full read on the next pass; the benefit is that `AzureSnapshot.fetchedAt`
+  truthfully dates the token it ships with.
+- **A token Graph rejects is not fatal.** `sync` catches the rejection —
+  `400 Request_UnsupportedQuery` naming the delta link, and the documented
+  `410 Gone` / `resyncRequired` — logs it with the token's age, discards it, and
+  falls back to a full read that primes a fresh token. A `400
+  Request_UnsupportedQuery` that is *not* about the delta token (a malformed
+  query) still throws, so a real bug stays loud instead of degrading into an
+  expensive full read on every pass.
+
 ### Server-side filter, and where it falls back
 
 The bulk `$filter` is:

--- a/packages/azure_api/README.md
+++ b/packages/azure_api/README.md
@@ -86,6 +86,26 @@ package does not open browsers or bind sockets itself. `LoopbackAuthorizer` is
 the desktop default (RFC 8252 loopback redirect); the Flutter app injects the
 `BrowserLauncher` (`url_launcher` / `Process.start`).
 
+### Delegated permissions
+
+`AzureCredentials.scopes` defaults to the delegated set the connector needs:
+
+- `User.ReadWrite.All`, `Group.ReadWrite.All` — the reads and the account /
+  membership writes;
+- `User-PasswordProfile.ReadWrite.All` — the password writes (`createUser`'s
+  `passwordProfile` and `setPassword`). `User.ReadWrite.All` does **not**
+  authorise that property, so without this one a reset comes back
+  `403 Authorization_RequestDenied` (#216). It is the least-privileged
+  permission for it; the older `Directory.AccessAsUser.All` covers it too but
+  hands the app everything the operator can do directory-wide.
+
+All three require **admin consent** on the app registration, and a newly added
+permission only reaches a token after re-consent — a cached refresh token keeps
+the scope set it was issued for. On top of the permission, a *delegated*
+password write also needs the signed-in operator to hold a role allowed to
+reset that account: User Administrator for ordinary users, Privileged
+Authentication Administrator when the target is itself an administrator.
+
 ### Token cache (encrypted at rest)
 
 The serialized credentials hold a **refresh token** and must be encrypted at

--- a/packages/azure_api/lib/azure_api.dart
+++ b/packages/azure_api/lib/azure_api.dart
@@ -36,4 +36,5 @@ export 'src/group_manager.dart' show GroupManager;
 export 'src/models/azure_group.dart' show AzureGroup;
 export 'src/models/azure_user.dart' show AzureUser;
 export 'src/snapshot.dart' show AzureSnapshot;
-export 'src/user_manager.dart' show UserDelta, UserManager;
+export 'src/user_manager.dart'
+    show AzurePasswordPermissionException, UserDelta, UserManager;

--- a/packages/azure_api/lib/src/auth/credentials.dart
+++ b/packages/azure_api/lib/src/auth/credentials.dart
@@ -28,6 +28,20 @@ class AzureCredentials {
 
   /// Delegated scopes requested. Defaults to the legacy `User.ReadWrite.All`
   /// plus `offline_access` (needed for refresh tokens) and the OIDC scopes.
+  ///
+  /// `User-PasswordProfile.ReadWrite.All` is requested on top of those because
+  /// `User.ReadWrite.All` does **not** authorise a write to a user's
+  /// `passwordProfile`: the on-demand password reset (`UserManager.setPassword`)
+  /// came back `403 Authorization_RequestDenied` without it (#216). It is the
+  /// least-privileged permission Graph documents for that property — the older
+  /// `Directory.AccessAsUser.All` also works but hands the app everything the
+  /// signed-in operator can do directory-wide, so it is deliberately not used.
+  ///
+  /// The permission requires **admin consent** on the app registration, and a
+  /// scope only reaches a token after re-consent (a cached refresh token keeps
+  /// the scope set it was issued for). Until consent is granted the token
+  /// request for this scope set is refused, so the tenant-side grant belongs
+  /// with — not after — a rollout of this default.
   final List<String> scopes;
 
   AzureCredentials({
@@ -43,6 +57,7 @@ class AzureCredentials {
             const [
               'https://graph.microsoft.com/User.ReadWrite.All',
               'https://graph.microsoft.com/Group.ReadWrite.All',
+              'https://graph.microsoft.com/User-PasswordProfile.ReadWrite.All',
               'offline_access',
             ];
 

--- a/packages/azure_api/lib/src/connector.dart
+++ b/packages/azure_api/lib/src/connector.dart
@@ -3,8 +3,10 @@ import 'package:account_core/account_core.dart' as core;
 import 'auth/auth_provider.dart';
 import 'auth/credentials.dart';
 import 'graph/graph_client.dart';
+import 'graph/graph_request.dart';
 import 'graph/graph_transport.dart';
 import 'group_manager.dart';
+import 'models/azure_group.dart';
 import 'models/azure_user.dart';
 import 'snapshot.dart';
 import 'user_manager.dart';
@@ -23,6 +25,7 @@ class AzureConnector {
   final AzureCredentials credentials;
   final GraphTransport _transport;
   final bool _ownsTransport;
+  final core.ILog? _log;
 
   /// User reads and writes.
   final UserManager users;
@@ -36,8 +39,10 @@ class AzureConnector {
     required bool ownsTransport,
     required this.users,
     required this.groups,
+    core.ILog? log,
   })  : _transport = transport,
-        _ownsTransport = ownsTransport;
+        _ownsTransport = ownsTransport,
+        _log = log;
 
   factory AzureConnector({
     required AzureCredentials credentials,
@@ -60,6 +65,7 @@ class AzureConnector {
       ownsTransport: ownsTransport,
       users: UserManager(graph, log: log),
       groups: GroupManager(graph, log: log),
+      log: log,
     );
   }
 
@@ -70,31 +76,118 @@ class AzureConnector {
   /// - [deltaToken] set → incremental: applies `/users/delta` changes and
   ///   removals on top of [previous] (required for a complete user list; when
   ///   omitted, only the changed users are returned).
+  ///
+  /// A delta token Graph refuses is never fatal (#213): the token is discarded,
+  /// the rejection is logged with the token's age, and the pass falls back to a
+  /// full read that primes a fresh token. The operator gets a complete snapshot
+  /// instead of an aborted pass that would re-send the same dead token forever.
+  ///
+  /// **Token invariant:** the token on the returned snapshot is always one
+  /// minted during *this* sync — from this pass's delta walk, or from
+  /// [UserManager.latestDeltaToken] on a full read — never a carried-over older
+  /// one. That is what makes [AzureSnapshot.fetchedAt] a truthful age for the
+  /// token it ships with, and what keeps a token from silently ageing past
+  /// Graph's 30-day limit while every sync appears to succeed.
   Future<AzureSnapshot> sync({
     String? deltaToken,
     AzureSnapshot? previous,
   }) async {
     final groupList = await groups.listGroups(credentials.schoolPrefix);
 
-    if (deltaToken == null) {
-      final token = await users.latestDeltaToken();
-      final userList = await users.load(credentials.schoolPrefix);
-      return AzureSnapshot(
-        fetchedAt: _now(),
-        deltaToken: token,
-        users: userList,
-        groups: groupList,
+    if (deltaToken == null) return _fullRead(groupList);
+
+    final UserDelta delta;
+    try {
+      delta = await users.delta(deltaToken, credentials.schoolPrefix);
+    } on GraphException catch (e) {
+      if (!_isRejectedDeltaToken(e)) rethrow;
+      _log?.addMessage(
+        core.Origin.azure,
+        'Azure: Graph rejected the stored delta token '
+        '(${_tokenAge(previous)}) — $e. Discarding it and re-reading all '
+        'accounts in full.',
+      );
+      return _fullRead(groupList);
+    }
+
+    // No `@odata.deltaLink` on the final page means this walk produced no
+    // resume point. Keeping the old token here (the pre-#213 behaviour) let a
+    // token stop advancing while every sync still reported success, until it
+    // aged past Graph's 30-day limit and every later pass died on it. Dropping
+    // it costs one full read next pass and always leaves a fresh token behind.
+    if (delta.deltaToken == null) {
+      _log?.addMessage(
+        core.Origin.azure,
+        'Azure: the delta response carried no deltaLink, so this sync leaves '
+        'no resume token — the next sync re-reads all accounts in full.',
       );
     }
 
-    final delta = await users.delta(deltaToken, credentials.schoolPrefix);
     final userList = _applyDelta(previous?.users ?? const [], delta);
     return AzureSnapshot(
       fetchedAt: _now(),
-      deltaToken: delta.deltaToken ?? deltaToken,
+      deltaToken: delta.deltaToken,
       users: userList,
       groups: groupList,
     );
+  }
+
+  /// The full user read — `$filter`+`$select` bulk pull plus a freshly primed
+  /// delta token — over the [groupList] this pass already read.
+  ///
+  /// The token is primed *before* the bulk read so anything that changes while
+  /// the (long) read runs is picked up by the next delta rather than lost.
+  Future<AzureSnapshot> _fullRead(List<AzureGroup> groupList) async {
+    final token = await users.latestDeltaToken();
+    final userList = await users.load(credentials.schoolPrefix);
+    return AzureSnapshot(
+      fetchedAt: _now(),
+      deltaToken: token,
+      users: userList,
+      groups: groupList,
+    );
+  }
+
+  /// Whether [e] means "this delta token is no longer usable", the one Graph
+  /// failure [sync] recovers from by re-reading in full (#213).
+  ///
+  /// Two shapes, both of them Graph's own:
+  /// - `410 Gone` — the documented `resyncRequired` / `syncStateNotFound`
+  ///   "start over" signal for a delta query.
+  /// - `400 Bad Request` with `Request_UnsupportedQuery` **and** a message
+  ///   naming the delta link, e.g. *"DeltaLink older than 30 days is not
+  ///   supported."* The code alone is deliberately not enough: Graph also
+  ///   returns it for a genuinely malformed query, which must stay loud rather
+  ///   than silently degrade into an expensive full read on every pass.
+  static bool _isRejectedDeltaToken(GraphException e) {
+    if (e.statusCode == 410) return true;
+    if (e.statusCode != 400) return false;
+    if (e.code?.toLowerCase() != 'request_unsupportedquery') return false;
+    final detail = (e.message ?? e.body).toLowerCase();
+    return detail.contains('deltalink') ||
+        detail.contains('delta link') ||
+        detail.contains('deltatoken') ||
+        detail.contains('delta token');
+  }
+
+  /// How old the token Graph just rejected was, for the log line — the
+  /// diagnostic that separates "Graph expired a genuinely old token" from "the
+  /// app kept re-sending a token that had stopped advancing" (#213).
+  ///
+  /// Reads [AzureSnapshot.fetchedAt] of the snapshot the token came with, which
+  /// dates the token itself thanks to the token invariant on [sync].
+  static String _tokenAge(AzureSnapshot? previous) {
+    final at = previous?.fetchedAt;
+    if (at == null) return 'age unknown — no previous snapshot';
+    final age = _now().difference(at);
+    return 'stored ${_formatAge(age)} ago, at ${at.toIso8601String()}';
+  }
+
+  static String _formatAge(Duration age) {
+    if (age.isNegative) return 'less than a minute';
+    if (age.inDays > 0) return '${age.inDays}d ${age.inHours % 24}h';
+    if (age.inHours > 0) return '${age.inHours}h ${age.inMinutes % 60}m';
+    return '${age.inMinutes}m';
   }
 
   /// Upserts [delta.changed] and drops [delta.removedIds] over [base], keeping

--- a/packages/azure_api/lib/src/graph/graph_client.dart
+++ b/packages/azure_api/lib/src/graph/graph_client.dart
@@ -178,8 +178,22 @@ class GraphClient {
 
   /// Extracts the value of a query parameter (e.g. `$deltatoken`) from a full
   /// Graph link URL.
-  static String? _tokenFrom(String link, String param) =>
-      Uri.parse(link).queryParameters[param];
+  ///
+  /// Percent-decodes only — deliberately **not** [Uri.queryParameters], which
+  /// form-decodes and so turns a literal `+` inside an opaque Graph token into
+  /// a space. A token corrupted that way comes back from Graph as the same
+  /// misleading *"DeltaLink older than 30 days is not supported"* 400 as a
+  /// genuinely expired one (#213).
+  static String? _tokenFrom(String link, String param) {
+    for (final pair in Uri.parse(link).query.split('&')) {
+      if (pair.isEmpty) continue;
+      final eq = pair.indexOf('=');
+      final name = eq < 0 ? pair : pair.substring(0, eq);
+      if (Uri.decodeComponent(name) != param) continue;
+      return eq < 0 ? '' : Uri.decodeComponent(pair.substring(eq + 1));
+    }
+    return null;
+  }
 
   static String _trimLeadingSlash(String path) =>
       path.startsWith('/') ? path.substring(1) : path;

--- a/packages/azure_api/lib/src/user_manager.dart
+++ b/packages/azure_api/lib/src/user_manager.dart
@@ -25,6 +25,42 @@ class UserDelta {
   });
 }
 
+/// Thrown when Graph refuses a password write (`403`), instead of letting the
+/// bare [GraphException] reach the operator (#216).
+///
+/// Writing `passwordProfile` is privileged well beyond an ordinary user write,
+/// and a refusal is nearly always one of two fixable directory-side causes
+/// rather than a bug: the sign-in lacks the
+/// `User-PasswordProfile.ReadWrite.All` delegated permission (admin-consented
+/// on the app registration, and only present on tokens issued *after* that
+/// consent), or the signed-in operator holds no role allowed to reset this
+/// target's password — User Administrator for ordinary users, Privileged
+/// Authentication Administrator when the target is itself an administrator.
+///
+/// [toString] names both, so the reason survives into the log; the UI layer
+/// phrases it for the operator.
+class AzurePasswordPermissionException implements Exception {
+  const AzurePasswordPermissionException(this.target, this.cause);
+
+  /// The object id or UPN whose password write was refused.
+  final String target;
+
+  /// The refusal Graph sent back (`403`, usually `Authorization_RequestDenied`).
+  final GraphException cause;
+
+  /// Graph's own error code, when it sent one.
+  String? get code => cause.code;
+
+  @override
+  String toString() =>
+      'Not allowed to set the password of $target. The sign-in needs the '
+      'User-PasswordProfile.ReadWrite.All Graph permission (admin-consented, '
+      'and re-consented since the last token), and the signed-in operator '
+      'needs a role that may reset this account (User Administrator, or '
+      'Privileged Authentication Administrator for an administrator). '
+      'Graph said: $cause';
+}
+
 /// Reads and writes Azure AD users via Microsoft Graph.
 ///
 /// Mirrors the legacy `UserManager.cs` surface, but never downloads the whole
@@ -282,20 +318,29 @@ class UserManager {
   /// [idOrUpn] is the object id or UPN. [forceChangePasswordNextSignIn] defaults
   /// to `true`, matching the legacy reset (the holder must pick a new password on
   /// next login).
+  ///
+  /// A `403` — the permission/role gap of #216 — is rethrown as an
+  /// [AzurePasswordPermissionException] naming what the directory is missing;
+  /// every other Graph failure propagates unchanged as a [GraphException].
   Future<void> setPassword(
     String idOrUpn,
     String password, {
     bool forceChangePasswordNextSignIn = true,
   }) async {
-    await _graph.patchJson(
-      _graph.uri('users/${Uri.encodeComponent(idOrUpn)}'),
-      <String, dynamic>{
-        'passwordProfile': <String, dynamic>{
-          'forceChangePasswordNextSignIn': forceChangePasswordNextSignIn,
-          'password': password,
+    try {
+      await _graph.patchJson(
+        _graph.uri('users/${Uri.encodeComponent(idOrUpn)}'),
+        <String, dynamic>{
+          'passwordProfile': <String, dynamic>{
+            'forceChangePasswordNextSignIn': forceChangePasswordNextSignIn,
+            'password': password,
+          },
         },
-      },
-    );
+      );
+    } on GraphException catch (e) {
+      if (e.statusCode != 403) rethrow;
+      throw AzurePasswordPermissionException(idOrUpn, e);
+    }
     _log?.addMessage(core.Origin.azure, 'Azure: reset password for $idOrUpn.');
   }
 

--- a/packages/azure_api/test/connector_test.dart
+++ b/packages/azure_api/test/connector_test.dart
@@ -187,5 +187,171 @@ void main() {
       );
       expect(deltaCall.url.queryParameters[r'$deltatoken'], 'OLDTOKEN');
     });
+
+    test(
+        'a delta walk that returns no deltaLink leaves no token rather than '
+        'carrying the old one forward (#213)', () async {
+      // Graph normally closes a delta walk with an `@odata.deltaLink`. When it
+      // does not, the pre-fix connector re-shipped the token it was handed, so
+      // the stored token stopped advancing while every sync still reported
+      // success — and kept ageing until Graph refused it for being >30 days
+      // old. No token at all is the honest answer: the next sync re-reads.
+      GraphResponse noLinkRoute(GraphRequest req) {
+        // Everything empty, and — the point of the test — the delta walk ends
+        // with no `@odata.deltaLink`.
+        return jsonOk({'value': const <Object>[]});
+      }
+
+      final connector = connectorWith(FakeGraphTransport(noLinkRoute));
+      final snapshot = await connector.sync(
+        deltaToken: 'OLDTOKEN',
+        previous: AzureSnapshot(
+          fetchedAt: DateTime.utc(2026, 6, 1),
+          deltaToken: 'OLDTOKEN',
+          users: const [],
+          groups: const [],
+        ),
+      );
+
+      expect(snapshot.deltaToken, isNull,
+          reason: 'a token that did not advance is dropped, never re-shipped');
+    });
+  });
+
+  group('rejected delta token (#213)', () {
+    /// Routes a delta *resume* to [rejection] while the full-read path
+    /// (`$deltatoken=latest` + the `$filter` bulk read) succeeds.
+    GraphResponse Function(GraphRequest) rejectingRoute(
+      GraphResponse rejection, {
+      List<String>? resumeTokens,
+    }) =>
+        (req) {
+          final path = req.url.path;
+          if (path.contains('/members')) {
+            return jsonOk(readFixture('group_members_3a.json'));
+          }
+          if (path.contains('groups')) {
+            return jsonOk(readFixture('groups.json'));
+          }
+          if (path.contains('users/delta')) {
+            final token = req.url.queryParameters[r'$deltatoken'];
+            if (token == 'latest') {
+              return jsonOk(readFixture('delta_latest.json'));
+            }
+            resumeTokens?.add(token ?? '');
+            return rejection;
+          }
+          if (req.url.queryParameters[r'$skiptoken'] == 'PAGE2') {
+            return jsonOk(readFixture('users_page2.json'));
+          }
+          return jsonOk(readFixture('users_page1.json'));
+        };
+
+    AzureSnapshot previousAt(DateTime at) => AzureSnapshot(
+          fetchedAt: at,
+          deltaToken: 'DEADTOKEN',
+          users: const [
+            AzureUser(id: '00000000-0000-0000-0000-000000000042', upn: 'old@x'),
+          ],
+          groups: const [],
+        );
+
+    test(
+        'a 400 Request_UnsupportedQuery about an expired deltaLink falls back '
+        'to a full read and primes a fresh token', () async {
+      final resumeTokens = <String>[];
+      final transport = FakeGraphTransport(rejectingRoute(
+        graphError(
+          400,
+          'Request_UnsupportedQuery',
+          'DeltaLink older than 30 days is not supported.',
+        ),
+        resumeTokens: resumeTokens,
+      ));
+      final log = RecordingLog();
+      final connector = AzureConnector(
+        credentials: credentials,
+        authProvider: const StaticAuthProvider('T'),
+        transport: transport,
+        log: log,
+      );
+
+      final snapshot = await connector.sync(
+        deltaToken: 'DEADTOKEN',
+        previous:
+            previousAt(DateTime.now().subtract(const Duration(hours: 14))),
+      );
+
+      // The pass completed with a *complete* snapshot, not the previous user
+      // list and not an exception.
+      expect(resumeTokens, ['DEADTOKEN'], reason: 'tried once, then given up');
+      expect(snapshot.users.map((u) => u.upn), [
+        'ann.peeters@student.school.example',
+        'bram.janssens@student.school.example',
+        'carla.maes@school.example',
+      ]);
+      expect(snapshot.groups, hasLength(2));
+      // …and with a fresh token, so the next sync resumes instead of hitting
+      // the same dead token forever.
+      expect(snapshot.deltaToken, 'PRIMEDTOKEN123');
+
+      // The bulk read really was the $filter-scoped one (PAIN-2 holds on the
+      // recovery path too).
+      final bulk = transport.requests.firstWhere(
+        (r) => r.url.path.endsWith('/users'),
+      );
+      expect(bulk.url.queryParameters[r'$filter'], isNotNull);
+
+      // The operator is told what happened, with the rejected token's age —
+      // the diagnostic that separates "genuinely old" from "stopped advancing".
+      final recovery = log.messages.firstWhere(
+        (m) => m.contains('rejected the stored delta token'),
+      );
+      expect(recovery, contains('14h'));
+      expect(recovery, contains('DeltaLink older than 30 days'));
+    });
+
+    test('Graph\'s documented 410 resyncRequired recovers the same way',
+        () async {
+      final transport = FakeGraphTransport(rejectingRoute(
+        graphError(410, 'resyncRequired', 'Resync required.'),
+      ));
+      final connector = connectorWith(transport);
+
+      final snapshot = await connector.sync(
+        deltaToken: 'DEADTOKEN',
+        previous: previousAt(DateTime.utc(2026, 6, 1)),
+      );
+
+      expect(snapshot.users, hasLength(3));
+      expect(snapshot.deltaToken, 'PRIMEDTOKEN123');
+    });
+
+    test(
+        'a 400 that is not about the delta token still fails the sync — a '
+        'malformed query must stay loud', () async {
+      final transport = FakeGraphTransport(rejectingRoute(
+        graphError(
+          400,
+          'Request_UnsupportedQuery',
+          "Unsupported or invalid query filter clause specified for property "
+              "'jobTitle'.",
+        ),
+      ));
+      final connector = connectorWith(transport);
+
+      await expectLater(
+        connector.sync(
+          deltaToken: 'DEADTOKEN',
+          previous: previousAt(DateTime.utc(2026, 6, 1)),
+        ),
+        throwsA(isA<GraphException>()),
+      );
+      expect(
+        transport.requests.where((r) => r.url.path.endsWith('/users')),
+        isEmpty,
+        reason: 'no silent, expensive full read behind a real query bug',
+      );
+    });
   });
 }

--- a/packages/azure_api/test/graph_client_test.dart
+++ b/packages/azure_api/test/graph_client_test.dart
@@ -114,5 +114,33 @@ void main() {
       expect(result.values, hasLength(4)); // 1 + (2 changed + 1 removed)
       expect(result.deltaToken, 'NEWDELTA456');
     });
+
+    test(
+        'a token carrying a literal "+" survives the deltaLink round trip '
+        '(#213)', () async {
+      // Graph tokens are opaque and are not form-encoded: a `+` in a deltaLink
+      // is a `+`. Reading it back with Uri.queryParameters form-decodes it to a
+      // space, and re-sending the mangled token earns the same misleading
+      // "DeltaLink older than 30 days is not supported" 400 as a genuinely
+      // expired one.
+      const token = 'aB+cd/ef+gh';
+      final transport = FakeGraphTransport((req) => jsonOk({
+            '@odata.deltaLink': 'https://graph.microsoft.com/v1.0/users/delta'
+                '?\$deltatoken=$token',
+            'value': const <Object>[],
+          }));
+      final client = clientWith(transport);
+
+      final result = await client.getDelta(client.uri('users/delta'));
+
+      expect(result.deltaToken, token);
+      expect(result.deltaToken, isNot(contains(' ')));
+
+      // …and the token that comes back is the one the next resume sends.
+      await client.getDelta(
+        client.uri('users/delta', query: {r'$deltatoken': result.deltaToken!}),
+      );
+      expect(transport.last.url.queryParameters[r'$deltatoken'], token);
+    });
   });
 }

--- a/packages/azure_api/test/user_manager_test.dart
+++ b/packages/azure_api/test/user_manager_test.dart
@@ -291,6 +291,70 @@ void main() {
         'jane.doe@student.school.example',
       );
     });
+
+    test('a refused write (403) names the permission and role gap (#216)',
+        () async {
+      // What the tenant actually answered: `User.ReadWrite.All` does not
+      // authorise a passwordProfile write, so Graph denies the PATCH. The bare
+      // GraphException told the operator nothing actionable.
+      final transport = FakeGraphTransport.constant(
+        graphError(403, 'Authorization_RequestDenied',
+            'Insufficient privileges to complete the operation.'),
+      );
+      final users = UserManager(clientWith(transport));
+
+      final error = await users
+          .setPassword('anna.smit@school.example', 'Bacoxy7!')
+          .then<Object?>((_) => null, onError: (Object e) => e);
+
+      expect(error, isA<AzurePasswordPermissionException>());
+      final refusal = error! as AzurePasswordPermissionException;
+      expect(refusal.target, 'anna.smit@school.example');
+      expect(refusal.code, 'Authorization_RequestDenied');
+      expect(refusal.cause.statusCode, 403);
+      expect(refusal.toString(), contains('anna.smit@school.example'));
+      expect(
+          refusal.toString(), contains('User-PasswordProfile.ReadWrite.All'));
+      expect(refusal.toString(), contains('User Administrator'));
+    });
+
+    test('any other Graph failure still propagates as a GraphException',
+        () async {
+      final transport = FakeGraphTransport.constant(
+        graphError(400, 'Request_BadRequest', 'password too weak'),
+      );
+      final users = UserManager(clientWith(transport));
+      await expectLater(
+        users.setPassword('id-1', 'x'),
+        throwsA(isA<GraphException>()),
+      );
+    });
+  });
+
+  group('AzureCredentials scopes (#216)', () {
+    test('requests the least-privileged passwordProfile write permission', () {
+      final credentials = AzureCredentials(
+        clientId: 'c',
+        tenantId: 't',
+        azureDomain: 'school.example',
+        schoolPrefix: 'GBS',
+      );
+      expect(
+        credentials.scopes,
+        containsAll(<String>[
+          'https://graph.microsoft.com/User.ReadWrite.All',
+          'https://graph.microsoft.com/Group.ReadWrite.All',
+          'https://graph.microsoft.com/User-PasswordProfile.ReadWrite.All',
+        ]),
+      );
+      // The broad older alternative is deliberately not requested: it grants
+      // everything the signed-in operator can do directory-wide.
+      expect(
+        credentials.scopes,
+        isNot(contains('https://graph.microsoft.com/'
+            'Directory.AccessAsUser.All')),
+      );
+    });
   });
 
   group('deleteUser', () {


### PR DESCRIPTION
## Summary

- **#213 — Azure delta token.** `AzureConnector.sync` now catches the rejected-token cases (400 `Request_UnsupportedQuery` naming the delta link, and 410 `resyncRequired`), logs the rejection with the stored token's age, discards it and falls back to the `$filter`-scoped full read plus a fresh token; a non-delta 400 still throws. The cause of the ageing token is confirmed from the code: `delta.deltaToken ?? deltaToken` re-shipped the old token whenever a walk ended without `@odata.deltaLink`, so it stopped advancing while syncs still reported success. That fallback is removed — no deltaLink means no token, which costs one full read next pass and makes a snapshot's `fetchedAt` a truthful token age. A second corruption path is closed too: `GraphClient._tokenFrom` used `Uri.queryParameters`, which form-decodes a literal `+` in an opaque token into a space; it now percent-decodes only.
- **#214 — Acties read-only fallback.** `linked == null` made both drill-downs silently swap interactive entry tiles for static bullet text. Added a keyed "Alleen-lezen overzicht" notice that distinguishes never-synced from failed-pass, with an inline Synchroniseer action (disabled and naming the holder when another operator holds the lease) and muted lock styling on the inert cards. `_fail` was evaluated and needs no change — it never nulls `_linked`. #210 is ruled out: the fallback branch dates to #154 (`3ac9e19`).
- **#215 — Personeel password search.** Dropped the `StaffFilterField` dropdown and the enum; the search box spans the column and matches any part of the full name, in either order.
- **#216 — Office 365 password reset 403.** `User.ReadWrite.All` does not authorise a `passwordProfile` write. Added `User-PasswordProfile.ReadWrite.All` (Graph's current least-privileged permission for that property, chosen over the broader legacy `Directory.AccessAsUser.All`) to the requested scopes, and made a refused reset surface as an operator-readable Dutch message naming the missing permission and roles instead of a raw `GraphException` — a refusal now ends one push rather than the whole batch.
- **#217 — follow-up from #215.** The Acties Personeel search still matched the display name as one contiguous substring and so missed the reversed order. Matching is lifted into a shared `NameQuery` used by both screens, so they cannot drift apart.

## Test plan

- [x] `dart format --set-exit-if-changed .` clean (289 files) and `flutter analyze` / `dart analyze --fatal-infos --fatal-warnings` clean at every commit
- [x] Package unit tests green throughout — 950 at #213/#215, 86 in `azure_api` incl. 3 new for #216
- [x] `account_manager` unit/widget: 303/303 at the tip (280 → 303 across the chunk), incl. the new `test/search/name_query_test.dart` (10 cases)
- [x] `flutter test integration_test/app_launch_test.dart -d windows` — 55/55 at the tip, incl. one new e2e each for #213, #214, #215, #216 and #217
- [x] Every new test was confirmed red on the unpatched code first; #216's e2e reproduced the reported surface exactly (`Reset mislukt: GraphException(403 (Authorization_RequestDenied))`)

## Tenant action required before #216 takes effect

The code change alone does not fix the 403 — the app registration "Arcadia Account Manager (Desktop)" (`da407efb-…`) currently holds only `User.ReadWrite.All`, `Group.ReadWrite.All`, `offline_access`, `openid`, `profile`. Someone must add delegated `User-PasswordProfile.ReadWrite.All` (`56760768-b641-451f-8906-e1b8ab31bca7`) and grant admin consent **before or with** rolling out this build, since a token request for an unconsented scope is refused outright; operators then need to sign out so cached refresh tokens pick up the new scope. The operator also needs User Administrator (Privileged Authentication Administrator if any target is itself an admin).

Closes #213
Closes #214
Closes #215
Closes #216
Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)