### PR TITLE
Batch: Azure account adoption, class-group linking, and the Acties filter (#224 #225 #226 #229 #230 #231 #233)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3449,6 +3449,92 @@ void main() {
     expect(azureWire.bulkReads, 1, reason: 'no second full read');
     expect(harness.controller.error, isNull);
   });
+
+  testWidgets(
+      "a transferred student's existing Office 365 account is found by "
+      'employeeId and repaired, never duplicated (#224)',
+      (WidgetTester tester) async {
+    // The real app over the *production* Azure pull — a real AzureConnector
+    // behind the real azureSyncer — with Graph answering the way the tenant
+    // answered for Ambre Kalenga Alfio: the school-scoped `$filter` finds
+    // nothing (no `companyName`, another school's `department`), so before the
+    // fix the account was simply absent from the snapshot and Acties →
+    // Leerlingen offered "Maak een nieuw Office 365 account". Applying that
+    // created a *second* account, silently: `createPrincipalName` resolves the
+    // UPN collision by suffixing, so the create succeeds.
+    //
+    // Only this layer sees the whole thing: the back-fill needs the WISA
+    // snapshot the same pass pulled, the linker needs the row it produces, and
+    // the repair the operator should see instead is a different action family
+    // than the one that was offered.
+    useTallWindow(tester);
+    final azureWire = TransferredStudentGraph();
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
+        schools: [wisaSchool(1, ours: true)],
+      ),
+      smartschool: ssSnap(
+        groups: [ssGroup('3C', code: '3C_ss')],
+        accounts: [ssAccount(accountId: 'W7')],
+        memberships: [member('jane', '3C_ss')],
+      ),
+      azureTransport: azureWire,
+      ourSchoolIds: const {1},
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // The bounded pull stayed bounded (PAIN-2): one `$filter` bulk read, plus
+    // one targeted lookup for the single id it could not account for.
+    expect(azureWire.bulkReads, 1);
+    expect(azureWire.employeeIdLookups, <String>["employeeId in ('W7')"]);
+
+    // The account the school filter cannot see is in the snapshot, and the
+    // linker joined it to the WISA student by employeeId alone.
+    expect(harness.app.azure.snapshot?.users.map((u) => u.id),
+        <String>['az-transferred']);
+    final linked = harness.controller.linked!.snapshot.accounts.single;
+    expect(linked.wisa, isNotNull);
+    expect(linked.azure?.id, 'az-transferred');
+
+    // Nothing anywhere in the pass proposes creating an account.
+    expect(
+      harness.controller.pendingEntries
+          .expand((e) => e.choices)
+          .expand((c) => c.alternatives)
+          .map((a) => a.kind),
+      isNot(contains('AddStudentToAzure')),
+    );
+
+    // And that is what the operator sees: browse Acties → Leerlingen the way
+    // they did when they reported this.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('3C'));
+    await tester.pumpAndSettle();
+    expect(
+        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+
+    expect(find.text('Maak een nieuw Office 365 account'), findsNothing,
+        reason: 'the account already exists — creating one duplicates it');
+    // The repair that adopts it. Stamping our `companyName` is what makes the
+    // adoption stick: without it the account stays invisible to the next
+    // sync's `$filter`, and the whole problem recurs every pass.
+    expect(find.text('Wijzig de school in Azure'), findsOneWidget);
+  });
 }
 
 /// A broker scripted per test — a fake WAM broker so no live tenant is touched.

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1217,6 +1217,78 @@ void main() {
   });
 
   testWidgets(
+      'a class Smartschool already has is never offered for creation '
+      'end-to-end (#225)', (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. Smartschool holds `2G` under
+    // `2de Jaar` with the subgroup `2G LAT` under it — but the `2G` node is not
+    // flagged as an official class, so the class link (which only ever adopts
+    // official classes) passed it over. The WISA class then read as one nobody
+    // had created, and the Klasgroepen list offered "Voeg deze klas toe aan
+    // Smartschool": a write that asks Smartschool for a second class named
+    // `2G`, which it either rejects or leaves standing beside the first.
+    //
+    // This is the layer that sees it: the wrong proposal is what the operator
+    // reads off the tile and clicks, and the notice that replaces it has to
+    // reach the same list through the linker, the dispatch, the materializer
+    // and the drill-down.
+    useTallWindow(tester);
+    final harness = nonOfficialSmartschoolClassHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+
+    // `2G` is on the list, and it says the class is already there — not that it
+    // needs creating.
+    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
+    expect(find.byKey(const ValueKey('entry-group-2G')), findsOneWidget);
+    expect(
+      find.textContaining(
+          'Deze klas bestaat in Smartschool maar is geen officiële klas'),
+      findsOneWidget,
+    );
+    expect(
+        find.textContaining('Voeg deze klas toe aan Smartschool'), findsNothing,
+        reason:
+            'Smartschool already has a 2G — creating a second is never due');
+    expect(find.textContaining('bevat nog geen leerlingen'), findsNothing,
+        reason: 'the empty-class advice is wrong for a provisioned class');
+
+    // The pass never constructed either create action for it, and the notice
+    // is manual — there is nothing here for the app to write.
+    final kinds = harness.controller.pendingEntries
+        .expand((e) => e.choices)
+        .expand((c) => c.alternatives)
+        .map((a) => a.kind)
+        .toList();
+    expect(kinds, contains('ClassExistsAsSmartschoolGroup'));
+    expect(kinds, isNot(contains('AddToSmartschool')));
+    expect(kinds, isNot(contains('CreateInSmartschool')));
+
+    // The subgroup keeps its own, correct Smartschool-only notice: it is an
+    // official class WISA has no counterpart for.
+    expect(find.byKey(const ValueKey('entry-group-2G LAT')), findsOneWidget);
+
+    // And the skip is no longer silent — the log names the group that was
+    // passed over and why.
+    final lines = harness.log.entries.map((e) => e.message).join('\n');
+    expect(lines, contains('Klas "2G" niet gekoppeld'));
+    expect(lines, contains('G2G'));
+  });
+
+  testWidgets(
       'the Acties drill-down opens on grade-years merged across the managed '
       'schools end-to-end, with no school level to guess at (#210)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3777,6 +3777,113 @@ void main() {
     expect(harness.controller.linked!.snapshot.staff.single.azure?.id,
         'az-transferred');
   });
