### PR TITLE
fix(state): scope PlacementResolver per school — 00 sentinel in class names, cross-school containsStudents (#221, #222)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1157,6 +1157,66 @@ void main() {
   });
 
   testWidgets(
+      'an empty class beside a sibling school\'s populated namesake stays the '
+      'read-only empty notice end-to-end (#222)', (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. Our school 1 has an empty
+    // `1A`; the sibling school 2 we do not manage has its own populated `1A`,
+    // pulled by the same shared WISA credentials. Only ours is linked (#205), so
+    // exactly one class reaches the Klasgroepen list — and it is empty.
+    //
+    // Before the fix the tally behind `containsStudents` pooled every school's
+    // students under the bare class name, so the sibling's student made our
+    // empty class read as populated: the list offered "Voeg deze klas toe aan
+    // Smartschool", the applyable action that also enrols students into the
+    // class it creates. This is the layer that sees it — the misclassification
+    // needs two schools in one snapshot, which no single-resolver assertion
+    // composes, and the flip is what the operator reads off the tile.
+    useTallWindow(tester);
+    final harness = siblingPopulatedClassHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+
+    // Our 1A is the only class on the list, and it reads as the empty one.
+    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
+    expect(find.byKey(const ValueKey('entry-group-1A')), findsOneWidget);
+    expect(find.textContaining('bevat nog geen leerlingen'), findsOneWidget);
+    expect(
+        find.textContaining('Voeg deze klas toe aan Smartschool'), findsNothing,
+        reason: 'nobody of ours is in 1A — creating + enrolling is not due');
+
+    // The notice is marked manual — there is nothing to write for an empty
+    // class — while the only applyable line stays the "ignore this class"
+    // opt-out every WISA-only class carries.
+    expect(find.textContaining('(manueel)'), findsOneWidget);
+    expect(find.textContaining('Negeer deze klas bij het importeren uit WISA'),
+        findsOneWidget);
+
+    // And the pass itself never constructed the create-and-enrol action for it.
+    final kinds = harness.controller.pendingEntries
+        .expand((e) => e.choices)
+        .expand((c) => c.alternatives)
+        .map((a) => a.kind)
+        .toList();
+    expect(kinds, contains('CreateInSmartschool'));
+    expect(kinds, isNot(contains('AddToSmartschool')));
+  });
+
+  testWidgets(
       'the Acties drill-down opens on grade-years merged across the managed '
       'schools end-to-end, with no school level to guess at (#210)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1209,6 +1209,96 @@ void main() {
   });
 
   testWidgets(
+      'a single-group class whose name another school shares raises no class '
+      'change, and "00" never reaches a class name end-to-end (#221)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. Two managed schools each have
+    // their own single-group `1C` — one `SyncKlas` row, `KLASGROEP = 00`, and
+    // (because `ADMINGROEP` is only unique within a school) a different
+    // `ADMINGROEP` each. Both students already sit in the Smartschool `1C`
+    // their WISA record names, so the correct pass proposes nothing.
+    //
+    // Before the fix the two schools' admin codes pooled under the bare name
+    // `1C`, the class read as sub-grouped, and each student's `KLASGROEP` was
+    // appended verbatim: every student of both classes was offered "Wijzig de
+    // klas in Smartschool — 1C → 1C 00", a move into a class that exists
+    // nowhere. This is the layer that sees it: the misclassification needs two
+    // schools in one snapshot, which no single-resolver assertion composes.
+    useTallWindow(tester);
+    final harness = subGroupSentinelHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // Not one class move is proposed anywhere in the pass, and no projected
+    // change carries the sentinel.
+    final alternatives = harness.controller.pendingEntries
+        .expand((e) => e.choices)
+        .expand((c) => c.alternatives);
+    expect(
+      alternatives.map((a) => a.kind),
+      isNot(contains('MoveToSmartschoolClassGroup')),
+      reason: 'both classes are single-group — nobody moves',
+    );
+    expect(
+      alternatives
+          .expand((a) => a.changes.fields)
+          .expand((f) => <String?>[f.before, f.after]),
+      isNot(contains('1C 00')),
+      reason: 'the "no sub-groups" sentinel is never part of a class name',
+    );
+
+    // Browse it the way the operator does: the merged first year holds both
+    // schools' `1C`, each still keyed to its own school partition. Closing a
+    // classroom rebuilds — and so collapses — the drill-down tree, so the year
+    // is re-opened for each school.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+
+    Future<void> openYear() async {
+      final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
+      await tester.ensureVisible(yearNode);
+      await tester.tap(yearNode);
+      await tester.pumpAndSettle();
+    }
+
+    await openYear();
+    expect(find.text('1C 00'), findsNothing,
+        reason: 'the sentinel never names a class in the drill-down either');
+
+    // Each school's class in turn: opened, and carrying no class-change row.
+    for (final school in <String>['1', '2']) {
+      if (harness.controller.selectedClassroom != null) {
+        await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
+        await tester.pumpAndSettle();
+        await openYear();
+      }
+      final classNode = find.byKey(ValueKey('rollup-class-class|$school|1|1C'));
+      expect(classNode, findsOneWidget);
+      await tester.ensureVisible(classNode);
+      await tester.tap(classNode);
+      await tester.pumpAndSettle();
+
+      // The drill-down really opened (both the populated and the empty branch
+      // render this header), so the absence assertions below mean something.
+      expect(
+          find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+      expect(harness.controller.selectedClassroom?.school, school);
+      expect(find.text('Wijzig de klas in Smartschool'), findsNothing,
+          reason: 'school $school\'s 1C is single-group — no move is due');
+      expect(find.textContaining('1C 00'), findsNothing);
+    }
+  });
+
+  testWidgets(
       'the Actions view splits Personeel and Leerlingen into tabs end-to-end: '
       'staff drill in one tab, students in the other (#179)',
       (WidgetTester tester) async {

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -258,16 +258,20 @@ class RecordingPasswordBackends implements PasswordBackends {
 // Record + snapshot builders.
 // ---------------------------------------------------------------------------
 
+/// A WISA student. [classSubGroup] is the raw `KLASGROEP` column: a real
+/// sub-group code for a split class, or the `00` "no sub-groups" sentinel —
+/// which must never end up in the student's class name (#221).
 wapi.WisaStudent wisaStudent({
   String wisaId = '1',
   String classGroup = '3C',
+  String classSubGroup = '',
   int schoolId = 1,
   core.Address address = _addr,
 }) =>
     wapi.WisaStudent(
       wisaId: core.WisaId(wisaId),
       classGroup: classGroup,
-      classSubGroup: '',
+      classSubGroup: classSubGroup,
       name: 'Doe',
       firstName: 'Jane',
       preferredName: '',
@@ -713,6 +717,64 @@ ReconcileHarness virtualClassGroupHarness() => ReconcileHarness(
       ),
       azure: azSnap(users: const []),
       ourSchoolIds: const {1, 99},
+    );
+
+/// A harness for the `00` sub-group sentinel (#221). Two managed schools that
+/// each have their own `1C`, and each of those is a **single-group** class: one
+/// `SyncKlas` row with `KLASGROEP = 00` and — because `ADMINGROEP` is only
+/// unique within a school — a *different* `ADMINGROEP` from the other school's.
+///
+/// Both students are already in the Smartschool class `1C` their WISA record
+/// names, so a correct pass proposes nothing. Before the fix the two schools'
+/// admin codes pooled under the bare name `1C`, the class read as sub-grouped,
+/// and each student's `KLASGROEP` was appended verbatim — so every student of
+/// both classes was offered "Wijzig de klas in Smartschool: 1C → 1C 00", a move
+/// into a class that exists nowhere.
+ReconcileHarness subGroupSentinelHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(wisaId: '1', classGroup: '1C', classSubGroup: '00'),
+          wisaStudent(
+            wisaId: '2',
+            classGroup: '1C',
+            classSubGroup: '00',
+            schoolId: 2,
+          ),
+        ],
+        schools: [wisaSchool(1), wisaSchool(2)],
+        classGroups: [
+          wisaClassGroup('1C', adminCode: 'a1', schoolCode: '111'),
+          wisaClassGroup(
+            '1C',
+            adminCode: 'a2',
+            schoolCode: '222',
+            schoolId: 2,
+          ),
+        ],
+      ),
+      smartschool: ssSnap(
+        groups: [ssGroup('1C', code: '1C_ss')],
+        accounts: [
+          ssAccount(),
+          ssAccount(
+            uid: 'jan',
+            accountId: '2',
+            mail: 'jan.peeters@student.school.example',
+            givenName: 'Jan',
+            surname: 'Peeters',
+          ),
+        ],
+        memberships: [member('jane', '1C_ss'), member('jan', '1C_ss')],
+      ),
+      azure: azSnap(users: [
+        azUser(),
+        azUser(
+          id: 'az2',
+          upn: 'jan.peeters@student.school.example',
+          employeeId: '2',
+        ),
+      ]),
+      ourSchoolIds: const {1, 2},
     );
 
 /// A harness for the school-label drill-down (#204). One student enrolled in

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -719,6 +719,45 @@ ReconcileHarness virtualClassGroupHarness() => ReconcileHarness(
       ourSchoolIds: const {1, 99},
     );
 
