### PR TITLE
chore(ci): bump pinned actions off the deprecated Node 20 runtime (#219)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@
 # Until issue #19 (account_core) lands a root `pubspec.yaml`, the Dart steps
 # are no-ops and the workflow reports green based on the workspace-detection
 # notice alone. That is intentional: we want CI scaffolding committed early.
+#
+# Action pinning: every JavaScript action here must run on Node 24 — Node 20
+# is deprecated and only shimmed for now (#219). Check each action's own
+# `runs.using` rather than assuming the newest major is node24: the artifact
+# actions shipped a node20 major *after* the one pinned here, so the first
+# node24 releases are `upload-artifact@v6` and `download-artifact@v7` (a
+# matched pair), and `sonarqube-scan-action@v7`. `subosito/flutter-action@v2`
+# is a composite action with no Node runtime and stays as-is.
 
 name: CI
 
@@ -42,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # SonarCloud needs full history for blame-based new-code detection.
           fetch-depth: 0
@@ -94,7 +102,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: steps.workspace.outputs.exists == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-lcov
           path: coverage/lcov.info
@@ -110,12 +118,12 @@ jobs:
     if: ${{ vars.SONARCLOUD_ENABLED == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: coverage-lcov
           path: coverage
@@ -123,7 +131,7 @@ jobs:
         continue-on-error: true
 
       - name: SonarQube Cloud scan
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -37,6 +37,14 @@
 # Overlap note: an older workflow (`ci.yml`) also runs `dart analyze` +
 # `dart test` on pull_request, plus coverage / SonarCloud. The two
 # workflows are kept side-by-side for now; consolidation is a follow-up.
+#
+# Action pinning: every JavaScript action here must run on Node 24 — Node 20
+# is deprecated and only shimmed for now (#219). When bumping a pin, check the
+# action's own `runs.using`, not just its major: `actions/checkout` reached
+# node24 at v5, `azure/login` at v3. These need runner >= 2.327.1; the
+# GitHub-hosted ubuntu-latest / windows-latest runners are well past that.
+# `subosito/flutter-action@v2` is a *composite* action (bash steps only), so
+# it has no Node runtime and is unaffected by the deprecation.
 
 name: Dart
 
@@ -65,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # The workspace now includes the Flutter app (account_manager), so the
       # root resolves with the Flutter SDK, not bare Dart. Flutter bundles
@@ -142,7 +150,7 @@ jobs:
       # by the steps below (OIDC), never stored as a secret.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Flutter SDK (bundles Dart) — the workspace root now includes the
       # Flutter app, so it resolves with `flutter pub get`.
@@ -167,7 +175,7 @@ jobs:
       # layer, per the live-testing policy.
       - name: Azure login (OIDC — no stored secret)
         if: env.AZURE_CLIENT_ID != '' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/develop')
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -199,7 +207,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Summary

Bumps every pinned action whose runtime was still Node 20, so CI keeps working when the runners drop the Node 24 shim.

Each action's runtime was read from its own `action.yml` (`runs.using`) **at the tag**, rather than assuming the latest major is Node 24 — which mattered: both artifact actions shipped a *further* Node 20 major after the version this repo had pinned.

| Action | Was | Now |
| --- | --- | --- |
| `actions/checkout` (×5) | v4 | v5 |
| `azure/login` | v2 | v3 |
| `actions/upload-artifact` | v4 | v6 |
| `actions/download-artifact` | v4 | v7 |
| `SonarSource/sonarqube-scan-action` | v6 | v7 |

`subosito/flutter-action@v2` is deliberately left pinned — it is a **composite** action (bash steps only), so it has no Node runtime and the deprecation does not apply to it. Nothing else in the workflows is on Node 20 after this.

Deliberately *not* taking the newest major where it carries unrelated breaking changes: `download-artifact@v8` defaults `digest-mismatch` to error, and `sonarqube-scan-action@v8` flips `skipSignatureVerification` to false. Neither belongs in a runtime bump.

**OIDC is unaffected.** `azure/login@v3`'s input set is byte-identical to v2 — only the runtime changed — so `client-id`/`tenant-id`/`allow-no-subscriptions` and the `id-token: write` permission are untouched.

**Runner minimum satisfied.** `checkout@v5` and the Node 24 artifact releases require runner 2.327.1+; run [32363830754](https://github.com/yvanvds/AccountManager/actions/runs/32363830754) shows **2.336.0** on both `ubuntu-24.04` and `windows-2025-vs2026`, including the Windows integration-test runner.

## Test plan

A workflow bump has no meaningful local test — **this PR's own CI run is the test**, across all five jobs. Locally verified only that nothing else moved:

- [x] `dart format --set-exit-if-changed .` clean (289 files, 0 changed)
- [x] `dart analyze --fatal-infos --fatal-warnings` clean
- [x] 953 package unit tests pass (11 skipped — the live-integration tests self-skip without credentials)
- [x] 303 `account_manager` widget tests pass
- [x] Both workflow files parse — validated by a YAML load that re-dumped every job and step
- [ ] **CI green on this PR** — the actual gate: checkout, Flutter setup, Azure OIDC login, artifact up/download, and the Sonar scan all exercised

Zero Dart files changed, so the Windows e2e suite was not run locally.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)