+
+  testWidgets(
+      'a WISA-only student reaches Acties under their own class, and one '
+      'apply provisions both of their accounts (#230)',
+      (WidgetTester tester) async {
+    // The new-intake case the operator reported as "they never get offered the
+    // account creates". Two halves, and only a run of the real app covers both.
+    //
+    // That they show up at all is the first half: a student present only in
+    // WISA has no Smartschool and no Azure record, so every join the linker
+    // makes is empty, and the managed-school filter (#178) drops exactly this
+    // shape of record when the school is *not* flagged as ours. Here it is, so
+    // they must land under their real class — not "Zonder klas", not
+    // "Niet toegewezen", not nowhere.
+    //
+    // The second half is what the panel offers. Provisioning is a chain:
+    // AddStudentToSmartschool builds its account with the Azure UPN as the
+    // `mail`, so it evaluates false until the Office 365 account exists, and the
+    // dispatcher — a pure function of the current record — can only ever offer
+    // the first link. The operator used to have to apply, notice the relink, and
+    // apply again. Now the State layer runs the follow-up against the freshly
+    // relinked record, so the one click the operator makes provisions the
+    // student end to end.
+    useTallWindow(tester);
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
+        schools: [wisaSchool(1, ours: true)],
+      ),
+      smartschool: ssSnap(
+        groups: [ssGroup('3C', code: '3C_ss')],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+      ourSchoolIds: const {1},
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // Browse Acties → Leerlingen the way the operator did when they reported
+    // this: the student is under their own year and class.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('3C'));
+    await tester.pumpAndSettle();
+    expect(
+        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+    expect(find.text('Jane Doe'), findsWidgets,
+        reason: 'a student with no downstream account is still listed');
+    expect(find.text('Maak een nieuw Office 365 account'), findsOneWidget);
+
+    // Apply that one row.
+    final entry = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student');
+    final id = entry.targetId;
+    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+    expect(find.text('Apply result'), findsOneWidget);
+
+    // Both accounts exist now, off that single click, and both writes are
+    // reported — the second is a real write the operator must see, not a
+    // silent extra.
+    expect(
+      harness.controller.applyResults!.map((r) => r.changes.summary),
+      <String>[
+        'Maak een nieuw Office 365 account',
+        'Maak een nieuw Smartschool account',
+      ],
+    );
+    expect(
+      harness.controller.applyResults!.map((r) => r.outcome.name),
+      everyElement('applied'),
+    );
+    expect(harness.graph.createdUsers.single['employeeId'], 'W7');
+    expect(harness.soap.soapActions.any((a) => a.contains('saveUser')), isTrue);
+
+    // The Smartschool account carries the UPN that actually landed — the whole
+    // reason the follow-up runs against the relinked record instead of the
+    // projection the first action described.
+    final linked = harness.controller.linked!.snapshot.accounts.single;
+    expect(linked.azure, isNotNull);
+    expect(linked.smartschool?.mail, linked.azure?.upn);
+
+    // And both writes are in the log the operator reads.
+    final messages = harness.log.entries.map((e) => e.message);
+    expect(messages, contains(contains('Maak een nieuw Office 365 account')));
+    expect(messages, contains(contains('Maak een nieuw Smartschool account')));
+  });
 }
 
 /// A broker scripted per test — a fake WAM broker so no live tenant is touched.

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3368,7 +3368,8 @@ void main() {
 
   testWidgets(
       'a Check for drift whose stored Azure delta token Graph refuses still '
-      'finishes, on a full re-read that leaves a usable token behind (#213)',
+      'finishes, on a full re-read that leaves a usable token behind, and '
+      'reads as the clean pass it was (#213/#229)',
       (WidgetTester tester) async {
     // The real app over the *production* Azure pull — a real AzureConnector
     // behind the real azureSyncer — with Graph answering a resume from the
@@ -3439,6 +3440,32 @@ void main() {
     expect(find.textContaining('Graph rejected the stored delta token'),
         findsOneWidget);
     expect(find.textContaining('stored 15h'), findsOneWidget);
+
+    // …and that is *all* the operator sees about it (#229). The recovery
+    // worked, so nothing in the panel is red: the transport used to log the raw
+    // Graph failure with addError right below the explanation, which made a
+    // pass that fully recovered read as a broken one.
+    expect(
+      harness.log.entries.where((e) => e.isError).map((e) => e.message),
+      isEmpty,
+    );
+    // Nor does any line — at any severity, on screen or in the buffer — carry
+    // the resume token itself, which the operator pastes into issues.
+    expect(
+      harness.log.entries.map((e) => e.message),
+      everyElement(isNot(contains('DEADTOKEN'))),
+    );
+    expect(find.textContaining('DEADTOKEN'), findsNothing);
+    // The transport line survives as an ordinary detail rather than being
+    // dropped, so what Graph actually answered is still there to read.
+    expect(
+      harness.log.entries.map((e) => e.message),
+      contains(allOf(
+        contains('users/delta'),
+        contains('DeltaLink older than 30 days'),
+        contains('handled'),
+      )),
+    );
 
     // A second drift check resumes from that fresh token: the recovery restored
     // incremental syncing rather than condemning the app to full reads.

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3468,7 +3468,7 @@ void main() {
     // the repair the operator should see instead is a different action family
     // than the one that was offered.
     useTallWindow(tester);
-    final azureWire = TransferredStudentGraph();
+    final azureWire = TransferredAccountGraph();
     final harness = ReconcileHarness(
       wisa: wisaSnap(
         students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
@@ -3534,6 +3534,106 @@ void main() {
     // adoption stick: without it the account stays invisible to the next
     // sync's `$filter`, and the whole problem recurs every pass.
     expect(find.text('Wijzig de school in Azure'), findsOneWidget);
+  });
+
+  testWidgets(
+      "a moved staff member's existing Office 365 account is found by "
+      'employeeId, so Acties → Personeel never offers a duplicate (#231)',
+      (WidgetTester tester) async {
+    // The staff half of #224, over the *production* Azure pull — a real
+    // AzureConnector behind the real azureSyncer. Anna Smit moved in from a
+    // sibling group school, so her account carries our `employeeId` (her WISA
+    // id, never her staff `code`) but a `department` still naming the school she
+    // came from. Neither leg of the connector's `$filter` matches it, so before
+    // the fix she was simply absent from the Azure snapshot and Acties →
+    // Personeel offered "Maak een nieuw Office 365 account" — which on apply
+    // created a second account, silently, because `createPrincipalName`
+    // resolves the UPN collision by suffixing.
+    //
+    // Only this layer sees the whole thing: the back-fill needs the *staff* half
+    // of the WISA snapshot the same pass pulled (`managedStaffEmployeeIds`), the
+    // linker needs the row it produces, and what the operator should be offered
+    // instead is a different action entirely.
+    useTallWindow(tester);
+    final azureWire = TransferredAccountGraph(
+      // wisaStaff()'s default wisaId — the staff Azure bridge is
+      // `wisaId ≡ employeeId`, so the staff code 'SMIT' is *not* the key.
+      employeeId: '42',
+      upn: 'smit.anna@other.example',
+      displayName: 'Smit Anna',
+      department: 'OTHER - Wiskunde',
+    );
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(students: const [], staff: [wisaStaff()]),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azureTransport: azureWire,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // The bounded pull stayed bounded (PAIN-2): one `$filter` bulk read, plus
+    // one targeted lookup for the single staff id it could not account for.
+    expect(azureWire.bulkReads, 1);
+    expect(azureWire.employeeIdLookups, <String>["employeeId in ('42')"]);
+
+    // The account the school filter cannot see is in the snapshot, and the
+    // linker joined it to the WISA staff record by employeeId alone.
+    expect(harness.app.azure.snapshot?.users.map((u) => u.id),
+        <String>['az-transferred']);
+    final linked = harness.controller.linked!.snapshot.staff.single;
+    expect(linked.wisa, isNotNull);
+    expect(linked.azure?.id, 'az-transferred');
+
+    // Nothing anywhere in the pass proposes creating an Azure account.
+    expect(
+      harness.controller.pendingEntries
+          .expand((e) => e.choices)
+          .expand((c) => c.alternatives)
+          .map((a) => a.kind),
+      isNot(contains('AddStaffToAzure')),
+    );
+
+    // And that is what the operator sees: browse Acties → Personeel the way
+    // they did when they reported this.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+    final staffSchool =
+        find.byKey(const ValueKey('rollup-school-school|staff'));
+    await tester.ensureVisible(staffSchool);
+    await tester.tap(staffSchool);
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
+    await tester.pumpAndSettle();
+    final staffClass = find
+        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
+    await tester.ensureVisible(staffClass);
+    await tester.tap(staffClass);
+    await tester.pumpAndSettle();
+    expect(
+        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+
+    expect(find.text('Maak een nieuw Office 365 account'), findsNothing,
+        reason: 'the account already exists — creating one duplicates it');
+    // The record is now WISA + Azure, so the only thing left to build is the
+    // Smartschool side — the proposal the adoption unlocks.
+    expect(find.text('Maak een nieuw Smartschool account'), findsOneWidget);
   });
 }
 

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3635,6 +3635,121 @@ void main() {
     // Smartschool side — the proposal the adoption unlocks.
     expect(find.text('Maak een nieuw Smartschool account'), findsOneWidget);
   });
+
+  testWidgets(
+      'an adopted staff account is stamped with our department, so the repair '
+      'sticks instead of depending on the back-fill forever (#233)',
+      (WidgetTester tester) async {
+    // The third piece of the transferred-account problem, and the one the staff
+    // family never had. #231 made the pull *find* Anna Smit's existing account
+    // by employeeId, but nothing wrote our marker onto it: her `department`
+    // still names the sibling group school, so neither leg of the connector's
+    // `$filter` matches and every single pass has to re-adopt her by back-fill.
+    // Once she leaves WISA her id drops out of `managedStaffEmployeeIds`, the
+    // back-fill stops asking, and the account is invisible for good — no
+    // RemoveStaffFromAzure would ever be proposed for it.
+    //
+    // Here the record is complete (WISA + Smartschool + Azure), which is the
+    // pass after AddStaffToSmartschool ran, so the modify branch is live.
+    useTallWindow(tester);
+    final azureWire = TransferredAccountGraph(
+      employeeId: '42',
+      upn: 'smit.anna@other.example',
+      displayName: 'Smit Anna',
+      department: 'OTHER - Wiskunde',
+    );
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(students: const [], staff: [wisaStaff()]),
+      smartschool: ssSnap(
+        groups: const [],
+        // Her Smartschool mail already matches the adopted UPN, so the only
+        // thing left wrong about this staff member is the Azure department.
+        accounts: [ssStaffAccount(mail: 'smit.anna@other.example')],
+        memberships: const [],
+      ),
+      azureTransport: azureWire,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // The starting state: invisible to the school-scoped read, present only
+    // because the #231 back-fill went looking for her by employeeId.
+    expect(azureWire.bulkReads, 1);
+    expect(azureWire.employeeIdLookups, <String>["employeeId in ('42')"]);
+    final linked = harness.controller.linked!.snapshot.staff.single;
+    expect(linked.wisa, isNotNull);
+    expect(linked.smartschool, isNotNull);
+    expect(linked.azure?.id, 'az-transferred');
+    expect(harness.app.azure.snapshot!.users.single.department,
+        'OTHER - Wiskunde');
+
+    // Acties → Personeel: the operator is offered the repair.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+    final staffSchool =
+        find.byKey(const ValueKey('rollup-school-school|staff'));
+    await tester.ensureVisible(staffSchool);
+    await tester.tap(staffSchool);
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
+    await tester.pumpAndSettle();
+    final staffClass = find
+        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
+    await tester.ensureVisible(staffClass);
+    await tester.tap(staffClass);
+    await tester.pumpAndSettle();
+    expect(find.text('Wijzig de school in Azure'), findsOneWidget);
+
+    // Apply just that row.
+    final entry = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'staff');
+    final id = entry.targetId;
+    await tester.ensureVisible(find.byKey(ValueKey('entry-staff-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-staff-$id')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+    expect(find.text('Apply result'), findsOneWidget);
+
+    // One PATCH, touching `department` only, with our prefix at the head and
+    // the subject the other school wrote still on it.
+    final patches =
+        harness.graph.requests.where((r) => r.method == 'PATCH').toList();
+    expect(patches, hasLength(1));
+    expect(patches.single.url.path, contains('az-transferred'));
+    expect(
+      jsonDecode(patches.single.body!) as Map<String, dynamic>,
+      <String, dynamic>{'department': 'GBS - Wiskunde'},
+    );
+    expect(azureWire.bulkReads, 1, reason: 'the repair is a write, not a read');
+
+    // Prefix-first is what makes it stick: that is exactly the
+    // `startswith(department,'GBS')` leg of UserManager.filterFor, so the next
+    // school-scoped bulk read returns the account on its own — no employeeId
+    // back-fill required, and a later departure can raise a removal.
+    final repaired = harness.app.azure.snapshot!.users.single.department!;
+    expect(repaired, 'GBS - Wiskunde');
+    expect(repaired.startsWith('GBS'), isTrue);
+    // …and the re-linked view the operator now sees carries it too.
+    expect(harness.controller.linked!.snapshot.staff.single.azure?.id,
+        'az-transferred');
+  });
 }
 
 /// A broker scripted per test — a fake WAM broker so no live tenant is touched.

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1341,6 +1341,174 @@ void main() {
   });
 
   testWidgets(
+      'the Acties filter collapses the drill-down to the work list end-to-end: '
+      'ticked-off classes and whole ticked-off years are gone, the switch is '
+      'set once and survives a tab change (#226)', (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. Four students across three
+    // classes of two managed schools; exactly one of them (Sam, in 3C) sits in
+    // the wrong Smartschool class, so exactly one class carries work.
+    //
+    // This is the layer that sees it: the tree the operator browses is built
+    // from the stored rollups by two projections one tab apart, the switch
+    // lives above the family tab bar and has to outlive a tab change, and
+    // "which nodes render" is a whole-page composition question that a widget
+    // test of one section structurally cannot answer.
+    useTallWindow(tester);
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(wisaId: '1', classGroup: '1C', classSubGroup: '00'),
+          wisaStudent(
+              wisaId: '2', classGroup: '1C', classSubGroup: '00', schoolId: 2),
+          wisaStudent(wisaId: '3', classGroup: '3C'),
+          wisaStudent(wisaId: '4', classGroup: '3D'),
+        ],
+        schools: [wisaSchool(1), wisaSchool(2)],
+        classGroups: [
+          wisaClassGroup('1C', adminCode: 'a1', schoolCode: '111'),
+          wisaClassGroup('1C', adminCode: 'a2', schoolCode: '222', schoolId: 2),
+          wisaClassGroup('3C', adminCode: 'a3', schoolCode: '111'),
+          wisaClassGroup('3D', adminCode: 'a4', schoolCode: '111'),
+        ],
+      ),
+      smartschool: ssSnap(
+        groups: [
+          ssGroup('1C', code: '1C_ss'),
+          ssGroup('2B', code: '2B_ss'),
+          ssGroup('3C', code: '3C_ss'),
+          ssGroup('3D', code: '3D_ss'),
+        ],
+        accounts: [
+          ssAccount(),
+          ssAccount(
+            uid: 'jan',
+            accountId: '2',
+            mail: 'jan.peeters@student.school.example',
+            givenName: 'Jan',
+            surname: 'Peeters',
+          ),
+          ssAccount(
+            uid: 'sam',
+            accountId: '3',
+            mail: 'sam.sels@student.school.example',
+            givenName: 'Sam',
+            surname: 'Sels',
+          ),
+          ssAccount(
+            uid: 'tom',
+            accountId: '4',
+            mail: 'tom.tas@student.school.example',
+            givenName: 'Tom',
+            surname: 'Tas',
+          ),
+        ],
+        memberships: [
+          member('jane', '1C_ss'),
+          member('jan', '1C_ss'),
+          // Sam's WISA class is 3C; Smartschool still has him in 2B.
+          member('sam', '2B_ss'),
+          member('tom', '3D_ss'),
+        ],
+      ),
+      // Every Azure account already carries the WISA display name, so the only
+      // student action the pass raises anywhere is Sam's class move. (The WISA
+      // fixture names every student "Jane Doe"; the tree is browsed by node,
+      // not by person, so only the class each of them sits in matters here.)
+      azure: azSnap(users: [
+        azUser(displayName: 'Jane Doe'),
+        azUser(
+          id: 'az2',
+          upn: 'jan.peeters@student.school.example',
+          employeeId: '2',
+          displayName: 'Jane Doe',
+        ),
+        azUser(
+          id: 'az3',
+          upn: 'sam.sels@student.school.example',
+          employeeId: '3',
+          displayName: 'Jane Doe',
+        ),
+        azUser(
+          id: 'az4',
+          upn: 'tom.tas@student.school.example',
+          employeeId: '4',
+          displayName: 'Jane Doe',
+        ),
+      ]),
+      ourSchoolIds: const {1, 2},
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // The stored overview really does hold a mix — one class with work, three
+    // without — so the absence assertions below mean something.
+    final pendingByClass = <String, int>{
+      for (final r in harness.controller.studentRollups)
+        for (final c in harness.controller.studentChildrenOf(r))
+          '${c.school}|${c.classroom}': c.pendingCount,
+    };
+    expect(pendingByClass['1|3C'], greaterThan(0));
+    expect(pendingByClass['1|3D'], 0);
+    expect(pendingByClass['1|1C'], 0);
+    expect(pendingByClass['2|1C'], 0);
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+
+    // One switch, on the Acties tab itself, already on.
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    expect(toggle, findsOneWidget);
+    expect(tester.widget<Switch>(toggle).value, isTrue);
+
+    // Jaar 1's two classes are both done, so the whole year is gone; Jaar 3
+    // stays because one of its classes is not.
+    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
+    expect(find.byKey(const ValueKey('rollup-grade-grades|1')), findsNothing,
+        reason: 'both of Jaar 1\'s classes are done — the year goes with them');
+    // …and the operator is told why a year they expected is missing.
+    expect(find.byKey(const ValueKey('actions-filter-hidden')), findsOneWidget);
+
+    // Inside the surviving year, the ticked-off class is gone too.
+    await tester.tap(find.byKey(const ValueKey('rollup-grade-grades|3')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-class-class|1|3|3C')),
+        findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('rollup-class-class|1|3|3D')), findsNothing,
+        reason: 'a class with nothing to do is not rendered under the filter');
+
+    // The switch is a mode, not a per-list setting: it outlives a tab change.
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+    expect(tester.widget<Switch>(toggle).value, isTrue);
+    await tester.tap(find.byKey(const ValueKey('actions-tab-leerlingen')));
+    await tester.pumpAndSettle();
+    expect(tester.widget<Switch>(toggle).value, isTrue);
+    expect(find.byKey(const ValueKey('rollup-grade-grades|1')), findsNothing);
+
+    // Switched off, the full inventory is back — every year, every class.
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-grade-grades|1')), findsOneWidget);
+    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-filter-hidden')), findsNothing);
+    await tester.tap(find.byKey(const ValueKey('rollup-grade-grades|3')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-class-class|1|3|3D')),
+        findsOneWidget);
+  });
+
+  testWidgets(
       'a single-group class whose name another school shares raises no class '
       'change, and "00" never reaches a class name end-to-end (#221)',
       (WidgetTester tester) async {
@@ -3120,12 +3288,12 @@ void main() {
 
   testWidgets(
       'the Actions Personeel classroom filters by any part of the name in any '
-      'order and by the only-with-actions toggle end-to-end, combining both '
-      '(#187/#217)', (WidgetTester tester) async {
+      'order and by the top-level only-with-actions switch end-to-end, '
+      'combining both (#187/#217/#226)', (WidgetTester tester) async {
     // The real app, real fonts, real window over a passive session: three staff
     // seeded into the one synthetic Personeel class — two share the surname
     // "Smit" (one carrying an action, one not) and one has a distinct voornaam.
-    // The operator narrows the list by name and by the has-actions toggle, and
+    // The operator narrows the list by name and by the has-actions switch, and
     // the two filters combine.
     useTallWindow(tester);
     final store = await seededLinkedStore([
@@ -3141,12 +3309,23 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    // Open the Actions tab (passive overview from the store), go to Personeel,
-    // and drill into the single staff class.
+    // Open the Actions tab (passive overview from the store). The global filter
+    // is on by default since #226 and sits above the family tab bar; this test
+    // is about the name search, so start from the full inventory.
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    expect(toggle, findsOneWidget);
+    expect(tester.widget<Switch>(toggle).value, isTrue);
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+
+    // Go to Personeel — the switch survives the tab change (#226) — and drill
+    // into the single staff class.
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
+    expect(tester.widget<Switch>(toggle).value, isFalse);
     await tester.tap(find.byKey(const ValueKey('rollup-school-school|staff')));
     await tester.pumpAndSettle();
     await tester
@@ -3196,15 +3375,15 @@ void main() {
     expect(
         find.text('Geen accounts die aan de filter voldoen.'), findsOneWidget);
 
-    // Back to "Smit", then combine with the only-with-actions toggle: only Anna
-    // keeps an action, so Clara (name-matched but action-free) drops too.
+    // Back to "Smit", then combine with the global only-with-actions switch
+    // back on: only Anna keeps an action, so Clara (name-matched but
+    // action-free) drops too.
     await tester.enterText(
         find.byKey(const ValueKey('actions-search')), 'smit');
     await tester.pump();
-    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
     await tester.ensureVisible(toggle);
     await tester.tap(toggle);
-    await tester.pump();
+    await tester.pumpAndSettle();
     expect(find.text('Anna Smit'), findsOneWidget);
     expect(find.text('Clara Smit'), findsNothing);
     expect(find.text('Bram Jansen'), findsNothing);

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -404,17 +404,22 @@ Future<ReconcileServices> bootstrapReconcile({
         payloadOf: (s) => s.toJson(),
         deltaTokenOf: (s) => s.deltaToken,
         onError: (e) => logSnapshotIssue(core.Origin.azure, e),
-        // The prefix-scoped pull is blind to a student who transferred in from
-        // a sibling group school — their account carries neither our
-        // `companyName` nor our `department` — so the app proposed creating a
-        // duplicate. Hand the connector the WISA ids this pass expects, and it
-        // looks the unaccounted-for ones up by `employeeId` (#224).
+        // The prefix-scoped pull is blind to anyone who transferred in from a
+        // sibling group school — a student's account carries neither our
+        // `companyName` nor our `department`, a staff member's `department`
+        // still names the school they came from — so the app proposed creating
+        // a duplicate. Hand the connector the WISA ids this pass expects, both
+        // populations, and it looks the unaccounted-for ones up by `employeeId`
+        // (#224 students, #231 staff).
         inner: azureSyncer(
           azConnector,
-          expectedEmployeeIds: () => managedStudentEmployeeIds(
-            app.wisa.snapshot,
-            ourSchoolIds: ourSchoolIds,
-          ),
+          expectedEmployeeIds: () => <String>{
+            ...managedStudentEmployeeIds(
+              app.wisa.snapshot,
+              ourSchoolIds: ourSchoolIds,
+            ),
+            ...managedStaffEmployeeIds(app.wisa.snapshot),
+          },
         ),
       ),
     ),

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -338,7 +338,17 @@ Future<ReconcileServices> bootstrapReconcile({
     onError: (e) => logSnapshotIssue(core.Origin.azure, e),
   );
 
-  final app = ApplicationState(
+  // The operator's managed-school set from Settings, shared by the linker
+  // (#178) and by the Azure back-fill below (#224) so both scope to the same
+  // schools. Null when no school is flagged, so a not-yet-configured group
+  // falls back to the snapshot's own `MarkAsOurs` flags.
+  final Set<int>? ourSchoolIds =
+      settings.wisaSchools.isEmpty ? null : settings.managedWisaSchoolIds;
+
+  // Assigned immediately below; the Azure syncer closes over it so it can read
+  // the WISA snapshot *this* pass just pulled (WISA always syncs first).
+  late final ApplicationState app;
+  app = ApplicationState(
     wisa: SystemState<wapi.WisaSnapshot>(
       system: core.Origin.wisa,
       initial: wisaSeed,
@@ -394,7 +404,18 @@ Future<ReconcileServices> bootstrapReconcile({
         payloadOf: (s) => s.toJson(),
         deltaTokenOf: (s) => s.deltaToken,
         onError: (e) => logSnapshotIssue(core.Origin.azure, e),
-        inner: azureSyncer(azConnector),
+        // The prefix-scoped pull is blind to a student who transferred in from
+        // a sibling group school — their account carries neither our
+        // `companyName` nor our `department` — so the app proposed creating a
+        // duplicate. Hand the connector the WISA ids this pass expects, and it
+        // looks the unaccounted-for ones up by `employeeId` (#224).
+        inner: azureSyncer(
+          azConnector,
+          expectedEmployeeIds: () => managedStudentEmployeeIds(
+            app.wisa.snapshot,
+            ourSchoolIds: ourSchoolIds,
+          ),
+        ),
       ),
     ),
   );
@@ -422,8 +443,7 @@ Future<ReconcileServices> bootstrapReconcile({
     // Actions view only surfaces schools we manage. Null when no school is
     // flagged, so a not-yet-configured group falls back to the snapshot's
     // `MarkAsOurs` flags rather than treating an empty managed set as "none".
-    ourSchoolIds:
-        settings.wisaSchools.isEmpty ? null : settings.managedWisaSchoolIds,
+    ourSchoolIds: ourSchoolIds,
   );
 
   // The live SignalR subscriber (#124): on every (re)connect it re-reads the

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -1526,8 +1526,31 @@ class ReconcileController extends ChangeNotifier {
       '${s.groups.length} groups; ${pendingActions.length} pending '
       'action(s), ${s.warnings.length} warning(s).',
     );
+    _logSkippedNamesakes(s.warnings);
     _setProgress(0.9);
     await _persist(_linked!);
+  }
+
+  /// Names every WISA class the group link passed over because Smartschool
+  /// already carries its name on a group it could not adopt (#225).
+  ///
+  /// The skip is correct — an unofficial group is not a class — but it used to
+  /// be invisible, and an unmatched WISA class reads exactly like a class that
+  /// does not exist downstream. That is what had the Klasgroepen list offering
+  /// to create a class Smartschool already had, so each one gets a line of its
+  /// own naming the group that was skipped and why.
+  void _logSkippedNamesakes(List<core.LinkWarning> warnings) {
+    for (final w in warnings) {
+      if (w is! core.SmartschoolNamesakeSkipped) continue;
+      final ss = w.smartschool;
+      log.addMessage(
+        core.Origin.smartschool,
+        'Klas "${w.wisaName}" niet gekoppeld: Smartschool heeft al '
+        '"${ss.name}" (code ${ss.id.value}), '
+        '${ss.official ? 'met een andere schrijfwijze' : 'maar geen '
+            'officiële klas'}.',
+      );
+    }
   }
 
   /// Materializes the fresh linked view and writes it to the shared store

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -1407,7 +1407,7 @@ class ReconcileController extends ChangeNotifier {
 
     try {
       for (final (index, option) in selected.indexed) {
-        results.add(await _applyOne(
+        results.addAll(await _applyOne(
           () => _applyAny(option.action, options),
           option.target,
           option.changes,
@@ -1454,7 +1454,16 @@ class ReconcileController extends ChangeNotifier {
     return applier.applyGroup(action as actions.GroupAction, options: options);
   }
 
-  Future<ActionOutcomeEntry> _applyOne(
+  /// Runs one selected option and returns a result row per **write it
+  /// performed**: the option's own, followed by any follow-up the State layer
+  /// chained onto it (#230).
+  ///
+  /// A new student's provisioning is one such chain — the Office 365 create
+  /// unlocks the Smartschool create, which the applier runs against the freshly
+  /// relinked record — and the operator's one click therefore made two writes.
+  /// Both are logged and both land in the results list; hiding the second would
+  /// under-report what the app just did.
+  Future<List<ActionOutcomeEntry>> _applyOne(
     Future<ApplyResult> Function() run,
     String target,
     actions.ChangeSet changes,
@@ -1463,31 +1472,46 @@ class ReconcileController extends ChangeNotifier {
       final applied = await run();
       if (applied.refreshed) _linked = applied.linked;
       final result = applied.result;
-      if (result.outcome == actions.ActionOutcome.failed) {
-        log.addError(
-          changes.system,
-          '$target — ${changes.summary}: ${result.error}',
-        );
-      } else {
-        log.addMessage(core.Origin.all, '$target — ${changes.summary}');
-      }
-      return ActionOutcomeEntry(
-        target: target,
-        changes: changes,
-        outcome: result.outcome,
-        error: result.error,
-      );
+      return <ActionOutcomeEntry>[
+        _record(target, changes, result),
+        for (final followUp in applied.followUps)
+          _record(target, followUp.changes, followUp),
+      ];
     } on Object catch (e) {
       // An action that throws (instead of returning failed) must not abort
       // the rest of the pass.
       log.addError(changes.system, '$target — ${changes.summary}: $e');
-      return ActionOutcomeEntry(
-        target: target,
-        changes: changes,
-        outcome: actions.ActionOutcome.failed,
-        error: e,
-      );
+      return <ActionOutcomeEntry>[
+        ActionOutcomeEntry(
+          target: target,
+          changes: changes,
+          outcome: actions.ActionOutcome.failed,
+          error: e,
+        ),
+      ];
     }
+  }
+
+  /// Logs one action's outcome and shapes it as a results-list row.
+  ActionOutcomeEntry _record(
+    String target,
+    actions.ChangeSet changes,
+    actions.ActionResult result,
+  ) {
+    if (result.outcome == actions.ActionOutcome.failed) {
+      log.addError(
+        changes.system,
+        '$target — ${changes.summary}: ${result.error}',
+      );
+    } else {
+      log.addMessage(core.Origin.all, '$target — ${changes.summary}');
+    }
+    return ActionOutcomeEntry(
+      target: target,
+      changes: changes,
+      outcome: result.outcome,
+      error: result.error,
+    );
   }
 
   Future<void> _relink() async {
@@ -1520,6 +1544,17 @@ class ReconcileController extends ChangeNotifier {
         generation: previous.generation + 1,
         schoolLabels: _schoolLabels(),
       );
+      // Say so when the managed-school filter dropped students (#230). The drop
+      // is deliberate (#178) but it used to be invisible, so a school the
+      // operator forgot to flag as ours in Instellingen looked exactly like a
+      // WISA pull that never returned the class.
+      if (view.skippedUnmanagedStudents > 0) {
+        log.addMessage(
+          core.Origin.wisa,
+          '${view.skippedUnmanagedStudents} leerling(en) overgeslagen: '
+          'niet in een school die we beheren.',
+        );
+      }
       final merge = mergeDecisions(
         accounts: view.accounts,
         groups: view.groups,

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -25,6 +25,13 @@ import '../search/name_query.dart';
 /// on-screen tiles build. The global "Dry-run all" / "Apply all" act on every
 /// pending entry across all classes.
 ///
+/// One view-wide switch above the family tab bar — "toon enkel accounts met
+/// acties", on by default — collapses all of that to the work list (#226):
+/// grade-years and classrooms with nothing pending are not rendered, and an
+/// opened classroom lists only accounts with a pending action. What it holds
+/// back is counted and named, so a year the operator expected is explained
+/// rather than merely absent.
+///
 /// A session with no linked view — passive, or one whose pass failed before it
 /// linked — can only show the stored documents, so both drill-downs say so out
 /// loud rather than quietly swapping in static cards (#214).
@@ -141,6 +148,29 @@ class _EntryRow extends _PendingRow {
 /// overview's category order (Leerlingen, then Personeel).
 enum _ActionFamilyTab { leerlingen, personeel }
 
+/// One family tab's drill-down after the global "toon enkel accounts met acties"
+/// filter has been applied (#226): the nodes that survive, plus a count of what
+/// it removed so the tree can say why a year is missing rather than silently
+/// shrinking.
+class _FilteredTree {
+  const _FilteredTree({
+    required this.roots,
+    this.groups,
+    required this.hidden,
+  });
+
+  /// The top-level accordion nodes still worth rendering.
+  final List<Rollup> roots;
+
+  /// The "Klasgroepen" node, or `null` when this tab carries none.
+  final Rollup? groups;
+
+  /// How many nodes disappeared from what the tree would otherwise show —
+  /// counted as the operator would browse it, so a hidden year counts once
+  /// rather than once per classroom inside it.
+  final int hidden;
+}
+
 class _ActionsBody extends StatefulWidget {
   const _ActionsBody({required this.controller});
 
@@ -155,11 +185,23 @@ class _ActionsBodyState extends State<_ActionsBody>
   late final TabController _tabs;
   int _shownIndex = 0;
 
-  /// The classroom drill-down filters (#187): show only accounts carrying an
-  /// applyable action (both tabs), and a name search (Personeel tab). They
-  /// combine — a filtered account list respects both. Reset when the family tab
-  /// changes so each tab opens at a clean, unfiltered list.
-  bool _onlyWithActions = false;
+  /// The **global** Acties filter (#226), promoted out of the per-classroom bar
+  /// it was born in (#187): with the switch on, everything below it shows only
+  /// what carries an applyable action — grade-year and classroom nodes with a
+  /// zero pending count are not rendered, a grade-year left with no visible
+  /// classroom goes with them, and an opened classroom lists only accounts with
+  /// a pending action.
+  ///
+  /// One decision per session rather than one per class, so it is deliberately
+  /// **not** reset by a family tab change ([_onTabChanged]): the operator's mode
+  /// outlives whichever tab they happen to be on. Defaults on — the Acties view
+  /// exists to answer "what needs doing?", and the full inventory is the
+  /// exception, not the starting point.
+  bool _onlyWithActions = true;
+
+  /// The Personeel name search (#187/#217). Unlike [_onlyWithActions] this is a
+  /// per-list lookup, not a mode, so it stays inside the opened classroom and is
+  /// cleared on every family tab change.
   final TextEditingController _search = TextEditingController();
 
   ReconcileController get controller => widget.controller;
@@ -238,12 +280,15 @@ class _ActionsBodyState extends State<_ActionsBody>
   /// Rebuilds the sliver content for the newly-selected family, and — when the
   /// selected family actually changed — closes any open drill-down so each tab
   /// opens at its own overview rather than showing the other family's detail.
+  ///
+  /// The name search is cleared, because it is a lookup inside the list that is
+  /// being left behind. [_onlyWithActions] is **not**: since #226 it is the
+  /// view-wide mode, set once above the tab bar, and resetting it here would put
+  /// the switch and the tree it governs out of step on every tab change.
   void _onTabChanged() {
     final index = _tabs.index;
     if (index != _shownIndex) {
       _shownIndex = index;
-      // A fresh tab opens at a clean, unfiltered list (#187).
-      _onlyWithActions = false;
       _search.clear();
       if (controller.selectedClassroom != null) controller.closeClassroom();
       if (controller.showingGroups) controller.closeGroups();
@@ -277,11 +322,94 @@ class _ActionsBodyState extends State<_ActionsBody>
   static SliverToBoxAdapter _gap(double height) =>
       SliverToBoxAdapter(child: SizedBox(height: height));
 
+  /// Whether a grade-year or classroom node survives the global filter (#226).
+  ///
+  /// [Rollup.pendingCount] is already "how many applyable actions sit under this
+  /// node", so hiding is a pure render-time projection of the stored overview —
+  /// no store or materializer change is involved.
+  bool _keepNode(Rollup r) => !_onlyWithActions || r.pendingCount > 0;
+
+  /// Whether a nested grade-year node (the Personeel tab's middle level) keeps
+  /// at least one visible classroom. A grade that would open onto nothing is
+  /// hidden as a whole rather than left as an empty accordion.
+  bool _keepGrade(Rollup grade) =>
+      !_onlyWithActions || controller.childrenOf(grade.key).any(_keepNode);
+
+  /// Whether the "Klasgroepen" node survives the global filter (#226).
+  ///
+  /// Deliberately **not** `pendingCount > 0`, unlike every other node. A class
+  /// group's candidates are not all applyable: since #225 a class can carry an
+  /// informational-only notice (`ClassExistsAsSmartschoolGroup` and friends),
+  /// which is manual work the operator still has to do — it just has no
+  /// automated write, so it adds nothing to the pending count. Filtering this
+  /// node on the pending count would hide exactly the notices #225 exists to
+  /// surface. A group document is only ever written for a class that needs
+  /// attention, so the node stays as long as it holds one.
+  bool _keepGroups(Rollup groups) => groups.accountCount > 0;
+
+  /// The Leerlingen drill-down after the global filter (#226): the merged
+  /// grade-years that still hold a visible classroom, plus the class-groups
+  /// node, and how many nodes went missing so the tree can say so.
+  _FilteredTree _studentTree() {
+    final roots = <Rollup>[];
+    var hidden = 0;
+    for (final root in controller.studentRollups) {
+      final classrooms = controller.studentChildrenOf(root);
+      final kept = classrooms.where(_keepNode).length;
+      if (_onlyWithActions && kept == 0) {
+        // The year itself disappears rather than opening onto an empty list.
+        hidden++;
+        continue;
+      }
+      roots.add(root);
+      hidden += classrooms.length - kept;
+    }
+    final groups = controller.groupRollup;
+    return _FilteredTree(
+      roots: roots,
+      groups: groups != null && _keepGroups(groups) ? groups : null,
+      hidden: hidden,
+    );
+  }
+
+  /// The Personeel drill-down after the global filter (#226): the staff school
+  /// node, kept only while some grade below it still holds a visible classroom.
+  _FilteredTree _staffTree() {
+    final root = controller.staffSchoolRollup;
+    if (root == null) return const _FilteredTree(roots: <Rollup>[], hidden: 0);
+    var hidden = 0;
+    var keptGrades = 0;
+    for (final grade in controller.childrenOf(root.key)) {
+      final classrooms = controller.childrenOf(grade.key);
+      final kept = classrooms.where(_keepNode).length;
+      if (_onlyWithActions && kept == 0) {
+        hidden++;
+        continue;
+      }
+      keptGrades++;
+      hidden += classrooms.length - kept;
+    }
+    if (_onlyWithActions && keptGrades == 0) {
+      return const _FilteredTree(roots: <Rollup>[], hidden: 1);
+    }
+    return _FilteredTree(roots: <Rollup>[root], hidden: hidden);
+  }
+
   List<Widget> _slivers(BuildContext context) {
     final slivers = <Widget>[
       _gap(PlinkSpacing.s6),
-      _section(_ActionsHeader(controller: controller)),
-      _gap(PlinkSpacing.s5),
+      _section(_ActionsHeader(
+        controller: controller,
+        onlyWithActions: _onlyWithActions,
+      )),
+      _gap(PlinkSpacing.s4),
+      // The one place the filter is set (#226): above the family tab bar, so it
+      // governs both tabs, the drill-down, and every classroom opened from it.
+      _section(_ActionsFilterBar(
+        onlyWithActions: _onlyWithActions,
+        onChanged: (v) => setState(() => _onlyWithActions = v),
+      )),
+      _gap(PlinkSpacing.s4),
       _section(_FamilyTabBar(controller: controller, tabs: _tabs)),
       _gap(PlinkSpacing.s4),
     ];
@@ -295,30 +423,40 @@ class _ActionsBodyState extends State<_ActionsBody>
       // synthetic staff school node (school → grade → classroom, unchanged); the
       // Leerlingen tab opens straight on the merged grade-years plus the
       // class-groups node (class groups are student-oriented).
-      final staffRollup = controller.staffSchoolRollup;
+      final tree = staffTab ? _staffTree() : _studentTree();
       slivers.add(_section(staffTab
           ? _DrillDownSection(
               controller: controller,
-              roots: <Rollup>[if (staffRollup != null) staffRollup],
+              roots: tree.roots,
               groups: null,
+              hidden: tree.hidden,
+              filtering: _onlyWithActions,
               emptyLabel: 'Geen openstaande personeelsacties.',
               childrenOf: (root) => <Widget>[
                 for (final grade in controller.childrenOf(root.key))
-                  _GradeNode(controller: controller, grade: grade),
+                  if (_keepGrade(grade))
+                    _GradeNode(
+                      controller: controller,
+                      grade: grade,
+                      onlyWithActions: _onlyWithActions,
+                    ),
               ],
             )
           : _DrillDownSection(
               controller: controller,
-              roots: controller.studentRollups,
-              groups: controller.groupRollup,
+              roots: tree.roots,
+              groups: tree.groups,
+              hidden: tree.hidden,
+              filtering: _onlyWithActions,
               emptyLabel: 'Nog geen gematerialiseerd overzicht.',
               childrenOf: (root) => <Widget>[
                 for (final classroom in controller.studentChildrenOf(root))
-                  _ClassroomTile(
-                    controller: controller,
-                    classroom: classroom,
-                    indent: PlinkSpacing.s5,
-                  ),
+                  if (_keepNode(classroom))
+                    _ClassroomTile(
+                      controller: controller,
+                      classroom: classroom,
+                      indent: PlinkSpacing.s5,
+                    ),
               ],
             )));
     } else {
@@ -354,12 +492,14 @@ class _ActionsBodyState extends State<_ActionsBody>
     }
     slivers.addAll(_readOnlySlivers());
 
-    Widget filterBar() => _section(_ClassroomFilterBar(
-          onlyWithActions: _onlyWithActions,
-          onOnlyWithActionsChanged: (v) => setState(() => _onlyWithActions = v),
-          showSearch: _staffTab,
-          searchController: _search,
-        ));
+    // Only the Personeel tab carries a per-list lookup; the mode switch that
+    // used to sit beside it now lives once, at the top of the view (#226).
+    final searchSlivers = _staffTab
+        ? <Widget>[
+            _section(_ClassroomSearchBar(searchController: _search)),
+            _gap(PlinkSpacing.s3),
+          ]
+        : const <Widget>[];
 
     if (controller.linked != null) {
       final situations = controller.classroomPendingSituations;
@@ -370,8 +510,7 @@ class _ActionsBodyState extends State<_ActionsBody>
       }
       final rows = _pendingRows(_filterSituations(situations));
       slivers
-        ..add(filterBar())
-        ..add(_gap(PlinkSpacing.s3))
+        ..addAll(searchSlivers)
         ..add(rows.isEmpty
             ? _section(const _EmptyLine(_noMatchLabel))
             : _rowsSliver(rows));
@@ -383,8 +522,7 @@ class _ActionsBodyState extends State<_ActionsBody>
       }
       final filtered = _filterAccounts(accounts);
       slivers
-        ..add(filterBar())
-        ..add(_gap(PlinkSpacing.s3))
+        ..addAll(searchSlivers)
         ..add(filtered.isEmpty
             ? _section(const _EmptyLine(_noMatchLabel))
             : SliverPadding(
@@ -537,9 +675,17 @@ class _ActionsBodyState extends State<_ActionsBody>
 /// (#110/#154): the secondary escape hatch that acts on every pending entry's
 /// chosen resolution, across all classes.
 class _ActionsHeader extends StatelessWidget {
-  const _ActionsHeader({required this.controller});
+  const _ActionsHeader({
+    required this.controller,
+    required this.onlyWithActions,
+  });
 
   final ReconcileController controller;
+
+  /// Whether the global filter is on, so the sub-line describes the tree the
+  /// operator is actually looking at (#226) — with the filter on there are no
+  /// ticked-off classes left to explain.
+  final bool onlyWithActions;
 
   @override
   Widget build(BuildContext context) {
@@ -555,9 +701,14 @@ class _ActionsHeader extends StatelessWidget {
         Text('Acties', style: text.headlineMedium),
         const SizedBox(height: PlinkSpacing.s2),
         Text(
-          count == 0
-              ? 'Geen openstaande acties. Klassen zonder acties tonen een vinkje.'
-              : '$count openstaande actie(s) — blader per jaar en klas.',
+          switch ((count, onlyWithActions)) {
+            (0, _) => 'Geen openstaande acties.',
+            (_, true) =>
+              '$count openstaande actie(s) — enkel jaren en klassen met '
+                  'acties worden getoond.',
+            (_, false) => '$count openstaande actie(s) — blader per jaar en '
+                'klas. Klassen zonder acties tonen een vinkje.',
+          },
           style: text.bodyMedium,
         ),
         const SizedBox(height: PlinkSpacing.s4),
@@ -592,6 +743,41 @@ class _ActionsHeader extends StatelessWidget {
           const SizedBox(height: PlinkSpacing.s4),
           const LinearProgressIndicator(),
         ],
+      ],
+    );
+  }
+}
+
+/// The one, view-wide "toon enkel accounts met acties" switch (#226).
+///
+/// It sits above the family tab bar, so the single decision it records governs
+/// both families, the whole jaar → klas drill-down, and every classroom opened
+/// from it. Its per-classroom ancestor (#187) had to be re-flipped in every
+/// class the operator opened and was reset on every tab change, which is why it
+/// never actually collapsed the tree to the work list.
+class _ActionsFilterBar extends StatelessWidget {
+  const _ActionsFilterBar({
+    required this.onlyWithActions,
+    required this.onChanged,
+  });
+
+  final bool onlyWithActions;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    return Row(
+      children: <Widget>[
+        Switch(
+          key: const ValueKey('actions-only-with-actions'),
+          value: onlyWithActions,
+          onChanged: onChanged,
+        ),
+        const SizedBox(width: PlinkSpacing.s2),
+        Expanded(
+          child: Text('Toon enkel accounts met acties', style: text.bodyMedium),
+        ),
       ],
     );
   }
@@ -824,6 +1010,8 @@ class _DrillDownSection extends StatelessWidget {
     required this.groups,
     required this.emptyLabel,
     required this.childrenOf,
+    required this.hidden,
+    required this.filtering,
   });
 
   final ReconcileController controller;
@@ -843,6 +1031,25 @@ class _DrillDownSection extends StatelessWidget {
 
   /// The message shown when this tab has nothing to browse.
   final String emptyLabel;
+
+  /// How many nodes the global filter removed from this tab's tree (#226).
+  final int hidden;
+
+  /// Whether the global filter is on — the difference between "there is nothing
+  /// here" and "the filter is holding it back", which is what tells an operator
+  /// why a year they expected is missing.
+  final bool filtering;
+
+  /// The footnote under a tree the filter has thinned out, so a missing year is
+  /// explained rather than merely absent.
+  String get _hiddenNote =>
+      'Verborgen door de filter: $hidden zonder openstaande acties.';
+
+  /// The stand-in for the tree when the filter hid every last node — distinct
+  /// from [emptyLabel], which means the shared view holds nothing at all.
+  String get _allHiddenNote =>
+      'Alles is verborgen door de filter: $hidden zonder openstaande acties. '
+      'Zet de filter af voor het volledige overzicht.';
 
   String? _freshness() {
     final state = controller.syncState;
@@ -874,7 +1081,13 @@ class _DrillDownSection extends StatelessWidget {
         ],
         const SizedBox(height: PlinkSpacing.s3),
         if (roots.isEmpty && groupsNode == null)
-          Text(emptyLabel, style: text.bodyMedium)
+          filtering && hidden > 0
+              ? Text(
+                  _allHiddenNote,
+                  key: const ValueKey('actions-filter-all-hidden'),
+                  style: text.bodyMedium,
+                )
+              : Text(emptyLabel, style: text.bodyMedium)
         else ...<Widget>[
           for (final root in roots)
             Container(
@@ -904,12 +1117,29 @@ class _DrillDownSection extends StatelessWidget {
               child: ListTile(
                 key: const ValueKey('rollup-groups'),
                 title: Text(groupsNode.label, style: text.bodyLarge),
-                subtitle: Text('${groupsNode.accountCount} klasgroep(en)',
-                    style: text.bodySmall),
+                subtitle: Text(
+                  // A node the filter kept while its badge shows a tick needs
+                  // its reason on the tile (#225/#226): every class in it
+                  // carries a notice to follow up by hand, none an automated
+                  // write.
+                  groupsNode.pendingCount == 0
+                      ? '${groupsNode.accountCount} klasgroep(en) — enkel '
+                          'meldingen om manueel op te volgen'
+                      : '${groupsNode.accountCount} klasgroep(en)',
+                  style: text.bodySmall,
+                ),
                 trailing: _PendingBadge(count: groupsNode.pendingCount),
                 onTap: controller.openGroups,
               ),
             ),
+          if (filtering && hidden > 0) ...<Widget>[
+            const SizedBox(height: PlinkSpacing.s1),
+            Text(
+              _hiddenNote,
+              key: const ValueKey('actions-filter-hidden'),
+              style: text.bodySmall,
+            ),
+          ],
         ],
       ],
     );
@@ -921,10 +1151,18 @@ class _DrillDownSection extends StatelessWidget {
 /// no school to nest under, so its grade-years are [_DrillDownSection] roots and
 /// carry their "Jaar N" label from [ReconcileController.gradeNodeLabel] instead.
 class _GradeNode extends StatelessWidget {
-  const _GradeNode({required this.controller, required this.grade});
+  const _GradeNode({
+    required this.controller,
+    required this.grade,
+    required this.onlyWithActions,
+  });
 
   final ReconcileController controller;
   final Rollup grade;
+
+  /// Whether the global filter is on, in which case only the classrooms of this
+  /// year that carry an applyable action are listed (#226).
+  final bool onlyWithActions;
 
   @override
   Widget build(BuildContext context) {
@@ -938,11 +1176,12 @@ class _GradeNode extends StatelessWidget {
       trailing: _PendingBadge(count: grade.pendingCount),
       children: <Widget>[
         for (final classroom in controller.childrenOf(grade.key))
-          _ClassroomTile(
-            controller: controller,
-            classroom: classroom,
-            indent: PlinkSpacing.s6,
-          ),
+          if (!onlyWithActions || classroom.pendingCount > 0)
+            _ClassroomTile(
+              controller: controller,
+              classroom: classroom,
+              indent: PlinkSpacing.s6,
+            ),
       ],
     );
   }
@@ -1023,69 +1262,39 @@ class _DetailHeader extends StatelessWidget {
   }
 }
 
-/// The filter bar above a drilled-into classroom's account list (#187): a
-/// "toon enkel accounts met acties" toggle (both tabs) and — on the Personeel
-/// tab — a name search. Both narrow the list below and combine: the shown list
-/// respects the toggle and the search together.
-class _ClassroomFilterBar extends StatelessWidget {
-  const _ClassroomFilterBar({
-    required this.onlyWithActions,
-    required this.onOnlyWithActionsChanged,
-    required this.showSearch,
-    required this.searchController,
-  });
+/// The name search above a drilled-into classroom's account list, on the
+/// Personeel tab only (#187/#217).
+///
+/// The "toon enkel accounts met acties" toggle that used to sit beside it moved
+/// to the top of the view in #226 — it is a mode, and the filter must not be
+/// settable in two places. A name search is the opposite: a lookup inside *this*
+/// list, so it stays here.
+class _ClassroomSearchBar extends StatelessWidget {
+  const _ClassroomSearchBar({required this.searchController});
 
-  final bool onlyWithActions;
-  final ValueChanged<bool> onOnlyWithActionsChanged;
-
-  /// Whether to render the name search field (Personeel tab only).
-  final bool showSearch;
   final TextEditingController searchController;
 
   @override
   Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        if (showSearch) ...<Widget>[
-          TextField(
-            key: const ValueKey('actions-search'),
-            controller: searchController,
-            decoration: InputDecoration(
-              isDense: true,
-              prefixIcon: const Icon(Icons.search, size: 18),
-              // Same wording as the Wachtwoorden → Personeel box, which matches
-              // the same way (#217): any part of the name, in any order.
-              hintText: 'Zoek op naam…',
-              border: const OutlineInputBorder(),
-              suffixIcon: searchController.text.isEmpty
-                  ? null
-                  : IconButton(
-                      key: const ValueKey('actions-search-clear'),
-                      icon: const Icon(Icons.close, size: 18),
-                      tooltip: 'Wis zoekopdracht',
-                      onPressed: searchController.clear,
-                    ),
-            ),
-          ),
-          const SizedBox(height: PlinkSpacing.s3),
-        ],
-        Row(
-          children: <Widget>[
-            Switch(
-              key: const ValueKey('actions-only-with-actions'),
-              value: onlyWithActions,
-              onChanged: onOnlyWithActionsChanged,
-            ),
-            const SizedBox(width: PlinkSpacing.s2),
-            Expanded(
-              child: Text('Toon enkel accounts met acties',
-                  style: text.bodyMedium),
-            ),
-          ],
-        ),
-      ],
+    return TextField(
+      key: const ValueKey('actions-search'),
+      controller: searchController,
+      decoration: InputDecoration(
+        isDense: true,
+        prefixIcon: const Icon(Icons.search, size: 18),
+        // Same wording as the Wachtwoorden → Personeel box, which matches the
+        // same way (#217): any part of the name, in any order.
+        hintText: 'Zoek op naam…',
+        border: const OutlineInputBorder(),
+        suffixIcon: searchController.text.isEmpty
+            ? null
+            : IconButton(
+                key: const ValueKey('actions-search-clear'),
+                icon: const Icon(Icons.close, size: 18),
+                tooltip: 'Wis zoekopdracht',
+                onPressed: searchController.clear,
+              ),
+      ),
     );
   }
 }

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -504,6 +504,152 @@ void main() {
     });
   });
 
+  group('provisioning a WISA-only student (#230)', () {
+    /// A new intake: one student in a managed school with neither a Smartschool
+    /// nor an Office 365 account, and the Smartschool class they belong to.
+    ReconcileHarness newIntakeHarness() => ReconcileHarness(
+          wisa: wisaSnap(
+            students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
+            schools: [wisaSchool(1, ours: true)],
+          ),
+          smartschool: ssSnap(
+            groups: [ssGroup('3C', code: '3C_ss')],
+            accounts: const [],
+            memberships: const [],
+          ),
+          azure: azSnap(users: const []),
+          ourSchoolIds: const {1},
+        );
+
+    /// The student's own pending entry (the Smartschool class the fixture
+    /// carries has no WISA counterpart, so it raises a group entry of its own).
+    PendingAccountEntry studentEntry(ReconcileController controller) =>
+        controller.pendingEntries.singleWhere((e) => e.family == 'student');
+
+    test('is offered exactly one applyable entry', () async {
+      final h = newIntakeHarness();
+      await h.controller.sync();
+
+      final entry = studentEntry(h.controller);
+      expect(entry.canApply, isTrue);
+      expect(entry.choices.single.selected.kind, 'AddStudentToAzure');
+    });
+
+    test('applying it provisions both accounts and reports both writes',
+        () async {
+      final h = newIntakeHarness();
+      await h.controller.sync();
+
+      await h.controller.applyEntry(studentEntry(h.controller));
+
+      expect(h.controller.error, isNull);
+      expect(
+        h.controller.applyResults!.map((r) => r.changes.summary),
+        <String>[
+          'Maak een nieuw Office 365 account',
+          'Maak een nieuw Smartschool account',
+        ],
+        reason: 'one click, the whole provisioning chain',
+      );
+      expect(
+        h.controller.applyResults!.map((r) => r.outcome),
+        everyElement(actions.ActionOutcome.applied),
+      );
+      // Both writes really happened, and the linked view carries both records.
+      expect(h.graph.createdUsers.single['employeeId'], 'W7');
+      expect(h.soap.soapActions.any((a) => a.contains('saveUser')), isTrue);
+      final linked = h.controller.linked!.snapshot.accounts.single;
+      expect(linked.azure, isNotNull);
+      expect(linked.smartschool, isNotNull);
+    });
+
+    test('the chained write is logged like any other', () async {
+      final h = newIntakeHarness();
+      await h.controller.sync();
+
+      await h.controller.applyEntry(studentEntry(h.controller));
+
+      expect(
+        h.log.entries.map((e) => e.message),
+        contains(contains('Maak een nieuw Smartschool account')),
+      );
+    });
+
+    test('a dry run projects only the write it can actually describe',
+        () async {
+      // The chain rides the incremental refresh, which a dry run does not
+      // perform — so it stays a projection of the one write, with no Graph POST
+      // and no Smartschool call behind it.
+      final h = newIntakeHarness();
+      await h.controller.sync();
+
+      await h.controller.dryRunEntry(studentEntry(h.controller));
+
+      expect(
+        h.controller.dryRunResults!.map((r) => r.changes.summary),
+        <String>['Maak een nieuw Office 365 account'],
+      );
+      expect(h.graph.createdUsers, isEmpty);
+      expect(h.soap.soapActions, isEmpty);
+    });
+  });
+
+  group('managed-school filter visibility (#230)', () {
+    test('a sync says how many students the filter dropped', () async {
+      // School 2 is not in the managed set, and its student owns no account of
+      // ours — so they are (correctly, #178) kept out of the Actions view. That
+      // used to happen with no node, no count and no log line, which is exactly
+      // how a school the operator forgot to flag in Instellingen reads.
+      final h = ReconcileHarness(
+        wisa: wisaSnap(
+          students: [
+            wisaStudent(wisaId: '1'),
+            wisaStudent(wisaId: '2', schoolId: 2),
+          ],
+          schools: [wisaSchool(1), wisaSchool(2)],
+        ),
+        smartschool: ssSnap(
+          groups: const [],
+          accounts: const [],
+          memberships: const [],
+        ),
+        azure: azSnap(users: const []),
+        ourSchoolIds: const {1},
+      );
+
+      await h.controller.sync();
+
+      expect(
+        h.log.entries.map((e) => e.message),
+        contains('1 leerling(en) overgeslagen: '
+            'niet in een school die we beheren.'),
+      );
+    });
+
+    test('a sync with nothing dropped stays quiet', () async {
+      final h = ReconcileHarness(
+        wisa: wisaSnap(
+          students: [wisaStudent(wisaId: '1')],
+          schools: [wisaSchool(1)],
+        ),
+        smartschool: ssSnap(
+          groups: const [],
+          accounts: const [],
+          memberships: const [],
+        ),
+        azure: azSnap(users: const []),
+        ourSchoolIds: const {1},
+      );
+
+      await h.controller.sync();
+
+      expect(
+        h.log.entries.map((e) => e.message),
+        isNot(contains(contains('overgeslagen'))),
+      );
+    });
+  });
+
   group('busy-pass progress (#176)', () {
     /// Records [ReconcileController.progress] on every notification, so a test
     /// can assert the pass stepped the bar forward through its stages even

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -450,6 +450,11 @@ ss.SmartschoolAccount ssAccount({
   String givenName = 'Jane',
   String surname = 'Doe',
   core.Address address = _addr,
+  // A staff-role account is what the linker's `_buildStaffRecords` seeds a
+  // LinkedStaff from; `fax` carries the zero-padded copy-code, so a fixture that
+  // wants no SetStaffCopyCode must set it.
+  core.PersonRole role = core.PersonRole.student,
+  String fax = '',
 }) =>
     ss.SmartschoolAccount(
       uid: uid,
@@ -457,7 +462,7 @@ ss.SmartschoolAccount ssAccount({
       mail: mail,
       registerId: '',
       stemId: 0,
-      role: core.PersonRole.student,
+      role: role,
       givenName: givenName,
       surname: surname,
       extraNames: '',
@@ -470,9 +475,31 @@ ss.SmartschoolAccount ssAccount({
       address: address,
       mobilePhone: '',
       homePhone: '',
-      fax: '',
+      fax: fax,
       untisId: '',
       status: 'actief',
+    );
+
+/// A Smartschool **staff** account — a teacher-role [ssAccount], the shape the
+/// linker seeds a `LinkedStaff` from. The defaults line up with [wisaStaff] so a
+/// complete staff record raises no Smartschool action of its own: `accountId` is
+/// the WISA staff `code` and `fax` the zero-padded `wisaId`.
+ss.SmartschoolAccount ssStaffAccount({
+  String uid = 'anna.smit',
+  String accountId = 'SMIT',
+  String mail = 'anna.smit@school.example',
+  String givenName = 'Anna',
+  String surname = 'Smit',
+  String fax = '0042',
+}) =>
+    ssAccount(
+      uid: uid,
+      accountId: accountId,
+      mail: mail,
+      givenName: givenName,
+      surname: surname,
+      role: core.PersonRole.teacher,
+      fax: fax,
     );
 
 az.AzureUser azUser({

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -943,6 +943,44 @@ ReconcileHarness siblingPopulatedClassHarness() => ReconcileHarness(
       ourSchoolIds: const {1},
     );
 
+/// A harness for the class Smartschool already has (#225). Our school 1 has the
+/// populated class `2G`; Smartschool holds `2G` too — under `2de Jaar`, beside
+/// the classes it *did* flag official, and with the subgroup `2G LAT` hanging
+/// under it — but the `2G` node itself is not flagged as an official class.
+///
+/// The official-class link skips it, correctly and (before #225) silently, so
+/// the WISA class read as one nobody had created yet: the Klasgroepen list
+/// offered "Voeg deze klas toe aan Smartschool", the applyable action that
+/// would have asked Smartschool for a second class named `2G`. The subgroup, an
+/// official class of its own with no WISA counterpart, keeps its own
+/// Smartschool-only notice — that one is correct.
+ReconcileHarness nonOfficialSmartschoolClassHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(wisaId: '1', classGroup: '2G')],
+        schools: [wisaSchool(1)],
+        classGroups: [
+          wisaClassGroup(
+            '2G',
+            description: '2e lj A Klassieke talen',
+            schoolCode: '111',
+            schoolId: 1,
+          ),
+        ],
+      ),
+      smartschool: ssSnap(
+        groups: [
+          ssGroup('2de Jaar',
+              code: '2dejaar', official: false, type: core.GroupType.group),
+          ssGroup('2G', code: 'G2G', official: false),
+          ssGroup('2G LAT', code: 'C2GLAT'),
+        ],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+      ourSchoolIds: const {1},
+    );
+
 /// A harness for the `00` sub-group sentinel (#221). Two managed schools that
 /// each have their own `1C`, and each of those is a **single-group** class: one
 /// `SyncKlas` row with `KLASGROEP = 00` and — because `ADMINGROEP` is only

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -60,11 +60,62 @@ class RecordingSoap implements ss.SmartschoolSoapTransport {
 class RecordingGraph implements az.GraphTransport {
   final List<az.GraphRequest> requests = <az.GraphRequest>[];
 
+  /// The bodies of every `POST /users` this transport accepted, in order — the
+  /// accounts a create action actually asked Graph to make (#230).
+  final List<Map<String, dynamic>> createdUsers = <Map<String, dynamic>>[];
+
+  int _created = 0;
+
+  /// A user PATCH/DELETE answers `204` the way Graph does, but a **create**
+  /// reads before it writes: `AddStudentToAzure` first asks
+  /// `employeeId in (…)` whether the person already has an account (#224), then
+  /// `createPrincipalName` probes `users/<upn>` for each UPN candidate until one
+  /// is free. This models an empty tenant — the collection reads come back
+  /// empty, the single-user reads `404` — and echoes the created resource the
+  /// way Graph does, so the whole create path runs offline (#230).
+  ///
+  /// Answering those GETs matters: a bare `204` decodes to an empty JSON object,
+  /// which `AzureUser.fromGraphJson` happily turns into a user, so every UPN
+  /// candidate would read as taken and `createPrincipalName` would spin forever.
   @override
   Future<az.GraphResponse> send(az.GraphRequest request) async {
     requests.add(request);
+    if (request.method == 'GET') {
+      return _singleUserPath.hasMatch(request.url.path)
+          ? const az.GraphResponse(
+              statusCode: 404,
+              headers: <String, String>{'content-type': 'application/json'},
+              body: '{"error":{"code":"Request_ResourceNotFound",'
+                  '"message":"Resource does not exist."}}',
+            )
+          : _ok(<String, dynamic>{'value': const <Object>[]}, statusCode: 200);
+    }
+    if (request.method == 'POST' && request.url.path.endsWith('/users')) {
+      final body = Map<String, dynamic>.from(
+        jsonDecode(request.body ?? '{}') as Map,
+      );
+      createdUsers.add(body);
+      return _ok(
+        <String, dynamic>{...body, 'id': 'az-created-${++_created}'},
+        statusCode: 201,
+      );
+    }
     return const az.GraphResponse(statusCode: 204);
   }
+
+  /// `/v1.0/users/<id-or-upn>` — a read of one user, as opposed to the
+  /// collection reads `/v1.0/users` and `/v1.0/users/delta`.
+  static final RegExp _singleUserPath = RegExp(r'/users/(?!delta$)[^/]+$');
+
+  static az.GraphResponse _ok(
+    Map<String, dynamic> body, {
+    required int statusCode,
+  }) =>
+      az.GraphResponse(
+        statusCode: statusCode,
+        headers: const <String, String>{'content-type': 'application/json'},
+        body: jsonEncode(body),
+      );
 }
 
 /// A [az.GraphTransport] that answers the way Graph does for a school whose

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -155,6 +155,104 @@ class StaleDeltaTokenGraph implements az.GraphTransport {
       );
 }
 
+/// A [az.GraphTransport] answering the way the tenant answered in #224: the
+/// school-scoped bulk read finds **nothing** for a student who transferred in
+/// from a sibling group school, while a targeted `employeeId in (…)` lookup
+/// turns up the Office 365 account they already have.
+///
+/// That account is exactly what the operator found on Ambre Kalenga Alfio: our
+/// `employeeId`, **no** `companyName`, a `department` still naming the school
+/// they came from, and a UPN whose given/family-name order that school mangled —
+/// so neither leg of the connector's `$filter` matches it and the UPN is no use
+/// as a matching key either.
+///
+/// Wire it into [ReconcileHarness.azureTransport] to drive the **production**
+/// Azure pull, the only place the back-fill lives.
+class TransferredStudentGraph implements az.GraphTransport {
+  TransferredStudentGraph({
+    this.employeeId = 'W7',
+    this.upn = 'alfio.ambre@student.other.example',
+    this.displayName = 'Alfio Ambre',
+    this.deltaToken = 'AZ-TOKEN',
+    this.visibleUsers = const <az.AzureUser>[],
+  });
+
+  /// The WISA id the existing account carries — the one usable matching key.
+  final String employeeId;
+  final String upn;
+  final String displayName;
+  final String deltaToken;
+
+  /// What the `$filter`-scoped bulk read returns. Empty by default: the whole
+  /// point is that the transferred account is not among them.
+  final List<az.AzureUser> visibleUsers;
+
+  final List<az.GraphRequest> requests = <az.GraphRequest>[];
+
+  /// Every `employeeId in (…)` filter the connector issued, in order — so a
+  /// test can prove it asked only about the ids it could not account for.
+  final List<String> employeeIdLookups = <String>[];
+
+  /// How many `$filter`-scoped bulk reads ran.
+  int bulkReads = 0;
+
+  @override
+  Future<az.GraphResponse> send(az.GraphRequest request) async {
+    requests.add(request);
+    final String path = request.url.path;
+    if (path.contains('/members') || path.contains('groups')) {
+      return _ok(<String, dynamic>{'value': const <Object>[]});
+    }
+    if (path.contains('users/delta')) {
+      return _ok(<String, dynamic>{
+        '@odata.deltaLink':
+            'https://graph.microsoft.com/v1.0/users/delta?\$deltatoken='
+                '$deltaToken',
+        'value': const <Object>[],
+      });
+    }
+    final String filter = request.url.queryParameters[r'$filter'] ?? '';
+    if (filter.startsWith('employeeId in')) {
+      employeeIdLookups.add(filter);
+      return _ok(<String, dynamic>{
+        'value': filter.contains("'$employeeId'")
+            ? <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'id': 'az-transferred',
+                  'userPrincipalName': upn,
+                  'employeeId': employeeId,
+                  'displayName': displayName,
+                  // No companyName: the other school never stamped one, and
+                  // ours was never stamped either.
+                  'department': 'OTHER-3A',
+                  'accountEnabled': true,
+                },
+              ]
+            : const <Object>[],
+      });
+    }
+    bulkReads++;
+    return _ok(<String, dynamic>{
+      'value': <Map<String, dynamic>>[
+        for (final az.AzureUser u in visibleUsers)
+          <String, dynamic>{
+            'id': u.id,
+            'userPrincipalName': u.upn,
+            if (u.employeeId != null) 'employeeId': u.employeeId,
+            if (u.companyName != null) 'companyName': u.companyName,
+            'accountEnabled': u.accountEnabled,
+          },
+      ],
+    });
+  }
+
+  static az.GraphResponse _ok(Map<String, dynamic> body) => az.GraphResponse(
+        statusCode: 200,
+        headers: const <String, String>{'content-type': 'application/json'},
+        body: jsonEncode(body),
+      );
+}
+
 /// A [az.GraphTransport] answering the way the tenant answered in #216: the
 /// user lookup succeeds, and the `passwordProfile` PATCH that follows is
 /// refused with `403 Authorization_RequestDenied`, because the app
@@ -1293,17 +1391,26 @@ class ReconcileHarness {
     final azureTransport = this.azureTransport;
     Syncer<az.AzureSnapshot> azSync;
     if (azureTransport != null) {
-      final inner = azureSyncer(az.AzureConnector(
-        credentials: az.AzureCredentials(
-          clientId: 'c',
-          tenantId: 't',
-          azureDomain: 'school.example',
-          schoolPrefix: 'GBS',
+      final inner = azureSyncer(
+        az.AzureConnector(
+          credentials: az.AzureCredentials(
+            clientId: 'c',
+            tenantId: 't',
+            azureDomain: 'school.example',
+            schoolPrefix: 'GBS',
+          ),
+          authProvider: const az.StaticAuthProvider('token'),
+          transport: azureTransport,
+          log: log,
         ),
-        authProvider: const az.StaticAuthProvider('token'),
-        transport: azureTransport,
-        log: log,
-      ));
+        // Exactly as `bootstrapReconcile` composes it (#224): the ids this pass
+        // expects Azure accounts for come from the WISA snapshot the same
+        // ApplicationState pulled moments earlier.
+        expectedEmployeeIds: () => managedStudentEmployeeIds(
+          app.wisa.snapshot,
+          ourSchoolIds: ourSchoolIds,
+        ),
+      );
       azSync = (previous) async {
         azSyncs++;
         return inner(previous);

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -553,15 +553,26 @@ ss.SmartschoolAccount ssStaffAccount({
       fax: fax,
     );
 
+/// An Azure account. [displayName] is left empty by default, which is what most
+/// fixtures want — it makes `ModifyAzureName` evaluate true, so the pass has an
+/// action to show. A fixture that needs an account with **nothing** pending
+/// (a class the Acties filter must hide, #226) passes the student's WISA
+/// `fullName` here so the names already agree.
 az.AzureUser azUser({
   String id = 'az1',
   String upn = 'jane.doe@student.school.example',
   String? employeeId = '1',
+  String displayName = '',
+  String givenName = '',
+  String surname = '',
 }) =>
     az.AzureUser(
       id: id,
       upn: upn,
       employeeId: employeeId,
+      displayName: displayName,
+      givenName: givenName,
+      surname: surname,
       companyName: 'GBS',
     );
 

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -155,32 +155,41 @@ class StaleDeltaTokenGraph implements az.GraphTransport {
       );
 }
 
-/// A [az.GraphTransport] answering the way the tenant answered in #224: the
-/// school-scoped bulk read finds **nothing** for a student who transferred in
-/// from a sibling group school, while a targeted `employeeId in (…)` lookup
-/// turns up the Office 365 account they already have.
+/// A [az.GraphTransport] answering the way the tenant answered in #224 (a
+/// student) and #231 (a staff member): the school-scoped bulk read finds
+/// **nothing** for someone who transferred in from a sibling group school, while
+/// a targeted `employeeId in (…)` lookup turns up the Office 365 account they
+/// already have.
 ///
 /// That account is exactly what the operator found on Ambre Kalenga Alfio: our
 /// `employeeId`, **no** `companyName`, a `department` still naming the school
 /// they came from, and a UPN whose given/family-name order that school mangled —
 /// so neither leg of the connector's `$filter` matches it and the UPN is no use
-/// as a matching key either.
+/// as a matching key either. A moved staff member's account is in the same
+/// state; only the `department` text differs, which is what [department] is for.
 ///
 /// Wire it into [ReconcileHarness.azureTransport] to drive the **production**
 /// Azure pull, the only place the back-fill lives.
-class TransferredStudentGraph implements az.GraphTransport {
-  TransferredStudentGraph({
+class TransferredAccountGraph implements az.GraphTransport {
+  TransferredAccountGraph({
     this.employeeId = 'W7',
     this.upn = 'alfio.ambre@student.other.example',
     this.displayName = 'Alfio Ambre',
+    this.department = 'OTHER-3A',
     this.deltaToken = 'AZ-TOKEN',
     this.visibleUsers = const <az.AzureUser>[],
   });
 
   /// The WISA id the existing account carries — the one usable matching key.
+  /// For a student that is `WisaStudent.wisaId`; for a staff member the
+  /// (nullable) `WisaStaff.wisaId`, never their `code`.
   final String employeeId;
   final String upn;
   final String displayName;
+
+  /// The `department` the school they came from left on the account — never
+  /// one of ours, which is the whole reason the `$filter` cannot see it.
+  final String department;
   final String deltaToken;
 
   /// What the `$filter`-scoped bulk read returns. Empty by default: the whole
@@ -224,7 +233,7 @@ class TransferredStudentGraph implements az.GraphTransport {
                   'displayName': displayName,
                   // No companyName: the other school never stamped one, and
                   // ours was never stamped either.
-                  'department': 'OTHER-3A',
+                  'department': department,
                   'accountEnabled': true,
                 },
               ]
@@ -1403,13 +1412,17 @@ class ReconcileHarness {
           transport: azureTransport,
           log: log,
         ),
-        // Exactly as `bootstrapReconcile` composes it (#224): the ids this pass
-        // expects Azure accounts for come from the WISA snapshot the same
-        // ApplicationState pulled moments earlier.
-        expectedEmployeeIds: () => managedStudentEmployeeIds(
-          app.wisa.snapshot,
-          ourSchoolIds: ourSchoolIds,
-        ),
+        // Exactly as `bootstrapReconcile` composes it (#224 students, #231
+        // staff): the ids this pass expects Azure accounts for come from both
+        // populations of the WISA snapshot the same ApplicationState pulled
+        // moments earlier.
+        expectedEmployeeIds: () => <String>{
+          ...managedStudentEmployeeIds(
+            app.wisa.snapshot,
+            ourSchoolIds: ourSchoolIds,
+          ),
+          ...managedStaffEmployeeIds(app.wisa.snapshot),
+        },
       );
       azSync = (previous) async {
         azSyncs++;

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -370,14 +370,15 @@ void main() {
         findsOneWidget);
   });
 
-  // --- Classroom filters: toggle + name search (#187) ----------------------
+  // --- The global Acties filter + the Personeel name search (#187/#226) -----
 
   testWidgets(
-      'the Leerlingen classroom toggle shows only accounts with actions, and '
-      'that tab carries no name search (#187)', (WidgetTester tester) async {
+      'the global filter lists only accounts with actions inside an opened '
+      'Leerlingen class, is set in exactly one place, and gives the full class '
+      'back when switched off (#187/#226)', (WidgetTester tester) async {
     _useTallWindow(tester);
     // A passive-session class with a mix: one student with an applyable action,
-    // one without. The toggle must narrow to the former (its `hasPending`).
+    // one without. The filter must narrow to the former (its `hasPending`).
     final store = await seededLinkedStore(<MaterializedAccount>[
       matAccount(id: 's1', label: 'Jane Doe', withAction: true),
       matAccount(id: 's2', label: 'Kees Bakker', withAction: false),
@@ -386,24 +387,32 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-    // Both accounts show unfiltered; the Leerlingen tab has no search box.
-    expect(find.text('Jane Doe'), findsOneWidget);
-    expect(find.text('Kees Bakker'), findsOneWidget);
-    expect(find.byKey(const ValueKey('actions-search')), findsNothing);
-
-    // Toggle "only with actions": the action-free account drops out.
+    // One switch, on the Acties tab itself and already on — the operator never
+    // sets it per class (#226).
     final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    expect(toggle, findsOneWidget);
+    expect(tester.widget<Switch>(toggle).value, isTrue);
+
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+    // The action-free account is already out, with nothing touched in here; the
+    // Leerlingen tab has no search box, and no second copy of the switch.
+    expect(find.text('Jane Doe'), findsOneWidget);
+    expect(find.text('Kees Bakker'), findsNothing);
+    expect(find.byKey(const ValueKey('actions-search')), findsNothing);
+    expect(toggle, findsOneWidget,
+        reason: 'the filter is not settable in two places');
+
+    // Switched off, the class is the full inventory again.
     await tester.ensureVisible(toggle);
     await tester.tap(toggle);
     await tester.pumpAndSettle();
     expect(find.text('Jane Doe'), findsOneWidget);
-    expect(find.text('Kees Bakker'), findsNothing);
+    expect(find.text('Kees Bakker'), findsOneWidget);
   });
 
   testWidgets(
       'the Personeel classroom search matches any part of the name in any '
-      'order and combines with the only-with-actions toggle (#187/#217)',
+      'order and combines with the only-with-actions filter (#187/#217/#226)',
       (WidgetTester tester) async {
     _useTallWindow(tester);
     // Three staff in the one synthetic Personeel class: two share the surname
@@ -415,6 +424,13 @@ void main() {
     ]);
     final harness = ReconcileHarness(linkedStore: store);
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The global filter is on by default (#226); this half of the test is about
+    // the name search, so start from the full inventory.
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
     await tester.pumpAndSettle();
 
     // Switch to the Personeel tab and drill into its single staff class.
@@ -476,15 +492,14 @@ void main() {
     expect(
         find.text('Geen accounts die aan de filter voldoen.'), findsOneWidget);
 
-    // Combine the toggle with the search: search "Smit" AND only-with-actions
-    // keeps just Anna (Clara matches the name but has no action).
+    // Combine the two: search "Smit" AND the global only-with-actions filter
+    // back on keeps just Anna (Clara matches the name but has no action).
     await tester.enterText(
         find.byKey(const ValueKey('actions-search')), 'smit');
     await tester.pump();
-    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
     await tester.ensureVisible(toggle);
     await tester.tap(toggle);
-    await tester.pump();
+    await tester.pumpAndSettle();
     expect(find.text('Anna Smit'), findsOneWidget);
     expect(find.text('Clara Smit'), findsNothing);
     expect(find.text('Bram Jansen'), findsNothing);
@@ -495,6 +510,146 @@ void main() {
     await tester.pump();
     expect(
         find.text('Geen accounts die aan de filter voldoen.'), findsOneWidget);
+  });
+
+  // --- The filter thins out the jaar → klas tree (#226) --------------------
+
+  /// A passive-session view shaped for the tree filter: Jaar 3 has one class
+  /// with work (3A) and one without (3B); Jaar 4 has two classes and nothing to
+  /// do in either; Jaar 5 has a single class with nothing to do.
+  Future<ReconcileHarness> filterTreeHarness() async => ReconcileHarness(
+        linkedStore: await seededLinkedStore(<MaterializedAccount>[
+          matAccount(
+              id: 's1',
+              label: 'Jane Doe',
+              gradeYear: '3',
+              classroom: '3A',
+              withAction: true),
+          matAccount(
+              id: 's2', label: 'Kees Bakker', gradeYear: '3', classroom: '3B'),
+          matAccount(
+              id: 's3', label: 'Piet Peeters', gradeYear: '4', classroom: '4A'),
+          matAccount(
+              id: 's4', label: 'Marie Maes', gradeYear: '4', classroom: '4B'),
+          matAccount(
+              id: 's5', label: 'Sam Sels', gradeYear: '5', classroom: '5A'),
+        ]),
+      );
+
+  testWidgets(
+      'with the filter on, the jaar → klas tree drops the classrooms and the '
+      'whole years with nothing pending, and says how many it hid (#226)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = await filterTreeHarness();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // Only the year that still has work is an accordion at all.
+    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
+    expect(find.byKey(const ValueKey('rollup-grade-grades|4')), findsNothing,
+        reason: "both of Jaar 4's classes are done — the year goes with them");
+    expect(find.byKey(const ValueKey('rollup-grade-grades|5')), findsNothing,
+        reason: 'Jaar 5 has one class and nothing to do in it');
+
+    // The hiding is announced, so a year the operator expected is explained
+    // rather than merely absent: 3B, Jaar 4 and Jaar 5.
+    expect(find.byKey(const ValueKey('actions-filter-hidden')), findsOneWidget);
+    expect(find.textContaining('Verborgen door de filter: 3'), findsOneWidget);
+
+    // Inside the surviving year, only the class with work is listed.
+    await tester.tap(find.byKey(const ValueKey('rollup-grade-grades|3')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-class-class|1|3|3A')),
+        findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('rollup-class-class|1|3|3B')), findsNothing,
+        reason: 'a ticked-off class is not rendered under the filter');
+
+    // Switched off, the tree is the full inventory again — every year, every
+    // class, and nothing left for the note to explain.
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
+    expect(find.byKey(const ValueKey('rollup-grade-grades|4')), findsOneWidget);
+    expect(find.byKey(const ValueKey('rollup-grade-grades|5')), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-filter-hidden')), findsNothing);
+    expect(find.byKey(const ValueKey('rollup-class-class|1|3|3B')),
+        findsOneWidget);
+  });
+
+  testWidgets(
+      'a view with nothing pending says the filter hid it all — not that there '
+      'is no overview (#226)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(id: 's1', label: 'Jane Doe'),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('actions-filter-all-hidden')),
+        findsOneWidget);
+    expect(find.textContaining('Zet de filter af'), findsOneWidget);
+    expect(find.text('Nog geen gematerialiseerd overzicht.'), findsNothing,
+        reason: 'there *is* a materialized overview — the filter is hiding it');
+
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    expect(
+        find.byKey(const ValueKey('actions-filter-all-hidden')), findsNothing);
+    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
+  });
+
+  testWidgets(
+      'the filter switch survives a Leerlingen ↔ Personeel tab change, and '
+      'thins the Personeel tree the same way (#226)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // One student and one staff member, neither carrying an action: both trees
+    // are empty under the filter and full without it.
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(id: 's1', label: 'Jane Doe'),
+      matStaff(id: 't1', label: 'Anna Smit'),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    expect(tester.widget<Switch>(toggle).value, isTrue);
+
+    // Personeel obeys the same switch: its school node has no work under it, so
+    // it is gone too, with the same explanation in its place.
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+    expect(tester.widget<Switch>(toggle).value, isTrue,
+        reason: 'the mode outlives the tab it was set on');
+    expect(
+        find.byKey(const ValueKey('rollup-school-school|staff')), findsNothing);
+    expect(find.byKey(const ValueKey('actions-filter-all-hidden')),
+        findsOneWidget);
+
+    // Switch it off from the Personeel tab: the staff tree comes back.
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-school-school|staff')),
+        findsOneWidget);
+
+    // Back to Leerlingen, and the off state came along — the tab change used to
+    // reset it, which is why the filter had to be re-flipped constantly (#226).
+    await tester.tap(find.byKey(const ValueKey('actions-tab-leerlingen')));
+    await tester.pumpAndSettle();
+    expect(tester.widget<Switch>(toggle).value, isFalse);
+    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('actions-filter-all-hidden')), findsNothing);
   });
 
   // --- Address diff in the drill-down (#153) -------------------------------
@@ -634,6 +789,10 @@ void main() {
   testWidgets(
       'a passive session surfaces the Klasgroepen node and opens the group '
       'detail (#119/#154)', (WidgetTester tester) async {
+    // Tall, like its siblings: the top-level filter switch #226 added above the
+    // family tab bar costs the group tiles their place on an 800×600 fold, and
+    // this test is about which node opened, not about where the fold falls.
+    _useTallWindow(tester);
     final snapshots = InMemorySnapshotStore();
     final linkedStore = InMemoryLinkedStore();
     await ReconcileHarness(store: snapshots, linkedStore: linkedStore)

--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -70,11 +70,11 @@ than `else`, but sets `OK = false` inside the missing branch, so the two
 branches are mutually exclusive just like the student parser. The staff
 lifecycle set is `AddStaffToAzure`, `AddStaffToSmartschool`,
 `RemoveStaffFromSmartschool`, `DontImportStaffFromWisa`, `RemoveStaffFromAzure`;
-the modify set is `UpdateStaffWisaName`, `ModifySmartschoolStaffEmail`,
-`SetStaffCopyCode`. Staff bridge to Smartschool by `WisaStaff.code` (not
-`wisaId`) — `AddStaffToSmartschool` and `UpdateStaffWisaName` write the code
-into `accountId` (spec §4, OQ-1), while the numeric `wisaId` becomes the
-copy-code.
+the modify set is `ModifyStaffAzureSchool`, `UpdateStaffWisaName`,
+`ModifySmartschoolStaffEmail`, `SetStaffCopyCode`. Staff bridge to Smartschool
+by `WisaStaff.code` (not `wisaId`) — `AddStaffToSmartschool` and
+`UpdateStaffWisaName` write the code into `accountId` (spec §4, OQ-1), while the
+numeric `wisaId` becomes the copy-code.
 
 `groupActions(snapshot)` walks the snapshot's class groups, ported from the
 legacy `GroupActionParser`. The split is on the WISA/Smartschool **pair** rather
@@ -170,6 +170,21 @@ connector leaves that guard to the caller), so an ANS/BNS student whose
   the action converges after one apply.
 - **Staff gender on create.** Legacy `AddToSmartschool` hard-codes `Female` for
   new staff (WISA staff rows carry no gender); preserved verbatim.
+- **`ModifyStaffAzureSchool` is an addition, not a port.** The legacy staff
+  family has no `department` repair, so an Azure account adopted by the
+  `employeeId` back-fill (#231) never carried our marker and stayed invisible to
+  the school-scoped bulk read forever (#233). It fires when `department` does not
+  *start with* the school prefix — a missing one included, mirroring what #224
+  taught the student `ModifyAzureSchool` about a null `companyName` — and it is
+  `startswith`, not the linker's laxer `contains`, because that is the exact
+  server-side test `UserManager.filterFor` applies. **Assumed value shape:**
+  `<school>` or `<school> - <suffix>` (real data carries a subject suffix,
+  `Arcadia - Wiskunde`), so only the leading school segment is replaced and any
+  suffix is preserved. Legacy's staff `RemoveFromAzure` renders the field under
+  an "Active Schools" header and both linkers test it with `contains`, so it may
+  instead enumerate several schools — in which case replacing the head segment
+  evicts a sibling school's claim and this needs to become a prepend. Tracked as
+  #237.
 - Smartschool `uid` uniqueness for new accounts is the caller's concern (the
   State layer holds the account set); the default builder is deliberately
   simple.

--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -64,6 +64,27 @@ per record, applies the legacy `AccountActionParser` rule:
 
 The two sets never coexist for one record, exactly as in legacy.
 
+### Unlocked follow-ups (#230)
+
+Dispatch is a pure function of the record **as it stands**, which cannot express
+a chain. Provisioning a brand-new student is one: `AddStudentToSmartschool`
+builds its account with the Azure UPN as the `mail`, so it evaluates false until
+`AddStudentToAzure` has run, and a WISA-only student is therefore offered exactly
+one create even though they need two.
+
+`StudentAction.unlocks` names the action types a write may unlock on the same
+target — `AddStudentToAzure.unlocks == {AddStudentToSmartschool}`, everything
+else empty. It stays a pure, constant declaration: it says what *may* follow,
+never what must, and the follow-up's own `evaluate()` still decides.
+
+Acting on it belongs to the State layer, not here: `StateApplier.applyStudent`
+re-reads the follow-up from the **relinked** view's own dispatch and runs it, so
+the operator's one apply provisions the student end to end. It must be the
+relinked record and never a projection — `createPrincipalName` resolves a UPN
+collision by suffixing, so the UPN that landed can differ from the one
+`describeChanges()` projected, and the Smartschool account would carry the wrong
+`mail`. The staff family has the same two-pass shape and is tracked as #240.
+
 `staffActions(snapshot, config)` does the same over the snapshot's staff
 records. The legacy staff parser writes the modify branch as `if (OK)` rather
 than `else`, but sets `OK = false` inside the missing branch, so the two

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -31,7 +31,8 @@ import 'group_placement.dart';
 ///   [ActionResult.group] (a [Group]), not [ActionResult.smartschool] (a
 ///   `SmartschoolAccount`).
 ///
-/// **Scope.** The whole family ships here. [DoNotImportFromWisa],
+/// **Scope.** The whole family ships here, plus one action legacy never had:
+/// [ClassExistsAsSmartschoolGroup] (informational, #225). [DoNotImportFromWisa],
 /// [DoNotImportFromSmartschool] (informational), and [ModifySmartschoolData]
 /// derive everything from the WISA/Smartschool group pair (#54). The remaining
 /// three — [AddToSmartschool], [CreateInSmartschool] (informational), and
@@ -157,6 +158,12 @@ class DoNotImportFromWisa extends GroupAction {
 /// gate on the parent, matching legacy, which offers the action regardless and
 /// only checks the parent at apply time.
 ///
+/// One guard legacy has no notion of: a class whose name Smartschool already
+/// carries in some form ([LinkedGroup.smartschoolNamesake], #225) is never
+/// offered for creation — the write would ask for a duplicate name, which
+/// Smartschool either rejects or ends up holding twice.
+/// [ClassExistsAsSmartschoolGroup] takes over for that shape.
+///
 /// **Key divergence.** Legacy builds the class `Code`/`Name`/`Untis` from the
 /// raw WISA `Group.Name`; the canonical [LinkedGroup.wisa] carries only the
 /// `fullName` (the cross-system match key), so the created class is keyed on
@@ -173,6 +180,7 @@ class AddToSmartschool extends GroupAction {
   bool evaluate() =>
       group.wisa != null &&
       group.smartschool == null &&
+      group.smartschoolNamesake == null &&
       placement.containsStudents;
 
   /// The official Smartschool class to create, derived from the WISA class and
@@ -271,7 +279,11 @@ class AddToSmartschool extends GroupAction {
 /// `false` and [apply] throws.
 ///
 /// Distinguished from [AddToSmartschool] purely by the [GroupPlacement]
-/// membership signal: same WISA-only shape, but `!containsStudents`.
+/// membership signal: same WISA-only shape, but `!containsStudents`. It carries
+/// the same #225 guard: a class Smartschool already has under this name is
+/// [ClassExistsAsSmartschoolGroup]'s business, not an "empty class" notice —
+/// telling the operator to delete a WISA class that *is* provisioned downstream
+/// is the wrong advice.
 class CreateInSmartschool extends GroupAction {
   /// The membership context, injected by the dispatch. Only
   /// [GroupPlacement.containsStudents] matters here (it must be `false`).
@@ -283,6 +295,7 @@ class CreateInSmartschool extends GroupAction {
   bool evaluate() =>
       group.wisa != null &&
       group.smartschool == null &&
+      group.smartschoolNamesake == null &&
       !placement.containsStudents;
 
   @override
@@ -300,6 +313,71 @@ class CreateInSmartschool extends GroupAction {
   Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
       throw UnsupportedError(
         'CreateInSmartschool is informational and cannot be applied '
+        '(canApply is false)',
+      );
+}
+
+/// A WISA class whose name Smartschool **already carries**, on a group the
+/// linker could not adopt as the class's counterpart (#225). Informational only
+/// (`canApply == false`): the resolution is a hand edit in Smartschool, which
+/// no API call here should guess at.
+///
+/// It has no legacy counterpart — legacy had no way to see the situation. The
+/// class exists downstream in one of two shapes, both readable off
+/// [LinkedGroup.smartschoolNamesake]:
+/// - the group is **not flagged as an official class**, so it holds no students
+///   and never links (the real `2G` of #225). The operator makes it official in
+///   Smartschool, and the next sync links it;
+/// - the group *is* an official class but spells its name differently enough
+///   that the match key does not join them (`2 G` vs `2G`). The operator aligns
+///   the two names.
+///
+/// Either way the important part is what this action *replaces*:
+/// [AddToSmartschool] / [CreateInSmartschool], which would have proposed
+/// creating a class that is already there.
+class ClassExistsAsSmartschoolGroup extends GroupAction {
+  const ClassExistsAsSmartschoolGroup(super.group);
+
+  @override
+  bool evaluate() =>
+      group.wisa != null &&
+      group.smartschool == null &&
+      group.smartschoolNamesake != null;
+
+  @override
+  bool get canApply => false;
+
+  Group get _namesake => group.smartschoolNamesake!;
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: _namesake.official
+            ? 'Deze klas bestaat in Smartschool als "${_namesake.name}", met '
+                'een andere schrijfwijze. Stem beide namen op elkaar af, dan '
+                'wordt ze gekoppeld.'
+            : 'Deze klas bestaat in Smartschool maar is geen officiële klas. '
+                'Maak ze in Smartschool officieel (of hernoem ze), dan wordt '
+                'ze gekoppeld.',
+        fields: [
+          FieldChange(
+            'name',
+            before: _namesake.name,
+            after: _wisa.name,
+          ),
+          FieldChange('code', before: _namesake.id.value),
+          FieldChange(
+            'officiële klas',
+            before: _namesake.official ? 'ja' : 'nee',
+            after: 'ja',
+          ),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      throw UnsupportedError(
+        'ClassExistsAsSmartschoolGroup is informational and cannot be applied '
         '(canApply is false)',
       );
 }

--- a/packages/account_actions/lib/src/group_dispatch.dart
+++ b/packages/account_actions/lib/src/group_dispatch.dart
@@ -10,11 +10,20 @@ import 'group_placement.dart';
 /// the split is on the WISA/Smartschool pair rather than all three systems
 /// (there is no Azure group action):
 /// - If the class is missing from WISA **or** Smartschool, the lifecycle-style
-///   actions ([DoNotImportFromWisa], [AddToSmartschool], [CreateInSmartschool],
-///   [DoNotImportFromSmartschool]) are considered — in that legacy order, so a
-///   WISA-only class raises both [DoNotImportFromWisa] and exactly one of
-///   [AddToSmartschool] / [CreateInSmartschool].
+///   actions ([DoNotImportFromWisa], [ClassExistsAsSmartschoolGroup],
+///   [AddToSmartschool], [CreateInSmartschool], [DoNotImportFromSmartschool])
+///   are considered — in that legacy order, so a WISA-only class raises both
+///   [DoNotImportFromWisa] and exactly one of [AddToSmartschool] /
+///   [CreateInSmartschool].
 /// - If it is present in both, only [ModifySmartschoolData] is considered.
+///
+/// [ClassExistsAsSmartschoolGroup] (#225) sits where the two create actions
+/// would: it fires exactly when the class already exists in Smartschool under a
+/// group the linker could not adopt ([LinkedGroup.smartschoolNamesake]), which
+/// is the same condition those two now refuse on. Unlike them it needs no
+/// placement — the situation is a property of the record alone — so it is
+/// raised whether or not [placementFor] is wired, and a WISA-only class is
+/// never left with a create proposal as its only reading.
 ///
 /// [placementFor] wires the membership-dependent creation actions (#65). When
 /// supplied it is called for each WISA-only class (`wisa != null &&
@@ -48,6 +57,7 @@ List<GroupAction> groupActionsFor(
         ]
       : <GroupAction>[
           DoNotImportFromWisa(group),
+          ClassExistsAsSmartschoolGroup(group),
           if (placement != null) AddToSmartschool(group, placement),
           if (placement != null) CreateInSmartschool(group, placement),
           DoNotImportFromSmartschool(group),

--- a/packages/account_actions/lib/src/staff_action.dart
+++ b/packages/account_actions/lib/src/staff_action.dart
@@ -457,6 +457,84 @@ class DontImportStaffFromWisa extends StaffAction {
 // Modify actions — evaluated only when all three systems are present (§6.3).
 // ---------------------------------------------------------------------------
 
+/// Stamp the school prefix on a staff member's Azure `department` — the staff
+/// counterpart of [ModifyAzureSchool], which the legacy family never had
+/// (#233).
+///
+/// **Why the family needs one.** Students carry the school marker in
+/// `companyName`; staff carry it in `department`. #231 taught the Azure pull to
+/// adopt a moved staff member's existing account by `employeeId`, but nothing
+/// then wrote our marker onto it, so the account stayed invisible to the
+/// school-scoped bulk read (`UserManager.filterFor`'s
+/// `startswith(department, <prefix>)` leg) and had to be re-adopted by the
+/// back-fill on *every* pass. Worse, once the member leaves WISA their id drops
+/// out of `managedStaffEmployeeIds`, the back-fill stops asking, and the account
+/// goes invisible for good — no `RemoveStaffFromAzure` is ever proposed. Setting
+/// the field is what makes the adoption stick.
+///
+/// **Trigger.** A `department` that does not *start with* the prefix — a
+/// **missing** one included, exactly as #224 taught [ModifyAzureSchool] to treat
+/// a null `companyName`. `startswith` (not the linker's laxer `contains`) is the
+/// criterion on purpose: it is precisely the server-side test the next bulk read
+/// applies, so one apply is guaranteed to make the account visible on its own.
+///
+/// **What it writes — an assumption worth stating.** Staff `department` values
+/// in real data carry a suffix (`Arcadia - Wiskunde`) where a student's
+/// `companyName` is flat, so overwriting the field with the bare prefix would
+/// discard whatever the other school wrote there. This action assumes the shape
+/// `<school>` or `<school> - <suffix>` and replaces **only** the leading school
+/// segment, preserving the rest: `OTHER - Wiskunde` → `<prefix> - Wiskunde`, a
+/// bare `OTHER` → `<prefix>`, and an unset field → `<prefix>` (what
+/// [AddStaffToAzure] writes on create). The legacy staff `RemoveFromAzure`
+/// renders this field under a **"Active Schools"** header and both linkers test
+/// it with `contains`, which hints it might instead enumerate several schools —
+/// in which case replacing the head segment evicts a sibling school's claim and
+/// this is the line to revisit. Filed as #237; nothing in either codebase ever
+/// writes such a value today.
+class ModifyStaffAzureSchool extends StaffAction {
+  const ModifyStaffAzureSchool(super.staff, super.config);
+
+  /// The repaired `department`: our prefix, plus whatever the field already
+  /// carried after the first ` - `.
+  String get _department =>
+      _withSchoolPrefix(_az.department, config.schoolPrefix);
+
+  @override
+  bool evaluate() {
+    final prefix = _n(config.schoolPrefix);
+    // No prefix configured: there is nothing to stamp, and blanking the field
+    // would only make the account less findable than it already is.
+    if (prefix == null) return false;
+    final department = _n(_az.department);
+    return department == null || !department.startsWith(prefix);
+  }
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.azure,
+        summary: 'Wijzig de school in Azure',
+        fields: [
+          FieldChange(
+            'department',
+            before: _az.department,
+            after: _department,
+          ),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) {
+    final department = _department;
+    return _azurePatch(
+      connectors,
+      options,
+      describeChanges(),
+      (users) => users.updateUser(_az.id, department: department),
+      () => _az.copyWith(department: department),
+    );
+  }
+}
+
 /// Correct the Smartschool internal number to equal the WISA staff
 /// [wapi.WisaStaff.code] (staff bridge to Smartschool, spec §4). Ported from
 /// `Action\StaffAccount\UpdateWisaName`.
@@ -627,8 +705,40 @@ class SetStaffCopyCode extends StaffAction {
 }
 
 // ---------------------------------------------------------------------------
-// Shared apply helper for the Smartschool modify actions.
+// Shared apply helpers for the modify actions.
 // ---------------------------------------------------------------------------
+
+extension _AzurePatch on StaffAction {
+  /// Runs an Azure PATCH ([write]) unless dry-run, and returns the projected
+  /// [record] as the mutated source record.
+  Future<ActionResult> _azurePatch(
+    Connectors connectors,
+    ApplyOptions options,
+    ChangeSet changes,
+    Future<void> Function(az.UserManager users) write,
+    az.AzureUser Function() record,
+  ) async {
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.azure,
+        azure: record(),
+      );
+    }
+    try {
+      await write(_requireAzure(connectors).users);
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.azure,
+        azure: record(),
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.azure, e);
+    }
+  }
+}
 
 extension _SmartschoolSave on StaffAction {
   /// Saves [updated] to Smartschool (`saveUser` with an unchanged password)
@@ -685,6 +795,22 @@ String _copyCode(String? wisaId) {
     code = '0$code';
   }
   return code;
+}
+
+/// Separates the school segment of a staff `department` from the rest of the
+/// value (`Arcadia - Wiskunde`). See [ModifyStaffAzureSchool] for the shape
+/// this assumes.
+const String _departmentSeparator = ' - ';
+
+/// [department] with its leading school segment replaced by [schoolPrefix], the
+/// suffix after the first [_departmentSeparator] preserved verbatim. A value
+/// with no separator is all school segment, so it is replaced whole; a blank or
+/// missing one becomes the bare prefix (what [AddStaffToAzure] writes on
+/// create).
+String _withSchoolPrefix(String? department, String schoolPrefix) {
+  final current = department?.trim() ?? '';
+  final at = current.indexOf(_departmentSeparator);
+  return at < 0 ? schoolPrefix : '$schoolPrefix${current.substring(at)}';
 }
 
 /// Trims + lower-cases for case-insensitive comparison (INV-12); blank → null.

--- a/packages/account_actions/lib/src/staff_action.dart
+++ b/packages/account_actions/lib/src/staff_action.dart
@@ -148,6 +148,33 @@ class AddStaffToAzure extends StaffAction {
 
     try {
       final users = _requireAzure(connectors).users;
+      // #231 (the staff half of #224): never create a second account for
+      // someone who already has one. The snapshot this action was derived from
+      // can be stale — or blind, when the account's `department` still names
+      // the sibling group school the member moved in from — and
+      // `createPrincipalName` resolves the UPN collision by suffixing, so the
+      // duplicate create would succeed silently. `employeeId` is the one key
+      // that survives a move between group schools, so a hit means the account
+      // exists and the next sync must adopt it instead.
+      //
+      // A staff row may carry no `wisaId` at all (`code` is the staff primary
+      // key, spec §3.4): then there is no id to look up — and none to stamp on
+      // the account either, so no future sync could confuse the two.
+      final expectedId = wisa.wisaId?.value.trim() ?? '';
+      if (expectedId.isNotEmpty) {
+        final existing = await users.findByEmployeeId(expectedId);
+        if (existing != null) {
+          return _failed(
+            changes,
+            Origin.azure,
+            StateError(
+              'Office 365 already has an account with employeeId '
+              '$expectedId (${existing.upn}). Sync Azure again so the existing '
+              'account is linked instead of creating a duplicate.',
+            ),
+          );
+        }
+      }
       final upn = await users.createPrincipalName(
         wisa.firstName,
         wisa.lastName,

--- a/packages/account_actions/lib/src/staff_dispatch.dart
+++ b/packages/account_actions/lib/src/staff_dispatch.dart
@@ -19,6 +19,11 @@ import 'staff_action_config.dart';
 /// The legacy `AddToAzureStaffGroup` / `AddToStaffGroup` actions are **not**
 /// dispatched here: they evaluate against Office 365 group membership, which a
 /// [LinkedStaff] does not carry (see the package README).
+///
+/// [ModifyStaffAzureSchool] has no legacy counterpart at all — the staff family
+/// never had a `department` repair (#233). Like the student `ModifyAzureSchool`
+/// it sits in the modify branch, so an adopted account is stamped on the pass
+/// *after* its Smartschool side is built and the record is complete.
 List<StaffAction> staffActionsFor(
   LinkedStaff staff,
   StaffActionConfig config,
@@ -28,6 +33,7 @@ List<StaffAction> staffActionsFor(
 
   final candidates = complete
       ? <StaffAction>[
+          ModifyStaffAzureSchool(staff, config),
           UpdateStaffWisaName(staff, config),
           ModifySmartschoolStaffEmail(staff, config),
           SetStaffCopyCode(staff, config),

--- a/packages/account_actions/lib/src/student_action.dart
+++ b/packages/account_actions/lib/src/student_action.dart
@@ -163,6 +163,25 @@ class AddStudentToAzure extends StudentAction {
 
     try {
       final users = _requireAzure(connectors).users;
+      // #224: never create a second account for a person who already has one.
+      // The snapshot this action was derived from can be stale — or blind, when
+      // the account carries neither our `companyName` nor our `department` — and
+      // `createPrincipalName` resolves the UPN collision by suffixing, so the
+      // duplicate create would succeed silently. `employeeId` is the one key
+      // that survives a transfer between group schools, so a hit means the
+      // account exists and the next sync must adopt it instead.
+      final existing = await users.findByEmployeeId(wisa.wisaId.value);
+      if (existing != null) {
+        return _failed(
+          changes,
+          Origin.azure,
+          StateError(
+            'Office 365 already has an account with employeeId '
+            '${wisa.wisaId.value} (${existing.upn}). Sync Azure again so the '
+            'existing account is linked instead of creating a duplicate.',
+          ),
+        );
+      }
       final upn = await users.createPrincipalName(
         given,
         wisa.name,
@@ -605,14 +624,18 @@ class ModifyAzureName extends StudentAction {
 
 /// Correct a student's Azure `companyName` to the school prefix. Ported from
 /// `Action\StudentAccount\ModifyAzureSchool`.
+///
+/// A **missing** `companyName` counts as differing (#224). The legacy guard
+/// returned false for null, which made the transferred-student case
+/// self-perpetuating: an adopted account whose `companyName` was never set is
+/// invisible to the next sync's `$filter`, and the one action that would stamp
+/// our prefix on it — this one — refused to fire precisely because the field was
+/// unset. Setting it is what makes the adoption stick.
 class ModifyAzureSchool extends StudentAction {
   const ModifyAzureSchool(super.account, super.config);
 
   @override
-  bool evaluate() {
-    final company = _az.companyName;
-    return company != null && !_eq(company, config.schoolPrefix);
-  }
+  bool evaluate() => !_eq(_az.companyName, config.schoolPrefix);
 
   @override
   ChangeSet describeChanges() => ChangeSet(

--- a/packages/account_actions/lib/src/student_action.dart
+++ b/packages/account_actions/lib/src/student_action.dart
@@ -62,6 +62,28 @@ sealed class StudentAction {
   /// ignored when [alternativeGroup] is `null`.
   bool get isDefaultAlternative => false;
 
+  /// The action types this one **unlocks** on the same target (#230).
+  ///
+  /// Provisioning a brand-new student is a chain, not a single action: the
+  /// Smartschool account is built with the Azure UPN as its `mail`, so
+  /// [AddStudentToSmartschool] cannot even [evaluate] true until
+  /// [AddStudentToAzure] has run. The dispatcher (§6.3) is a pure function of
+  /// the *current* record, so it can only ever offer the first link of that
+  /// chain — which is why a WISA-only student used to be offered one create,
+  /// leaving the operator to apply, wait for the relink, and apply again.
+  ///
+  /// Declaring the follow-up here lets the State layer run it immediately
+  /// against the **freshly relinked** record. It must be the relinked record
+  /// and never a projection: `createPrincipalName` resolves a UPN collision by
+  /// suffixing, so the UPN that actually landed can differ from the one
+  /// [describeChanges] projected, and the Smartschool account would then carry
+  /// the wrong `mail`.
+  ///
+  /// Pure and constant — it names what *may* follow, never what must: the
+  /// follow-up's own [evaluate] still decides whether it applies, exactly as it
+  /// would on the next sync.
+  Set<Type> get unlocks => const {};
+
   /// Performs the change on the target system. Impure. With
   /// [ApplyOptions.dryRun] set, performs **no** writes and returns the
   /// projected [ActionResult] (PAIN-3).
@@ -114,6 +136,13 @@ class AddStudentToAzure extends StudentAction {
 
   @override
   bool evaluate() => account.isInOurWisa && account.azure == null;
+
+  /// Creating the Office 365 account unlocks the Smartschool create, which
+  /// needs the fresh UPN as the new account's `mail` (#230). Without the chain
+  /// a new student's second create only appears on the *next* pass, so the
+  /// Acties panel never showed the full provisioning intent.
+  @override
+  Set<Type> get unlocks => const {AddStudentToSmartschool};
 
   @override
   ChangeSet describeChanges() {

--- a/packages/account_actions/test/group_apply_test.dart
+++ b/packages/account_actions/test/group_apply_test.dart
@@ -237,4 +237,74 @@ void main() {
       );
     });
   });
+
+  group('ClassExistsAsSmartschoolGroup is informational (#225)', () {
+    test('canApply is false and apply throws UnsupportedError', () {
+      final action = ClassExistsAsSmartschoolGroup(
+        linkedGroup(
+          wisa: wisaGroup(name: '2G'),
+          smartschoolNamesake: ssGroupNode(code: 'G2G', name: '2G'),
+        ),
+      );
+      expect(action.canApply, isFalse);
+      expect(
+        () => action.apply(const Connectors(), const ApplyOptions()),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('a non-official namesake reads as "not an official class"', () {
+      final action = ClassExistsAsSmartschoolGroup(
+        linkedGroup(
+          wisa: wisaGroup(name: '2G'),
+          smartschoolNamesake: ssGroupNode(code: 'G2G', name: '2G'),
+        ),
+      );
+      expect(action.evaluate(), isTrue);
+      final changes = action.describeChanges();
+      expect(changes.system, Origin.smartschool);
+      expect(changes.summary, contains('geen officiële klas'));
+      // The operator has to find the group in Smartschool: name and code.
+      expect(
+        changes.fields.map((f) => '${f.field}:${f.before}'),
+        containsAll(<String>['name:2G', 'code:G2G']),
+      );
+    });
+
+    test('an official namesake reads as a spelling mismatch instead', () {
+      final action = ClassExistsAsSmartschoolGroup(
+        linkedGroup(
+          wisa: wisaGroup(name: '2G'),
+          smartschoolNamesake: ssGroup(code: 'C2G', name: '2 G'),
+        ),
+      );
+      expect(action.evaluate(), isTrue);
+      final changes = action.describeChanges();
+      expect(changes.summary, contains('andere schrijfwijze'));
+      expect(changes.summary, isNot(contains('geen officiële klas')));
+      expect(
+        changes.fields.map((f) => '${f.field}:${f.before}'),
+        contains('name:2 G'),
+      );
+    });
+
+    test('does not evaluate without a namesake, or once the class is linked',
+        () {
+      expect(
+        ClassExistsAsSmartschoolGroup(linkedGroup(wisa: wisaGroup()))
+            .evaluate(),
+        isFalse,
+      );
+      expect(
+        ClassExistsAsSmartschoolGroup(
+          linkedGroup(
+            wisa: wisaGroup(),
+            smartschool: ssGroup(),
+            smartschoolNamesake: ssGroupNode(),
+          ),
+        ).evaluate(),
+        isFalse,
+      );
+    });
+  });
 }

--- a/packages/account_actions/test/group_dispatch_test.dart
+++ b/packages/account_actions/test/group_dispatch_test.dart
@@ -63,6 +63,70 @@ void main() {
       expect(called, isFalse, reason: 'only WISA-only classes need placement');
     });
 
+    test(
+        'WISA only, but Smartschool already has the name → the notice replaces '
+        'the create (#225)', () {
+      // The `2G` of #225: WISA has the populated class, Smartschool has a group
+      // of the same name that is not flagged official, so the linker could not
+      // adopt it. Offering to create the class would ask Smartschool for a
+      // duplicate name.
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(name: '2G'),
+          smartschoolNamesake: ssGroupNode(code: 'G2G', name: '2G'),
+        ),
+        placementFor: (_) => groupPlacement(containsStudents: true),
+      );
+      expect(
+        actions.map((a) => a.runtimeType),
+        [DoNotImportFromWisa, ClassExistsAsSmartschoolGroup],
+      );
+    });
+
+    test('the namesake notice also displaces the empty-class notice (#225)',
+        () {
+      // Same shape with an empty WISA class: "delete this class, it has no
+      // students" is the wrong advice for a class that *is* provisioned
+      // downstream.
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(name: '2G'),
+          smartschoolNamesake: ssGroupNode(code: 'G2G', name: '2G'),
+        ),
+        placementFor: (_) => groupPlacement(containsStudents: false),
+      );
+      expect(
+        actions.map((a) => a.runtimeType),
+        [DoNotImportFromWisa, ClassExistsAsSmartschoolGroup],
+      );
+    });
+
+    test('the namesake notice needs no placement to be raised (#225)', () {
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(name: '2G'),
+          smartschoolNamesake: ssGroupNode(code: 'G2G', name: '2G'),
+        ),
+      );
+      expect(
+        actions.map((a) => a.runtimeType),
+        [DoNotImportFromWisa, ClassExistsAsSmartschoolGroup],
+      );
+    });
+
+    test('a linked class never carries the namesake notice (#225)', () {
+      // Defensive: the linker only sets the namesake on an unlinked class, but
+      // the both-present branch must not raise it even if one arrived.
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(),
+          smartschool: ssGroup(),
+          smartschoolNamesake: ssGroupNode(code: 'G3A', name: '3A'),
+        ),
+      );
+      expect(actions, isEmpty);
+    });
+
     test('Smartschool only → DoNotImportFromSmartschool (informational)', () {
       final actions = groupActionsFor(linkedGroup(smartschool: ssGroup()));
       expect(actions.map((a) => a.runtimeType), [DoNotImportFromSmartschool]);

--- a/packages/account_actions/test/group_purity_test.dart
+++ b/packages/account_actions/test/group_purity_test.dart
@@ -102,6 +102,25 @@ void main() {
       );
     });
 
+    test('neither create action evaluates once Smartschool has the name (#225)',
+        () {
+      final group = linkedGroup(
+        wisa: wisaGroup(name: '2G'),
+        smartschoolNamesake: ssGroupNode(code: 'G2G', name: '2G'),
+      );
+      expect(
+        AddToSmartschool(group, groupPlacement(containsStudents: true))
+            .evaluate(),
+        isFalse,
+        reason: 'creating it would ask Smartschool for a duplicate name',
+      );
+      expect(
+        CreateInSmartschool(group, groupPlacement(containsStudents: false))
+            .evaluate(),
+        isFalse,
+      );
+    });
+
     test('DoNotImportFromWisa describes the rule it would add', () {
       final change =
           DoNotImportFromWisa(linkedGroup(wisa: wisaGroup(name: '3A')))

--- a/packages/account_actions/test/staff_apply_test.dart
+++ b/packages/account_actions/test/staff_apply_test.dart
@@ -138,6 +138,16 @@ void main() {
         () async {
       final transport = RecordingGraphTransport(
         handler: (req) {
+          if (req.method == 'GET' &&
+              (req.url.queryParameters[r'$filter'] ?? '')
+                  .startsWith('employeeId in')) {
+            // The tenant holds no account for this WISA id (#231).
+            return az.GraphResponse(
+              statusCode: 200,
+              headers: const {'content-type': 'application/json'},
+              body: jsonEncode({'value': const <Object>[]}),
+            );
+          }
           if (req.method == 'GET') {
             // No existing user with the candidate UPN → it is unique.
             return az.GraphResponse(
@@ -173,6 +183,123 @@ void main() {
       expect(result.azure?.upn, 'anna.smit@school.example');
       expect(result.azure?.employeeId, '42');
       expect((result.azure! as az.AzureUser).department, 'SSM');
+    });
+
+    test(
+        'AddStaffToAzure: refuses to create when the tenant already has an '
+        'account with this employeeId (#231)', () async {
+      // The duplicate this guards, the staff half of #224: the account is
+      // invisible to the school-scoped pull (its `department` still names the
+      // sibling group school the member moved in from), so the snapshot says
+      // "no Azure account" and the dispatcher raises the create.
+      // `createPrincipalName` would resolve the UPN collision by suffixing, so
+      // the create *succeeds* and the person silently ends up with two.
+      final transport = RecordingGraphTransport(
+        handler: (req) {
+          if (req.method == 'GET' &&
+              (req.url.queryParameters[r'$filter'] ?? '')
+                  .startsWith('employeeId in')) {
+            return az.GraphResponse(
+              statusCode: 200,
+              headers: const {'content-type': 'application/json'},
+              body: jsonEncode({
+                'value': [
+                  {
+                    'id': 'az-moved',
+                    'userPrincipalName': 'smit.anna@other.example',
+                    'employeeId': '42',
+                    'department': 'OTHER - Wiskunde',
+                  },
+                ],
+              }),
+            );
+          }
+          // Everything a create needs is deliberately available: the projected
+          // UPN is free (404) and the POST would succeed. So an unguarded apply
+          // creates the duplicate cleanly — this test's failure mode without
+          // the guard is "it created one", not "it errored on the way".
+          if (req.method == 'GET') {
+            return az.GraphResponse(
+              statusCode: 404,
+              body: jsonEncode({
+                'error': {'code': 'NotFound', 'message': 'no'},
+              }),
+            );
+          }
+          if (req.method == 'POST') {
+            return az.GraphResponse(
+              statusCode: 201,
+              headers: const {'content-type': 'application/json'},
+              body: jsonEncode({
+                'id': 'az-duplicate',
+                'userPrincipalName': 'anna.smit@school.example',
+              }),
+            );
+          }
+          return const az.GraphResponse(statusCode: 204);
+        },
+      );
+      final connectors = Connectors(azure: azureConnector(transport));
+      final action = AddStaffToAzure(
+        linkedStaff(wisa: wisaStaff(wisaId: '42')),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+
+      expect(result.outcome, ActionOutcome.failed);
+      expect(transport.sent('POST'), isFalse, reason: 'nothing was created');
+      expect(result.azure, isNull);
+      // The operator is told what to do about it, and which account it is.
+      expect('${result.error}', contains('42'));
+      expect('${result.error}', contains('smit.anna@other.example'));
+    });
+
+    test(
+        'AddStaffToAzure: a staff member with no wisaId is created without an '
+        'employeeId lookup (#231)', () async {
+      // `wisaId` is nullable on a staff row (`code` is the staff primary key,
+      // OQ-1). There is nothing to look up — and nothing to stamp on the new
+      // account either — so the guard must step aside rather than send Graph a
+      // filter with an empty literal in it.
+      final transport = RecordingGraphTransport(
+        handler: (req) {
+          if (req.method == 'GET') {
+            return az.GraphResponse(
+              statusCode: 404,
+              body: jsonEncode({
+                'error': {'code': 'NotFound', 'message': 'no'},
+              }),
+            );
+          }
+          if (req.method == 'POST') {
+            return az.GraphResponse(
+              statusCode: 201,
+              headers: const {'content-type': 'application/json'},
+              body: jsonEncode({
+                'id': 'az-new',
+                'userPrincipalName': 'anna.smit@school.example',
+              }),
+            );
+          }
+          return const az.GraphResponse(statusCode: 204);
+        },
+      );
+      final connectors = Connectors(azure: azureConnector(transport));
+      final action = AddStaffToAzure(
+        linkedStaff(wisa: wisaStaff(wisaId: null)),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(
+        transport.requests.where(
+          (r) => (r.url.queryParameters[r'$filter'] ?? '')
+              .startsWith('employeeId in'),
+        ),
+        isEmpty,
+      );
     });
 
     test('AddStaffToSmartschool: saves account, accountId ← WISA code',

--- a/packages/account_actions/test/staff_apply_test.dart
+++ b/packages/account_actions/test/staff_apply_test.dart
@@ -49,6 +49,25 @@ void main() {
       expect(transport.soapActions, isEmpty);
     });
 
+    test('ModifyStaffAzureSchool dry run: no PATCH, repaired value projected',
+        () async {
+      final transport = RecordingGraphTransport();
+      final connectors = Connectors(azure: azureConnector(transport));
+      final action = ModifyStaffAzureSchool(
+        linkedStaff(
+          wisa: wisaStaff(),
+          smartschool: ssStaff(),
+          azure: azureStaff(department: 'OTHER - Wiskunde'),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, ApplyOptions.dry);
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(transport.requests, isEmpty);
+      expect((result.azure! as az.AzureUser).department, 'SSM - Wiskunde');
+    });
+
     test('SetStaffCopyCode dry run: no write, padded fax projected', () async {
       final transport = RecordingSmartschoolTransport();
       final connectors =
@@ -322,6 +341,41 @@ void main() {
       expect(result.smartschool?.mail, 'anna.smit@school.example');
       // The WISA numeric id becomes the copy-code (fax).
       expect((result.smartschool! as ss.SmartschoolAccount).fax, '42');
+    });
+
+    test(
+        'ModifyStaffAzureSchool: PATCHes department so the next bulk read can '
+        'see the account (#233)', () async {
+      final transport = RecordingGraphTransport();
+      final connectors = Connectors(azure: azureConnector(transport));
+      final action = ModifyStaffAzureSchool(
+        linkedStaff(
+          wisa: wisaStaff(),
+          smartschool: ssStaff(),
+          azure: azureStaff(id: 'az-moved', department: 'OTHER - Wiskunde'),
+        ),
+        cfg,
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+      expect(result.outcome, ActionOutcome.applied);
+      expect(result.system, Origin.azure);
+
+      final patch = transport.requests
+          .singleWhere((r) => r.method == 'PATCH', orElse: () => throw 'none');
+      expect(patch.url.path, contains('az-moved'));
+      expect(
+        jsonDecode(patch.body!) as Map<String, dynamic>,
+        {'department': 'SSM - Wiskunde'},
+        reason: 'only the department is touched, prefix first',
+      );
+      // Prefix-first is the whole point: it is the `startswith(department, …)`
+      // leg of UserManager.filterFor, so the school-scoped pull now returns the
+      // account without the employeeId back-fill having to find it (#231).
+      expect(
+        (result.azure! as az.AzureUser).department!.startsWith('SSM'),
+        isTrue,
+      );
     });
 
     test('RemoveStaffFromAzure: deletes the user', () async {

--- a/packages/account_actions/test/staff_dispatch_test.dart
+++ b/packages/account_actions/test/staff_dispatch_test.dart
@@ -50,6 +50,24 @@ void main() {
       expect(actions.whereType<UpdateStaffWisaName>(), isEmpty);
       expect(actions.whereType<ModifySmartschoolStaffEmail>(), isEmpty);
       expect(actions.whereType<SetStaffCopyCode>(), isEmpty);
+      expect(actions.whereType<ModifyStaffAzureSchool>(), isEmpty);
+    });
+
+    test(
+        'an adopted account with another school\'s department is not repaired '
+        'until the record is complete (#233)', () {
+      // WISA + Azure, no Smartschool — the state #231's back-fill leaves a
+      // moved staff member in. The mutually exclusive branches (§6.3) mean the
+      // department repair waits for the pass after AddStaffToSmartschool, the
+      // same way the student `ModifyAzureSchool` does.
+      final actions = staffActionsFor(
+        linkedStaff(
+          wisa: wisaStaff(),
+          azure: azureStaff(department: 'OTHER - Wiskunde'),
+        ),
+        cfg,
+      );
+      expect(types(actions), [AddStaffToSmartschool, DontImportStaffFromWisa]);
     });
   });
 
@@ -102,6 +120,31 @@ void main() {
         cfg,
       );
       expect(types(actions), [SetStaffCopyCode]);
+    });
+
+    test(
+        "an Azure department naming another school → only "
+        'ModifyStaffAzureSchool (#233)', () {
+      final actions = staffActionsFor(
+        linkedStaff(
+          wisa: wisaStaff(),
+          smartschool: ssStaff(),
+          azure: azureStaff(department: 'OTHER - Wiskunde'),
+        ),
+        cfg,
+      );
+      expect(types(actions), [ModifyStaffAzureSchool]);
+    });
+
+    test('a fully-synced staff member with our prefix raises no repair (#233)',
+        () {
+      // The default fixture's `department` is exactly the prefix, so the new
+      // action must not turn every clean staff record into a pending item.
+      expect(
+        staffActionsFor(fullySyncedStaff(), cfg)
+            .whereType<ModifyStaffAzureSchool>(),
+        isEmpty,
+      );
     });
 
     test('present-branch never emits a lifecycle action', () {

--- a/packages/account_actions/test/staff_purity_test.dart
+++ b/packages/account_actions/test/staff_purity_test.dart
@@ -97,6 +97,88 @@ void main() {
     });
   });
 
+  group('ModifyStaffAzureSchool stamps our prefix on `department` (#233)', () {
+    ModifyStaffAzureSchool actionFor(String? department) =>
+        ModifyStaffAzureSchool(
+          linkedStaff(
+            wisa: wisaStaff(),
+            smartschool: ssStaff(),
+            azure: azureStaff(department: department),
+          ),
+          cfg,
+        );
+
+    test('a missing department counts as differing and becomes the prefix', () {
+      // The self-perpetuating case: an account with no `department` is
+      // invisible to the next sync's `$filter`, so if the one action that would
+      // stamp our prefix refused to fire on null, the adoption could never
+      // stick. Same lesson #224 taught the student `companyName` repair.
+      final action = actionFor(null);
+      expect(action.evaluate(), isTrue);
+      final change = action.describeChanges();
+      expect(change.system, Origin.azure);
+      final field = change.fields.single;
+      expect(field.field, 'department');
+      expect(field.before, isNull);
+      expect(field.after, 'SSM');
+    });
+
+    test('another school + a subject suffix keeps the suffix', () {
+      // What a move from a sibling group school leaves behind. Overwriting the
+      // whole field with the bare prefix would throw away 'Wiskunde', which the
+      // other school wrote and WISA cannot tell us.
+      final action = actionFor('OTHER - Wiskunde');
+      expect(action.evaluate(), isTrue);
+      expect(action.describeChanges().fields.single.after, 'SSM - Wiskunde');
+    });
+
+    test('another school with no suffix is replaced whole', () {
+      final action = actionFor('OTHER');
+      expect(action.evaluate(), isTrue);
+      expect(action.describeChanges().fields.single.after, 'SSM');
+    });
+
+    test('a department already carrying our prefix does not fire', () {
+      expect(actionFor('SSM').evaluate(), isFalse);
+      expect(actionFor('SSM - Wiskunde').evaluate(), isFalse);
+      // Trimmed + case-insensitive, like every other comparison (INV-12).
+      expect(actionFor('  ssm - Wiskunde ').evaluate(), isFalse);
+    });
+
+    test('it converges: the repaired value re-evaluates to false', () {
+      final repaired =
+          actionFor('OTHER - Wiskunde').describeChanges().fields.single.after;
+      expect(actionFor(repaired).evaluate(), isFalse);
+    });
+
+    test('no configured prefix → nothing to stamp, so it never fires', () {
+      // Blanking the field would only make the account harder to find than the
+      // misconfiguration already makes it.
+      final action = ModifyStaffAzureSchool(
+        linkedStaff(
+          wisa: wisaStaff(),
+          smartschool: ssStaff(),
+          azure: azureStaff(department: 'OTHER'),
+        ),
+        staffConfig(schoolPrefix: '  '),
+      );
+      expect(action.evaluate(), isFalse);
+    });
+
+    test('describeChanges leaves the bound Azure record untouched (INV-42)',
+        () {
+      final azure = azureStaff(department: 'OTHER - Wiskunde');
+      final staff = linkedStaff(
+        wisa: wisaStaff(),
+        smartschool: ssStaff(),
+        azure: azure,
+      );
+      ModifyStaffAzureSchool(staff, cfg).describeChanges();
+      expect(identical(staff.azure, azure), isTrue);
+      expect(azure.department, 'OTHER - Wiskunde');
+    });
+  });
+
   group('staffActions over a LinkedSnapshot', () {
     test('emits actions per staff record, in snapshot order', () {
       final snapshot = LinkedSnapshot.fromRecords(

--- a/packages/account_actions/test/student_apply_test.dart
+++ b/packages/account_actions/test/student_apply_test.dart
@@ -111,6 +111,16 @@ void main() {
     test('AddStudentToAzure: creates the user and returns it', () async {
       final transport = RecordingGraphTransport(
         handler: (req) {
+          if (req.method == 'GET' &&
+              (req.url.queryParameters[r'$filter'] ?? '')
+                  .startsWith('employeeId in')) {
+            // The tenant holds no account for this WISA id (#224).
+            return az.GraphResponse(
+              statusCode: 200,
+              headers: const {'content-type': 'application/json'},
+              body: jsonEncode({'value': const <Object>[]}),
+            );
+          }
           if (req.method == 'GET') {
             // No existing user with the candidate UPN → it is unique.
             return az.GraphResponse(
@@ -141,6 +151,72 @@ void main() {
       expect(transport.sent('POST', pathContains: 'users'), isTrue);
       expect(result.azure?.id, 'az-new');
       expect(result.azure?.employeeId, 'W1');
+    });
+
+    test(
+        'AddStudentToAzure: refuses to create when the tenant already has an '
+        'account with this employeeId (#224)', () async {
+      // The duplicate this guards: the account is invisible to the school-
+      // scoped pull (no companyName, another school's department), so the
+      // snapshot says "no Azure account" and the dispatcher raises the create.
+      // `createPrincipalName` would resolve the UPN collision by suffixing, so
+      // the create *succeeds* and the person silently ends up with two.
+      final transport = RecordingGraphTransport(
+        handler: (req) {
+          if (req.method == 'GET' &&
+              (req.url.queryParameters[r'$filter'] ?? '')
+                  .startsWith('employeeId in')) {
+            return az.GraphResponse(
+              statusCode: 200,
+              headers: const {'content-type': 'application/json'},
+              body: jsonEncode({
+                'value': [
+                  {
+                    'id': 'az-transferred',
+                    'userPrincipalName': 'alfio.ambre@student.other.example',
+                    'employeeId': 'W1',
+                    'department': 'OTHER-3A',
+                  },
+                ],
+              }),
+            );
+          }
+          // Everything a create needs is deliberately available: the projected
+          // UPN is free (404) and the POST would succeed. So an unguarded apply
+          // creates the duplicate cleanly — this test's failure mode without
+          // the guard is "it created one", not "it errored on the way".
+          if (req.method == 'GET') {
+            return az.GraphResponse(
+              statusCode: 404,
+              body: jsonEncode({
+                'error': {'code': 'NotFound', 'message': 'no'},
+              }),
+            );
+          }
+          if (req.method == 'POST') {
+            return az.GraphResponse(
+              statusCode: 201,
+              headers: const {'content-type': 'application/json'},
+              body: jsonEncode({
+                'id': 'az-duplicate',
+                'userPrincipalName': 'jan.peeters@student.school.example',
+              }),
+            );
+          }
+          return const az.GraphResponse(statusCode: 204);
+        },
+      );
+      final connectors = Connectors(azure: azureConnector(transport));
+      final action = AddStudentToAzure(linked(wisa: wisaStudent()), cfg);
+
+      final result = await action.apply(connectors, const ApplyOptions());
+
+      expect(result.outcome, ActionOutcome.failed);
+      expect(transport.sent('POST'), isFalse, reason: 'nothing was created');
+      expect(result.azure, isNull);
+      // The operator is told what to do about it, and which account it is.
+      expect('${result.error}', contains('W1'));
+      expect('${result.error}', contains('alfio.ambre@student.other.example'));
     });
 
     test('AddStudentToSmartschool: saves account, mail = Azure UPN', () async {

--- a/packages/account_actions/test/student_dispatch_test.dart
+++ b/packages/account_actions/test/student_dispatch_test.dart
@@ -65,6 +65,46 @@ void main() {
       expect(actions.single.alternativeGroup, isNull);
     });
 
+    test('the WISA-only create declares its Smartschool follow-up (#230)', () {
+      // Provisioning a new student is a chain the dispatcher cannot express:
+      // AddStudentToSmartschool needs the Azure UPN as the new account's mail,
+      // so it evaluates false until the Azure account exists. Naming the
+      // follow-up here is what lets the State layer run it straight after the
+      // create, against the relinked record — one click, both accounts.
+      final actions = studentActionsFor(linked(wisa: wisaStudent()), cfg);
+      final create = actions.single as AddStudentToAzure;
+      expect(create.unlocks, <Type>{AddStudentToSmartschool});
+    });
+
+    test('the Smartschool create ends the chain (#230)', () {
+      // Nothing follows it: the record is complete afterwards, so the next pass
+      // is the ordinary modify branch, not another link of this chain.
+      final actions = studentActionsFor(
+        linked(wisa: wisaStudent(), azure: azureUser()),
+        cfg,
+      );
+      expect(actions.single.unlocks, isEmpty);
+    });
+
+    test('every other student action unlocks nothing (#230)', () {
+      // The chain is opt-in per action; a stray declaration would make the
+      // applier write beyond what the operator selected.
+      for (final account in <LinkedAccount>[
+        linked(smartschool: ssAccount(status: 'actief')),
+        linked(azure: azureUser(companyName: 'SSM')),
+        linked(
+          wisa: wisaStudent(wisaId: 'W1'),
+          smartschool: ssAccount(accountId: 'W9'),
+          azure: azureUser(),
+        ),
+      ]) {
+        for (final action in studentActionsFor(account, cfg)) {
+          if (action is AddStudentToAzure) continue;
+          expect(action.unlocks, isEmpty, reason: '${action.runtimeType}');
+        }
+      }
+    });
+
     test('disabled Smartschool-only account → Delete only (not Unregister)',
         () {
       final actions = studentActionsFor(

--- a/packages/account_actions/test/student_dispatch_test.dart
+++ b/packages/account_actions/test/student_dispatch_test.dart
@@ -137,6 +137,25 @@ void main() {
       expect(types(actions), [ModifyAzureSchool]);
     });
 
+    test('a missing companyName fires ModifyAzureSchool too (#224)', () {
+      // The adopted transfer account: `companyName` was never stamped by the
+      // school it came from. The old `company != null` guard made this the one
+      // case the repair refused to fire on — which kept the account invisible
+      // to the next sync's `$filter` and made the whole problem recur forever.
+      final actions = studentActionsFor(
+        linked(
+          wisa: wisaStudent(),
+          smartschool: ssAccount(),
+          azure: azureUser(companyName: null, department: 'OTHER-3A'),
+        ),
+        cfg,
+      );
+      expect(types(actions), [ModifyAzureSchool]);
+      final change = actions.single.describeChanges();
+      expect(change.fields.single.before, isNull);
+      expect(change.fields.single.after, 'SSM');
+    });
+
     test('present-branch never emits a lifecycle action', () {
       final actions = studentActionsFor(
         linked(

--- a/packages/account_actions/test/support/fixtures.dart
+++ b/packages/account_actions/test/support/fixtures.dart
@@ -385,12 +385,14 @@ GroupPlacement groupPlacement({
 LinkedGroup linkedGroup({
   Group? wisa,
   Group? smartschool,
+  Group? smartschoolNamesake,
   az.AzureGroup? azure,
   LinkConfidence confidence = LinkConfidence.high,
 }) =>
     LinkedGroup(
       wisa: wisa,
       smartschool: smartschool,
+      smartschoolNamesake: smartschoolNamesake,
       azure: azure,
       confidence: confidence,
     );

--- a/packages/account_core/lib/src/group.dart
+++ b/packages/account_core/lib/src/group.dart
@@ -119,6 +119,44 @@ class Group {
       );
 }
 
+/// The cross-system match key for a group *name* (#225).
+///
+/// A class carries no stable id across WISA, Smartschool and Azure — the name
+/// **is** the bridge — so every layer that joins groups by name must normalize
+/// it the same way, or the linker and the placement resolver disagree about
+/// which classes exist. Trimmed and lower-cased (INV-12), plus every run of
+/// whitespace collapsed to a single ASCII space: a class name is typed by an
+/// operator in Smartschool, so it picks up double spaces and the non-breaking
+/// space a copy-paste leaves behind, neither of which makes it a different
+/// class from the WISA one.
+///
+/// Returns `null` for a null or blank name so an empty key never matches or
+/// indexes anything.
+String? normalizeGroupName(String? name) {
+  if (name == null) return null;
+  final collapsed = name.replaceAll(_whitespaceRun, ' ').trim();
+  return collapsed.isEmpty ? null : collapsed.toLowerCase();
+}
+
+/// A deliberately *looser* key than [normalizeGroupName]: the same name with
+/// **all** whitespace removed, so `2G` and `2 G` share one key.
+///
+/// Never used to link two systems' groups together — dropping the space that
+/// separates a class from its sub-group (`5A 01`) would fuse names that really
+/// are distinct. It exists for the one question where a false positive is
+/// cheap and a false negative is not: "does a group by roughly this name
+/// already exist in Smartschool?" (#225). Answering that wrongly-yes costs an
+/// informational notice; answering it wrongly-no proposes creating a class
+/// Smartschool already has.
+String? groupNameFingerprint(String? name) =>
+    normalizeGroupName(name)?.replaceAll(' ', '');
+
+/// A run of Unicode whitespace, spelled out rather than left to `\s` alone so
+/// the non-breaking (U+00A0) and narrow no-break (U+202F) spaces are covered
+/// whatever the regex engine's reading of `\s` is.
+final RegExp _whitespaceRun =
+    RegExp(r'[\s\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000]+');
+
 /// First-class many-to-many link between a [Person] and a [Group].
 ///
 /// Replaces the legacy "groups own their members" model. Multiple memberships

--- a/packages/account_core/lib/src/linked.dart
+++ b/packages/account_core/lib/src/linked.dart
@@ -142,11 +142,29 @@ class LinkedGroup {
   final AzureGroup? azure;
   final LinkConfidence confidence;
 
+  /// A Smartschool group that already carries this class's name but which the
+  /// group link could **not** adopt as [smartschool] (#225) — set only when
+  /// [smartschool] is null and [wisa] is not.
+  ///
+  /// Two shapes reach here, and the difference is visible on the record itself
+  /// ([Group.official], [Group.name]):
+  /// - the namesake is not flagged as an official class, so the link skipped
+  ///   it (a class Smartschool holds as an organisational group);
+  /// - the namesake *is* an official class but its name differs from the WISA
+  ///   one by more than the match key tolerates (`2 G` vs `2G`).
+  ///
+  /// Either way the class exists downstream in some form, so proposing to
+  /// create it would ask Smartschool for a duplicate name — it either rejects
+  /// the write or ends up with two classes. The action engine raises an
+  /// explicit notice on this field instead of a create.
+  final Group? smartschoolNamesake;
+
   const LinkedGroup({
     this.wisa,
     this.smartschool,
     this.azure,
     required this.confidence,
+    this.smartschoolNamesake,
   });
 }
 
@@ -173,6 +191,30 @@ class ResolveDuplicateMail extends LinkWarning {
   final List<SmartschoolAccount> accounts;
 
   const ResolveDuplicateMail({required this.mail, required this.accounts});
+}
+
+/// #225: a WISA class whose name already exists in Smartschool as a group the
+/// class link did not adopt — because the group is not flagged as an official
+/// class, or because its name differs from the WISA one by more than the match
+/// key tolerates.
+///
+/// The skip itself is legitimate (only official classes link), but it used to
+/// be **silent**: the WISA class then looked unmatched, and the action engine
+/// offered to create a class Smartschool already had. Every skipped namesake is
+/// surfaced so the operator can see which class was passed over and why.
+class SmartschoolNamesakeSkipped extends LinkWarning {
+  /// The WISA class name as written (its `fullName`, the match key's source).
+  final String wisaName;
+
+  /// The Smartschool group carrying that name. [Group.official] says which of
+  /// the two skip reasons applies; [Group.name] shows the name as Smartschool
+  /// spells it.
+  final Group smartschool;
+
+  const SmartschoolNamesakeSkipped({
+    required this.wisaName,
+    required this.smartschool,
+  });
 }
 
 /// Per-system tally for one [LinkedSnapshot], mirroring the counters legacy

--- a/packages/account_core/test/group_test.dart
+++ b/packages/account_core/test/group_test.dart
@@ -141,4 +141,40 @@ void main() {
       // Both are valid records — nothing here prevents holding both.
     });
   });
+
+  group('group-name normalization (#225)', () {
+    test('trims, lower-cases, and collapses internal whitespace runs', () {
+      expect(normalizeGroupName('  2G  '), '2g');
+      expect(normalizeGroupName('5A  01'), '5a 01');
+      expect(normalizeGroupName('5A\t01'), '5a 01');
+    });
+
+    test('non-breaking spaces normalize to a plain space', () {
+      // What an operator's copy-paste leaves in a Smartschool class name; it
+      // does not make it a different class from the WISA one.
+      expect(normalizeGroupName('5A\u00a001'), '5a 01');
+      expect(normalizeGroupName('5A\u202f01'), '5a 01');
+      expect(normalizeGroupName('5A\u00a0\u00a001'), '5a 01');
+    });
+
+    test('a blank or null name is no key at all', () {
+      expect(normalizeGroupName(null), isNull);
+      expect(normalizeGroupName('   '), isNull);
+      expect(normalizeGroupName('\u00a0'), isNull);
+    });
+
+    test('the space between a class and its sub-group is preserved', () {
+      // The looser fingerprint drops it; the match key must not, or `5A 01`
+      // and `5A01` would link as one class.
+      expect(normalizeGroupName('5A 01'), isNot(normalizeGroupName('5A01')));
+    });
+
+    test('the fingerprint ignores whitespace entirely', () {
+      expect(groupNameFingerprint('2 G'), groupNameFingerprint('2G'));
+      expect(groupNameFingerprint('2\u00a0g'), '2g');
+      expect(groupNameFingerprint('5A 01'), '5a01');
+      expect(groupNameFingerprint('  '), isNull);
+      expect(groupNameFingerprint(null), isNull);
+    });
+  });
 }

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -140,6 +140,7 @@ LinkedSnapshot link(
     azureSnapshot,
     effectiveOurSchoolIds,
     virtualSchoolIds,
+    warnings,
   );
 
   return LinkedSnapshot.fromRecords(
@@ -433,6 +434,18 @@ List<_StaffRecord> _buildStaffRecords(
 /// `AddSmartschoolChildGroups` walked the "Leerlingen" subtree and linked only
 /// official classes); organisational sub-groups never match or seed orphans.
 ///
+/// That skip used to be *silent*, which is how #225 happened: a class that
+/// exists in Smartschool but is not flagged official reads exactly like a class
+/// that is not there at all, and the action engine then offered to create it —
+/// a duplicate name Smartschool either rejects or ends up holding twice. So
+/// **every** Smartschool group is indexed by name, official or not: a WISA class
+/// left unlinked but whose name a Smartschool group already carries keeps that
+/// group on [LinkedGroup.smartschoolNamesake] (never as [LinkedGroup.smartschool]
+/// — an unofficial group is still not a class) and raises a
+/// [SmartschoolNamesakeSkipped] warning. The namesake lookup falls back to the
+/// whitespace-insensitive [groupNameFingerprint], so a hand-typed `2 G` is
+/// recognised as the existing `2G` even though it is too loose a key to link on.
+///
 /// Azure carries no `official`-style signal — [az.AzureGroup] is just
 /// `{id, displayName, securityEnabled}` — so an unmatched Azure group is kept
 /// as an orphan *unless* its name looks administrative (see
@@ -451,10 +464,25 @@ List<LinkedGroup> _linkGroups(
   az.AzureSnapshot azureSnapshot,
   Set<int> ourSchoolIds,
   Set<int> virtualSchoolIds,
+  List<LinkWarning> warnings,
 ) {
   final records = <_GroupRecord>[];
   // Normalized fullName/name/displayName -> the record indexed under it.
   final byName = <String, _GroupRecord>{};
+
+  // Every Smartschool group by name, official or not (#225) — the index the
+  // "does this class already exist downstream?" guard consults after the link
+  // passes have run. Two keys per group: the exact match key, and the looser
+  // whitespace-insensitive fingerprint. First wins on both, so the answer is a
+  // deterministic function of snapshot order (INV-20).
+  final ssByName = <String, Group>{};
+  final ssByFingerprint = <String, Group>{};
+  for (final group in smartschoolSnapshot.groups) {
+    final key = normalizeGroupName(group.name);
+    if (key == null) continue;
+    ssByName.putIfAbsent(key, () => group);
+    ssByFingerprint.putIfAbsent(groupNameFingerprint(group.name)!, () => group);
+  }
 
   // 1. Seed one record per distinct WISA class group, in snapshot order, keyed
   //    by its `fullName`. Class groups of schools we do not manage are skipped
@@ -469,7 +497,7 @@ List<LinkedGroup> _linkGroups(
     if (!_seedsClassGroups(group.schoolId, ourSchoolIds, virtualSchoolIds)) {
       continue;
     }
-    final key = _norm(group.fullName);
+    final key = normalizeGroupName(group.fullName);
     if (key == null || byName.containsKey(key)) continue;
     final rec = _GroupRecord(wisa: group);
     records.add(rec);
@@ -482,7 +510,7 @@ List<LinkedGroup> _linkGroups(
   //    dropped.
   for (final group in smartschoolSnapshot.groups) {
     if (!group.official) continue;
-    final key = _norm(group.name);
+    final key = normalizeGroupName(group.name);
     if (key == null) continue;
     final existing = byName[key];
     if (existing != null) {
@@ -494,11 +522,40 @@ List<LinkedGroup> _linkGroups(
     }
   }
 
+  // 2b. A WISA class the official pass left unmatched, whose name Smartschool
+  //     already carries in *some* form, keeps that namesake (#225) instead of
+  //     reading as "not there" — the state that made the engine propose
+  //     creating a duplicate class. Runs after pass 2 so a class that did link
+  //     is never second-guessed, and skips a group another WISA class already
+  //     linked to: that name belongs to *that* class, not this one. A
+  //     Smartschool-only orphan (#52) is deliberately not "taken" — no WISA
+  //     class owns it, and its name is exactly the one a create would collide
+  //     with.
+  final claimed = <String>{
+    for (final rec in records)
+      if (rec.wisa != null && rec.smartschool != null)
+        rec.smartschool!.id.value,
+  };
+  for (final rec in records) {
+    final wisa = rec.wisa;
+    if (wisa == null || rec.smartschool != null) continue;
+    final key = normalizeGroupName(wisa.fullName);
+    if (key == null) continue;
+    final namesake =
+        ssByName[key] ?? ssByFingerprint[groupNameFingerprint(wisa.fullName)!];
+    if (namesake == null || claimed.contains(namesake.id.value)) continue;
+    rec.smartschoolNamesake = namesake;
+    warnings.add(
+      SmartschoolNamesakeSkipped(
+          wisaName: wisa.fullName, smartschool: namesake),
+    );
+  }
+
   // 3. Attach Azure groups by displayName. An Azure group matching no
   //    existing record becomes an orphan too (#52), but only when it looks
   //    like a stale class rather than a staff/administrative group.
   for (final group in azureSnapshot.groups) {
-    final key = _norm(group.displayName);
+    final key = normalizeGroupName(group.displayName);
     if (key == null) continue;
     final existing = byName[key];
     if (existing != null) {
@@ -516,6 +573,7 @@ List<LinkedGroup> _linkGroups(
       LinkedGroup(
         wisa: rec.wisa == null ? null : _wisaToCoreGroup(rec.wisa!),
         smartschool: rec.smartschool,
+        smartschoolNamesake: rec.smartschoolNamesake,
         azure: rec.azure,
         confidence:
             rec.wisa != null && rec.smartschool != null && rec.azure != null
@@ -546,7 +604,7 @@ const List<String> _nonClassGroupSuffixes = [
 /// Whether an unmatched Azure group is plausible as a stale class rather than
 /// a known staff/administrative group. See [_nonClassGroupSuffixes].
 bool _looksLikeClassGroup(String? displayName) {
-  final name = _norm(displayName);
+  final name = normalizeGroupName(displayName);
   if (name == null) return false;
   return !_nonClassGroupSuffixes.any(name.endsWith);
 }
@@ -606,6 +664,10 @@ class _GroupRecord {
   Group? smartschool;
   az.AzureGroup? azure;
 
+  /// The Smartschool group carrying this class's name that the official-class
+  /// pass could not adopt (#225). See [LinkedGroup.smartschoolNamesake].
+  Group? smartschoolNamesake;
+
   _GroupRecord({this.wisa, this.smartschool, this.azure});
 }
 
@@ -620,6 +682,11 @@ bool _isStaffRole(PersonRole? role) =>
 /// Trims and lowercases [value] for case-insensitive, whitespace-tolerant
 /// comparison (INV-12). Returns `null` when [value] is null or blank so empty
 /// keys never match or index anything.
+///
+/// For **identifiers** — mails, uids, wisaIds, staff codes — where internal
+/// whitespace is not a thing an operator types by accident. Group *names* go
+/// through [normalizeGroupName] instead, which additionally collapses internal
+/// whitespace runs and non-breaking spaces (#225).
 String? _norm(String? value) {
   if (value == null) return null;
   final trimmed = value.trim();

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -184,6 +184,39 @@ void main() {
       expect(a.confidence, LinkConfidence.medium);
     });
 
+    test(
+        'a transferred student\'s account links by employeeId alone — no '
+        'companyName, an unusable UPN (#224)', () {
+      // The state a transfer from a sibling group school leaves behind: the
+      // account exists, the employeeId is our WISA id, `companyName` was never
+      // stamped, `department` still names the other school, and that school
+      // mangled the given/family-name order of a foreign name, so the UPN is
+      // nothing we would ever project. `employeeId` is the only usable key —
+      // and it must be enough, or the app proposes a second account.
+      final snapshot = link(
+        wisaSnap([wisaStudent('W7')]),
+        ssSnap(const []),
+        azSnap([
+          azureUser(
+            id: 'az-transferred',
+            upn: 'alfio.ambre@student.other.example',
+            employeeId: 'W7',
+            department: 'OTHER-3A',
+          ),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      // One record, not two: the Azure user joined the WISA student rather
+      // than being dropped as "another school's" or kept as an orphan.
+      expect(snapshot.accounts, hasLength(1));
+      final a = snapshot.accounts.single;
+      expect(a.wisa?.wisaId.value, 'W7');
+      expect(a.azure?.id, 'az-transferred');
+      expect(a.smartschool, isNull);
+    });
+
     test('a WISA student leaves groups untouched', () {
       final snapshot = link(
         wisaSnap([wisaStudent('W10')]),

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -793,6 +793,40 @@ void main() {
       expect(s.confidence, LinkConfidence.medium);
     });
 
+    test(
+        'a moved staff member\'s account links by employeeId alone — another '
+        'school\'s department, an unusable UPN (#231)', () {
+      // The state a move from a sibling group school leaves behind, the staff
+      // counterpart of #224: the account exists, its `employeeId` is our WISA
+      // id, but `department` still names the school they came from — so it
+      // matches neither leg of the connector's `$filter` *and* would be dropped
+      // here as "another school's" if `employeeId` did not bridge it. The UPN
+      // that school wrote is no key either. Without this link the app proposes
+      // a second Office 365 account.
+      final snapshot = link(
+        wisaSnap(const [], staff: [wisaStaff('SMITA', wisaId: '42')]),
+        ssSnap(const []),
+        azSnap([
+          azureUser(
+            id: 'az-moved',
+            upn: 'smit.anna@other.example',
+            employeeId: '42',
+            department: 'OTHER - Wiskunde',
+          ),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      // One record, not two: the Azure user joined the WISA staff member
+      // rather than being dropped as another school's.
+      expect(snapshot.staff, hasLength(1));
+      final s = snapshot.staff.single;
+      expect(s.wisa?.wisaId?.value, '42');
+      expect(s.azure?.id, 'az-moved');
+      expect(s.smartschool, isNull);
+    });
+
     test('staff and students partition cleanly from one Smartschool list', () {
       // A teacher and a student share neither key; each must land in exactly
       // one population, never both.

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -7,6 +7,10 @@ import 'support/fixtures.dart';
 
 const _prefix = 'Arcadia';
 
+/// A non-breaking space (U+00A0) — what a class name pasted into Smartschool
+/// often carries where the WISA name has a plain space (#225).
+const _nbsp = '\u00a0';
+
 void main() {
   group('link — student scenarios', () {
     test('fully linked across three systems → high confidence', () {
@@ -379,6 +383,141 @@ void main() {
       // The organisational group with the same name is ignored.
       expect(g.smartschool, isNull);
       expect(g.confidence, LinkConfidence.medium);
+    });
+
+    test(
+        'a non-official namesake is kept on the record and warned about (#225)',
+        () {
+      // The `2G` of #225: Smartschool holds the class as a group that is not
+      // flagged official. The link still refuses it — it is not a class — but
+      // the record must say the name is taken, or the action engine proposes
+      // creating a class Smartschool already has.
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('2G')]),
+        ssSnap(const [], groups: [ssGroup('2G', code: 'G2G', official: false)]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final g = snapshot.groups.single;
+      expect(g.smartschool, isNull, reason: 'a group is still not a class');
+      expect(g.smartschoolNamesake?.id.value, 'G2G');
+      expect(g.smartschoolNamesake?.official, isFalse);
+
+      final warning = snapshot.warnings.single as SmartschoolNamesakeSkipped;
+      expect(warning.wisaName, '2G');
+      expect(warning.smartschool.id.value, 'G2G');
+    });
+
+    test('a class Smartschool does not have carries no namesake (#225)', () {
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('2G')]),
+        ssSnap(const [], groups: [ssGroup('2F', official: false)]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      expect(snapshot.groups.single.smartschoolNamesake, isNull);
+      expect(snapshot.warnings, isEmpty);
+    });
+
+    test('a linked class never carries a namesake or a warning (#225)', () {
+      // Two Smartschool groups share the name; the official one links, so
+      // nothing was skipped that matters.
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('2G')]),
+        ssSnap(const [], groups: [
+          ssGroup('2G', code: 'G2G', official: false),
+          ssGroup('2G', code: 'C2G'),
+        ]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final g = snapshot.groups.single;
+      expect(g.smartschool?.id.value, 'C2G');
+      expect(g.smartschoolNamesake, isNull);
+      expect(snapshot.warnings, isEmpty);
+    });
+
+    test('an internal double space in the Smartschool name still links (#225)',
+        () {
+      final snapshot = link(
+        wisaSnap(const [],
+            classGroups: [wisaClassGroup('5A', groupName: '01')]),
+        ssSnap(const [], groups: [ssGroup('5A  01', code: 'C5A01')]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final g = snapshot.groups.single;
+      expect(g.smartschool?.id.value, 'C5A01');
+      expect(snapshot.warnings, isEmpty);
+    });
+
+    test('a non-breaking space in the Smartschool name still links (#225)', () {
+      // A class name an operator pasted into Smartschool: the separator is
+      // U+00A0, not a plain space, so it used to be a different class entirely.
+      final snapshot = link(
+        wisaSnap(const [],
+            classGroups: [wisaClassGroup('5A', groupName: '01')]),
+        ssSnap(const [], groups: [ssGroup('5A${_nbsp}01', code: 'C5A01')]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final g = snapshot.groups.single;
+      expect(g.smartschool?.id.value, 'C5A01');
+    });
+
+    test(
+        'an official class spelled "2 G" does not link but blocks the create '
+        '(#225)', () {
+      // Too loose a key to link on — dropping the space that separates a class
+      // from its sub-group would fuse names that really are distinct — but
+      // definitely close enough to refuse to create a second `2G`.
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('2G')]),
+        ssSnap(const [], groups: [ssGroup('2 G', code: 'C2G')]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      // The official orphan seeds its own record (#52); ours is the WISA one.
+      final ours = snapshot.groups.firstWhere((g) => g.wisa != null);
+      expect(ours.smartschool, isNull);
+      expect(ours.smartschoolNamesake?.id.value, 'C2G');
+      expect(ours.smartschoolNamesake?.official, isTrue);
+      expect(
+        (snapshot.warnings.single as SmartschoolNamesakeSkipped).wisaName,
+        '2G',
+      );
+    });
+
+    test('a namesake another class already holds is not reported twice (#225)',
+        () {
+      // WISA has both `2G` and `2 G`; the official Smartschool `2 G` links to
+      // the latter, so it is not `2G`'s name that is taken.
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [
+          wisaClassGroup('2G'),
+          wisaClassGroup('2 G'),
+        ]),
+        ssSnap(const [], groups: [ssGroup('2 G', code: 'C2G')]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final plain = snapshot.groups.firstWhere((g) => g.wisa!.name == '2G');
+      expect(plain.smartschoolNamesake, isNull);
+      expect(snapshot.warnings, isEmpty);
     });
 
     test('subgroup fullName (name + groupName) is the match key', () {

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -268,12 +268,19 @@ List<String> structuralSignature(LinkedSnapshot snapshot) {
         g.confidence.name,
         'w:${g.wisa?.name ?? '-'}',
         's:${g.smartschool?.id.value ?? '-'}',
+        // The unadoptable Smartschool namesake (#225) is part of the record's
+        // meaning — it is what suppresses the create proposal — so a shift in
+        // which group is picked must show up as a signature difference.
+        'n:${g.smartschoolNamesake?.id.value ?? '-'}',
         'a:${g.azure?.id ?? '-'}',
       ].join('|');
 
   String warning(LinkWarning w) => switch (w) {
         ResolveDuplicateMail(:final mail, :final accounts) =>
           'dupmail:$mail:${(accounts.map((x) => x.uid).toList()..sort()).join(',')}',
+        SmartschoolNamesakeSkipped(:final wisaName, :final smartschool) =>
+          'namesake:$wisaName:${smartschool.id.value}:'
+              '${smartschool.official ? 'official' : 'group'}',
       };
 
   return [

--- a/packages/account_state/lib/src/apply/state_applier.dart
+++ b/packages/account_state/lib/src/apply/state_applier.dart
@@ -20,14 +20,24 @@ import 'wisa_import_rules.dart';
 /// dry run or a failed apply the snapshot is untouched, so [linked] is `null`
 /// and the caller keeps its previous [LinkedState].
 class ApplyResult {
-  const ApplyResult(this.result, this.linked);
+  const ApplyResult(this.result, this.linked, {this.followUps = const []});
 
   /// The action's own result — outcome, changes, mutated record.
   final ActionResult result;
 
   /// The linked view recomputed after the incremental refresh, or `null` when
-  /// nothing was written (dry run / failure).
+  /// nothing was written (dry run / failure). When [followUps] ran, this is the
+  /// view the **last** of them left behind.
   final LinkedState? linked;
+
+  /// The results of the follow-up actions this write unlocked on the same
+  /// target and the applier ran straight away (#230), in the order they ran.
+  ///
+  /// Empty for every action that declares no `unlocks`, and for a dry run or a
+  /// failed write (nothing was written, so nothing was unlocked). The caller
+  /// reports these beside [result]: they are writes the operator's one click
+  /// performed and must see.
+  final List<ActionResult> followUps;
 
   /// Whether the snapshot was patched and [linked] recomputed.
   bool get refreshed => linked != null;
@@ -130,17 +140,93 @@ class StateApplier {
         ourSchoolIds: ourSchoolIds,
       );
 
-  /// Applies a [StudentAction] and refreshes the snapshot on a real write.
+  /// Applies a [StudentAction] and refreshes the snapshot on a real write, then
+  /// runs whatever that write unlocked on the same student (#230).
   Future<ApplyResult> applyStudent(
     StudentAction action, {
     ApplyOptions options = const ApplyOptions(),
   }) async {
     final result = await action.apply(connectors, options);
-    return _refresh(
+    final applied = await _refresh(
       result,
       removedSmartschoolUid: action.target.smartschool?.uid,
       removedAzureId: action.target.azure?.id,
     );
+    return _chainStudentFollowUps(action, applied, options);
+  }
+
+  /// Runs the follow-up actions [action]'s write unlocked on the same student,
+  /// against the **relinked** record (#230).
+  ///
+  /// Provisioning a new student is a two-link chain: `AddStudentToSmartschool`
+  /// builds the account with the Azure UPN as its `mail`, so it cannot evaluate
+  /// true until `AddStudentToAzure` has run. The dispatcher is a pure function
+  /// of the current record and can only offer the first link, so one click used
+  /// to create the Office 365 account and stop, leaving the Smartschool create
+  /// to a second pass the operator had to notice and trigger.
+  ///
+  /// Each link is taken from the freshly recomputed [LinkedState]'s own
+  /// dispatch — the same list the UI would show on the next render — so the
+  /// follow-up is bound to the record the previous write produced, placement
+  /// and all, and its own `evaluate()` has already agreed it applies. Never a
+  /// projection: `createPrincipalName` resolves a UPN collision by suffixing,
+  /// so the UPN that landed can differ from the projected one.
+  ///
+  /// The walk is bounded three ways, so no declaration can spin it: nothing is
+  /// unlocked when nothing was written (a dry run or a failure returns no
+  /// refreshed view), each action type runs at most once per chain, and a
+  /// failed link stops it — the failure is reported and the next sync re-offers
+  /// whatever is still missing.
+  Future<ApplyResult> _chainStudentFollowUps(
+    StudentAction action,
+    ApplyResult applied,
+    ApplyOptions options,
+  ) async {
+    var linked = applied.linked;
+    if (linked == null || action.unlocks.isEmpty) return applied;
+
+    final targetId = action.target.id;
+    final ran = <Type>{action.runtimeType};
+    final followUps = <ActionResult>[];
+    var unlocks = action.unlocks;
+
+    while (unlocks.isNotEmpty) {
+      final next = _unlockedStudentAction(linked!, targetId, unlocks, ran);
+      if (next == null) break;
+      ran.add(next.runtimeType);
+      final result = await next.apply(connectors, options);
+      followUps.add(result);
+      final refreshed = await _refresh(
+        result,
+        removedSmartschoolUid: next.target.smartschool?.uid,
+        removedAzureId: next.target.azure?.id,
+      );
+      if (!refreshed.refreshed) break;
+      linked = refreshed.linked;
+      unlocks = next.unlocks;
+    }
+
+    if (followUps.isEmpty) return applied;
+    return ApplyResult(applied.result, linked, followUps: followUps);
+  }
+
+  /// The first action [linked]'s dispatch raised for [targetId] whose type is
+  /// named by [unlocks] and has not run yet this chain, or null when the write
+  /// unlocked nothing after all.
+  StudentAction? _unlockedStudentAction(
+    LinkedState linked,
+    core.LinkedAccountId targetId,
+    Set<Type> unlocks,
+    Set<Type> ran,
+  ) {
+    for (final candidate in linked.studentActions) {
+      if (candidate.target.id == targetId &&
+          unlocks.contains(candidate.runtimeType) &&
+          !ran.contains(candidate.runtimeType)) {
+        return candidate;
+      }
+    }
+    return null;
   }
 
   /// Applies a [StaffAction] and refreshes the snapshot on a real write.

--- a/packages/account_state/lib/src/link/placement.dart
+++ b/packages/account_state/lib/src/link/placement.dart
@@ -105,7 +105,7 @@ class PlacementResolver {
     // the current-class and logical-parent lookups). First wins on a
     // collision, keeping the result a deterministic function of snapshot order.
     for (final group in smartschool.groups) {
-      final name = _norm(group.name);
+      final name = normalizeGroupName(group.name);
       if (name != null) _groupsByName.putIfAbsent(name, () => group);
       _groupsByCode.putIfAbsent(group.id.value, () => group);
     }
@@ -146,7 +146,7 @@ class PlacementResolver {
       if (wisaId != null) {
         _wisaStudentByWisaId.putIfAbsent(wisaId, () => student);
       }
-      final classGroup = _norm(student.classGroup);
+      final classGroup = normalizeGroupName(student.classGroup);
       if (classGroup != null && _isOurSchool(student.schoolId)) {
         _classGroupsWithStudents.add(classGroup);
       }
@@ -170,12 +170,12 @@ class PlacementResolver {
     // duplicate fullNames to the first record (INV-20), so this mirrors it.
     final adminCodesByClass = <(int, String), Set<String>>{};
     for (final group in wisa.classGroups) {
-      final name = _norm(group.name);
+      final name = normalizeGroupName(group.name);
       if (name != null) {
         adminCodesByClass.putIfAbsent(
             (group.schoolId, name), () => <String>{}).add(group.adminCode);
       }
-      final fullName = _norm(group.fullName);
+      final fullName = normalizeGroupName(group.fullName);
       if (fullName != null) _wisaByFullName.putIfAbsent(fullName, () => group);
     }
     for (final entry in adminCodesByClass.entries) {
@@ -242,7 +242,7 @@ class PlacementResolver {
     return ClassPlacement(
       className: className,
       currentClass: currentClass,
-      resolveClass: (name) => _groupsByName[_norm(name)],
+      resolveClass: (name) => _groupsByName[normalizeGroupName(name)],
     );
   }
 
@@ -263,7 +263,7 @@ class PlacementResolver {
     final classGroup = student.classGroup;
     final subGroup = student.classSubGroup.trim();
     if (subGroup.isEmpty || subGroup == _noSubGroupSentinel) return classGroup;
-    final name = _norm(classGroup);
+    final name = normalizeGroupName(classGroup);
     if (name == null) return classGroup;
     return _subGroupClasses.contains((student.schoolId, name))
         ? '$classGroup $subGroup'
@@ -286,9 +286,9 @@ class PlacementResolver {
   GroupPlacement groupPlacementFor(LinkedGroup group) {
     // [LinkedGroup.wisa] is keyed by fullName; recover the source WISA class to
     // read its bare name and year.
-    final wisaClass = _wisaByFullName[_norm(group.wisa?.name)];
+    final wisaClass = _wisaByFullName[normalizeGroupName(group.wisa?.name)];
     final containsStudents = wisaClass != null &&
-        _classGroupsWithStudents.contains(_norm(wisaClass.name));
+        _classGroupsWithStudents.contains(normalizeGroupName(wisaClass.name));
     final parentCode = classTree.parentCodeForYear(wisaClass?.year ?? -1);
     final parent = parentCode == null ? null : _groupsByCode[parentCode];
 
@@ -307,6 +307,11 @@ const String _noSubGroupSentinel = '00';
 /// Trims and lower-cases [value] for case-insensitive, whitespace-tolerant
 /// matching (INV-12), returning `null` for a null or blank input so an empty
 /// key never indexes or matches anything. Mirrors the linker's `_norm`.
+///
+/// For identifiers only (a Smartschool `uid`). Every group *name* key here goes
+/// through [normalizeGroupName] instead — the same function the linker keys its
+/// own group records by (#225), so the two layers cannot disagree about which
+/// class a name refers to.
 String? _norm(String? value) {
   if (value == null) return null;
   final trimmed = value.trim();

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -301,6 +301,12 @@ Map<String, List<String>> _warningsByUid(List<core.LinkWarning> warnings) {
         for (final a in accounts) {
           (byUid[a.uid] ??= <String>[]).add(message);
         }
+      case core.SmartschoolNamesakeSkipped():
+        // Names a *class*, not an account, so it has no uid to hang on. The
+        // class itself carries the situation as the informational
+        // `ClassExistsAsSmartschoolGroup` candidate on its group document, and
+        // the sync log names every skipped namesake (#225).
+        break;
     }
   }
   return byUid;

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -47,6 +47,7 @@ MaterializedView materialize(
   final warningsByUid = _warningsByUid(linked.snapshot.warnings);
 
   final accounts = <MaterializedAccount>[];
+  var skippedUnmanagedStudents = 0;
   for (final account in linked.snapshot.accounts) {
     // #178: keep the Actions view to schools we manage. A student present only
     // in a sibling school we do not manage ([WisaPresence.groupOnly]) with no
@@ -54,9 +55,15 @@ MaterializedView materialize(
     // A groupOnly student who still has one of *our* accounts is a departed
     // student whose Smartschool/Azure cleanup we keep (#134); [_placeAccount]
     // re-buckets them to "Niet toegewezen" so no non-managed school node shows.
+    //
+    // The drop is counted (#230): silently vanishing is indistinguishable from
+    // a student the pull never returned, which is exactly how an unflagged
+    // school in Instellingen used to read — no node, no count, no log line, and
+    // an operator hunting a missing intake with nothing to go on.
     if (account.wisaPresence == core.WisaPresence.groupOnly &&
         account.smartschool == null &&
         account.azure == null) {
+      skippedUnmanagedStudents++;
       continue;
     }
     final place = _placeAccount(account, schoolLabels);
@@ -106,6 +113,7 @@ MaterializedView materialize(
     accounts: accounts,
     groups: groups,
     rollups: [...rollups, if (groupsRollup != null) groupsRollup],
+    skippedUnmanagedStudents: skippedUnmanagedStudents,
   );
 }
 

--- a/packages/account_state/lib/src/materialize/materialized_state.dart
+++ b/packages/account_state/lib/src/materialize/materialized_state.dart
@@ -680,6 +680,7 @@ class MaterializedView {
     required this.accounts,
     required this.rollups,
     this.groups = const [],
+    this.skippedUnmanagedStudents = 0,
   });
 
   final int generation;
@@ -688,4 +689,13 @@ class MaterializedView {
   /// The per-group documents for the group-action family (#119).
   final List<MaterializedGroup> groups;
   final List<Rollup> rollups;
+
+  /// How many linked students the materialize deliberately left out because
+  /// they exist only in a school we do **not** manage and own no account of
+  /// ours (#178) — the drop that used to be silent (#230).
+  ///
+  /// Not part of the persisted view; it is pass metadata the sync reports, so an
+  /// operator who cannot find an intake in Acties can tell "filtered out by the
+  /// managed-school flags in Instellingen" from "never came back from WISA".
+  final int skippedUnmanagedStudents;
 }

--- a/packages/account_state/lib/src/sync/application_state.dart
+++ b/packages/account_state/lib/src/sync/application_state.dart
@@ -68,9 +68,12 @@ class ApplicationState {
 /// connector can look up by `employeeId` the ones the prefix-scoped read did not
 /// turn up (#224). Reading it lazily is what lets the wiring site point it at
 /// the WISA snapshot the same [ApplicationState] pulled moments earlier — WISA
-/// always syncs before Azure in a pass. Supply
-/// [managedStudentEmployeeIds] over `app.wisa.snapshot` for the production
-/// behaviour; omit it and the pull is exactly as it shipped before #224.
+/// always syncs before Azure in a pass. Supply the union of
+/// [managedStudentEmployeeIds] and [managedStaffEmployeeIds] over
+/// `app.wisa.snapshot` for the production behaviour — both populations transfer
+/// between the group's schools, and both are invisible to the prefix-scoped
+/// read afterwards (#224 students, #231 staff). Omit it and the pull is exactly
+/// as it shipped before #224.
 ///
 /// WISA and Smartschool have no equivalent helper: their syncers are the
 /// one-liner `(_) => connector.sync(...)`, written at the wiring site because
@@ -111,5 +114,30 @@ Set<String> managedStudentEmployeeIds(
     for (final student in snapshot.students)
       if (effective.isEmpty || effective.contains(student.schoolId))
         if (student.wisaId.value.trim().isNotEmpty) student.wisaId.value.trim(),
+  };
+}
+
+/// The WISA ids of the staff in [snapshot] — the personeel half of the ids
+/// [azureSyncer] hands the connector, and the staff counterpart of
+/// [managedStudentEmployeeIds] (#231).
+///
+/// A staff member who moves in from a sibling group school leaves the same
+/// wreckage a transferred student does: the Office 365 account already exists
+/// and carries their WISA id as `employeeId`, but its `department` still names
+/// the school they came from, so neither leg of the connector's `$filter`
+/// matches it and the app proposed creating a second one.
+///
+/// Unlike [managedStudentEmployeeIds] there is nothing to scope by: the
+/// `SmaSyncPer` pull carries no school id per staff row, so every staff member
+/// it returned is one this pass expects an account for. `wisaId` is **nullable**
+/// on a staff row (`code` is the staff primary key, spec §3.4 / OQ-1); a member
+/// without one is dropped, since `wisaId ≡ employeeId` is the only Azure bridge
+/// the linker has for staff and there is nothing to look up.
+Set<String> managedStaffEmployeeIds(WisaSnapshot? snapshot) {
+  if (snapshot == null) return const <String>{};
+  return <String>{
+    for (final member in snapshot.staff)
+      if ((member.wisaId?.value.trim() ?? '').isNotEmpty)
+        member.wisaId!.value.trim(),
   };
 }

--- a/packages/account_state/lib/src/sync/application_state.dart
+++ b/packages/account_state/lib/src/sync/application_state.dart
@@ -63,12 +63,53 @@ class ApplicationState {
 /// previous user list to `/users/delta`, so the app never re-pulls the whole
 /// tenant.
 ///
+/// [expectedEmployeeIds] is read **at sync time** (hence a callback, not a
+/// value): it names the WISA ids this pass expects Azure accounts for, so the
+/// connector can look up by `employeeId` the ones the prefix-scoped read did not
+/// turn up (#224). Reading it lazily is what lets the wiring site point it at
+/// the WISA snapshot the same [ApplicationState] pulled moments earlier — WISA
+/// always syncs before Azure in a pass. Supply
+/// [managedStudentEmployeeIds] over `app.wisa.snapshot` for the production
+/// behaviour; omit it and the pull is exactly as it shipped before #224.
+///
 /// WISA and Smartschool have no equivalent helper: their syncers are the
 /// one-liner `(_) => connector.sync(...)`, written at the wiring site because
 /// their per-sync parameters (WISA schools/workdate, the import-rule sets) come
 /// from live-config that a later slice folds in.
-Syncer<AzureSnapshot> azureSyncer(AzureConnector connector) =>
+Syncer<AzureSnapshot> azureSyncer(
+  AzureConnector connector, {
+  Iterable<String> Function()? expectedEmployeeIds,
+}) =>
     (previous) => connector.sync(
           deltaToken: previous?.deltaToken,
           previous: previous,
+          expectedEmployeeIds: expectedEmployeeIds?.call() ?? const <String>[],
         );
+
+/// The WISA ids of the students in [snapshot] that belong to a school we
+/// manage — the ids [azureSyncer] hands the connector as the accounts this pass
+/// expects to find in Azure (#224).
+///
+/// [ourSchoolIds] is the operator's managed-school set from Settings, exactly as
+/// handed to `link()`. `null` falls back to the snapshot's own
+/// `WisaSchool.isOurs` flags, and an empty effective set means ownership is
+/// unconfigured — in which case every WISA student counts, mirroring the
+/// linker's own `_isOurWisaSchool` fallback. Scoping matters: a sibling school's
+/// student is none of our business, and looking their account up would grow the
+/// bounded pull for nothing.
+Set<String> managedStudentEmployeeIds(
+  WisaSnapshot? snapshot, {
+  Set<int>? ourSchoolIds,
+}) {
+  if (snapshot == null) return const <String>{};
+  final effective = ourSchoolIds ??
+      <int>{
+        for (final school in snapshot.schools)
+          if (school.isOurs) school.id,
+      };
+  return <String>{
+    for (final student in snapshot.students)
+      if (effective.isEmpty || effective.contains(student.schoolId))
+        if (student.wisaId.value.trim().isNotEmpty) student.wisaId.value.trim(),
+  };
+}

--- a/packages/account_state/test/application_state_test.dart
+++ b/packages/account_state/test/application_state_test.dart
@@ -178,5 +178,122 @@ void main() {
       expect(snapshot.deltaToken, 'PRIMED2');
       expect(azure.lastSync, snapshot.fetchedAt);
     });
+
+    test('the expected employeeIds are read at sync time, not at wiring time',
+        () async {
+      // The seam that lets the Azure pull see the WISA snapshot this pass just
+      // produced (#224): the syncer is built before WISA has synced, so the ids
+      // must come from a callback, not a captured value.
+      var ids = <String>[];
+      final state = SystemState<AzureSnapshot>(
+        system: core.Origin.azure,
+        syncer: azureSyncer(
+          AzureConnector(
+            credentials: AzureCredentials(
+              clientId: 'c',
+              tenantId: 't',
+              azureDomain: 'school.example',
+              schoolPrefix: 'GBS',
+            ),
+            authProvider: const StaticAuthProvider('T'),
+            transport: transport,
+          ),
+          expectedEmployeeIds: () => ids,
+        ),
+      );
+
+      // Nothing expected yet ⇒ no employeeId lookup at all.
+      await state.sync();
+      expect(
+        transport.requests.where(
+          (r) => (r.url.queryParameters[r'$filter'] ?? '')
+              .startsWith('employeeId in'),
+        ),
+        isEmpty,
+      );
+
+      // The WISA pull lands between the two syncs; the next Azure pass sees it.
+      ids = <String>['W7'];
+      await state.sync();
+      expect(
+        transport.requests
+            .map((r) => r.url.queryParameters[r'$filter'])
+            .whereType<String>()
+            .where((f) => f.startsWith('employeeId in')),
+        ["employeeId in ('W7')"],
+      );
+    });
+  });
+
+  group('managedStudentEmployeeIds (#224)', () {
+    WisaStudent student(String id, {int schoolId = 1}) => WisaStudent(
+          wisaId: core.WisaId(id),
+          classGroup: '1A',
+          classSubGroup: '',
+          name: 'Doe',
+          firstName: 'Jane',
+          preferredName: '',
+          birthDate: DateTime.utc(2010),
+          stemId: '',
+          gender: core.Gender.female,
+          nationalId: '',
+          birthPlace: '',
+          nationality: '',
+          address: const core.Address(
+            street: '',
+            houseNumber: '',
+            postalCode: '',
+            city: '',
+            country: '',
+          ),
+          classChange: DateTime.utc(2026),
+          schoolId: schoolId,
+        );
+
+    WisaSnapshot snap(
+      List<WisaStudent> students, {
+      List<WisaSchool> schools = const [],
+    }) =>
+        WisaSnapshot(
+          fetchedAt: DateTime.utc(2026),
+          students: students,
+          staff: const [],
+          classGroups: const [],
+          schools: schools,
+        );
+
+    test('no snapshot yet ⇒ nothing expected', () {
+      expect(managedStudentEmployeeIds(null), isEmpty);
+    });
+
+    test('scopes to the managed schools from Settings', () {
+      final ids = managedStudentEmployeeIds(
+        snap([student('W1'), student('W2', schoolId: 2)]),
+        ourSchoolIds: const {1},
+      );
+      // A sibling school's student is none of our business, and looking their
+      // account up would grow the bounded pull for nothing.
+      expect(ids, {'W1'});
+    });
+
+    test('falls back to the snapshot\'s own isOurs flags', () {
+      final ids = managedStudentEmployeeIds(
+        snap(
+          [student('W1'), student('W2', schoolId: 2)],
+          schools: [
+            const WisaSchool(id: 1, name: '', code: '', isOurs: false),
+            const WisaSchool(id: 2, name: '', code: '', isOurs: true),
+          ],
+        ),
+      );
+      expect(ids, {'W2'});
+    });
+
+    test('an unconfigured ownership set means every student counts', () {
+      final ids = managedStudentEmployeeIds(
+        snap([student('W1'), student('W2', schoolId: 2)]),
+      );
+      expect(ids, {'W1', 'W2'});
+    });
   });
 }

--- a/packages/account_state/test/application_state_test.dart
+++ b/packages/account_state/test/application_state_test.dart
@@ -296,4 +296,54 @@ void main() {
       expect(ids, {'W1', 'W2'});
     });
   });
+
+  group('managedStaffEmployeeIds (#231)', () {
+    WisaStaff member(String code, {String? wisaId}) => WisaStaff(
+          code: core.WisaStaffCode(code),
+          wisaId: wisaId == null ? null : core.WisaId(wisaId),
+          firstName: 'Anna',
+          lastName: 'Smit',
+        );
+
+    WisaSnapshot snap(List<WisaStaff> staff) => WisaSnapshot(
+          fetchedAt: DateTime.utc(2026),
+          students: const [],
+          staff: staff,
+          classGroups: const [],
+          schools: const [],
+        );
+
+    test('no snapshot yet ⇒ nothing expected', () {
+      expect(managedStaffEmployeeIds(null), isEmpty);
+    });
+
+    test('every staff member the SmaSyncPer pull returned counts', () {
+      // No school scoping is possible or wanted: a staff row carries no school
+      // id, so the pull is already exactly the staff we manage.
+      expect(
+        managedStaffEmployeeIds(
+            snap([member('SMIT', wisaId: '42'), member('JANS', wisaId: '43')])),
+        {'42', '43'},
+      );
+    });
+
+    test('the wisaId is the id, never the staff code', () {
+      // The Azure bridge for staff is `wisaId ≡ employeeId` (linker
+      // `_buildStaffRecords` step 3); `code` bridges Smartschool instead
+      // (OQ-1), and looking it up in Graph would match nothing.
+      expect(managedStaffEmployeeIds(snap([member('SMIT', wisaId: '42')])),
+          {'42'});
+    });
+
+    test('a staff member without a wisaId is dropped, not asked about', () {
+      // `wisaId` is nullable on a staff row; without one there is no
+      // `employeeId` to look up and none on the account to find either.
+      expect(
+        managedStaffEmployeeIds(
+          snap([member('SMIT'), member('JANS', wisaId: '  43  ')]),
+        ),
+        {'43'},
+      );
+    });
+  });
 }

--- a/packages/account_state/test/linked_state_test.dart
+++ b/packages/account_state/test/linked_state_test.dart
@@ -607,6 +607,51 @@ void main() {
     });
 
     test(
+        'a class Smartschool already holds as a plain group is never proposed '
+        'for creation (#225)', () {
+      // The `2G` of #225 driven through the layer the app actually uses: WISA
+      // has the populated class, Smartschool has it as a group that is not
+      // flagged as an official class. The class exists — proposing to create it
+      // asks Smartschool for a duplicate name.
+      final wisa = _wSnap(
+        students: [_wStudent(wisaId: '1', classGroup: '2G')],
+        classGroups: [_wClass('2G', adminCode: 'g1')],
+      );
+      final smartschool = _sSnap(
+        groups: [
+          _ssGroup('Eerste graad',
+              code: 'G1', official: false, type: core.GroupType.group),
+          _ssGroup('2G',
+              code: 'G2G', official: false, type: core.GroupType.group),
+        ],
+      );
+
+      final state = LinkedState.recompute(
+        wisa: wisa,
+        smartschool: smartschool,
+        azure: _aSnap(),
+        resolver: _SeqResolver(),
+        studentConfig: _studentConfig,
+        staffConfig: _staffConfig,
+        classTree: const SmartschoolClassTree(grades: ['G1', 'G2', 'G3']),
+      );
+
+      expect(state.groupActions.whereType<AddToSmartschool>(), isEmpty);
+      expect(state.groupActions.whereType<CreateInSmartschool>(), isEmpty);
+      final notice =
+          state.groupActions.whereType<ClassExistsAsSmartschoolGroup>().single;
+      expect(notice.canApply, isFalse);
+      expect(notice.describeChanges().summary, contains('geen officiële klas'));
+
+      // And the skip is on the record for the operator to read, not silent.
+      final warning = state.snapshot.warnings
+          .whereType<core.SmartschoolNamesakeSkipped>()
+          .single;
+      expect(warning.wisaName, '2G');
+      expect(warning.smartschool.id.value, 'G2G');
+    });
+
+    test(
         'MoveToSmartschoolClassGroup surfaces only with the placement callback',
         () {
       final wisa = _wSnap(students: [_wStudent(wisaId: '1', classGroup: '3C')]);

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -482,6 +482,35 @@ void main() {
       expect(view.rollups.where((r) => r.level == RollupLevel.school), isEmpty);
     });
 
+    test('the suppressed student is counted, not silently dropped (#230)', () {
+      // Suppressing them is right (#178), vanishing without trace is not: an
+      // unflagged school in Instellingen then looks exactly like a WISA pull
+      // that never returned the class, which is what the operator hit.
+      final view = materialize(
+        linkedInSchool(schoolId: 2, ourSchoolIds: {1}, withOurAccounts: false),
+        generation: 1,
+      );
+
+      expect(view.skippedUnmanagedStudents, 1);
+    });
+
+    test('nothing is counted when every student is placed (#230)', () {
+      final managed = materialize(
+        linkedInSchool(schoolId: 1, ourSchoolIds: {1}),
+        generation: 1,
+      );
+      expect(managed.skippedUnmanagedStudents, 0);
+
+      // A groupOnly student who still owns one of our accounts is *kept* (#134)
+      // — re-bucketed, not skipped, so counting them would be a false alarm.
+      final departed = materialize(
+        linkedInSchool(schoolId: 2, ourSchoolIds: {1}),
+        generation: 1,
+      );
+      expect(departed.accounts, hasLength(1));
+      expect(departed.skippedUnmanagedStudents, 0);
+    });
+
     test('toggling the managed set flips which schools appear', () {
       // Same student in school 2. Not managing school 2 → suppressed from the
       // school tree (re-bucketed to unassigned); managing it → it shows.

--- a/packages/account_state/test/password_queue_capture_test.dart
+++ b/packages/account_state/test/password_queue_capture_test.dart
@@ -288,62 +288,33 @@ void main() {
       expect(entry.mail, 'jan.peeters@student.school.example');
     });
 
-    test('an Azure create enqueues the Azure password only', () async {
-      // WISA present, Azure missing → AddStudentToAzure.
+    test(
+        "provisioning a new student fills both halves of one sheet from the "
+        "operator's single apply (#230)", () async {
+      // WISA only — a new intake. The dispatcher offers just AddStudentToAzure,
+      // because the Smartschool create needs the Azure UPN as its mail; the
+      // State layer then chains that follow-up against the relinked record, so
+      // one apply mints two passwords. They belong to the same student, so they
+      // must land on one sheet — not two rows (legacy `AccountPassword`).
       final harness = _Harness(wisa: _wSnap(students: [_wStudent()]));
       final target = _linkedStudent(wisa: _wStudent());
 
-      await harness.applier.applyStudent(
+      final applied = await harness.applier.applyStudent(
         AddStudentToAzure(target, harness.applier.studentConfig),
       );
+      expect(applied.followUps, hasLength(1), reason: 'the chain ran');
 
       final entries = await harness.queue.load();
-      expect(entries, hasLength(1));
+      expect(entries, hasLength(1), reason: 'one sheet per student, not two');
       final entry = entries.single;
-      expect(entry.azurePassword, 'pw1');
-      expect(entry.smartschoolPassword, isNull);
-      expect(entry.displayName, 'Jan Peeters');
-    });
-
-    test(
-        'Azure then Smartschool creates merge onto one entry with both passwords',
-        () async {
-      // The realistic two-pass flow: Azure is created first (Smartschool-create
-      // requires Azure to exist), then Smartschool. Both are the same WISA
-      // student, so they must land on one sheet — not two rows.
-      final harness = _Harness(wisa: _wSnap(students: [_wStudent()]));
-
-      final azApplied = await harness.applier.applyStudent(
-        AddStudentToAzure(
-          _linkedStudent(wisa: _wStudent()),
-          harness.applier.studentConfig,
-        ),
-      );
-      // After the Azure create the queue holds one entry with only the Azure
-      // password.
-      final afterAzure = await harness.queue.load();
-      expect(afterAzure, hasLength(1));
-      expect(afterAzure.single.azurePassword, 'pw1');
-      expect(afterAzure.single.smartschoolPassword, isNull);
-
-      // Now Smartschool, targeting the account with the freshly created Azure
-      // record (as the dispatcher would after the incremental relink).
-      final createdAzure = azApplied.result.azure! as az.AzureUser;
-      await harness.applier.applyStudent(
-        AddStudentToSmartschool(
-          _linkedStudent(wisa: _wStudent(), azure: createdAzure),
-          harness.applier.studentConfig,
-        ),
-      );
-
-      final merged = await harness.queue.load();
-      expect(merged, hasLength(1), reason: 'one sheet per student, not two');
-      final entry = merged.single;
-      expect(entry.azurePassword, 'pw1', reason: 'kept from the Azure create');
+      expect(entry.kind, PasswordAccountKind.account);
+      expect(entry.azurePassword, 'pw1', reason: 'from the Azure create');
       expect(entry.smartschoolPassword, 'pw2',
-          reason: 'filled by the Smartschool create — a distinct password');
+          reason: 'from the chained Smartschool create — a distinct password');
+      expect(entry.displayName, 'Jan Peeters');
       expect(entry.accountName, 'jan.peeters',
           reason: 'the now-known Smartschool uid');
+      expect(entry.classGroup, '3A');
     });
 
     test('a dry-run create enqueues nothing (no write, no password)', () async {

--- a/packages/account_state/test/password_queue_capture_test.dart
+++ b/packages/account_state/test/password_queue_capture_test.dart
@@ -23,8 +23,9 @@ const core.Address _addr = core.Address(
 
 // ---------------------------------------------------------------------------
 // Fakes: a SOAP transport whose every write succeeds, and a Graph transport
-// that answers the create path — 404 to the pre-create UPN-existence probe (so
-// `createPrincipalName` takes the first candidate) and 201 with an id echo to
+// that answers the create path — an empty `employeeId in (…)` collection to the
+// duplicate-account guard (#224), 404 to the pre-create UPN-existence probe (so
+// `createPrincipalName` takes the first candidate), and 201 with an id echo to
 // the POST that creates the user.
 // ---------------------------------------------------------------------------
 
@@ -52,6 +53,16 @@ class _CreatingGraph implements az.GraphTransport {
       return az.GraphResponse(
         statusCode: 201,
         body: '{"id":"az-created-$_created"}',
+      );
+    }
+    // The duplicate guard's lookup (#224): a `$filter` query never 404s — it
+    // answers with an empty collection when the tenant holds no such account.
+    if ((request.url.queryParameters[r'$filter'] ?? '')
+        .startsWith('employeeId in')) {
+      return const az.GraphResponse(
+        statusCode: 200,
+        headers: {'content-type': 'application/json'},
+        body: '{"value":[]}',
       );
     }
     // The UPN-existence probe (GET) — report "not found" so the first

--- a/packages/account_state/test/state_applier_test.dart
+++ b/packages/account_state/test/state_applier_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:account_actions/account_actions.dart';
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart';
@@ -22,7 +24,13 @@ const core.Address _addr = core.Address(
 // ---------------------------------------------------------------------------
 
 class _RecordingSoap implements ss.SmartschoolSoapTransport {
+  _RecordingSoap({this.resultCode = 0});
+
   final List<String> soapActions = [];
+
+  /// The integer result every write returns; non-zero is Smartschool's way of
+  /// saying the call failed.
+  final int resultCode;
 
   @override
   Future<String> send({
@@ -31,23 +39,55 @@ class _RecordingSoap implements ss.SmartschoolSoapTransport {
     required String envelope,
   }) async {
     soapActions.add(soapAction);
-    // Every recorded write succeeds (return code 0).
     return '<?xml version="1.0" encoding="utf-8"?>'
         '<soap:Envelope '
         'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
-        '<soap:Body><response><return>0</return></response>'
+        '<soap:Body><response><return>$resultCode</return></response>'
         '</soap:Body></soap:Envelope>';
   }
 }
 
+/// Graph for an empty tenant. PATCH/DELETE answer `204` the way Graph does,
+/// while a **create** reads before it writes — `employeeId in (…)` to prove the
+/// person has no account yet (#224), then `users/<upn>` per UPN candidate until
+/// one is free — so those reads must answer "nothing here" and the create must
+/// echo the new resource (#230). A bare `204` would decode to an empty JSON
+/// object, which `AzureUser.fromGraphJson` turns into a user, so every UPN
+/// candidate would read as taken and `createPrincipalName` would spin forever.
 class _RecordingGraph implements az.GraphTransport {
   final List<az.GraphRequest> requests = [];
+
+  int _created = 0;
+
+  static final RegExp _singleUserPath = RegExp(r'/users/(?!delta$)[^/]+$');
 
   @override
   Future<az.GraphResponse> send(az.GraphRequest request) async {
     requests.add(request);
+    if (request.method == 'GET') {
+      return _singleUserPath.hasMatch(request.url.path)
+          ? const az.GraphResponse(
+              statusCode: 404,
+              headers: {'content-type': 'application/json'},
+              body: '{"error":{"code":"Request_ResourceNotFound"}}',
+            )
+          : _ok(<String, dynamic>{'value': const <Object>[]}, 200);
+    }
+    if (request.method == 'POST' && request.url.path.endsWith('/users')) {
+      final body = Map<String, dynamic>.from(
+        jsonDecode(request.body ?? '{}') as Map,
+      );
+      return _ok({...body, 'id': 'az-created-${++_created}'}, 201);
+    }
     return const az.GraphResponse(statusCode: 204);
   }
+
+  static az.GraphResponse _ok(Map<String, dynamic> body, int statusCode) =>
+      az.GraphResponse(
+        statusCode: statusCode,
+        headers: const {'content-type': 'application/json'},
+        body: jsonEncode(body),
+      );
 }
 
 ss.SmartschoolConnector _ssConn(_RecordingSoap t) =>
@@ -235,7 +275,8 @@ class _Harness {
     List<wapi.WisaStudent> wisaBaseStudents = const [],
     ss.SmartschoolSnapshot? smartschool,
     az.AzureSnapshot? azure,
-  }) {
+    int soapResultCode = 0,
+  }) : soap = _RecordingSoap(resultCode: soapResultCode) {
     final ssSnap = smartschool ?? _sSnap();
     final azSnap = azure ?? _aSnap();
     rules = WisaImportRules();
@@ -284,7 +325,7 @@ class _Harness {
     );
   }
 
-  final soap = _RecordingSoap();
+  final _RecordingSoap soap;
   final graph = _RecordingGraph();
   late final WisaImportRules rules;
   late final ApplicationState app;
@@ -411,6 +452,127 @@ void main() {
         ['KEEP'],
       );
       expect(applied.refreshed, isTrue);
+    });
+  });
+
+  group('provisioning a new student is one chain, not two passes (#230)', () {
+    /// A student who exists only in WISA — a new intake with neither a
+    /// Smartschool nor an Office 365 account. The dispatcher can only offer the
+    /// Azure create: `AddStudentToSmartschool` builds its account with the Azure
+    /// UPN as the `mail`, so it evaluates false until that account exists.
+    _Harness newIntake({int soapResultCode = 0}) => _Harness(
+          wisa: _wSnap(students: [_wStudent(wisaId: 'W1')]),
+          soapResultCode: soapResultCode,
+        );
+
+    test('the Azure create chains the Smartschool create it unlocked',
+        () async {
+      final harness = newIntake();
+      final before = await harness.applier.link();
+      final create = before.studentActions.single;
+      expect(create, isA<AddStudentToAzure>(),
+          reason: 'the dispatcher can only see the first link of the chain');
+
+      final applied = await harness.applier.applyStudent(create);
+
+      // Both writes happened, off one apply.
+      expect(applied.result.outcome, ActionOutcome.applied);
+      expect(applied.result.system, core.Origin.azure);
+      expect(applied.followUps.map((r) => r.changes.summary),
+          ['Maak een nieuw Smartschool account']);
+      expect(applied.followUps.single.outcome, ActionOutcome.applied);
+
+      // And both records are in the snapshots the pass left behind.
+      final azure = harness.app.azure.snapshot!.users.single;
+      expect(azure.employeeId, 'W1');
+      final smartschool = harness.app.smartschool.snapshot!.accounts.single;
+      expect(smartschool.accountId, 'W1');
+      expect(smartschool.mail, azure.upn,
+          reason: 'the follow-up read the UPN that actually landed, not the '
+              'projected one');
+      expect(harness.counts, [0, 0, 0],
+          reason: 'the chain rides the incremental refresh — no re-sync');
+    });
+
+    test('the chained account is what the linker now sees', () async {
+      final harness = newIntake();
+      final create = (await harness.applier.link()).studentActions.single;
+
+      final applied = await harness.applier.applyStudent(create);
+
+      final linked = applied.linked!.snapshot.accounts.single;
+      expect(linked.wisa, isNotNull);
+      expect(linked.azure, isNotNull);
+      expect(linked.smartschool, isNotNull,
+          reason: 'the returned view is the one the *last* link produced');
+      expect(
+        applied.linked!.studentActions.whereType<AddStudentToAzure>(),
+        isEmpty,
+      );
+      expect(
+        applied.linked!.studentActions.whereType<AddStudentToSmartschool>(),
+        isEmpty,
+      );
+    });
+
+    test('a dry run projects the first write and chains nothing', () async {
+      final harness = newIntake();
+      final create = (await harness.applier.link()).studentActions.single;
+
+      final applied =
+          await harness.applier.applyStudent(create, options: ApplyOptions.dry);
+
+      expect(applied.result.outcome, ActionOutcome.dryRun);
+      expect(applied.followUps, isEmpty,
+          reason: 'nothing was written, so nothing was unlocked');
+      expect(harness.soap.soapActions, isEmpty);
+      expect(harness.graph.requests.where((r) => r.method == 'POST'), isEmpty);
+      expect(harness.app.smartschool.snapshot!.accounts, isEmpty);
+    });
+
+    test('a failing follow-up stops the chain and is reported', () async {
+      // Smartschool refuses the create (non-zero return code); the Azure
+      // account it followed still exists and must stay in the snapshot, so the
+      // next pass offers exactly the one create that is still missing.
+      final harness = newIntake(soapResultCode: 1);
+      final create = (await harness.applier.link()).studentActions.single;
+
+      final applied = await harness.applier.applyStudent(create);
+
+      expect(applied.result.outcome, ActionOutcome.applied);
+      expect(applied.followUps.single.outcome, ActionOutcome.failed);
+      expect(applied.linked, isNotNull,
+          reason: 'the successful Azure write is still reflected');
+      expect(harness.app.azure.snapshot!.users, hasLength(1));
+      expect(harness.app.smartschool.snapshot!.accounts, isEmpty);
+      expect(
+        applied.linked!.studentActions.single,
+        isA<AddStudentToSmartschool>(),
+      );
+    });
+
+    test('both minted passwords land on one password sheet (#105)', () async {
+      final queue = InMemoryPasswordQueueStore();
+      final harness = newIntake();
+      final applier = StateApplier(
+        app: harness.app,
+        connectors: Connectors(
+          smartschool: _ssConn(harness.soap),
+          azure: _azConn(harness.graph),
+        ),
+        resolver: _SeqResolver(),
+        wisaRules: harness.rules,
+        studentConfig: _studentConfig(),
+        staffConfig: _staffConfig(),
+        passwordQueue: queue,
+      );
+
+      await applier.applyStudent((await applier.link()).studentActions.single);
+
+      final entry = (await queue.load()).single;
+      expect(entry.azurePassword, isNotNull);
+      expect(entry.smartschoolPassword, isNotNull,
+          reason: 'the chained create merges onto the entry the first left');
     });
   });
 

--- a/packages/azure_api/README.md
+++ b/packages/azure_api/README.md
@@ -45,6 +45,16 @@ becoming a dead end:
   Request_UnsupportedQuery` that is *not* about the delta token (a malformed
   query) still throws, so a real bug stays loud instead of degrading into an
   expensive full read on every pass.
+- **A recovered failure is never logged as an error.** `GraphClient` logs every
+  non-2xx reply, and on its own cannot tell a rejection the caller handles from a
+  fatal one — so a pass that fully recovered used to read as a broken one.
+  `UserManager.delta` therefore hands the client the failure shape it expects
+  (`GraphFailurePredicate`); a match is logged as an ordinary detail beside the
+  connector's own explanation, everything else stays an error. Logged URLs also
+  have their `$deltatoken` / `$skiptoken` values replaced with `<redacted>` at
+  every severity — a resume token is kilobytes of live tenant state, and log
+  lines end up pasted into issues. `$deltatoken=latest` is Graph's own sentinel,
+  not a secret, and stays readable.
 
 ### Server-side filter, and where it falls back
 

--- a/packages/azure_api/lib/azure_api.dart
+++ b/packages/azure_api/lib/azure_api.dart
@@ -28,7 +28,8 @@ export 'src/config/live_config.dart' show AzureLiveConfig;
 export 'src/connector.dart' show AzureConnector;
 export 'src/graph/graph_batch.dart'
     show BatchRequest, BatchResponse, GraphBatch;
-export 'src/graph/graph_client.dart' show DeltaResult, GraphClient;
+export 'src/graph/graph_client.dart'
+    show DeltaResult, GraphClient, GraphFailurePredicate;
 export 'src/graph/graph_request.dart'
     show GraphException, GraphRequest, GraphResponse;
 export 'src/graph/graph_transport.dart' show GraphTransport, HttpGraphTransport;

--- a/packages/azure_api/lib/src/connector.dart
+++ b/packages/azure_api/lib/src/connector.dart
@@ -88,13 +88,21 @@ class AzureConnector {
   /// one. That is what makes [AzureSnapshot.fetchedAt] a truthful age for the
   /// token it ships with, and what keeps a token from silently ageing past
   /// Graph's 30-day limit while every sync appears to succeed.
+  ///
+  /// [expectedEmployeeIds] are the WISA ids this pass expects to find accounts
+  /// for. Any that the prefix-scoped read did not turn up are looked up
+  /// directly by `employeeId` and merged in ([_adoptByEmployeeId], #224), so a
+  /// student who transferred in from a sibling group school — whose account
+  /// carries neither our `companyName` nor our `department` — is seen instead of
+  /// being proposed for a second, duplicate account.
   Future<AzureSnapshot> sync({
     String? deltaToken,
     AzureSnapshot? previous,
+    Iterable<String> expectedEmployeeIds = const <String>[],
   }) async {
     final groupList = await groups.listGroups(credentials.schoolPrefix);
 
-    if (deltaToken == null) return _fullRead(groupList);
+    if (deltaToken == null) return _fullRead(groupList, expectedEmployeeIds);
 
     final UserDelta delta;
     try {
@@ -107,7 +115,7 @@ class AzureConnector {
         '(${_tokenAge(previous)}) — $e. Discarding it and re-reading all '
         'accounts in full.',
       );
-      return _fullRead(groupList);
+      return _fullRead(groupList, expectedEmployeeIds);
     }
 
     // No `@odata.deltaLink` on the final page means this walk produced no
@@ -123,7 +131,10 @@ class AzureConnector {
       );
     }
 
-    final userList = _applyDelta(previous?.users ?? const [], delta);
+    final userList = await _adoptByEmployeeId(
+      _applyDelta(previous?.users ?? const [], delta),
+      expectedEmployeeIds,
+    );
     return AzureSnapshot(
       fetchedAt: _now(),
       deltaToken: delta.deltaToken,
@@ -137,15 +148,84 @@ class AzureConnector {
   ///
   /// The token is primed *before* the bulk read so anything that changes while
   /// the (long) read runs is picked up by the next delta rather than lost.
-  Future<AzureSnapshot> _fullRead(List<AzureGroup> groupList) async {
+  Future<AzureSnapshot> _fullRead(
+    List<AzureGroup> groupList,
+    Iterable<String> expectedEmployeeIds,
+  ) async {
     final token = await users.latestDeltaToken();
-    final userList = await users.load(credentials.schoolPrefix);
+    final userList = await _adoptByEmployeeId(
+      await users.load(credentials.schoolPrefix),
+      expectedEmployeeIds,
+    );
     return AzureSnapshot(
       fetchedAt: _now(),
       deltaToken: token,
       users: userList,
       groups: groupList,
     );
+  }
+
+  /// Completes [current] with the accounts the prefix-scoped read cannot see
+  /// (#224): for every id in [expectedEmployeeIds] that no user in [current]
+  /// carries, one targeted `employeeId` lookup, merged in by object id.
+  ///
+  /// This is the whole fix for the transferred-student duplicate. The `$filter`
+  /// that keeps the bulk read bounded (PAIN-2) — `companyName eq` /
+  /// `startswith(department, …)` against the school prefix — matches nothing on
+  /// an account a sibling school left behind, and `_walkDelta` applies the same
+  /// test client-side, so an incremental pass is equally blind. The linker
+  /// already has the `employeeId → wisaId` bridge; it just never got the row.
+  /// Only the ids that went unaccounted for are asked about, so the set stays
+  /// small.
+  ///
+  /// A Graph failure here is **not** fatal: this step enriches a snapshot that
+  /// is otherwise complete, and losing the whole pass over it would be worse
+  /// than missing the adoption for one sync. The failure is logged as an error,
+  /// and `AddStudentToAzure` still refuses to create over an existing
+  /// `employeeId` at apply time, so a missed adoption cannot become a duplicate.
+  Future<List<AzureUser>> _adoptByEmployeeId(
+    List<AzureUser> current,
+    Iterable<String> expectedEmployeeIds,
+  ) async {
+    final known = <String>{
+      for (final u in current)
+        if ((u.employeeId ?? '').trim().isNotEmpty)
+          u.employeeId!.trim().toLowerCase(),
+    };
+    final missing = <String>{
+      for (final id in expectedEmployeeIds)
+        if (id.trim().isNotEmpty && !known.contains(id.trim().toLowerCase()))
+          id.trim(),
+    };
+    if (missing.isEmpty) return current;
+
+    final List<AzureUser> adopted;
+    try {
+      adopted = await users.loadByEmployeeIds(missing);
+    } on Object catch (e) {
+      _log?.addError(
+        core.Origin.azure,
+        'Azure: could not look up ${missing.length} unmatched employeeId(s) — '
+        '$e. Any existing account for them stays unseen this pass.',
+      );
+      return current;
+    }
+    if (adopted.isEmpty) return current;
+
+    final byId = {for (final u in current) u.id: u};
+    var added = 0;
+    for (final u in adopted) {
+      if (byId.containsKey(u.id)) continue;
+      byId[u.id] = u;
+      added++;
+    }
+    if (added == 0) return current;
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: adopted $added existing account(s) found by employeeId that the '
+      'school filter does not match (transferred students).',
+    );
+    return byId.values.toList();
   }
 
   /// Whether [e] means "this delta token is no longer usable", the one Graph

--- a/packages/azure_api/lib/src/connector.dart
+++ b/packages/azure_api/lib/src/connector.dart
@@ -81,6 +81,9 @@ class AzureConnector {
   /// the rejection is logged with the token's age, and the pass falls back to a
   /// full read that primes a fresh token. The operator gets a complete snapshot
   /// instead of an aborted pass that would re-send the same dead token forever.
+  /// Because the recovery is complete, nothing about it is logged as an error —
+  /// [UserManager.delta] tells the transport this refusal is expected, so a pass
+  /// that recovered does not read as a broken one (#229).
   ///
   /// **Token invariant:** the token on the returned snapshot is always one
   /// minted during *this* sync — from this pass's delta walk, or from
@@ -108,7 +111,7 @@ class AzureConnector {
     try {
       delta = await users.delta(deltaToken, credentials.schoolPrefix);
     } on GraphException catch (e) {
-      if (!_isRejectedDeltaToken(e)) rethrow;
+      if (!e.isRejectedDeltaToken) rethrow;
       _log?.addMessage(
         core.Origin.azure,
         'Azure: Graph rejected the stored delta token '
@@ -226,28 +229,6 @@ class AzureConnector {
       'school filter does not match (transferred students).',
     );
     return byId.values.toList();
-  }
-
-  /// Whether [e] means "this delta token is no longer usable", the one Graph
-  /// failure [sync] recovers from by re-reading in full (#213).
-  ///
-  /// Two shapes, both of them Graph's own:
-  /// - `410 Gone` — the documented `resyncRequired` / `syncStateNotFound`
-  ///   "start over" signal for a delta query.
-  /// - `400 Bad Request` with `Request_UnsupportedQuery` **and** a message
-  ///   naming the delta link, e.g. *"DeltaLink older than 30 days is not
-  ///   supported."* The code alone is deliberately not enough: Graph also
-  ///   returns it for a genuinely malformed query, which must stay loud rather
-  ///   than silently degrade into an expensive full read on every pass.
-  static bool _isRejectedDeltaToken(GraphException e) {
-    if (e.statusCode == 410) return true;
-    if (e.statusCode != 400) return false;
-    if (e.code?.toLowerCase() != 'request_unsupportedquery') return false;
-    final detail = (e.message ?? e.body).toLowerCase();
-    return detail.contains('deltalink') ||
-        detail.contains('delta link') ||
-        detail.contains('deltatoken') ||
-        detail.contains('delta token');
   }
 
   /// How old the token Graph just rejected was, for the log line — the

--- a/packages/azure_api/lib/src/graph/graph_client.dart
+++ b/packages/azure_api/lib/src/graph/graph_client.dart
@@ -17,6 +17,12 @@ class DeltaResult {
   const DeltaResult({required this.values, this.deltaToken});
 }
 
+/// Tests a non-2xx Graph reply for "this is the failure I came prepared for".
+///
+/// Handed to [GraphClient] by a caller that recovers from a specific shape, so
+/// the transport can log that reply as a detail instead of an error (#229).
+typedef GraphFailurePredicate = bool Function(GraphException failure);
+
 /// Authenticated, paging-aware Microsoft Graph client.
 ///
 /// Sits above the swappable [GraphTransport]: resolves a bearer token from the
@@ -56,11 +62,14 @@ class GraphClient {
 
   /// GET a single resource (or the first page of a collection) and return the
   /// decoded JSON object.
+  ///
+  /// [expected] declares a failure shape the caller recovers from; see [_send].
   Future<Map<String, dynamic>> getJson(
     Uri url, {
     Map<String, String>? headers,
+    GraphFailurePredicate? expected,
   }) async {
-    final resp = await _send('GET', url, headers: headers);
+    final resp = await _send('GET', url, headers: headers, expected: expected);
     return resp.json;
   }
 
@@ -90,12 +99,18 @@ class GraphClient {
   /// Walk a delta collection: follows `@odata.nextLink` to gather all changed
   /// resources, then captures the `$deltatoken` from the terminal
   /// `@odata.deltaLink` for the next incremental sync.
-  Future<DeltaResult> getDelta(Uri url, {Map<String, String>? headers}) async {
+  ///
+  /// [expected] declares a failure shape the caller recovers from; see [_send].
+  Future<DeltaResult> getDelta(
+    Uri url, {
+    Map<String, String>? headers,
+    GraphFailurePredicate? expected,
+  }) async {
     final items = <Map<String, dynamic>>[];
     String? deltaToken;
     Uri? next = url;
     while (next != null) {
-      final body = await getJson(next, headers: headers);
+      final body = await getJson(next, headers: headers, expected: expected);
       items.addAll(_values(body));
       next = _nextLink(body);
       final deltaLink = body['@odata.deltaLink'] as String?;
@@ -139,11 +154,20 @@ class GraphClient {
     await _send('DELETE', url, headers: headers);
   }
 
+  /// Issues one request and turns a non-2xx reply into a [GraphException].
+  ///
+  /// The exception is always thrown; [expected] only decides how loudly the
+  /// reply is logged. Without it the transport cannot know whether the caller
+  /// recovers, so every failure is an error — which is how a delta-token
+  /// rejection the connector fully recovers from still painted the operator's
+  /// log red (#229). A caller that comes prepared for a shape says so, and that
+  /// reply is logged as an ordinary detail beside the caller's own explanation.
   Future<GraphResponse> _send(
     String method,
     Uri url, {
     String? body,
     Map<String, String>? headers,
+    GraphFailurePredicate? expected,
   }) async {
     final token = await _auth.getAccessToken();
     final request = GraphRequest(
@@ -159,10 +183,69 @@ class GraphClient {
     final resp = await _transport.send(request);
     if (!resp.isSuccess) {
       final ex = GraphException(resp.statusCode, resp.body);
-      _log?.addError(core.Origin.azure, '$method $url → $ex');
+      final line = '$method ${redactUrl(url)} → $ex';
+      if (expected != null && expected(ex)) {
+        _log?.addMessage(
+          core.Origin.azure,
+          '$line (handled — the sync recovers from this)',
+        );
+      } else {
+        _log?.addError(core.Origin.azure, line);
+      }
       throw ex;
     }
     return resp;
+  }
+
+  /// Query parameters whose values are opaque resume tokens.
+  ///
+  /// A Graph delta token runs to kilobytes, means nothing to a human, and is
+  /// live state for the tenant — and the operator pastes log lines into issues.
+  /// It is stripped from every logged URL at every severity (#229).
+  static const Set<String> _opaqueTokenParams = {
+    r'$deltatoken',
+    r'$skiptoken',
+  };
+
+  /// What replaces an opaque token in a logged URL.
+  static const String _redactedToken = '<redacted>';
+
+  /// Graph's own sentinel for "mint me a token for right now" — a literal, not
+  /// a secret, and the one thing that tells a primed full read apart from a
+  /// resume in the log. Kept readable.
+  static const String _latestToken = 'latest';
+
+  /// [url] as it should appear in a log line: every opaque resume token
+  /// replaced by [_redactedToken], everything else byte-for-byte unchanged.
+  static String redactUrl(Uri url) {
+    final query = url.query;
+    if (query.isEmpty) return url.toString();
+    final redacted = _redactQuery(query);
+    if (redacted == query) return url.toString();
+    // Pure string surgery on the rendered URL: rebuilding through [Uri] would
+    // re-encode the placeholder (and re-encode the untouched parts besides).
+    final full = url.toString();
+    final start = full.indexOf('?') + 1;
+    final end = url.hasFragment ? full.indexOf('#', start) : full.length;
+    return full.replaceRange(start, end, redacted);
+  }
+
+  static String _redactQuery(String query) {
+    final pairs = <String>[];
+    for (final pair in query.split('&')) {
+      final eq = pair.indexOf('=');
+      if (eq < 0) {
+        pairs.add(pair);
+        continue;
+      }
+      final name = pair.substring(0, eq);
+      final value = pair.substring(eq + 1);
+      final redact = _opaqueTokenParams
+              .contains(Uri.decodeComponent(name).toLowerCase()) &&
+          Uri.decodeComponent(value) != _latestToken;
+      pairs.add(redact ? '$name=$_redactedToken' : pair);
+    }
+    return pairs.join('&');
   }
 
   List<Map<String, dynamic>> _values(Map<String, dynamic> body) {

--- a/packages/azure_api/lib/src/graph/graph_request.dart
+++ b/packages/azure_api/lib/src/graph/graph_request.dart
@@ -70,6 +70,35 @@ class GraphException implements Exception {
   /// Graph's `error.message`, when present.
   String? get message => _errorField('message');
 
+  /// Whether this is Graph's way of saying *"the delta token you resumed from
+  /// is no longer usable"* — the one Graph failure the Azure connector recovers
+  /// from, by discarding the token and re-reading in full (#213).
+  ///
+  /// Two shapes, both of them Graph's own:
+  /// - `410 Gone` — the documented `resyncRequired` / `syncStateNotFound`
+  ///   "start over" signal for a delta query.
+  /// - `400 Bad Request` with `Request_UnsupportedQuery` **and** a message
+  ///   naming the delta link, e.g. *"DeltaLink older than 30 days is not
+  ///   supported."* The code alone is deliberately not enough: Graph also
+  ///   returns it for a genuinely malformed query, which must stay loud rather
+  ///   than silently degrade into an expensive full read on every pass.
+  ///
+  /// The classification lives on the reply rather than on the connector because
+  /// two layers need it: `UserManager.delta` hands it to `GraphClient` as the
+  /// failure shape it expects — so the transport logs it as a detail instead of
+  /// an error nobody should act on (#229) — and `AzureConnector.sync` uses it to
+  /// decide to fall back to a full read.
+  bool get isRejectedDeltaToken {
+    if (statusCode == 410) return true;
+    if (statusCode != 400) return false;
+    if (code?.toLowerCase() != 'request_unsupportedquery') return false;
+    final detail = (message ?? body).toLowerCase();
+    return detail.contains('deltalink') ||
+        detail.contains('delta link') ||
+        detail.contains('deltatoken') ||
+        detail.contains('delta token');
+  }
+
   String? _errorField(String field) {
     try {
       final decoded = jsonDecode(body);

--- a/packages/azure_api/lib/src/user_manager.dart
+++ b/packages/azure_api/lib/src/user_manager.dart
@@ -98,6 +98,82 @@ class UserManager {
     return "companyName eq '$p' or startswith(department,'$p')";
   }
 
+  /// How many `employeeId`s one [loadByEmployeeIds] request asks about. Graph
+  /// caps an `in (…)` list well below the URL length limit, so the lookup is
+  /// chunked rather than sent as one enormous filter.
+  static const int _employeeIdChunk = 15;
+
+  /// Targeted read of the users carrying one of [employeeIds], regardless of
+  /// `companyName`/`department` (#224).
+  ///
+  /// [load] and [delta] are deliberately scoped to the school's own prefix
+  /// (PAIN-2), which makes them blind to exactly the account this lookup is
+  /// for: a student who transferred in from a sibling school inside the tenant
+  /// already has an Office 365 account whose `employeeId` is their WISA id, but
+  /// whose `companyName` is unset and whose `department` still names the other
+  /// school. Nothing else about such an account is trustworthy — another school
+  /// routinely mangles the given/family-name order of a foreign name, so the UPN
+  /// is not a usable key. The `employeeId` is.
+  ///
+  /// The caller passes only the ids it could **not** account for, so the set
+  /// stays small and bounded and the PAIN-2 property of the bulk read survives.
+  /// Blank ids are dropped, duplicates collapse, and the result is de-duplicated
+  /// by Azure object id.
+  Future<List<AzureUser>> loadByEmployeeIds(
+      Iterable<String> employeeIds) async {
+    // A set literal preserves insertion order, so the chunking (and therefore
+    // the requests a test asserts on) is deterministic.
+    final unique = <String>{
+      for (final raw in employeeIds)
+        if (raw.trim().isNotEmpty) raw.trim(),
+    }.toList();
+    if (unique.isEmpty) return const <AzureUser>[];
+
+    final found = <String, AzureUser>{};
+    for (var i = 0; i < unique.length; i += _employeeIdChunk) {
+      final chunk = unique.sublist(
+        i,
+        (i + _employeeIdChunk).clamp(0, unique.length),
+      );
+      final literals =
+          chunk.map((id) => "'${_escapeODataString(id)}'").join(',');
+      final url = _graph.uri(
+        'users',
+        query: {
+          r'$select': _select,
+          r'$count': 'true',
+          r'$filter': 'employeeId in ($literals)',
+        },
+      );
+      final rows = await _graph.getCollection(
+        url,
+        headers: _advancedQueryHeaders,
+      );
+      for (final row in rows) {
+        final user = AzureUser.fromGraphJson(row);
+        found[user.id] = user;
+      }
+    }
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: looked up ${unique.length} employeeId(s) directly — '
+      '${found.length} existing account(s) found.',
+    );
+    return found.values.toList();
+  }
+
+  /// The single user carrying [employeeId], or `null` when the tenant has none.
+  ///
+  /// The pre-create guard of #224: `employeeId` is the one key that survives a
+  /// transfer between group schools, so an account bearing it already belongs to
+  /// this person and a second one must never be created. Graph resolves a UPN
+  /// collision by suffixing, so without this check a duplicate create *succeeds*
+  /// and is silent.
+  Future<AzureUser?> findByEmployeeId(String employeeId) async {
+    final matches = await loadByEmployeeIds([employeeId]);
+    return matches.isEmpty ? null : matches.first;
+  }
+
   /// Bulk read of the school's users with `$filter` + `$select`, following
   /// pagination. This is the first-sync path; subsequent syncs should use
   /// [delta].

--- a/packages/azure_api/lib/src/user_manager.dart
+++ b/packages/azure_api/lib/src/user_manager.dart
@@ -243,13 +243,28 @@ class UserManager {
 
   /// Incremental delta read: resumes from a token returned by a previous
   /// [deltaInitial]/[delta] call. Only changed and removed users come back.
+  ///
+  /// This is the one read whose caller (`AzureConnector.sync`) comes prepared
+  /// for a refusal: a token Graph no longer accepts is recovered from with a
+  /// full read (#213). The transport is told so, so it logs that reply as a
+  /// detail rather than as an error the operator should act on (#229). Every
+  /// other failure — including a resume that fails for any other reason — stays
+  /// an error.
   Future<UserDelta> delta(String deltaToken, String schoolPrefix) {
     final url = _graph.uri('users/delta', query: {r'$deltatoken': deltaToken});
-    return _walkDelta(url, schoolPrefix);
+    return _walkDelta(
+      url,
+      schoolPrefix,
+      expected: (e) => e.isRejectedDeltaToken,
+    );
   }
 
-  Future<UserDelta> _walkDelta(Uri url, String schoolPrefix) async {
-    final result = await _graph.getDelta(url);
+  Future<UserDelta> _walkDelta(
+    Uri url,
+    String schoolPrefix, {
+    GraphFailurePredicate? expected,
+  }) async {
+    final result = await _graph.getDelta(url, expected: expected);
     final changed = <AzureUser>[];
     final removedIds = <String>[];
     for (final row in result.values) {

--- a/packages/azure_api/test/connector_test.dart
+++ b/packages/azure_api/test/connector_test.dart
@@ -311,6 +311,57 @@ void main() {
       expect(recovery, contains('DeltaLink older than 30 days'));
     });
 
+    test(
+        'a pass that recovered logs no error at all, and never prints the dead '
+        'token (#229)', () async {
+      // The recovery of #213 worked, but the transport still logged the raw
+      // Graph failure with `addError` — carrying the whole ~2.5 KB
+      // `$deltatoken` in the URL — so a pass that fully recovered read as a
+      // broken one in the operator's log.
+      const dead = 'DEADTOKEN-2exa-dDwCZX0Ak-7duGZuSQD3Pc';
+      final transport = FakeGraphTransport(rejectingRoute(graphError(
+        400,
+        'Request_UnsupportedQuery',
+        'DeltaLink older than 30 days is not supported.',
+      )));
+      final log = RecordingLog();
+      final connector = AzureConnector(
+        credentials: credentials,
+        authProvider: const StaticAuthProvider('T'),
+        transport: transport,
+        log: log,
+      );
+
+      final snapshot = await connector.sync(
+        deltaToken: dead,
+        previous: previousAt(DateTime.now().subtract(const Duration(days: 46))),
+      );
+
+      // The pass really did recover.
+      expect(snapshot.deltaToken, 'PRIMEDTOKEN123');
+      expect(snapshot.users, hasLength(3));
+
+      // Nothing red: a failure the connector handles is not logged at the same
+      // severity as one it does not.
+      expect(log.errors, isEmpty);
+
+      // …and the resume token is nowhere in the log, at any severity.
+      for (final line in [...log.messages, ...log.errors]) {
+        expect(line, isNot(contains(dead)));
+      }
+      // The transport line is still there as a detail — the operator can see
+      // what Graph actually said.
+      expect(
+        log.messages,
+        contains(contains('DeltaLink older than 30 days')),
+      );
+      // And so is the connector's own explanation, with the token's age.
+      expect(
+        log.messages,
+        contains(contains('Graph rejected the stored delta token')),
+      );
+    });
+
     test('Graph\'s documented 410 resyncRequired recovers the same way',
         () async {
       final transport = FakeGraphTransport(rejectingRoute(

--- a/packages/azure_api/test/connector_test.dart
+++ b/packages/azure_api/test/connector_test.dart
@@ -354,4 +354,141 @@ void main() {
       );
     });
   });
+
+  group('employeeId back-fill (#224)', () {
+    /// The transferred-in student's Graph row: our `employeeId`, **no**
+    /// `companyName`, a `department` naming the school they came from, and a
+    /// UPN whose given/family order the other school mangled. Neither leg of
+    /// [UserManager.filterFor] matches it, so it is absent from every
+    /// prefix-scoped read.
+    const Map<String, dynamic> ambre = <String, dynamic>{
+      'id': 'az-transferred',
+      'userPrincipalName': 'alfio.ambre@student.other.example',
+      'employeeId': 'W7',
+      'displayName': 'Alfio Ambre',
+      'department': 'OTHER-3A',
+    };
+
+    /// [route], plus an answer for the targeted `employeeId in (…)` lookup.
+    GraphResponse Function(GraphRequest) routeWithBackfill({
+      required List<String> lookups,
+      List<Map<String, dynamic>> hits = const [ambre],
+    }) =>
+        (req) {
+          final filter = req.url.queryParameters[r'$filter'] ?? '';
+          if (req.url.path.endsWith('/users') &&
+              filter.startsWith('employeeId in')) {
+            lookups.add(filter);
+            return jsonOk({'value': hits});
+          }
+          return route(req);
+        };
+
+    test(
+        'a full sync adopts the account the school filter cannot see, asking '
+        'only about the ids it could not account for', () async {
+      final lookups = <String>[];
+      final transport = FakeGraphTransport(routeWithBackfill(lookups: lookups));
+      final log = RecordingLog();
+      final connector = AzureConnector(
+        credentials: credentials,
+        authProvider: const StaticAuthProvider('T'),
+        transport: transport,
+        log: log,
+      );
+
+      // `users_page1/2.json` carry W1001, W1002 and S2001; W7 is the transfer.
+      final snapshot = await connector.sync(
+        expectedEmployeeIds: const ['W1001', 'W1002', 'S2001', 'W7'],
+      );
+
+      // The three already-visible ids were never asked about — the bounded
+      // pull (PAIN-2) stays bounded.
+      expect(lookups, ["employeeId in ('W7')"]);
+      // …and the missing account is in the snapshot, so the linker's
+      // employeeId → wisaId bridge can reach it.
+      final adopted = snapshot.users.singleWhere((u) => u.employeeId == 'W7');
+      expect(adopted.id, 'az-transferred');
+      expect(adopted.companyName, isNull);
+      expect(snapshot.users, hasLength(4));
+      expect(
+        log.messages.any((m) => m.contains('adopted 1 existing account')),
+        isTrue,
+      );
+    });
+
+    test('an incremental sync adopts it too — the delta path is equally blind',
+        () async {
+      final lookups = <String>[];
+      final transport = FakeGraphTransport(routeWithBackfill(lookups: lookups));
+      final connector = connectorWith(transport);
+
+      final snapshot = await connector.sync(
+        deltaToken: 'OLDTOKEN',
+        previous: AzureSnapshot(
+          fetchedAt: DateTime.utc(2026, 6, 1),
+          deltaToken: 'OLDTOKEN',
+          users: const [],
+          groups: const [],
+        ),
+        expectedEmployeeIds: const ['W7'],
+      );
+
+      expect(lookups, ["employeeId in ('W7')"]);
+      expect(snapshot.users.map((u) => u.employeeId), contains('W7'));
+    });
+
+    test('no lookup at all when every expected id is already accounted for',
+        () async {
+      final lookups = <String>[];
+      final transport = FakeGraphTransport(routeWithBackfill(lookups: lookups));
+      final connector = connectorWith(transport);
+
+      final snapshot =
+          await connector.sync(expectedEmployeeIds: const ['W1001', 'S2001']);
+
+      expect(lookups, isEmpty);
+      expect(snapshot.users, hasLength(3));
+    });
+
+    test('an id the tenant has no account for changes nothing', () async {
+      final transport = FakeGraphTransport(
+        routeWithBackfill(lookups: <String>[], hits: const []),
+      );
+      final connector = connectorWith(transport);
+
+      final snapshot = await connector.sync(expectedEmployeeIds: const ['W99']);
+      expect(snapshot.users, hasLength(3));
+    });
+
+    test(
+        'a Graph failure on the lookup logs and leaves the snapshot otherwise '
+        'complete, rather than losing the whole pass', () async {
+      GraphResponse failingLookup(GraphRequest req) {
+        final filter = req.url.queryParameters[r'$filter'] ?? '';
+        if (req.url.path.endsWith('/users') &&
+            filter.startsWith('employeeId in')) {
+          return graphError(400, 'Request_UnsupportedQuery', 'nope');
+        }
+        return route(req);
+      }
+
+      final log = RecordingLog();
+      final connector = AzureConnector(
+        credentials: credentials,
+        authProvider: const StaticAuthProvider('T'),
+        transport: FakeGraphTransport(failingLookup),
+        log: log,
+      );
+
+      final snapshot = await connector.sync(expectedEmployeeIds: const ['W7']);
+
+      expect(snapshot.users, hasLength(3));
+      expect(snapshot.deltaToken, 'PRIMEDTOKEN123');
+      expect(
+        log.errors.any((m) => m.contains('unmatched employeeId')),
+        isTrue,
+      );
+    });
+  });
 }

--- a/packages/azure_api/test/graph_client_test.dart
+++ b/packages/azure_api/test/graph_client_test.dart
@@ -65,6 +65,131 @@ void main() {
     });
   });
 
+  group('failure logging (#229)', () {
+    /// The Graph reply the operator's stale token drew.
+    GraphResponse rejectedToken() => graphError(
+          400,
+          'Request_UnsupportedQuery',
+          'DeltaLink older than 30 days is not supported.',
+        );
+
+    test('an opaque resume token never reaches the log, at any severity',
+        () async {
+      // The ~2.5 KB `$deltatoken` the failing URL carries is live tenant state
+      // in a line the operator pastes into an issue.
+      const secret = 'SUPER-SECRET-RESUME-TOKEN';
+      final transport = FakeGraphTransport.constant(rejectedToken());
+      final log = RecordingLog();
+      final client = GraphClient(
+        transport: transport,
+        auth: const StaticAuthProvider('T'),
+        log: log,
+      );
+
+      await expectLater(
+        client.getJson(
+          client.uri('users/delta', query: {r'$deltatoken': secret}),
+        ),
+        throwsA(isA<GraphException>()),
+      );
+
+      expect(log.errors, hasLength(1));
+      expect(log.errors.single, isNot(contains(secret)));
+      expect(log.errors.single, contains('<redacted>'));
+      // The rest of the URL — the part that says what was being asked — is
+      // untouched, and so is Graph's own explanation.
+      expect(log.errors.single, contains('users/delta'));
+      expect(log.errors.single, contains('DeltaLink older than 30 days'));
+    });
+
+    test(
+        'a paging \$skiptoken is redacted too, while \$deltatoken=latest stays'
+        ' readable', () async {
+      final transport = FakeGraphTransport.constant(
+        graphError(400, 'Request_UnsupportedQuery', 'Bad page.'),
+      );
+      final log = RecordingLog();
+      final client = GraphClient(
+        transport: transport,
+        auth: const StaticAuthProvider('T'),
+        log: log,
+      );
+
+      await expectLater(
+        client.getJson(client.uri('users', query: {r'$skiptoken': 'PAGE-XYZ'})),
+        throwsA(isA<GraphException>()),
+      );
+      // `latest` is Graph's own sentinel, not a secret — and it is what tells a
+      // primed full read apart from a resume in the log.
+      await expectLater(
+        client.getJson(
+          client.uri('users/delta', query: {r'$deltatoken': 'latest'}),
+        ),
+        throwsA(isA<GraphException>()),
+      );
+
+      expect(log.errors.first, isNot(contains('PAGE-XYZ')));
+      expect(log.errors.first, contains('<redacted>'));
+      expect(log.errors.last, contains('latest'));
+      expect(log.errors.last, isNot(contains('<redacted>')));
+    });
+
+    test(
+        'a failure the caller declared it expects is logged as a detail, not an '
+        'error — and is still thrown', () async {
+      final transport = FakeGraphTransport.constant(rejectedToken());
+      final log = RecordingLog();
+      final client = GraphClient(
+        transport: transport,
+        auth: const StaticAuthProvider('T'),
+        log: log,
+      );
+
+      await expectLater(
+        client.getDelta(
+          client.uri('users/delta', query: {r'$deltatoken': 'DEADTOKEN'}),
+          expected: (e) => e.isRejectedDeltaToken,
+        ),
+        throwsA(isA<GraphException>()),
+      );
+
+      expect(log.errors, isEmpty,
+          reason: 'the caller recovers — nothing here for the operator to act '
+              'on');
+      expect(log.messages.single, contains('handled'));
+      expect(log.messages.single, contains('DeltaLink older than 30 days'));
+      expect(log.messages.single, isNot(contains('DEADTOKEN')));
+    });
+
+    test('a failure outside the declared shape stays an error', () async {
+      // Same status and code, a different cause: a genuinely malformed query
+      // must stay loud even on the read that comes prepared for a dead token.
+      final transport = FakeGraphTransport.constant(graphError(
+        400,
+        'Request_UnsupportedQuery',
+        "Unsupported or invalid query filter clause specified for property "
+            "'jobTitle'.",
+      ));
+      final log = RecordingLog();
+      final client = GraphClient(
+        transport: transport,
+        auth: const StaticAuthProvider('T'),
+        log: log,
+      );
+
+      await expectLater(
+        client.getDelta(
+          client.uri('users/delta', query: {r'$deltatoken': 'DEADTOKEN'}),
+          expected: (e) => e.isRejectedDeltaToken,
+        ),
+        throwsA(isA<GraphException>()),
+      );
+
+      expect(log.messages, isEmpty);
+      expect(log.errors.single, contains('jobTitle'));
+    });
+  });
+
   group('pagination', () {
     test('getCollection follows @odata.nextLink across all pages', () async {
       final transport = FakeGraphTransport((req) {

--- a/packages/azure_api/test/user_manager_test.dart
+++ b/packages/azure_api/test/user_manager_test.dart
@@ -406,4 +406,129 @@ void main() {
       expect(upn, 'jan.peeters@school.example');
     });
   });
+
+  group('loadByEmployeeIds (#224)', () {
+    /// One Graph `/users` row for a transferred-in student: the employeeId is
+    /// ours, the companyName is unset and the department still names the school
+    /// they came from — the exact shape [UserManager.load]'s `$filter` misses.
+    Map<String, dynamic> transferred(String employeeId) => <String, dynamic>{
+          'id': 'az-$employeeId',
+          'userPrincipalName': 'alfio.ambre@student.other.example',
+          'employeeId': employeeId,
+          'displayName': 'Alfio Ambre',
+          'department': 'OTHER-3A',
+        };
+
+    test('asks Graph for exactly the ids, with the advanced-query header',
+        () async {
+      final transport = FakeGraphTransport(
+        (_) => jsonOk({'value': <Object>[]}),
+      );
+      final users = UserManager(clientWith(transport));
+
+      await users.loadByEmployeeIds(['W1', 'W2']);
+
+      expect(transport.requests, hasLength(1));
+      final req = transport.last;
+      expect(req.method, 'GET');
+      expect(req.url.path, endsWith('/users'));
+      expect(
+        req.url.queryParameters[r'$filter'],
+        "employeeId in ('W1','W2')",
+      );
+      expect(req.url.queryParameters[r'$count'], 'true');
+      expect(req.headers['ConsistencyLevel'], 'eventual');
+      // The pull stays as narrow as the bulk read's (PAIN-2).
+      expect(
+        req.url.queryParameters[r'$select'],
+        'id,userPrincipalName,employeeId,displayName,givenName,surname,'
+        'companyName,department,accountEnabled',
+      );
+    });
+
+    test('returns the accounts the school filter cannot see', () async {
+      final transport = FakeGraphTransport(
+        (_) => jsonOk({
+          'value': [transferred('W7')],
+        }),
+      );
+      final users = UserManager(clientWith(transport));
+
+      final found = await users.loadByEmployeeIds(['W7']);
+
+      expect(found, hasLength(1));
+      expect(found.single.employeeId, 'W7');
+      expect(found.single.companyName, isNull);
+      expect(found.single.upn, 'alfio.ambre@student.other.example');
+    });
+
+    test('chunks a long id list and de-duplicates the result', () async {
+      final ids = [for (var i = 0; i < 32; i++) 'W$i'];
+      final transport = FakeGraphTransport(
+        (_) => jsonOk({
+          // Every chunk answers with the same row, so a naive merge would
+          // report it three times.
+          'value': [transferred('W7')],
+        }),
+      );
+      final users = UserManager(clientWith(transport));
+
+      final found = await users.loadByEmployeeIds(ids);
+
+      expect(transport.requests, hasLength(3), reason: '15 + 15 + 2');
+      expect(
+        transport.requests.last.url.queryParameters[r'$filter'],
+        "employeeId in ('W30','W31')",
+      );
+      expect(found, hasLength(1));
+    });
+
+    test('blank and duplicate ids never reach Graph', () async {
+      final transport = FakeGraphTransport(
+        (_) => jsonOk({'value': <Object>[]}),
+      );
+      final users = UserManager(clientWith(transport));
+
+      expect(await users.loadByEmployeeIds(const ['', '  ']), isEmpty);
+      expect(transport.requests, isEmpty);
+
+      await users.loadByEmployeeIds([' W1 ', 'W1', '']);
+      expect(
+        transport.last.url.queryParameters[r'$filter'],
+        "employeeId in ('W1')",
+      );
+    });
+
+    test('escapes a single quote in an id', () async {
+      final transport = FakeGraphTransport(
+        (_) => jsonOk({'value': <Object>[]}),
+      );
+      final users = UserManager(clientWith(transport));
+
+      await users.loadByEmployeeIds(["O'1"]);
+      expect(
+        transport.last.url.queryParameters[r'$filter'],
+        "employeeId in ('O''1')",
+      );
+    });
+
+    test('findByEmployeeId returns the hit, or null when the tenant has none',
+        () async {
+      final hit = FakeGraphTransport(
+        (_) => jsonOk({
+          'value': [transferred('W7')],
+        }),
+      );
+      expect(
+        (await UserManager(clientWith(hit)).findByEmployeeId('W7'))?.id,
+        'az-W7',
+      );
+
+      final miss = FakeGraphTransport((_) => jsonOk({'value': <Object>[]}));
+      expect(
+        await UserManager(clientWith(miss)).findByEmployeeId('W7'),
+        isNull,
+      );
+    });
+  });
 }

--- a/packages/smartschool_api/lib/src/parsing/group_tree.dart
+++ b/packages/smartschool_api/lib/src/parsing/group_tree.dart
@@ -59,9 +59,14 @@ SmartschoolGroup _parseGroupElement(XmlElement el, String? parentCode) {
       case 'untis':
         group.untis = child.innerText;
       case 'visible':
-        group.visible = child.innerText == '1';
+        group.visible = _flag(child.innerText);
       case 'isOfficial':
-        group.official = child.innerText == '1';
+        // Trimmed, like `adminNumber` below: a `1` that arrives padded (a CDATA
+        // section wrapped onto its own line) must not silently read as "not an
+        // official class" — that drops the class from the group link entirely
+        // and its WISA twin then looks like a class nobody has created yet
+        // (#225).
+        group.official = _flag(child.innerText);
       case 'coAccountLabel':
         group.coAccountLabel = child.innerText;
       case 'adminNumber':
@@ -100,6 +105,10 @@ Iterable<XmlElement> _childGroups(XmlElement el) sync* {
     }
   }
 }
+
+/// Smartschool's boolean flags, which it spells `1`/`0`. Trimmed, so a value
+/// padded by the surrounding XML still reads as the flag it is.
+bool _flag(String raw) => raw.trim() == '1';
 
 core.GroupType _typeFrom(String raw) {
   switch (raw) {

--- a/packages/smartschool_api/test/parsing/group_tree_test.dart
+++ b/packages/smartschool_api/test/parsing/group_tree_test.dart
@@ -85,4 +85,50 @@ void main() {
     expect(forest.first.name, 'Solo');
     expect(forest.first.code, 'S1');
   });
+
+  group('a class node carrying a subgroup (#225)', () {
+    // The shape of the real `2G`: an official class with its own subgroup
+    // hanging under it. The parent must keep its own name, code and
+    // official flag — a subgroup that reaches the snapshot while its parent
+    // does not is what made the class look like it had never been created.
+    const xml = '<groups><group>'
+        '<name>2G</name><type>K</type><code>C2G</code>'
+        '<isOfficial>1</isOfficial><adminNumber>77</adminNumber>'
+        '<children><group>'
+        '<name>2G LAT</name><type>K</type><code>C2GLAT</code>'
+        '<isOfficial>1</isOfficial>'
+        '</group></children>'
+        '</group></groups>';
+    final forest = parseGroupTree(base64.encode(utf8.encode(xml)));
+
+    test('the parent keeps its own name, code and isOfficial', () {
+      final parent = forest.single;
+      expect(parent.name, '2G');
+      expect(parent.code, 'C2G');
+      expect(parent.official, isTrue);
+      expect(parent.type, core.GroupType.classGroup);
+      expect(parent.adminNumber, 77);
+    });
+
+    test('the subgroup is nested under it, never in its place', () {
+      final child = forest.single.children.single;
+      expect(child.name, '2G LAT');
+      expect(child.code, 'C2GLAT');
+      expect(child.parentCode, 'C2G');
+      // A child can only be reached through its parent, so a snapshot that
+      // holds the subgroup necessarily holds the class above it.
+      expect(forest.single.children, hasLength(1));
+    });
+  });
+
+  test('a padded 1/0 flag still reads as the flag it is (#225)', () {
+    // A class whose `isOfficial` arrives wrapped onto its own line must not
+    // silently read as "not an official class" — that drops it from the group
+    // link and its WISA twin then looks like a class nobody has created.
+    const xml = '<group><name>2G</name><type>K</type><code>C2G</code>'
+        '<isOfficial>\n  1\n</isOfficial><visible> 1 </visible></group>';
+    final parsed = parseGroupTree(base64.encode(utf8.encode(xml))).single;
+    expect(parsed.official, isTrue);
+    expect(parsed.visible, isTrue);
+  });
 }


### PR DESCRIPTION
Batch chunk A — seven issues, one commit each, each individually green on the full local gates.

The run started from five filed issues (#224–#228); five more (#229, #230, #231, #233, and the deferred questions) were filed by workers as they went and folded into the batch, so #227/#228 moved to the next chunk.

## What changed

**`eb0afd9` — #224 transferred student's Office 365 account is invisible, so we propose a duplicate**
The `$filter` that bounds the Azure pull (`companyName eq <prefix> or startswith(department, <prefix>)`) hid exactly the accounts a transfer leaves behind. Added `UserManager.loadByEmployeeIds` (chunked `employeeId in (…)`) and an `AzureConnector` back-fill for WISA students the prefix-scoped read could not account for, covering both the full-read and delta paths; guarded `AddStudentToAzure.apply` with a pre-create `employeeId` lookup; and let `ModifyAzureSchool` fire on a **null** `companyName` so the adoption sticks.

**`7c37350` — #231 the staff counterpart**
`expectedEmployeeIds` was student-only, so a moved staff member's account was never pulled and `AddStaffToAzure` could duplicate it. Added `managedStaffEmployeeIds` (fed by the nullable `WisaStaff.wisaId` — the only Azure bridge for staff), unioned both populations into the syncer wiring, and guarded the create.

**`a0a7036` — #233 an adopted staff account is never stamped with our department**
The staff family had no Azure-writing modify action at all, so an account adopted by the back-fill never became visible to the bulk read on its own and was re-adopted every pass. Added `ModifyStaffAzureSchool`, null-tolerant and triggered on `startswith` to match `filterFor`'s server-side leg. It replaces only the leading school segment and preserves any subject suffix (`OTHER - Wiskunde` → `GBS - Wiskunde`) — an assumption tracked in #237, which needs one read-only look at the live tenant to confirm.

**`dc6b43e` — #229 a recovered delta-token rejection logs as a red error carrying the token**
`GraphClient._send` logged every non-2xx with `addError`, so a rejection the connector fully recovers from (#213) looked fatal and dumped the whole `$deltatoken`. Callers now declare the failure shape they expect (logged as a detail, still thrown), and every logged URL redacts `$deltatoken`/`$skiptoken` at every severity — `$deltatoken=latest` stays readable, since it is what separates a primed full read from a resume.

**`9bab0fc` — #230 WISA-only students never get offered both creates**
Dispatch is a pure function of the record as it stands, and `AddStudentToSmartschool` needs the Azure UPN as its `mail` — so only the Azure create could ever be offered. Added a constant `StudentAction.unlocks` and chaining in `StateApplier` that re-reads the follow-up from the **relinked** view (never the projected one: `createPrincipalName` suffixes on collision). Bounded: no refreshed view chains nothing, one run per action type, a failed link stops it. Separately, students dropped by the managed-school filter (#178) are now counted and logged instead of vanishing.

**`5f4a0a1` — #225 klas 2G proposed for creation although Smartschool has it**
Unofficial or differently-spelled Smartschool namesakes were skipped silently, so the WISA class looked uncreated. The linker now indexes **all** Smartschool groups by normalised name, attaches an unadopted namesake to the WISA record, and warns; the create actions are replaced by an informational `ClassExistsAsSmartschoolGroup` notice. Also found a concrete mechanism for the reported case: `isOfficial`/`visible` were parsed with an untrimmed `== '1'`, so a padded value read as "not an official class". The "missing from the snapshot" cause is ruled out by construction — no import rule can drop a parent while keeping its child, so a snapshot reporting `2G LAT` necessarily contains `2G`.

**`834fa29` — #226 promote the "toon enkel accounts met acties" filter**
The toggle moved above the family tab bar, defaults on, and survives tab changes; the jaar/klas tree is filtered bottom-up on `Rollup.pendingCount`, and what the filter removed is counted and named on screen. One deliberate deviation from the issue text: the Klasgroepen node is **not** hidden on a zero pending count, because after #225 a class commonly carries only informational notices — real manual work that contributes nothing to `pendingCount`. Filtering it there would have buried exactly what #225 shipped to surface.

## Test plan

Every commit was verified individually before landing; the numbers below are the final state of the branch.

- `dart format --set-exit-if-changed .` — clean, 289 files, 0 changed
- `dart analyze --fatal-infos --fatal-warnings` / `flutter analyze` — clean
- `dart test` per package — account_core 76, wisa_api 127, smartschool_api 135, azure_api 102, account_linker 67, account_actions 148, account_state 377, account_store 8 — all pass; ~11 skipped throughout are the opt-in live tests, deliberately not run
- `flutter test` (account_manager widget) — 312 pass
- `flutter test integration_test/app_launch_test.dart -d windows` — 63 pass, including the new e2e cases for #224, #225, #226, #229, #230, #231 and #233
- Each issue's new test was confirmed **failing on unpatched code** before the fix was restored — for #224 that is the operator-visible symptom itself (`Found 1 widget with text "Maak een nieuw Office 365 account"`).

No live WISA / Smartschool / Azure hosts were contacted.

## Follow-ups filed during this chunk

Scheduled into the next chunk: #234, #235, #236, #239, #240, #241 — plus #227 and #228 from the original list.

Deferred, because they need a decision rather than code:
- **#232** — should an adopted transfer account's UPN local part be normalised, and what happens to mail sent to the old address?
- **#237** — confirm what a staff Azure `department` actually holds, one school or several. Legacy renders it under an "Active Schools" header and both linkers test it with `contains`, which would make `a0a7036`'s head-replacement wrong (it should prepend). Nothing in either codebase writes such a value today, so it cannot be settled from the repo.

Closes #224
Closes #225
Closes #226
Closes #229
Closes #230
Closes #231
Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