+/// A harness for the cross-school `containsStudents` pool (#222). Our school 1
+/// has an **empty** `1A`; the sibling school 2 — which we do not manage, but
+/// whose rows the shared WISA credentials pull anyway — has its own `1A` with a
+/// student in it, and its class arrives *first* in the pull.
+///
+/// Only our own `1A` is linked (#205), so the Klasgroepen list holds exactly one
+/// class. It must carry the informational "this WISA class has no students yet"
+/// notice: before the fix the sibling school's student was pooled under the bare
+/// name `1A`, so our empty class read as populated and was offered as the
+/// applyable "Voeg deze klas toe aan Smartschool" — the action that also enrols
+/// students into the class it creates.
+ReconcileHarness siblingPopulatedClassHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(wisaId: '2', classGroup: '1A', schoolId: 2)],
+        schools: [wisaSchool(1), wisaSchool(2)],
+        classGroups: [
+          wisaClassGroup(
+            '1A',
+            description: 'Klas van een andere school',
+            schoolCode: '222',
+            schoolId: 2,
+          ),
+          wisaClassGroup(
+            '1A',
+            description: 'Onze lege eerste klas',
+            schoolCode: '111',
+            schoolId: 1,
+          ),
+        ],
+      ),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+      ourSchoolIds: const {1},
+    );
+
 /// A harness for the `00` sub-group sentinel (#221). Two managed schools that
 /// each have their own `1C`, and each of those is a **single-group** class: one
 /// `SyncKlas` row with `KLASGROEP = 00` and — because `ADMINGROEP` is only

--- a/packages/account_state/lib/src/link/linked_state.dart
+++ b/packages/account_state/lib/src/link/linked_state.dart
@@ -63,8 +63,11 @@ class LinkedState {
   /// [ourSchoolIds] is the set of WISA school ids the operator actually manages
   /// (from the persisted `AppSettings.wisaSchools` ownership flags, #178). It is
   /// threaded into `link()` so `wisaPresence` is authoritative from Settings
-  /// rather than only the snapshot's `MarkAsOurs` flags. When null, `link()`
-  /// falls back to those snapshot flags (see its doc-comment).
+  /// rather than only the snapshot's `MarkAsOurs` flags, **and** into the
+  /// [PlacementResolver] so "does this class hold students?" counts only the
+  /// students of a school we manage (#222) — the two must agree, since the
+  /// linker seeds a class group only for a managed school (#205). When null,
+  /// both fall back to those snapshot flags (see their doc-comments).
   factory LinkedState.recompute({
     required wapi.WisaSnapshot wisa,
     required ss.SmartschoolSnapshot smartschool,
@@ -93,6 +96,7 @@ class LinkedState {
       wisa: wisa,
       smartschool: smartschool,
       classTree: classTree,
+      ourSchoolIds: ourSchoolIds,
     );
 
     return LinkedState(

--- a/packages/account_state/lib/src/link/placement.dart
+++ b/packages/account_state/lib/src/link/placement.dart
@@ -128,23 +128,34 @@ class PlacementResolver {
       if (classGroup != null) _classGroupsWithStudents.add(classGroup);
     }
 
-    // Class names that use sub-groups: legacy `ClassGroupManager.UseSubGroups`
-    // — a class whose rows carry more than one distinct admin code. Also index
-    // WISA classes by fullName so [groupPlacementFor] can recover the source
-    // class (bare name / year) from a [LinkedGroup] keyed by fullName.
-    final adminCodesByName = <String, Set<String>>{};
+    // Classes that use sub-groups: legacy `ClassGroupManager.UseSubGroups` —
+    // a class whose rows carry more than one distinct admin code.
+    //
+    // The tally is keyed on `(schoolId, name)`, **not** on the name alone
+    // (#221). `ADMINGROEP` is only unique *within* a school, and this snapshot
+    // pools every school the shared WISA credentials reach — including sibling
+    // schools we do not manage. Two schools that each have their own
+    // single-group `1C` therefore contribute two distinct admin codes for the
+    // name `1C`, and a name-keyed tally reads that as "1C uses sub-groups" for
+    // both, which appended each student's `KLASGROEP` to their class name.
+    //
+    // Also index WISA classes by fullName so [groupPlacementFor] can recover
+    // the source class (bare name / year) from a [LinkedGroup] keyed by
+    // fullName. That index stays name-keyed and first-wins on purpose: a
+    // [LinkedGroup] carries no school, and the linker itself collapses
+    // duplicate fullNames to the first record (INV-20), so this mirrors it.
+    final adminCodesByClass = <(int, String), Set<String>>{};
     for (final group in wisa.classGroups) {
       final name = _norm(group.name);
       if (name != null) {
-        adminCodesByName
-            .putIfAbsent(name, () => <String>{})
-            .add(group.adminCode);
+        adminCodesByClass.putIfAbsent(
+            (group.schoolId, name), () => <String>{}).add(group.adminCode);
       }
       final fullName = _norm(group.fullName);
       if (fullName != null) _wisaByFullName.putIfAbsent(fullName, () => group);
     }
-    for (final entry in adminCodesByName.entries) {
-      if (entry.value.length > 1) _subGroupClassNames.add(entry.key);
+    for (final entry in adminCodesByClass.entries) {
+      if (entry.value.length > 1) _subGroupClasses.add(entry.key);
     }
   }
 
@@ -155,7 +166,11 @@ class PlacementResolver {
   final Map<String, Group> _groupsByCode = {};
   final Map<String, Group> _currentClassByUid = {};
   final Map<String, wapi.WisaStudent> _wisaStudentByWisaId = {};
-  final Set<String> _subGroupClassNames = {};
+
+  /// The `(schoolId, normalized class name)` pairs whose class carries more
+  /// than one admin code — i.e. the classes that really are split into
+  /// sub-groups, within the one school that says so.
+  final Set<(int, String)> _subGroupClasses = {};
   final Map<String, wapi.WisaClassGroup> _wisaByFullName = {};
   final Set<String> _classGroupsWithStudents = {};
 
@@ -165,7 +180,7 @@ class PlacementResolver {
   ///
   /// - [ClassPlacement.className] is the WISA `classGroup`, plus the
   ///   `classSubGroup` when the class uses sub-groups (legacy
-  ///   `Student.ClassName`).
+  ///   `Student.ClassName`) — see [_classNameFor] for the sub-group rules.
   /// - [ClassPlacement.currentClass] is the student's current official
   ///   Smartschool class, sourced from the memberships, or `null` when the
   ///   student has no Smartschool account or no official class membership.
@@ -174,10 +189,7 @@ class PlacementResolver {
   ClassPlacement classPlacementFor(LinkedAccount account) {
     final wisaId = _norm(account.wisa?.wisaId.value);
     final student = wisaId == null ? null : _wisaStudentByWisaId[wisaId];
-    final classGroup = student?.classGroup ?? '';
-    final subGroup = student?.classSubGroup ?? '';
-    final useSubGroups = _subGroupClassNames.contains(_norm(classGroup));
-    final className = useSubGroups ? '$classGroup $subGroup' : classGroup;
+    final className = _classNameFor(student);
 
     final uid = _norm(account.smartschool?.uid);
     final currentClass = uid == null ? null : _currentClassByUid[uid];
@@ -187,6 +199,30 @@ class PlacementResolver {
       currentClass: currentClass,
       resolveClass: (name) => _groupsByName[_norm(name)],
     );
+  }
+
+  /// The official class name for [student] (legacy `Student.ClassName`): the
+  /// bare `classGroup`, widened to `'classGroup subGroup'` only when the
+  /// student's own school splits that class into sub-groups.
+  ///
+  /// Two guards sit in front of that widening (#221):
+  /// - the sub-group test is scoped to the student's `schoolId`, so a
+  ///   same-named class in another school can never make this one look split;
+  /// - a `classSubGroup` that is blank or the [_noSubGroupSentinel] names no
+  ///   real group, so it is never appended. This mirrors the guard
+  ///   [wapi.WisaClassGroup.fullName] applies on the class-group side, without
+  ///   which a student's `KLASGROEP` of `00` produced the class `'1C 00'` and
+  ///   proposed moving their whole class into it.
+  String _classNameFor(wapi.WisaStudent? student) {
+    if (student == null) return '';
+    final classGroup = student.classGroup;
+    final subGroup = student.classSubGroup.trim();
+    if (subGroup.isEmpty || subGroup == _noSubGroupSentinel) return classGroup;
+    final name = _norm(classGroup);
+    if (name == null) return classGroup;
+    return _subGroupClasses.contains((student.schoolId, name))
+        ? '$classGroup $subGroup'
+        : classGroup;
   }
 
   /// Builds the [GroupPlacement] for one WISA-only class (the dispatcher only
@@ -213,6 +249,11 @@ class PlacementResolver {
     );
   }
 }
+
+/// WISA's `KLASGROEP` value for "this class has no sub-groups". It is a
+/// sentinel, not a group code, so it must never surface in a class name —
+/// see [wapi.WisaClassGroup.fullName], which guards the class-group side.
+const String _noSubGroupSentinel = '00';
 
 /// Trims and lower-cases [value] for case-insensitive, whitespace-tolerant
 /// matching (INV-12), returning `null` for a null or blank input so an empty

--- a/packages/account_state/lib/src/link/placement.dart
+++ b/packages/account_state/lib/src/link/placement.dart
@@ -83,12 +83,24 @@ class SmartschoolClassTree {
 ///
 /// Keeping the walk here preserves `account_actions`' pure-function boundary:
 /// an action reads the placement it is handed, it never touches a snapshot.
+///
+/// `ourSchoolIds` is the set of WISA school ids the operator manages, the same
+/// Settings-derived set `LinkedState` threads into `link()` (#178/#205). The
+/// snapshots pool every school the shared WISA credentials reach, so the
+/// resolver needs it to keep a sibling school's rows from answering questions
+/// about *our* classes (#221/#222). When omitted it falls back to the
+/// snapshot's own `WisaSchool.isOurs` flags, exactly like `link()`.
 class PlacementResolver {
   PlacementResolver({
     required wapi.WisaSnapshot wisa,
     required ss.SmartschoolSnapshot smartschool,
     this.classTree = const SmartschoolClassTree(),
-  }) {
+    Set<int>? ourSchoolIds,
+  }) : _ourSchoolIds = ourSchoolIds ??
+            <int>{
+              for (final school in wisa.schools)
+                if (school.isOurs) school.id,
+            } {
     // Index the Smartschool tree by name (for resolveClass) and by code (for
     // the current-class and logical-parent lookups). First wins on a
     // collision, keeping the result a deterministic function of snapshot order.
@@ -119,13 +131,25 @@ class PlacementResolver {
     // only carries the `wisaId` linking key. Also collect the class names that
     // currently hold a student — legacy `WisaClassGroup.ContainsStudents`
     // (`student.ClassGroup == Name`).
+    //
+    // Only students of a school we manage are tallied (#222). The snapshot
+    // pools every school the shared WISA credentials reach, so a sibling
+    // school's populated `1A` used to make *our* empty `1A` read as populated —
+    // and [groupPlacementFor] then raised `AddToSmartschool` (which also enrols
+    // students) instead of the informational `CreateInSmartschool`. Filtering at
+    // the tally rather than at the lookup is deliberate: a [LinkedGroup] carries
+    // no school, so [groupPlacementFor] has nothing to scope by (see there).
+    // The index itself stays unfiltered — a `groupOnly` student still gets their
+    // own class placement.
     for (final student in wisa.students) {
       final wisaId = _norm(student.wisaId.value);
       if (wisaId != null) {
         _wisaStudentByWisaId.putIfAbsent(wisaId, () => student);
       }
       final classGroup = _norm(student.classGroup);
-      if (classGroup != null) _classGroupsWithStudents.add(classGroup);
+      if (classGroup != null && _isOurSchool(student.schoolId)) {
+        _classGroupsWithStudents.add(classGroup);
+      }
     }
 
     // Classes that use sub-groups: legacy `ClassGroupManager.UseSubGroups` —
@@ -162,6 +186,18 @@ class PlacementResolver {
   /// The class-tree config driving [GroupPlacement.parent] resolution.
   final SmartschoolClassTree classTree;
 
+  /// The WISA school ids the operator actually manages (#222), from the
+  /// persisted Settings ownership flags the State layer threads in — the same
+  /// set the linker scopes group seeding by (#205). When the caller passes
+  /// none it is derived from the snapshot's own `WisaSchool.isOurs` flags,
+  /// exactly as `link()` derives its own fallback, so the two layers always
+  /// agree on which classes exist and which students populate them.
+  ///
+  /// An **empty** set means ownership is unconfigured, in which case every
+  /// school counts as ours — mirroring the linker's `_isOurWisaSchool` and
+  /// preserving the pre-#222 pooled behaviour for an unconfigured install.
+  final Set<int> _ourSchoolIds;
+
   final Map<String, Group> _groupsByName = {};
   final Map<String, Group> _groupsByCode = {};
   final Map<String, Group> _currentClassByUid = {};
@@ -172,7 +208,16 @@ class PlacementResolver {
   /// sub-groups, within the one school that says so.
   final Set<(int, String)> _subGroupClasses = {};
   final Map<String, wapi.WisaClassGroup> _wisaByFullName = {};
+
+  /// Normalized class names that hold at least one student **of a school we
+  /// manage** (#222) — legacy `WisaClassGroup.ContainsStudents`, scoped.
   final Set<String> _classGroupsWithStudents = {};
+
+  /// Whether [schoolId] is one of the schools we manage. Mirrors the linker's
+  /// `_isOurWisaSchool`: an empty [_ourSchoolIds] means ownership is
+  /// unconfigured, so every school counts as ours.
+  bool _isOurSchool(int schoolId) =>
+      _ourSchoolIds.isEmpty || _ourSchoolIds.contains(schoolId);
 
   /// Builds the [ClassPlacement] for one student (the dispatcher only calls
   /// this for `account.wisa != null` records; a WISA-less lifecycle account
@@ -230,7 +275,11 @@ class PlacementResolver {
   ///
   /// - [GroupPlacement.containsStudents] is whether the WISA class currently
   ///   holds students (legacy `WisaClassGroup.ContainsStudents`), which selects
-  ///   `AddToSmartschool` (populated) over `CreateInSmartschool` (empty).
+  ///   `AddToSmartschool` (populated) over `CreateInSmartschool` (empty). Only
+  ///   students of a school we manage count (#222): a [LinkedGroup] is only ever
+  ///   seeded from a managed school's class (#205), so a sibling school's
+  ///   same-named class must not decide ours. The scoping happens where the
+  ///   tally is built, not here — see the constructor.
   /// - [GroupPlacement.parent] is the resolved Smartschool parent group
   ///   (legacy `GetLogicalParent` → `Root.FindByCode`), or `null` when the
   ///   class year is out of range or the parent node is absent from the tree.

--- a/packages/account_state/test/linked_state_test.dart
+++ b/packages/account_state/test/linked_state_test.dart
@@ -486,6 +486,87 @@ void main() {
 
       expect(resolver.groupPlacementFor(_linkedWisaGroup('1A')).parent, isNull);
     });
+
+    // #222: the WISA snapshot pools every school the shared credentials reach,
+    // so the student tally behind `containsStudents` must be scoped to the
+    // schools we manage — the same set the linker seeds class groups by (#205).
+    test('a sibling school\'s populated class does not populate ours', () {
+      final resolver = PlacementResolver(
+        wisa: _wSnap(
+          // Our own 1A is empty; the sibling school's 1A holds the student.
+          students: [_wStudent(wisaId: '1', classGroup: '1A', schoolId: 2)],
+          classGroups: [_wClass('1A', adminCode: 'a1', schoolId: 1)],
+        ),
+        smartschool: _sSnap(),
+        ourSchoolIds: const {1},
+      );
+
+      expect(
+        resolver.groupPlacementFor(_linkedWisaGroup('1A')).containsStudents,
+        isFalse,
+        reason: 'another school\'s students never populate our class',
+      );
+    });
+
+    test(
+        'our own populated class stays populated beside a sibling\'s empty one',
+        () {
+      final resolver = PlacementResolver(
+        wisa: _wSnap(
+          students: [_wStudent(wisaId: '1', classGroup: '1A')],
+          classGroups: [
+            _wClass('1A', adminCode: 'a1', schoolId: 1),
+            _wClass('1A', adminCode: 'a2', schoolCode: '222', schoolId: 2),
+          ],
+        ),
+        smartschool: _sSnap(),
+        ourSchoolIds: const {1},
+      );
+
+      expect(
+        resolver.groupPlacementFor(_linkedWisaGroup('1A')).containsStudents,
+        isTrue,
+      );
+    });
+
+    test('with ownership unconfigured every school still counts', () {
+      // Mirrors the linker's `_isOurWisaSchool` fallback: no managed set and no
+      // `isOurs` flags means ownership is unconfigured, not "nothing is ours".
+      final resolver = PlacementResolver(
+        wisa: _wSnap(
+          students: [_wStudent(wisaId: '1', classGroup: '1A', schoolId: 2)],
+          classGroups: [_wClass('1A', adminCode: 'a1', schoolId: 1)],
+        ),
+        smartschool: _sSnap(),
+      );
+
+      expect(
+        resolver.groupPlacementFor(_linkedWisaGroup('1A')).containsStudents,
+        isTrue,
+      );
+    });
+
+    test('the managed set falls back to the snapshot\'s isOurs flags', () {
+      // No caller-supplied set, but the snapshot says which school is ours —
+      // the same derivation `link()` applies, so the two layers agree.
+      final resolver = PlacementResolver(
+        wisa: _wSnap(
+          students: [_wStudent(wisaId: '1', classGroup: '1A', schoolId: 2)],
+          classGroups: [_wClass('1A', adminCode: 'a1', schoolId: 1)],
+          schools: const [
+            wapi.WisaSchool(
+                id: 1, name: 'Onze school', code: 'ISM', isOurs: true),
+            wapi.WisaSchool(id: 2, name: 'Andere school', code: 'AND'),
+          ],
+        ),
+        smartschool: _sSnap(),
+      );
+
+      expect(
+        resolver.groupPlacementFor(_linkedWisaGroup('1A')).containsStudents,
+        isFalse,
+      );
+    });
   });
 
   group('LinkedState wires placementFor into the dispatchers', () {
@@ -624,6 +705,70 @@ void main() {
 
       final action = state.groupActions.whereType<AddToSmartschool>().single;
       expect(action.target.wisa!.instituteNumber, '111');
+    });
+  });
+
+  group('containsStudents counts only the students we manage (#222)', () {
+    /// Recomputes over [classGroups] + [students] with the managed-school set
+    /// pinned to [ourSchoolIds] — the Settings-derived path the app wires.
+    LinkedState recompute({
+      required List<wapi.WisaClassGroup> classGroups,
+      required List<wapi.WisaStudent> students,
+      Set<int>? ourSchoolIds,
+    }) =>
+        LinkedState.recompute(
+          wisa: _wSnap(students: students, classGroups: classGroups),
+          smartschool: _sSnap(
+            groups: [
+              _ssGroup('Eerste graad',
+                  code: 'G1', official: false, type: core.GroupType.group),
+            ],
+          ),
+          azure: _aSnap(),
+          resolver: _SeqResolver(),
+          studentConfig: _studentConfig,
+          staffConfig: _staffConfig,
+          classTree: const SmartschoolClassTree(grades: ['G1', 'G2', 'G3']),
+          ourSchoolIds: ourSchoolIds,
+        );
+
+    test(
+        'our empty class beside a sibling\'s populated one is the empty notice',
+        () {
+      // Our 1A holds nobody; the sibling school we do not manage has its own 1A
+      // with a student in it. Pooled, that student flipped `containsStudents`
+      // and raised the applyable AddToSmartschool — which also enrols students
+      // — for a class that is empty.
+      final state = recompute(
+        classGroups: [
+          _wClass('1A', adminCode: 'a2', schoolCode: '222', schoolId: 2),
+          _wClass('1A', adminCode: 'a1', schoolCode: '111', schoolId: 1),
+        ],
+        students: [_wStudent(wisaId: '1', classGroup: '1A', schoolId: 2)],
+        ourSchoolIds: const {1},
+      );
+
+      expect(state.groupActions.whereType<AddToSmartschool>(), isEmpty,
+          reason: 'our 1A holds no student of ours');
+      final notice = state.groupActions.whereType<CreateInSmartschool>().single;
+      expect(notice.canApply, isFalse);
+      expect(notice.target.wisa!.name, '1A');
+    });
+
+    test('our own populated class still raises the applyable create action',
+        () {
+      // The mirror image: the sibling school's 1A is the empty one now.
+      final state = recompute(
+        classGroups: [
+          _wClass('1A', adminCode: 'a2', schoolCode: '222', schoolId: 2),
+          _wClass('1A', adminCode: 'a1', schoolCode: '111', schoolId: 1),
+        ],
+        students: [_wStudent(wisaId: '1', classGroup: '1A')],
+        ourSchoolIds: const {1},
+      );
+
+      expect(state.groupActions.whereType<CreateInSmartschool>(), isEmpty);
+      expect(state.groupActions.whereType<AddToSmartschool>(), hasLength(1));
     });
   });
 

--- a/packages/account_state/test/linked_state_test.dart
+++ b/packages/account_state/test/linked_state_test.dart
@@ -255,6 +255,113 @@ void main() {
       expect(placement.className, '3C');
     });
 
+    test(
+        'two schools that each have their own single-group 1C keep the bare '
+        'name — admin codes never pool across schools (#221)', () {
+      // `ADMINGROEP` is only unique *within* a school, and the snapshot pools
+      // every school. Keyed on the name alone, school 1's `a1` and school 2's
+      // `a2` read as two admin codes for "1C", so both schools' students got
+      // their `KLASGROEP` appended and every one of them was proposed for a
+      // move to the non-existent class "1C 00".
+      final resolver = PlacementResolver(
+        wisa: _wSnap(
+          students: [
+            _wStudent(
+                wisaId: '1',
+                classGroup: '1C',
+                classSubGroup: '00',
+                schoolId: 1),
+            _wStudent(
+                wisaId: '2',
+                classGroup: '1C',
+                classSubGroup: '00',
+                schoolId: 2),
+          ],
+          classGroups: [
+            _wClass('1C', adminCode: 'a1', schoolId: 1),
+            _wClass('1C', adminCode: 'a2', schoolId: 2),
+          ],
+        ),
+        smartschool: _sSnap(),
+      );
+
+      expect(resolver.classPlacementFor(_linkedStudent(wisaId: '1')).className,
+          '1C');
+      expect(resolver.classPlacementFor(_linkedStudent(wisaId: '2')).className,
+          '1C');
+    });
+
+    test(
+        'a genuinely sub-grouped class still widens even when another school '
+        'shares its name (#221)', () {
+      // The over-correction guard: per-school scoping must not swallow a real
+      // split. School 1's `1A` has two admin codes of its own.
+      final resolver = PlacementResolver(
+        wisa: _wSnap(
+          students: [
+            _wStudent(wisaId: '1', classGroup: '1A', classSubGroup: 'A'),
+            _wStudent(
+                wisaId: '2',
+                classGroup: '1A',
+                classSubGroup: '00',
+                schoolId: 2),
+          ],
+          classGroups: [
+            _wClass('1A', groupName: 'A', adminCode: 'a1'),
+            _wClass('1A', groupName: 'B', adminCode: 'a2'),
+            _wClass('1A', adminCode: 'z9', schoolId: 2),
+          ],
+        ),
+        smartschool: _sSnap(),
+      );
+
+      expect(resolver.classPlacementFor(_linkedStudent(wisaId: '1')).className,
+          '1A A');
+      expect(resolver.classPlacementFor(_linkedStudent(wisaId: '2')).className,
+          '1A',
+          reason: 'school 2\'s own 1A is single-group');
+    });
+
+    test(
+        'a student whose KLASGROEP is the 00 sentinel keeps the bare name even '
+        'in a sub-grouped class (#221)', () {
+      // `00` means "no sub-groups" — it names no group, so it is never part of
+      // a class name (the guard `WisaClassGroup.fullName` already applies).
+      final resolver = PlacementResolver(
+        wisa: _wSnap(
+          students: [
+            _wStudent(wisaId: '1', classGroup: '1A', classSubGroup: '00'),
+          ],
+          classGroups: [
+            _wClass('1A', groupName: 'A', adminCode: 'a1'),
+            _wClass('1A', groupName: 'B', adminCode: 'a2'),
+          ],
+        ),
+        smartschool: _sSnap(),
+      );
+
+      expect(resolver.classPlacementFor(_linkedStudent(wisaId: '1')).className,
+          '1A');
+    });
+
+    test('a blank sub-group never leaves a trailing separator (#221)', () {
+      final resolver = PlacementResolver(
+        wisa: _wSnap(
+          students: [
+            _wStudent(wisaId: '1', classGroup: '1A', classSubGroup: '  '),
+          ],
+          classGroups: [
+            _wClass('1A', groupName: 'A', adminCode: 'a1'),
+            _wClass('1A', groupName: 'B', adminCode: 'a2'),
+          ],
+        ),
+        smartschool: _sSnap(),
+      );
+
+      expect(resolver.classPlacementFor(_linkedStudent(wisaId: '1')).className,
+          '1A');
+    });
+
     test('currentClass is the student\'s official-class membership', () {
       final resolver = PlacementResolver(
         wisa: _wSnap(students: [_wStudent(wisaId: '1', classGroup: '3C')]),


### PR DESCRIPTION
Two related fixes to `PlacementResolver`, which pooled per-school WISA data across every school in the snapshot. WISA's shared credentials pull sibling schools we do not manage, so "same class name in another school" silently contaminated both halves of the resolver's derived state.

## #221 — WISA class names got the `00` sub-group sentinel appended

Student class placements came out as `"1C 00"` instead of `"1C"`, raising bogus "Wijzig de klas in Smartschool" actions for entire classes (21 accounts in the reported case). Two stacked defects:

- The "does this class use sub-groups?" tally counted distinct `ADMINGROEP` values keyed on the bare class name, pooled across all schools. `ADMINGROEP` is only unique *within* a school, so two schools that each have their own single-group `1C` contributed two admin codes and the class was misclassified as sub-grouped. The tally is now keyed on `(schoolId, name)`.
- `classPlacementFor` then appended the student's `classSubGroup` verbatim — and that value is the literal string `00`, WISA's "no sub-groups" sentinel. `WisaClassGroup.fullName` guards exactly this; the student-side path did not. It now refuses to widen a class name with a blank or `'00'` sub-group.

Deliberately left alone, with in-code comments explaining why: `_wisaByFullName`'s first-wins index (both uses derive from the `fullName` key, so either record answers identically — it mirrors the linker's INV-20 dedupe), and `wisa_api`'s per-school class-group dedupe (matching legacy's cross-school dedupe would *delete* same-named classes across schools, which is worse than the current behaviour).

## #222 — `containsStudents` flipped on a sibling school's class

Found while fixing #221, and the group-side counterpart that fix could not reach. `_classGroupsWithStudents` was a set of bare class names filled from every `wisa.students` row regardless of `schoolId`, including unmanaged schools. An empty `1A` of ours therefore read as populated whenever any sibling school's `1A` held a student, so the group dispatcher raised `AddToSmartschool` (which also enrols students) instead of `CreateInSmartschool`.

`PlacementResolver` now takes `ourSchoolIds`, falling back to the snapshot's `WisaSchool.isOurs` flags exactly as `link()` does (empty = unconfigured = everything ours), and tallies only students of a managed school. `LinkedState.recompute` threads the same Settings-derived set it already passes to `link()`. The filter sits on the tally rather than the lookup because a `LinkedGroup` carries no school.

## Test plan

Both commits were verified independently and pass on their own.

**#221 (86934a8)**
- `dart format --set-exit-if-changed` — clean, 289 files, 0 changed
- `flutter analyze` — clean, no issues
- 957 pure-Dart package tests pass (account_core 71, account_store 8, wisa_api 127, smartschool_api 132, azure_api 86, account_linker 58, account_actions 120, account_state 355 incl. 4 new `PlacementResolver` regressions)
- 303 `account_manager` widget tests pass
- `flutter test integration_test/app_launch_test.dart -d windows` — 56/56 pass, incl. 1 new e2e scenario
- Fail-without-fix proven for all 5 new tests by stashing only `placement.dart`: the 4 unit tests reproduce `1C 00` / `1A 00` / `1A   `, the e2e test fails on `not contains MoveToSmartschoolClassGroup`

**#222 (74d33cc)**
- `dart format --set-exit-if-changed .` — clean, 289 files
- `flutter analyze` — clean, 0 issues
- 963 pure-Dart package tests pass (`dart test packages`, 11 skipped), incl. 361 in account_state
- 303 `account_manager` widget/unit tests pass (`flutter test`)
- `flutter test integration_test/app_launch_test.dart -d windows` — 57/57 pass
- Fail-without-fix proven: with the school filter neutralised, 3 of the 5 new tests fail (2 resolver-level plus the `LinkedState` empty-notice one) and the new e2e test fails at the "bevat nog geen leerlingen" assertion

Closes #221
Closes #222
