### PR TITLE
Batch: Office 365 class groups, live werkdatum, and import-rule matching (#228 #238 #239 #240 #241 #245)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -4010,6 +4010,71 @@ void main() {
   });
 
   testWidgets(
+      'a Synchroniseer says in the Log panel which werkdatum it pulled, and '
+      'names the virtuele werkdatum where a virtual school used it (#239)',
+      (WidgetTester tester) async {
+    // The operator's actual predicament: Acties is empty for the new intake and
+    // nothing anywhere in the app names the school year the view describes, so
+    // a pull that landed on last year's roster is indistinguishable from a class
+    // that went missing. The pass now says what it asked WISA for, in the same
+    // panel the skipped namesakes (#225), the skipped students (#230) and the
+    // unmatched import rules (#241) report into — and this drives the real app
+    // over the *production* WISA pull, so the line is checked against what
+    // actually went out on the wire.
+    useTallWindow(tester);
+    final stored = AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9, 1)),
+        virtualWorkDate:
+            WorkDateSetting(isNow: false, date: DateTime(2025, 10, 1)),
+      ),
+      wisaSchools: const <WisaSchoolProfile>[
+        WisaSchoolProfile(
+          schoolId: 99,
+          code: 'V',
+          name: 'Virtuele school',
+          virtual: true,
+        ),
+      ],
+    );
+    final wire = RecordingWisaSoap(schools: const <(int, String, String)>[
+      (1, 'School 1', 'S1'),
+      (99, 'Virtuele school', 'V'),
+    ]);
+    final harness = ReconcileHarness(
+      wisaTransport: wire,
+      liveSettings: LiveSettings(stored),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // Both dates really went out — the ordinary school on the werkdatum, the
+    // virtual one on the virtuele werkdatum.
+    expect(wire.werkdatums, <String>['01/09/2025', '01/10/2025']);
+    // …and the Log panel names them, in the wire's own dd/MM/yyyy, beside the
+    // school that used the second one.
+    expect(find.byKey(const ValueKey('reconcile-log-panel')), findsOneWidget);
+    expect(
+      find.textContaining(
+        'Pulling WISA with werkdatum 01/09/2025; virtuele werkdatum '
+        '01/10/2025 for V.',
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
       'a Check for drift whose stored Azure delta token Graph refuses still '
       'finishes, on a full re-read that leaves a usable token behind, and '
       'reads as the clean pass it was (#213/#229)',

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -22,6 +22,7 @@ import 'package:account_state/account_state.dart'
         CosmosThrottleGovernor,
         InMemoryLinkedStore,
         InMemorySignalHub,
+        LiveSettings,
         MaterializedAccount,
         SecretRef,
         SignalRConfig,
@@ -35,6 +36,7 @@ import 'package:account_state/account_state.dart'
         WisaConnection,
         WisaSchoolProfile,
         WisaSchoolProfileLabel,
+        WorkDateSetting,
         signalRRecordSeparator;
 import 'package:azure_api/azure_api.dart'
     show AzureCredentials, StaticAuthProvider;
@@ -3902,6 +3904,109 @@ void main() {
     // operator could not make before.
     expect(find.textContaining('Import rule "organisatie"'), findsNothing);
     expect(find.textContaining('Import rule "KLASSEN"'), findsNothing);
+  });
+
+  testWidgets(
+      'a werkdatum saved in Instellingen reaches the very next Synchroniseer, '
+      'and Check for drift refuses until it has (#238)',
+      (WidgetTester tester) async {
+    // The whole loop the operator lives, end-to-end in the real app: sync,
+    // change the werkdatum in Instellingen, save, sync again — and read back
+    // which date WISA was actually asked for. Both bootstraps share **one**
+    // LiveSettings, exactly as `main()` wires them; before #238 they each held
+    // their own frozen copy, so a saved werkdatum reached the connector only
+    // after a relaunch and nothing on screen said so.
+    useTallWindow(tester);
+    final stored = AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9, 1)),
+      ),
+    );
+    final live = LiveSettings(stored);
+    final wire = RecordingWisaSoap();
+    final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+    final settings = SettingsHarness(initial: stored, liveSettings: live);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // A first Synchroniseer pulls WISA with the stored werkdatum.
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(wire.werkdatums, <String>['01/09/2025']);
+
+    // Now the operator moves the werkdatum, the way they do: Instellingen →
+    // Algemeen → Kies datum → Opslaan.
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+    final pick = find.byKey(const ValueKey('settings-workdate-pick'));
+    await tester.ensureVisible(pick);
+    await tester.pumpAndSettle();
+    await tester.tap(pick);
+    await tester.pumpAndSettle();
+    await tester.tap(find.descendant(
+      of: find.byType(DatePickerDialog),
+      matching: find.text('15'),
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.descendant(
+      of: find.byType(DatePickerDialog),
+      matching: find.text('OK'),
+    ));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    expect(
+      (await settings.store.load()).wisa.workDate.date,
+      DateTime(2025, 9, 15),
+    );
+
+    // Back on Reconcile the change is *visible*: Check for drift is disabled
+    // and says why. A drift pass never re-reads WISA, so running one now would
+    // relink against the roster the change never reached and publish that to
+    // every other operator.
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('reconcile-drift-blocked')),
+      findsOneWidget,
+    );
+    expect(
+      find.text('WISA-instellingen gewijzigd — synchroniseer eerst.'),
+      findsOneWidget,
+    );
+    final OutlinedButton drift = tester.widget<OutlinedButton>(
+      find.byKey(const ValueKey('reconcile-drift')),
+    );
+    expect(drift.onPressed, isNull);
+    // Synchroniseer stays available — it is the way out.
+    final FilledButton syncButton = tester.widget<FilledButton>(
+      find.byKey(const ValueKey('reconcile-sync')),
+    );
+    expect(syncButton.onPressed, isNotNull);
+
+    // Pressing it pulls WISA with the werkdatum just saved — no relaunch — and
+    // the drift check is offered again.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(wire.werkdatums, <String>['01/09/2025', '15/09/2025']);
+    expect(find.byKey(const ValueKey('reconcile-drift-blocked')), findsNothing);
+    expect(
+      tester
+          .widget<OutlinedButton>(find.byKey(const ValueKey('reconcile-drift')))
+          .onPressed,
+      isNotNull,
+    );
   });
 
   testWidgets(

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1362,20 +1362,144 @@ void main() {
     expect(body['mailEnabled'], isTrue);
     expect(body['securityEnabled'], isFalse);
 
-    // The created group is spliced into the snapshot, so the very next render
-    // no longer offers the create — it offers the roster the empty group needs.
+    // The one click also filled the group (#245). Graph creates a group empty,
+    // so the create used to land an `GBS-2F` with nobody in it and the roster
+    // waited for a second click; the applier now chains the membership write
+    // against the relinked record — the only place the id Graph just minted
+    // exists — and both sub-groups' students land in the one parent group.
+    expect(
+      harness.graph.batchedWrites,
+      hasLength(2),
+      reason: "both sub-groups' students belong to the one parent group",
+    );
+    expect(
+      harness.graph.batchedWrites,
+      everyElement(startsWith('POST /groups/az-group-1/members')),
+    );
+    expect(
+      find.textContaining('Werk het ledenbestand van GBS-2F bij (2 toevoegen'),
+      findsOneWidget,
+      reason: 'the chained write is reported beside the create, not hidden',
+    );
+
+    // …so nothing about this class is left pending: no create, and no roster.
     final kinds = harness.controller.pendingEntries
         .expand((e) => e.choices)
         .expand((c) => c.alternatives)
         .map((a) => a.kind)
         .toList();
     expect(kinds, isNot(contains('CreateAzureClassGroup')));
-    expect(kinds, contains('SyncAzureClassGroupMembers'));
+    expect(kinds, isNot(contains('SyncAzureClassGroupMembers')));
+  });
+
+  testWidgets(
+      "a student's Office 365 class group is reported on their own account "
+      'end-to-end, pointing at the one class-level write (#245)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. Both classes already have
+    // their group and are in sync with Smartschool, so the Azure roster is the
+    // only work: Jane is missing from her own GBS-1A, and Sam — who moved to
+    // 1B — is missing from GBS-1B while still sitting in GBS-1A.
+    //
+    // This is the layer that sees what the issue is actually about: whether an
+    // operator who opens *one* student finds their class-group placement there
+    // at all. The Klasgroepen row and the account row are two projections of the
+    // same dispatch, composed by different screens, and only a full-app run
+    // shows both and proves the write is offered exactly once.
+    useTallWindow(tester);
+    final harness = azureClassMembershipHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+
+    // The class rows still carry the single applyable write, on both classes.
+    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+    // (Both classes raise the same kind of action, so the list also renders a
+    // "same situation" header carrying the first one's summary — hence
+    // findsWidgets rather than findsOneWidget.)
     expect(
-      find.textContaining('Werk het ledenbestand van GBS-2F bij (2 toevoegen'),
-      findsOneWidget,
-      reason: 'both sub-groups\' students belong to the one parent group',
+      find.textContaining('Werk het ledenbestand van GBS-1A bij '
+          '(1 toevoegen, 1 verwijderen)'),
+      findsWidgets,
     );
+    expect(
+      find.textContaining('Werk het ledenbestand van GBS-1B bij (1 toevoegen'),
+      findsWidgets,
+    );
+    await tester.tap(find.byKey(const ValueKey('actions-groups-back')));
+    await tester.pumpAndSettle();
+
+    // Nothing applyable hangs off either class's *students*, so the work list
+    // hides them — the switch is what turns the view into the inventory an
+    // operator answering a phone call browses (#226).
+    expect(find.byKey(const ValueKey('rollup-grade-grades|1')), findsNothing);
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+
+    // Closing a classroom rebuilds — and so collapses — the tree, so the year
+    // is re-opened for each of the two students.
+    Future<void> openYear() async {
+      final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
+      await tester.ensureVisible(yearNode);
+      await tester.tap(yearNode);
+      await tester.pumpAndSettle();
+    }
+
+    // Sam, in 1B: one line, naming both groups, and marked as a manual fix.
+    await openYear();
+    await tester
+        .ensureVisible(find.byKey(const ValueKey('rollup-class-class|1|1|1B')));
+    await tester.tap(find.byKey(const ValueKey('rollup-class-class|1|1|1B')));
+    await tester.pumpAndSettle();
+    expect(find.text('Sam Sels'), findsOneWidget);
+    expect(
+      find.textContaining(
+          'Zit in de verkeerde Office 365-klasgroep: GBS-1A in plaats van '
+          'GBS-1B'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('(manueel)'), findsWidgets,
+        reason: 'the class row performs the write, so this one diagnoses');
+
+    // Jane, in 1A: the plain "missing from her own group" reading.
+    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
+    await tester.pumpAndSettle();
+    await openYear();
+    await tester
+        .ensureVisible(find.byKey(const ValueKey('rollup-class-class|1|1|1A')));
+    await tester.tap(find.byKey(const ValueKey('rollup-class-class|1|1|1A')));
+    await tester.pumpAndSettle();
+    expect(find.text('Jane Doe'), findsOneWidget);
+    expect(
+      find.textContaining('Ontbreekt in de Office 365-klasgroep GBS-1A'),
+      findsOneWidget,
+    );
+
+    // And the account view offers no second write for the same fact: only the
+    // two class-level syncs are applyable anywhere.
+    final applyable = harness.controller.pendingEntries
+        .expand((e) => e.choices)
+        .expand((c) => c.alternatives)
+        .where((a) => a.canApply)
+        .map((a) => a.kind)
+        .toList();
+    expect(applyable,
+        ['SyncAzureClassGroupMembers', 'SyncAzureClassGroupMembers']);
   });
 
   testWidgets(

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -4592,6 +4592,119 @@ void main() {
     expect(messages, contains(contains('Maak een nieuw Office 365 account')));
     expect(messages, contains(contains('Maak een nieuw Smartschool account')));
   });
+
+  testWidgets(
+      'a WISA-only staff member is provisioned by one apply in Acties → '
+      'Personeel (#240)', (WidgetTester tester) async {
+    // The staff twin of the #230 student case, and the same two-pass friction:
+    // AddStaffToSmartschool builds its account with the Azure UPN as the `mail`,
+    // so it evaluates false until the Office 365 account exists, and the
+    // dispatch — a pure function of the record as it stands — can only ever
+    // offer the first link. The operator had to apply, notice the relink, and
+    // apply again; Acties → Personeel never showed the full provisioning intent.
+    //
+    // Only a run of the real app covers the whole path: the staff member has to
+    // reach the synthetic "Personeel" tree at all, the tile has to offer the
+    // create, and the follow-up has to run against the record the *relink*
+    // produced — `createPrincipalName` suffixes on a UPN collision, so the
+    // Smartschool account must carry the UPN that landed, not the projection.
+    useTallWindow(tester);
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(students: const [], staff: [wisaStaff()]),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // Browse Acties → Personeel: the staff member is under the synthetic staff
+    // school, with the first link of the chain offered and only that one.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+    final staffSchool =
+        find.byKey(const ValueKey('rollup-school-school|staff'));
+    await tester.ensureVisible(staffSchool);
+    await tester.tap(staffSchool);
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
+    await tester.pumpAndSettle();
+    final staffClass = find
+        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
+    await tester.ensureVisible(staffClass);
+    await tester.tap(staffClass);
+    await tester.pumpAndSettle();
+    expect(
+        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+    expect(find.text('Anna Smit'), findsWidgets,
+        reason: 'a staff member with no downstream account is still listed');
+    expect(find.text('Maak een nieuw Office 365 account'), findsOneWidget);
+    expect(find.text('Maak een nieuw Smartschool account'), findsNothing,
+        reason: 'the dispatch can only see the first link of the chain');
+
+    // Apply that one row.
+    final entry = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'staff');
+    final id = entry.targetId;
+    await tester.ensureVisible(find.byKey(ValueKey('entry-staff-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-staff-$id')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+    expect(find.text('Apply result'), findsOneWidget);
+
+    // Both accounts exist now, off that single click, and both writes are
+    // reported — the second is a real write the operator must see, not a silent
+    // extra. The third row is the entry's *other* pending item, the WISA ignore
+    // rule this family also offers for a staff member with no Smartschool
+    // account; it is not part of the chain (tracked as #248).
+    expect(
+      harness.controller.applyResults!.map((r) => r.changes.summary),
+      <String>[
+        'Maak een nieuw Office 365 account',
+        'Maak een nieuw Smartschool account',
+        'Negeer dit account bij het importeren uit WISA',
+      ],
+    );
+    expect(
+      harness.controller.applyResults!.map((r) => r.outcome.name),
+      everyElement('applied'),
+    );
+    expect(harness.graph.createdUsers.single['employeeId'], '42',
+        reason: 'the staff Azure bridge is wisaId, never the staff code');
+    expect(harness.soap.soapActions.any((a) => a.contains('saveUser')), isTrue);
+
+    // The Smartschool account carries the UPN that actually landed, and the
+    // WISA staff `code` as its accountId (the staff Smartschool bridge).
+    final linked = harness.controller.linked!.snapshot.staff.single;
+    expect(linked.azure, isNotNull);
+    expect(linked.smartschool?.mail, linked.azure?.upn);
+    expect(linked.smartschool?.accountId, 'SMIT');
+
+    // And both writes are in the log the operator reads.
+    final messages = harness.log.entries.map((e) => e.message);
+    expect(messages, contains(contains('Maak een nieuw Office 365 account')));
+    expect(messages, contains(contains('Maak een nieuw Smartschool account')));
+  });
 }
 
 /// A broker scripted per test — a fake WAM broker so no live tenant is touched.

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3832,6 +3832,79 @@ void main() {
   });
 
   testWidgets(
+      'a Smartschool import rule fires however the operator spelled it, and a '
+      'rule that matches nothing says so in the log (#241)',
+      (WidgetTester tester) async {
+    // The whole loop the operator lives: author the rules in Instellingen, then
+    // Synchronise and read the Log panel. The rules used to be matched against
+    // the group tree with a raw `==`, so a rule typed in lower case — or one
+    // carrying the spacing of a name pasted out of Smartschool — quietly did
+    // nothing at all, and looked exactly like a rule that had matched a subtree
+    // which was already empty. Both halves are checked end-to-end here: the
+    // differently-spelled rules really prune the pull, and the third rule
+    // (a typo) is named in the panel instead of vanishing.
+    useTallWindow(tester);
+    final settings = SettingsHarness();
+    final wire = _GroupTreeSoap();
+    // The next session's reconcile stack, whose Smartschool pull is the
+    // production connector over that wire; its rules are picked up from the
+    // settings document below, as bootstrapReconcile picks them up on open.
+    final harness = ReconcileHarness(smartschoolTransport: wire);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-smartschool');
+
+    // Smartschool spells them `Organisatie` and `Klassen`; the operator does
+    // not, and never had a reason to think it mattered. The third rule names a
+    // group Smartschool does not carry at all.
+    await addSmartschoolRule(tester, 'discardGroup', 'organisatie');
+    await addSmartschoolRule(tester, 'noSubgroups', 'KLASSEN');
+    await addSmartschoolRule(tester, 'discardGroup', 'Sportclub');
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await settings.store.load();
+    expect(saved.smartschoolRules, hasLength(3));
+    harness.smartschoolRules = saved.smartschoolRules;
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // The pull really was pruned by rules spelled nothing like the tree:
+    // "Organisatie" and its subtree are gone, "Klassen" survives as a leaf, and
+    // the connector never even asked Smartschool about the removed groups.
+    expect(
+      harness.app.smartschool.snapshot?.groups.map((g) => g.id.value).toList(),
+      <String>['SCH', 'KLA'],
+    );
+    expect(wire.accountCodes, <String>['SCH', 'KLA']);
+
+    // …and the rule that matched nothing is named in the Log panel, so the
+    // typo is visible rather than silent.
+    expect(
+      find.textContaining(
+        'Import rule "Sportclub" matched no Smartschool group in this pull',
+      ),
+      findsOneWidget,
+    );
+    // The two that did fire are not reported — that is the distinction the
+    // operator could not make before.
+    expect(find.textContaining('Import rule "organisatie"'), findsNothing);
+    expect(find.textContaining('Import rule "KLASSEN"'), findsNothing);
+  });
+
+  testWidgets(
       'a Check for drift whose stored Azure delta token Graph refuses still '
       'finishes, on a full re-read that leaves a usable token behind, and '
       'reads as the clean pass it was (#213/#229)',

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1289,6 +1289,96 @@ void main() {
   });
 
   testWidgets(
+      'a class without an Office 365 group is proposed once — named after the '
+      'parent class — and applying it creates a unified group end-to-end '
+      '(#228)', (WidgetTester tester) async {
+    // The real app, real fonts, real navigation, over the real Graph write
+    // path. Our school runs `1A` (already provisioned as GBS-1A, with its
+    // student in it) and the sub-grouped `2F` (`2F ECO` + `2F MAW`), which has
+    // no group at all. Four linked class records, one missing group.
+    //
+    // This is the layer that sees the two things that matter: that the operator
+    // gets **one** proposal rather than one per sub-group — the bare class name
+    // is gone by the time an action sees a record, so a naive implementation
+    // offers `GBS-2F ECO` and `GBS-2F MAW` — and that the write Graph receives
+    // is a mail-enabled Microsoft 365 group, not the security group legacy made
+    // for staff.
+    useTallWindow(tester);
+    final harness = azureClassGroupHarness(withStaleGroup: true);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+
+    // One proposal, named after the parent class `2F` — not `2F ECO`.
+    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
+    expect(
+      find.text('Maak de Office 365-groep GBS-2F voor klas 2F'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('GBS-2F ECO'), findsNothing,
+        reason: 'sub-groups get no group of their own');
+    expect(find.byKey(const ValueKey('entry-group-1A')), findsNothing,
+        reason: 'GBS-1A exists and holds its student — nothing to propose');
+
+    // The group of a class that no longer exists is reported, never deleted.
+    expect(
+      find.textContaining('De klas 9Z bestaat niet meer'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('(manueel)'), findsWidgets);
+
+    // Expand the class's row and apply just it.
+    const entry = ValueKey('entry-group-2F ECO');
+    await tester.ensureVisible(find.byKey(entry));
+    await tester.tap(find.byKey(entry));
+    await tester.pumpAndSettle();
+    const row = ValueKey('entry-apply-2F ECO');
+    await tester.ensureVisible(find.byKey(row));
+    await tester.tap(find.byKey(row));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+    expect(find.text('Apply result'), findsOneWidget);
+
+    // Graph was asked for exactly one group, and for the right kind of group.
+    expect(harness.graph.createdGroups, hasLength(1));
+    final body = harness.graph.createdGroups.single;
+    expect(body['displayName'], 'GBS-2F');
+    expect(body['mailNickname'], 'GBS-2F');
+    expect(body['groupTypes'], ['Unified']);
+    expect(body['mailEnabled'], isTrue);
+    expect(body['securityEnabled'], isFalse);
+
+    // The created group is spliced into the snapshot, so the very next render
+    // no longer offers the create — it offers the roster the empty group needs.
+    final kinds = harness.controller.pendingEntries
+        .expand((e) => e.choices)
+        .expand((c) => c.alternatives)
+        .map((a) => a.kind)
+        .toList();
+    expect(kinds, isNot(contains('CreateAzureClassGroup')));
+    expect(kinds, contains('SyncAzureClassGroupMembers'));
+    expect(
+      find.textContaining('Werk het ledenbestand van GBS-2F bij (2 toevoegen'),
+      findsOneWidget,
+      reason: 'both sub-groups\' students belong to the one parent group',
+    );
+  });
+
+  testWidgets(
       'the Acties drill-down opens on grade-years merged across the managed '
       'schools end-to-end, with no school level to guess at (#210)',
       (WidgetTester tester) async {

--- a/account_manager/lib/main.dart
+++ b/account_manager/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:account_state/account_state.dart' show LiveSettings;
 import 'package:azure_api/azure_api.dart'
     show
         EncryptedTokenCache,
@@ -52,6 +53,14 @@ void main() {
 
   final session = SignInSession(broker);
 
+  // One settings document, shared by the two otherwise-independent bootstraps
+  // (#238). The Settings view publishes every document it loads or saves into
+  // it; the reconcile stack's WISA pull reads it back at pull time, and the
+  // reconcile screen refuses a drift check while a saved change has not been
+  // synced yet. Without this shared instance the two stacks each held their own
+  // copy and a save reached the connectors only on the next launch.
+  final liveSettings = LiveSettings();
+
   runApp(
     AccountManagerApp(
       session: session,
@@ -64,7 +73,11 @@ void main() {
       // failed attempt is not cached, so the reconcile screen's retry re-runs it.
       reconcileBootstrap: config.isConfigured
           ? _memoizeOnSuccess(
-              () => bootstrapReconcile(session: session, aad: config),
+              () => bootstrapReconcile(
+                session: session,
+                aad: config,
+                liveSettings: liveSettings,
+              ),
             )
           : null,
       // The settings seams (Cosmos-backed store + Key Vault secrets) are
@@ -74,7 +87,12 @@ void main() {
       // incomplete config, so it must not depend on the connectors bootstrapping
       // successfully.
       settingsBootstrap: config.isConfigured
-          ? _memoizeOnSuccess(() => bootstrapSettings(session: session))
+          ? _memoizeOnSuccess(
+              () => bootstrapSettings(
+                session: session,
+                liveSettings: liveSettings,
+              ),
+            )
           : null,
     ),
   );

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -388,6 +388,7 @@ Future<ReconcileServices> bootstrapReconcile({
           wisaConnector,
           settings: live,
           rules: wisaRules,
+          log: logBuffer,
           clock: now,
         ),
       ),
@@ -563,10 +564,16 @@ String smartschoolSiteFrom(String uri) {
 /// Schools are re-read per sync so a WISA-side school change is picked up;
 /// `MarkAsVirtual` rules and the operator's virtual marks are applied to them
 /// before the row pulls, the other rules at snapshot construction.
+///
+/// Because this is the one place a pass's work dates are resolved, it is also
+/// the one place that can say what they were: [log] gets a single
+/// [wisaPullMessage] line naming them, written before the row queries go out so
+/// even a pull that then fails has said what it asked for (#239).
 Syncer<wapi.WisaSnapshot> wisaSyncer(
   wapi.WisaConnector connector, {
   required LiveSettings settings,
   required WisaImportRules rules,
+  core.ILog? log,
   DateTime Function() clock = DateTime.now,
 }) =>
     (_) async {
@@ -582,13 +589,63 @@ Syncer<wapi.WisaSnapshot> wisaSyncer(
         current.virtualWisaSchoolIds,
       );
       final at = clock();
+      final workDate = current.wisa.workDate.resolve(at);
+      final virtualWorkDate = current.wisa.virtualWorkDate.resolve(at);
+      log?.addMessage(
+        core.Origin.wisa,
+        wisaPullMessage(
+          schools: schools,
+          workDate: workDate,
+          virtualWorkDate: virtualWorkDate,
+        ),
+      );
       return connector.sync(
         schools: schools,
-        workDate: current.wisa.workDate.resolve(at),
-        virtualWorkDate: current.wisa.virtualWorkDate.resolve(at),
+        workDate: workDate,
+        virtualWorkDate: virtualWorkDate,
         rules: importRules,
       );
     };
+
+/// The single line a WISA pull writes to name the dates it asked WISA for
+/// (#239).
+///
+/// The werkdatum is a per-pass input the whole materialized view depends on:
+/// WISA returns enrolments *as of* that date, so a pass run on the wrong side of
+/// the school-year rollover simply has none of the new intake in it — which on
+/// the Acties screen reads exactly like a class that went missing. Nothing else
+/// in the app names the school year the current view describes, so an operator
+/// could only tell the two apart by opening Instellingen and reasoning about the
+/// boundary themselves.
+///
+/// Both dates are rendered with the connector's own [wapi.formatWerkdatum], so
+/// the line reads exactly as the `Werkdatum` SOAP parameter went out. The
+/// virtuele werkdatum is named only when a school in *this* pull actually used
+/// it — reporting a second date no query carried would be its own kind of lie.
+String wisaPullMessage({
+  required Iterable<wapi.WisaSchool> schools,
+  required DateTime workDate,
+  required DateTime virtualWorkDate,
+}) {
+  final virtual = <String>[
+    for (final s in schools)
+      if (s.isVirtual) _schoolLabel(s),
+  ];
+  final head = 'Pulling WISA with werkdatum ${wapi.formatWerkdatum(workDate)}';
+  if (virtual.isEmpty) return '$head.';
+  return '$head; virtuele werkdatum '
+      '${wapi.formatWerkdatum(virtualWorkDate)} for ${virtual.join(', ')}.';
+}
+
+/// How a school is named in the pull line: the short code the rest of the WISA
+/// sync log uses ("Loading classgroups from ISMAA succeeded."), falling back to
+/// the long name and finally the id, so a school whose `SMAGetInst` row carries
+/// no DESCRIPTION is still identifiable rather than an empty gap.
+String _schoolLabel(wapi.WisaSchool school) {
+  if (school.code.trim().isNotEmpty) return school.code.trim();
+  if (school.name.trim().isNotEmpty) return school.name.trim();
+  return 'school ${school.id}';
+}
 
 /// Flags the operator's virtual WISA schools on a freshly loaded school list.
 ///

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -85,6 +85,7 @@ class StoreEndpoints {
 class ReconcileServices {
   const ReconcileServices({
     required this.settings,
+    required this.liveSettings,
     required this.app,
     required this.applier,
     required this.controller,
@@ -95,7 +96,16 @@ class ReconcileServices {
     this.passwordFileOpener = openPasswordExport,
   });
 
+  /// The settings document as it stood when the stack was assembled. A
+  /// point-in-time copy: what the WISA pull actually uses lives in
+  /// [liveSettings] (#238).
   final AppSettings settings;
+
+  /// The shared settings holder the WISA syncer reads at pull time and the
+  /// Settings view publishes into, so a saved werkdatum reaches the next
+  /// Synchroniseer without relaunching the app (#238).
+  final LiveSettings liveSettings;
+
   final ApplicationState app;
   final StateApplier applier;
   final ReconcileController controller;
@@ -141,15 +151,22 @@ class ReconcileConfigException implements Exception {
 /// connectors (Graph calls carry the session token from #98), and assembles
 /// `ApplicationState` → `StateApplier` → [ReconcileController].
 ///
+/// [liveSettings] is the process-wide settings holder the Settings view
+/// publishes into (#238). The WISA pull reads its werkdatum pair and virtual
+/// marks from it at pull time, so a save reaches the next Synchroniseer without
+/// a relaunch. Production wires the same instance into [bootstrapSettings];
+/// omitting it gives this stack a private holder that only bootstrap writes.
+///
 /// The optional parameters are test seams; production callers pass only
-/// [session] and [aad]. The Cosmos containers are provisioned out of band (see
-/// `docs/port-plan.md`); bootstrap additionally runs an idempotent
-/// [ensureContainers] preflight (a metadata read that creates nothing on the
-/// provisioned account) so a never-stood-up container surfaces at startup rather
-/// than as a silent item-write 404 mid-session (#150).
+/// [session], [aad] and [liveSettings]. The Cosmos containers are provisioned
+/// out of band (see `docs/port-plan.md`); bootstrap additionally runs an
+/// idempotent [ensureContainers] preflight (a metadata read that creates nothing
+/// on the provisioned account) so a never-stood-up container surfaces at startup
+/// rather than as a silent item-write 404 mid-session (#150).
 Future<ReconcileServices> bootstrapReconcile({
   required SignInSession session,
   required AadAppConfig aad,
+  LiveSettings? liveSettings,
   StoreEndpoints? endpoints,
   SettingsStore? settingsStore,
   SecretProvider? secretProvider,
@@ -200,6 +217,12 @@ Future<ReconcileServices> bootstrapReconcile({
 
   final store = settingsStore ?? CosmosSettingsStore(client);
   final settings = await store.load();
+  // Adopt what we just loaded as the live document (#238). Everything that has
+  // to honour a later save — the WISA pull's werkdatum pair and virtual marks,
+  // and the drift gate that refuses to reconcile against a roster the change
+  // never reached — reads `live.current`, never this local.
+  final live = liveSettings ?? LiveSettings();
+  live.publish(settings);
 
   // The cold snapshot store (#107): a fresh session seeds its SystemStates from
   // here instead of pulling, and every successful sync writes the fresh
@@ -352,34 +375,21 @@ Future<ReconcileServices> bootstrapReconcile({
     wisa: SystemState<wapi.WisaSnapshot>(
       system: core.Origin.wisa,
       initial: wisaSeed,
-      // Schools are re-read per sync so a WISA-side school change is picked
-      // up; MarkAsVirtual rules and the operator's per-school virtual marks
-      // (#203) are applied to them before the row pulls, the other rules at
-      // snapshot construction. Rules are read live from the shared holder so a
-      // DontImportFromWisa apply affects the re-sync (#72).
-      // The pull is wrapped so each fresh snapshot is persisted (#107).
+      // The pull is wrapped so each fresh snapshot is persisted (#107); what it
+      // asks WISA for is composed by [wisaSyncer], which reads the settings and
+      // the rules live.
       syncer: persistingSyncer<wapi.WisaSnapshot>(
         system: core.Origin.wisa,
         store: snapshots,
         syncedBy: syncedBy,
         payloadOf: (s) => s.toJson(),
         onError: (e) => logSnapshotIssue(core.Origin.wisa, e),
-        inner: (_) async {
-          final schools = markVirtualSchools(
-            wapi.WisaConnector.applySchoolRules(
-              await wisaConnector.loadSchools(),
-              wisaRules.rules,
-            ),
-            settings.virtualWisaSchoolIds,
-          );
-          final at = now();
-          return wisaConnector.sync(
-            schools: schools,
-            workDate: settings.wisa.workDate.resolve(at),
-            virtualWorkDate: settings.wisa.virtualWorkDate.resolve(at),
-            rules: wisaRules.rules,
-          );
-        },
+        inner: wisaSyncer(
+          wisaConnector,
+          settings: live,
+          rules: wisaRules,
+          clock: now,
+        ),
       ),
     ),
     smartschool: SystemState<ss.SmartschoolSnapshot>(
@@ -482,6 +492,9 @@ Future<ReconcileServices> bootstrapReconcile({
     // (#207), so a profile stored before the two halves existed stops rendering
     // as "School 25" in the Settings grid, which consults no snapshot.
     settingsStore: store,
+    // The live document, so the drift gate can tell that the WISA pull inputs
+    // moved since the installed snapshot was pulled (#238).
+    liveSettings: live,
     publisher: signalPublisher,
     subscriber: signalSubscriber,
     clock: now,
@@ -489,6 +502,7 @@ Future<ReconcileServices> bootstrapReconcile({
 
   return ReconcileServices(
     settings: settings,
+    liveSettings: live,
     app: app,
     applier: applier,
     controller: controller,
@@ -531,6 +545,50 @@ String smartschoolSiteFrom(String uri) {
   if (host.isNotEmpty) return host.split('.').first;
   return trimmed;
 }
+
+/// The WISA pull, composed the way the app runs it — the counterpart of
+/// `account_state`'s [azureSyncer], so a test can drive the *production* pull
+/// over a fake SOAP transport instead of re-deriving it.
+///
+/// Two things are read **live**, at pull time, rather than captured when the
+/// stack is wired:
+///
+/// - the import [rules], so a `DontImportFromWisa` apply reaches the re-sync it
+///   triggers (#72);
+/// - the operator's [settings] — the werkdatum, the virtuele werkdatum, and the
+///   per-school virtual marks (#203). Before #238 these were closed over as an
+///   immutable `AppSettings` read once at bootstrap, so saving a new werkdatum
+///   in Instellingen changed nothing until the app was relaunched.
+///
+/// Schools are re-read per sync so a WISA-side school change is picked up;
+/// `MarkAsVirtual` rules and the operator's virtual marks are applied to them
+/// before the row pulls, the other rules at snapshot construction.
+Syncer<wapi.WisaSnapshot> wisaSyncer(
+  wapi.WisaConnector connector, {
+  required LiveSettings settings,
+  required WisaImportRules rules,
+  DateTime Function() clock = DateTime.now,
+}) =>
+    (_) async {
+      // One consistent read for the whole pull: a save landing mid-pull must not
+      // split the school list and the work dates across two documents.
+      final current = settings.current;
+      final importRules = rules.rules;
+      final schools = markVirtualSchools(
+        wapi.WisaConnector.applySchoolRules(
+          await connector.loadSchools(),
+          importRules,
+        ),
+        current.virtualWisaSchoolIds,
+      );
+      final at = clock();
+      return connector.sync(
+        schools: schools,
+        workDate: current.wisa.workDate.resolve(at),
+        virtualWorkDate: current.wisa.virtualWorkDate.resolve(at),
+        rules: importRules,
+      );
+    };
 
 /// Flags the operator's virtual WISA schools on a freshly loaded school list.
 ///

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -275,6 +275,7 @@ class ReconcileController extends ChangeNotifier {
     this.syncedBy = '',
     this.schoolProfiles = const <WisaSchoolProfile>[],
     this.settingsStore,
+    this.liveSettings,
     this.publisher,
     this.subscriber,
     this.persistTimeout = const Duration(minutes: 10),
@@ -282,6 +283,13 @@ class ReconcileController extends ChangeNotifier {
   }) : _now = clock ?? DateTime.now {
     final sub = subscriber;
     if (sub != null) _signalSub = sub.signals.listen(_onSignal);
+    // The snapshot this session starts with — seeded from the cold store, or
+    // pulled later — belongs to the settings as they stand right now (#238).
+    _wisaPullFingerprint = _wisaFingerprint();
+    // A save the operator makes in Instellingen must repaint this screen: it is
+    // kept alive across tab switches, so nothing else would tell it the WISA
+    // pull inputs moved.
+    _settingsSub = liveSettings?.changes.listen((_) => notifyListeners());
   }
 
   /// The three connector snapshots (owned by the State layer).
@@ -324,6 +332,20 @@ class ReconcileController extends ChangeNotifier {
   /// repair.
   final SettingsStore? settingsStore;
 
+  /// The live settings document (#238) — the same holder the WISA syncer reads
+  /// at pull time and the Settings view publishes into on every load and save.
+  ///
+  /// The controller uses it for one thing: to tell whether the WISA pull inputs
+  /// (werkdatum, virtuele werkdatum, virtual-school marks) have moved since the
+  /// snapshot this session holds was pulled. A drift pass never re-reads WISA —
+  /// that is what Synchroniseer is for — so once they have, a drift check would
+  /// silently relink against a roster built with the old settings and publish
+  /// the result to every other operator. [driftBlockedReason] refuses instead.
+  ///
+  /// Null in the harnesses that do not model settings at all; the gate is then
+  /// never armed and drift behaves exactly as before.
+  final LiveSettings? liveSettings;
+
   /// Publishes a [ChangeSignal] when this session takes/releases the sync lease
   /// or writes a new view generation, so other operators are nudged in real time
   /// (#116). Null when no realtime transport is wired — the store's `generation`
@@ -347,6 +369,13 @@ class ReconcileController extends ChangeNotifier {
   final DateTime Function() _now;
 
   StreamSubscription<ChangeSignal>? _signalSub;
+
+  StreamSubscription<AppSettings>? _settingsSub;
+
+  /// The [wisaPullFingerprint] of the settings the WISA snapshot this session
+  /// holds was pulled with (#238). Re-stamped on every WISA pull; compared
+  /// against the live document to arm [driftBlockedReason].
+  late String _wisaPullFingerprint;
 
   ReconcilePhase _phase = ReconcilePhase.idle;
   double _progress = 0.0;
@@ -875,6 +904,42 @@ class ReconcileController extends ChangeNotifier {
   /// The operator (UPN) holding the sync/drift lease, when [syncLockedByOther].
   String? get syncLockOwner => _lock?.owner;
 
+  /// The [wisaPullFingerprint] of the live settings, or the stamped one when no
+  /// [liveSettings] holder is wired (which leaves the gate permanently open).
+  String _wisaFingerprint() {
+    final live = liveSettings;
+    return live == null
+        ? _wisaPullFingerprint
+        : wisaPullFingerprint(live.current);
+  }
+
+  /// Why **Check for drift** is unavailable right now, or `null` when it can
+  /// run (#238).
+  ///
+  /// A drift pass deliberately re-reads only Smartschool and Azure: the WISA
+  /// roster it links them against is whatever this session already holds, cold
+  /// seed included. So once the operator saves a werkdatum — or a virtuele
+  /// werkdatum, or a school's virtual mark — that roster is not the one their
+  /// change asks for, and a drift pass would relink against the old one,
+  /// materialize the result, bump the generation and broadcast it to every other
+  /// operator. Refusing until a full [sync] has pulled WISA with the new
+  /// settings is the honest answer.
+  String? get driftBlockedReason => _wisaFingerprint() == _wisaPullFingerprint
+      ? null
+      : 'WISA-instellingen gewijzigd — synchroniseer eerst.';
+
+  /// Whether **Check for drift** can be started right now: no pass running, no
+  /// other operator holding the lease, and the WISA settings unchanged since
+  /// this session's roster was pulled (#238).
+  bool get canCheckDrift =>
+      !busy && !syncLockedByOther && driftBlockedReason == null;
+
+  /// Records that the WISA snapshot now in hand was pulled with [fingerprint] —
+  /// the live settings as they stood when the pull *started*, so a save landing
+  /// mid-pull stays pending rather than being credited to a pull that never saw
+  /// it (#238).
+  void _stampWisaPull(String fingerprint) => _wisaPullFingerprint = fingerprint;
+
   /// Whether the store holds a materialized overview (rollups) to drill into —
   /// true after any session has synced, even without a pull this session.
   bool get hasOverview => _rollups.isNotEmpty;
@@ -1115,8 +1180,13 @@ class ReconcileController extends ChangeNotifier {
     _begin(ReconcilePhase.syncing);
     try {
       final previous = app.wisa.snapshot;
+      // Read before the pull, stamped after it: the syncer resolves the very
+      // same document, so this names exactly the settings WISA was asked with
+      // (#238).
+      final pulledWith = _wisaFingerprint();
       log.addMessage(core.Origin.wisa, 'Syncing WISA…');
       final fresh = await app.sync(core.Origin.wisa) as wapi.WisaSnapshot;
+      _stampWisaPull(pulledWith);
       _recordPull(core.Origin.wisa, fresh);
       _setProgress(0.25);
       log.addMessage(
@@ -1186,8 +1256,19 @@ class ReconcileController extends ChangeNotifier {
   /// Explicitly re-reads Smartschool and Azure (drift introduced by edits made
   /// through other tools) and re-links. WISA is not re-pulled — that is what
   /// [sync] is for.
+  ///
+  /// Refuses outright while [driftBlockedReason] is set: because WISA is not
+  /// re-pulled here, a pass run after a werkdatum change would reconcile against
+  /// the roster the change never reached and publish that to the whole team
+  /// (#238). The button is disabled with the same reason on screen; this guard
+  /// is the backstop for every other caller.
   Future<void> checkDrift() async {
     if (busy) return;
+    final blocked = driftBlockedReason;
+    if (blocked != null) {
+      log.addMessage(core.Origin.wisa, blocked);
+      return;
+    }
     if (!await _acquireLock()) return;
     _begin(ReconcilePhase.syncing);
     try {
@@ -1205,8 +1286,10 @@ class ReconcileController extends ChangeNotifier {
 
       if (app.wisa.snapshot == null) {
         await _renewLock();
+        final pulledWith = _wisaFingerprint();
         log.addMessage(core.Origin.wisa, 'Syncing WISA…');
         _recordPull(core.Origin.wisa, await app.sync(core.Origin.wisa));
+        _stampWisaPull(pulledWith);
       }
 
       await _relink();
@@ -1845,6 +1928,7 @@ class ReconcileController extends ChangeNotifier {
   @override
   void dispose() {
     _signalSub?.cancel();
+    _settingsSub?.cancel();
     subscriber?.close();
     super.dispose();
   }

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -492,7 +492,10 @@ class ReconcileController extends ChangeNotifier {
       group: (a) => a.alternativeGroup,
       isDefault: (a) => a.isDefaultAlternative,
       changes: (a) => a.describeChanges(),
-      canApply: (_) => true,
+      // Since #245 the student family has an informational member too
+      // (`AzureClassGroupMembership`), so the apply affordance is gated on the
+      // action rather than assumed, exactly as the group family's is.
+      canApply: (a) => a.canApply,
     ));
     entries.addAll(_entriesFor(
       family: 'staff',

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -534,7 +534,9 @@ class ReconcileController extends ChangeNotifier {
       group: (a) => a.alternativeGroup,
       isDefault: (a) => a.isDefaultAlternative,
       changes: (a) => a.describeChanges(),
-      canApply: (_) => true,
+      // Read off the action like the other two families since #240: every staff
+      // action is applyable today, but nothing here should assume it.
+      canApply: (a) => a.canApply,
     ));
     entries.addAll(_entriesFor(
       family: 'group',

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -190,6 +190,9 @@ class _Header extends StatelessWidget {
     final bool ink = Theme.of(context).brightness == Brightness.dark;
     final bool hasFreshness = controller.syncState.systems.isNotEmpty;
     final lockedByOther = controller.syncLockedByOther;
+    // Why Check for drift is unavailable, when it is the WISA settings rather
+    // than another operator's lease that blocks it (#238).
+    final String? driftBlocked = controller.driftBlockedReason;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -212,14 +215,28 @@ class _Header extends StatelessWidget {
             ),
             OutlinedButton.icon(
               key: const ValueKey('reconcile-drift'),
-              onPressed: controller.busy || lockedByOther
-                  ? null
-                  : controller.checkDrift,
+              // Also disabled while a saved WISA setting has not been synced
+              // yet: a drift pass never re-reads WISA, so it would reconcile
+              // against the roster the change never reached (#238).
+              onPressed:
+                  controller.canCheckDrift ? controller.checkDrift : null,
               icon: const Icon(Icons.difference_outlined),
               label: const Text('Check for drift'),
             ),
           ],
         ),
+        if (driftBlocked != null) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s3),
+          Row(
+            key: const ValueKey('reconcile-drift-blocked'),
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(Icons.info_outline, size: 16, color: colors.primary),
+              const SizedBox(width: PlinkSpacing.s2),
+              Flexible(child: Text(driftBlocked, style: text.bodySmall)),
+            ],
+          ),
+        ],
         if (hasFreshness) ...<Widget>[
           const SizedBox(height: PlinkSpacing.s4),
           _LastSyncBox(controller: controller),

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -24,7 +24,10 @@ import '../settings/settings_bootstrap.dart';
 ///   secret; typing one replaces it via [SecretProvider.write].
 /// - **No restart needed.** A reload affordance re-reads the document from the
 ///   store into the form, so a settings change another operator made (or the
-///   operator's own save) can be pulled back without relaunching.
+///   operator's own save) can be pulled back without relaunching — and every
+///   document this view loads or saves is published into the shared
+///   [LiveSettings] holder, so the reconcile stack's WISA pull honours it on the
+///   very next Synchroniseer rather than on the next app launch (#238).
 ///
 /// The **Smartschool** import rules are authored here (#202): add / edit /
 /// remove the two rules the legacy app offers (`DiscardSmartschoolGroup`,
@@ -146,6 +149,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     try {
       final services = _services ?? await make();
       final settings = await services.store.load();
+      services.liveSettings?.publish(settings);
       if (!mounted) return;
       setState(() {
         _services = services;
@@ -171,6 +175,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
     });
     try {
       final settings = await services.store.load();
+      // A reload can pull in another operator's save; the reconcile stack must
+      // see the same document this form now shows (#238).
+      services.liveSettings?.publish(settings);
       if (!mounted) return;
       setState(() => _loaded = settings);
       _populate(settings);
@@ -410,6 +417,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
     try {
       final next = _collect(base);
       await services.store.save(next);
+      // Hand the saved document to the running reconcile stack (#238). Without
+      // this the WISA pull kept using the werkdatum read at bootstrap, so the
+      // save only took effect after a relaunch — and said so nowhere.
+      services.liveSettings?.publish(next);
 
       // Secrets are write-only: a non-empty field replaces the stored value; a
       // blank one leaves it untouched. The value is never read back into the UI.

--- a/account_manager/lib/src/settings/settings_bootstrap.dart
+++ b/account_manager/lib/src/settings/settings_bootstrap.dart
@@ -68,6 +68,7 @@ class SettingsServices {
     required this.store,
     required this.secrets,
     this.fetchWisaSchools,
+    this.liveSettings,
   });
 
   /// The persistence seam for the [AppSettings] document (#114: Cosmos-backed).
@@ -82,6 +83,13 @@ class SettingsServices {
   /// cannot fetch (no fetcher wired); the screen then keeps the manual-entry
   /// path only.
   final WisaSchoolFetcher? fetchWisaSchools;
+
+  /// The process-wide settings holder the reconcile stack reads at pull time
+  /// (#238). The screen publishes every document it loads or saves into it, so
+  /// a saved werkdatum reaches the next Synchroniseer instead of waiting for a
+  /// relaunch. Null when the build wires no reconcile stack (the settings-only
+  /// harnesses), which simply skips the hand-off.
+  final LiveSettings? liveSettings;
 }
 
 /// Wires the Settings view's two seams for one signed-in session: a
@@ -95,6 +103,7 @@ class SettingsServices {
 /// a reload affordance can re-read without re-bootstrapping.
 Future<SettingsServices> bootstrapSettings({
   required SignInSession session,
+  LiveSettings? liveSettings,
   StoreEndpoints? endpoints,
   SettingsStore? settingsStore,
   SecretProvider? secretProvider,
@@ -121,5 +130,6 @@ Future<SettingsServices> bootstrapSettings({
     store: store,
     secrets: secrets,
     fetchWisaSchools: fetchWisaSchools ?? fetchWisaSchoolsLive,
+    liveSettings: liveSettings,
   );
 }

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1856,6 +1856,10 @@ class ReconcileHarness {
         ),
         settings: this.liveSettings,
         rules: wisaRules,
+        // The same LogBuffer the connector writes into, so the werkdatum line
+        // the pass announces (#239) lands in the harness log beside the
+        // per-school lines — and beside what `RecordingWisaSoap` saw go out.
+        log: log,
         clock: () => kFixtureDate,
       );
       wisaSync = (previous) async {

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -69,6 +69,10 @@ class RecordingGraph implements az.GraphTransport {
   /// (#228).
   final List<Map<String, dynamic>> createdGroups = <Map<String, dynamic>>[];
 
+  /// Every `$batch` sub-request this transport accepted, as `<METHOD> <url>` —
+  /// the membership writes a class-group roster sync performs (#228/#245).
+  final List<String> batchedWrites = <String>[];
+
   int _created = 0;
 
   /// A user PATCH/DELETE answers `204` the way Graph does, but a **create**
@@ -120,6 +124,26 @@ class RecordingGraph implements az.GraphTransport {
           'mail': '${body['mailNickname']}@student.school.example',
         },
         statusCode: 201,
+      );
+    }
+    // The membership writes ride in a `$batch`, and Graph answers with a
+    // per-sub-request status list rather than a bare 204 (#228/#245).
+    if (request.method == 'POST' && request.url.path.endsWith(r'/$batch')) {
+      final body = Map<String, dynamic>.from(
+        jsonDecode(request.body ?? '{}') as Map,
+      );
+      final subs = (body['requests'] as List).cast<Map<String, dynamic>>();
+      for (final sub in subs) {
+        batchedWrites.add('${sub['method']} ${sub['url']}');
+      }
+      return _ok(
+        <String, dynamic>{
+          'responses': <Map<String, dynamic>>[
+            for (final sub in subs)
+              <String, dynamic>{'id': sub['id'], 'status': 204},
+          ],
+        },
+        statusCode: 200,
       );
     }
     return const az.GraphResponse(statusCode: 204);
@@ -447,13 +471,18 @@ wapi.WisaStudent wisaStudent({
   String classSubGroup = '',
   int schoolId = 1,
   core.Address address = _addr,
+  // Most fixtures browse the tree by node rather than by person, so every
+  // student is "Jane Doe" by default; a fixture that has to tell two students
+  // apart on screen (#245) names them.
+  String firstName = 'Jane',
+  String name = 'Doe',
 }) =>
     wapi.WisaStudent(
       wisaId: core.WisaId(wisaId),
       classGroup: classGroup,
       classSubGroup: classSubGroup,
-      name: 'Doe',
-      firstName: 'Jane',
+      name: name,
+      firstName: firstName,
       preferredName: '',
       birthDate: kFixtureDate,
       stemId: '',
@@ -975,6 +1004,87 @@ ReconcileHarness azureClassGroupHarness({bool withStaleGroup = false}) =>
         groups: [
           azClassGroup('1A', memberIds: const ['az1']),
           if (withStaleGroup) azClassGroup('9Z'),
+        ],
+      ),
+      ourSchoolIds: const {1},
+    );
+
+/// A harness for the **per-student** view of Office 365 class-group membership
+/// (#245). Both classes already have their group, and both classes are in sync
+/// between WISA and Smartschool, so the only work anywhere is the Azure roster:
+///
+/// - Jane's class is `1A` and `GBS-1A` exists, but she is not in it;
+/// - Sam moved to `1B`, so he is missing from `GBS-1B` **and** still sitting in
+///   `GBS-1A` — the "wrong class group" shape.
+///
+/// The class rows in Klasgroepen therefore carry the two applyable roster syncs,
+/// and each student's own card carries the informational reading of the same
+/// fact.
+ReconcileHarness azureClassMembershipHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(wisaId: '1', classGroup: '1A'),
+          wisaStudent(
+            wisaId: '2',
+            classGroup: '1B',
+            firstName: 'Sam',
+            name: 'Sels',
+          ),
+        ],
+        schools: [wisaSchool(1)],
+        classGroups: [
+          wisaClassGroup('1A', description: 'Eerste jaar A'),
+          wisaClassGroup('1B', description: 'Eerste jaar B'),
+        ],
+      ),
+      smartschool: ssSnap(
+        // In sync with WISA, so no class raises Smartschool work of its own.
+        groups: [
+          ssGroup('1A',
+              description: 'Eerste jaar A',
+              instituteNumber: '123',
+              untis: '1A'),
+          ssGroup('1B',
+              description: 'Eerste jaar B',
+              instituteNumber: '123',
+              untis: '1B'),
+        ],
+        accounts: [
+          ssAccount(
+              uid: 'jane',
+              accountId: '1',
+              mail: 'jane.doe@student.school.example'),
+          ssAccount(
+            uid: 'sam',
+            accountId: '2',
+            mail: 'sam.sels@student.school.example',
+            givenName: 'Sam',
+            surname: 'Sels',
+          ),
+        ],
+        // Smartschool already has both students in their WISA class, so no
+        // `MoveToSmartschoolClassGroup` competes with the Azure reading.
+        memberships: [member('jane', '1A'), member('sam', '1B')],
+      ),
+      azure: azSnap(
+        users: [
+          azUser(
+            id: 'az1',
+            upn: 'jane.doe@student.school.example',
+            employeeId: '1',
+            displayName: 'Jane Doe',
+          ),
+          azUser(
+            id: 'az2',
+            upn: 'sam.sels@student.school.example',
+            employeeId: '2',
+            displayName: 'Sam Sels',
+          ),
+        ],
+        groups: [
+          // Sam is in Jane's group; Jane is in nobody's.
+          azClassGroup('1A', memberIds: const ['az2']),
+          azClassGroup('1B'),
         ],
       ),
       ourSchoolIds: const {1},

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1734,6 +1734,8 @@ class ReconcileHarness {
     az.AzureSnapshot? azureInitial,
     this.azureGate,
     this.azureTransport,
+    this.smartschoolTransport,
+    this.smartschoolRules = const <ss.SmartschoolImportRule>[],
     this.passwordGraph,
     this.syncedBy = 'operator@school.example',
     Set<int>? ourSchoolIds,
@@ -1755,10 +1757,33 @@ class ReconcileHarness {
       if (error != null) throw error;
       return wisaResult;
     };
-    Syncer<ss.SmartschoolSnapshot> ssSync = (_) async {
-      ssSyncs++;
-      return ssResult;
-    };
+    // The Smartschool pull. Scripted by default; wiring a
+    // [smartschoolTransport] swaps in the *production* pull instead — a real
+    // [ss.SmartschoolConnector] over that SOAP wire, applying
+    // [smartschoolRules] and logging into this harness's LogBuffer exactly as
+    // `bootstrapReconcile` composes it (`ssConnector.sync(rules:
+    // settings.smartschoolRules)`). That is the only way a test can drive the
+    // operator's own import rules through the pass they trigger, and see what
+    // the Log panel then tells them (#241).
+    final ssTransport = smartschoolTransport;
+    Syncer<ss.SmartschoolSnapshot> ssSync;
+    if (ssTransport != null) {
+      final connector = ss.SmartschoolConnector.fromParts(
+        site: 'demo',
+        accessCode: 'secret',
+        transport: ssTransport,
+        log: log,
+      );
+      ssSync = (_) async {
+        ssSyncs++;
+        return connector.sync(rules: smartschoolRules);
+      };
+    } else {
+      ssSync = (_) async {
+        ssSyncs++;
+        return ssResult;
+      };
+    }
     // The Azure pull. By default it is scripted like the other two; wiring an
     // [azureTransport] swaps in the *production* pull instead — a real
     // [az.AzureConnector] behind the real [azureSyncer], logging into this
@@ -1953,6 +1978,22 @@ class ReconcileHarness {
   /// scripted [azResult]. Lets a test answer as Graph does (e.g. rejecting a
   /// stored delta token, #213) and drive the result through the real pass.
   final az.GraphTransport? azureTransport;
+
+  /// When set, the Smartschool pull is the **production** one — a real
+  /// [ss.SmartschoolConnector] over this SOAP wire — instead of the scripted
+  /// [ssResult]. The counterpart of [azureTransport], and the only way a test
+  /// can answer as Smartschool's group tree does and see what the operator's
+  /// own [smartschoolRules] then do to the pull (#241).
+  final ss.SmartschoolSoapTransport? smartschoolTransport;
+
+  /// The operator's Smartschool import rules, applied by the production pull
+  /// [smartschoolTransport] enables — the settings document's
+  /// `smartschoolRules`, as `bootstrapReconcile` hands them to the connector.
+  /// Ignored by the scripted pull, which returns [ssResult] whole.
+  ///
+  /// Read at sync time, like [ssResult]: assign between passes to model the
+  /// session that bootstraps on rules the operator has just saved in Settings.
+  List<ss.SmartschoolImportRule> smartschoolRules;
 
   /// When set, the Passwords screen writes through the **production**
   /// [ConnectorPasswordBackends] over this transport instead of the recording

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -359,6 +359,86 @@ class TransferredAccountGraph implements az.GraphTransport {
       );
 }
 
+/// A [wapi.WisaSoapTransport] serving a tiny, complete WISA export for one
+/// school, so the **production** WISA pull (a real [wapi.WisaConnector] behind
+/// the real `wisaSyncer`) runs offline.
+///
+/// Every query is answered with a well-formed CSV blob in the base64
+/// `GetCSVDataResponse` envelope the connector decodes, and each request's
+/// `QueryCode` + `Werkdatum` are recorded — which is the whole point: the
+/// werkdatum an operator saves in Instellingen is only observable on the wire,
+/// as the `Werkdatum` parameter of the row queries (#238).
+///
+/// Wire it into [ReconcileHarness.wisaTransport].
+class RecordingWisaSoap implements wapi.WisaSoapTransport {
+  RecordingWisaSoap({
+    this.schools = const <(int, String, String)>[(1, 'School 1', 'S1')],
+  });
+
+  /// The schools `SMAGetInst` reports, as `(id, name, code)`.
+  final List<(int, String, String)> schools;
+
+  /// Every query issued, as `(queryCode, schoolId, werkdatum)` — the werkdatum
+  /// exactly as it went on the wire (`dd/MM/yyyy`).
+  final List<(String, String, String)> queries = <(String, String, String)>[];
+
+  /// The distinct werkdatums the row queries (class groups / students / staff)
+  /// were issued with, in order of first use. `SMAGetInst` carries none.
+  List<String> get werkdatums => <String>{
+        for (final q in queries)
+          if (q.$3.isNotEmpty) q.$3,
+      }.toList();
+
+  @override
+  Future<String> send({
+    required Uri endpoint,
+    required String soapAction,
+    required String envelope,
+  }) async {
+    final query = _tag.firstMatch(envelope)?.group(1) ?? '';
+    final params = <String, String>{
+      for (final m in _param.allMatches(envelope))
+        m.group(1)!: m.group(2) ?? '',
+    };
+    queries.add((query, params['IS_ID'] ?? '', params['Werkdatum'] ?? ''));
+    return _envelope(_csvFor(query));
+  }
+
+  String _csvFor(String query) => switch (query) {
+        wapi.WisaQuery.getSchools => <String>[
+            'ID,NAME,DESCRIPTION',
+            for (final (id, name, code) in schools) '$id,$name,$code',
+          ].join('\n'),
+        wapi.WisaQuery.syncClassGroups =>
+          'KLAS,KLASGROEP,OMSCHRIJVING,ADMINGROEP,INSTELLINGSNUMMER\n'
+              '3C,00,Derde jaar C,a1,111',
+        wapi.WisaQuery.syncStudents =>
+          'KLAS,KLASGROEP,NAAM,VOORNAAM,ROEPNAAM,GEBOORTEDATUM,WISAID,'
+              'STAMBOEKNUMMER,GESLACHT,RIJKSREGISTERNR,GEBOORTEPLAATS,'
+              'NATIONALITEIT,STRAAT,STRAATNR,BUSNR,POSTCODE,WOONPLAATS,'
+              'KLASWIJZIGING\n'
+              '3C,,Doe,Jane,,1/7/2010,1,,V,,,,Straat,1,,2000,Antwerpen,'
+              '1/9/2025',
+        wapi.WisaQuery.syncStaff => 'CODE,WISAID,FAMILIENAAM,VOORNAAM',
+        _ => '',
+      };
+
+  static String _envelope(String csv) {
+    final encoded = base64.encode(latin1.encode(csv));
+    return '<?xml version="1.0" encoding="utf-8"?>'
+        '<SOAP-ENV:Envelope '
+        'xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">'
+        '<SOAP-ENV:Body><NS1:GetCSVDataResponse '
+        'xmlns:NS1="urn:WisaAPIService-WisaAPIService">'
+        '<Result>$encoded</Result>'
+        '</NS1:GetCSVDataResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>';
+  }
+
+  static final RegExp _tag = RegExp(r'<QueryCode[^>]*>([^<]*)</QueryCode>');
+  static final RegExp _param =
+      RegExp(r'<Name>([^<]*)</Name><Value[^>]*>([^<]*)</Value>');
+}
+
 /// A [az.GraphTransport] answering the way the tenant answered in #216: the
 /// user lookup succeeds, and the `passwordProfile` PATCH that follows is
 /// refused with `403 Authorization_RequestDenied`, because the app
@@ -1736,14 +1816,17 @@ class ReconcileHarness {
     this.azureTransport,
     this.smartschoolTransport,
     this.smartschoolRules = const <ss.SmartschoolImportRule>[],
+    this.wisaTransport,
     this.passwordGraph,
     this.syncedBy = 'operator@school.example',
     Set<int>? ourSchoolIds,
     List<WisaSchoolProfile> schoolProfiles = const <WisaSchoolProfile>[],
     this.settingsStore,
+    LiveSettings? liveSettings,
   })  : wisaResult = (wisa ?? wisaSnap()),
         ssResult = (smartschool ?? ssSnap()),
         azResult = (azure ?? azSnap()),
+        liveSettings = liveSettings ?? LiveSettings(),
         linkedStore = linkedStore ?? InMemoryLinkedStore() {
     log = LogBuffer(clock: () => kFixtureDate);
     final wisaRules = WisaImportRules();
@@ -1751,12 +1834,44 @@ class ReconcileHarness {
     // The scripted per-system pulls (with call counters). When a [store] is
     // wired, each is wrapped so a successful pull persists — mirroring how
     // bootstrap composes persistence over the real syncers (#107).
-    Syncer<wapi.WisaSnapshot> wisaSync = (_) async {
-      wisaSyncs++;
-      final error = wisaError;
-      if (error != null) throw error;
-      return wisaResult;
-    };
+    //
+    // The WISA pull. Scripted by default; wiring a [wisaTransport] swaps in the
+    // *production* pull instead — a real [wapi.WisaConnector] behind the real
+    // [wisaSyncer], reading the werkdatum pair and virtual marks live from
+    // [liveSettings] exactly as `bootstrapReconcile` composes them. That is the
+    // only way a test can save a werkdatum in Instellingen and then see which
+    // one the next Synchroniseer actually asked WISA for (#238).
+    final wisaWire = wisaTransport;
+    Syncer<wapi.WisaSnapshot> wisaSync;
+    if (wisaWire != null) {
+      final inner = wisaSyncer(
+        wapi.WisaConnector.fromParts(
+          server: 'wisa.example',
+          port: 9000,
+          database: 'wisadb',
+          username: 'operator',
+          password: 'geheim',
+          transport: wisaWire,
+          log: log,
+        ),
+        settings: this.liveSettings,
+        rules: wisaRules,
+        clock: () => kFixtureDate,
+      );
+      wisaSync = (previous) async {
+        wisaSyncs++;
+        final error = wisaError;
+        if (error != null) throw error;
+        return inner(previous);
+      };
+    } else {
+      wisaSync = (_) async {
+        wisaSyncs++;
+        final error = wisaError;
+        if (error != null) throw error;
+        return wisaResult;
+      };
+    }
     // The Smartschool pull. Scripted by default; wiring a
     // [smartschoolTransport] swaps in the *production* pull instead — a real
     // [ss.SmartschoolConnector] over that SOAP wire, applying
@@ -1925,6 +2040,9 @@ class ReconcileHarness {
       // so a pull can fill their names back in (#207).
       schoolProfiles: schoolProfiles,
       settingsStore: settingsStore,
+      // The same holder the WISA pull reads, so the drift gate sees a save the
+      // moment Instellingen publishes it (#238).
+      liveSettings: this.liveSettings,
       publisher: publisher ?? signalHub?.publisher(),
       subscriber: subscriber ?? signalHub?.subscriber(),
       persistTimeout: persistTimeout ?? const Duration(minutes: 10),
@@ -1985,6 +2103,20 @@ class ReconcileHarness {
   /// can answer as Smartschool's group tree does and see what the operator's
   /// own [smartschoolRules] then do to the pull (#241).
   final ss.SmartschoolSoapTransport? smartschoolTransport;
+
+  /// When set, the WISA pull is the **production** one — a real
+  /// [wapi.WisaConnector] behind the real [wisaSyncer] — instead of the scripted
+  /// [wisaResult]. The third of the connector seams, and the only way a test can
+  /// read back which `Werkdatum` a pass actually asked WISA for after the
+  /// operator changed it in Instellingen (#238).
+  final wapi.WisaSoapTransport? wisaTransport;
+
+  /// The live settings document (#238): what the production WISA pull reads its
+  /// werkdatum pair and virtual-school marks from at pull time, and what the
+  /// controller's drift gate compares against. Publish into it to model the
+  /// operator saving in Instellingen mid-session — the real Settings view does
+  /// exactly that, into the very same holder.
+  final LiveSettings liveSettings;
 
   /// The operator's Smartschool import rules, applied by the production pull
   /// [smartschoolTransport] enables — the settings document's
@@ -2110,6 +2242,7 @@ class ReconcileHarness {
   /// The bundle the screen's bootstrap seam expects.
   ReconcileServices get services => ReconcileServices(
         settings: const AppSettings(),
+        liveSettings: liveSettings,
         app: app,
         applier: applier,
         controller: controller,

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -64,6 +64,11 @@ class RecordingGraph implements az.GraphTransport {
   /// accounts a create action actually asked Graph to make (#230).
   final List<Map<String, dynamic>> createdUsers = <Map<String, dynamic>>[];
 
+  /// The bodies of every `POST /groups` this transport accepted, in order — the
+  /// Office 365 class groups a create action actually asked Graph to make
+  /// (#228).
+  final List<Map<String, dynamic>> createdGroups = <Map<String, dynamic>>[];
+
   int _created = 0;
 
   /// A user PATCH/DELETE answers `204` the way Graph does, but a **create**
@@ -97,6 +102,23 @@ class RecordingGraph implements az.GraphTransport {
       createdUsers.add(body);
       return _ok(
         <String, dynamic>{...body, 'id': 'az-created-${++_created}'},
+        statusCode: 201,
+      );
+    }
+    // An Office 365 class group create (#228). Like the user create it reads
+    // first — `mailNickname eq …` to prove no group answers on that address —
+    // which the collection branch above already answers empty.
+    if (request.method == 'POST' && request.url.path.endsWith('/groups')) {
+      final body = Map<String, dynamic>.from(
+        jsonDecode(request.body ?? '{}') as Map,
+      );
+      createdGroups.add(body);
+      return _ok(
+        <String, dynamic>{
+          ...body,
+          'id': 'az-group-${++_created}',
+          'mail': '${body['mailNickname']}@student.school.example',
+        },
         statusCode: 201,
       );
     }
@@ -581,13 +603,21 @@ core.Group ssGroup(
   String? code,
   bool official = true,
   core.GroupType type = core.GroupType.classGroup,
+  String description = '',
+  String? instituteNumber,
+  String? untis,
 }) =>
     core.Group(
       id: core.GroupId(code ?? name),
       name: name,
-      description: '',
+      description: description,
       type: type,
       official: official,
+      instituteNumber: instituteNumber,
+      // Untis defaults to blank — which reads as drift against the class name,
+      // so most fixtures get a `ModifySmartschoolData` for free. Pass the name
+      // to build a class that is genuinely in sync with WISA.
+      untis: untis ?? '',
       origin: core.Origin.smartschool,
     );
 
@@ -861,6 +891,92 @@ ReconcileHarness foreignClassGroupHarness() => ReconcileHarness(
         memberships: const [],
       ),
       azure: azSnap(users: const []),
+      ourSchoolIds: const {1},
+    );
+
+/// A harness for the Office 365 class groups of #228. Our school 1 runs a
+/// sub-grouped class `2F` (`2F ECO` + `2F MAW`, the shape of a 1ste-graad class)
+/// and a plain class `1A`, all fully provisioned in Smartschool so the only work
+/// left is on the Azure side.
+///
+/// Azure already holds `GBS-1A` with its student, so `1A` is done; `2F` has no
+/// group at all. Four linked class-group records, **one** missing Office 365
+/// group, so exactly one create proposal must reach the operator — named after
+/// the parent class, never after a sub-group.
+///
+/// [withStaleGroup] adds `GBS-9Z`, the group of a class that no longer exists,
+/// which must be reported for manual cleanup and never deleted.
+ReconcileHarness azureClassGroupHarness({bool withStaleGroup = false}) =>
+    ReconcileHarness(
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(wisaId: '1', classGroup: '1A'),
+          wisaStudent(wisaId: '2', classGroup: '2F', classSubGroup: 'ECO'),
+          wisaStudent(wisaId: '3', classGroup: '2F', classSubGroup: 'MAW'),
+        ],
+        schools: [wisaSchool(1)],
+        classGroups: [
+          wisaClassGroup('1A', description: 'Eerste jaar A'),
+          wisaClassGroup('2F',
+              groupName: 'ECO', adminCode: 'a', description: 'Tweede jaar F'),
+          wisaClassGroup('2F',
+              groupName: 'MAW', adminCode: 'b', description: 'Tweede jaar F'),
+        ],
+      ),
+      smartschool: ssSnap(
+        // In sync with their WISA counterparts, so the only work this fixture
+        // raises is on the Office 365 side.
+        groups: [
+          ssGroup('1A',
+              description: 'Eerste jaar A',
+              instituteNumber: '123',
+              untis: '1A'),
+          ssGroup('2F ECO',
+              description: 'Tweede jaar F',
+              instituteNumber: '123',
+              untis: '2F ECO'),
+          ssGroup('2F MAW',
+              description: 'Tweede jaar F',
+              instituteNumber: '123',
+              untis: '2F MAW'),
+        ],
+        accounts: [
+          ssAccount(
+              uid: 'jane', accountId: '1', mail: 'a1@student.school.example'),
+          ssAccount(
+              uid: 'joe', accountId: '2', mail: 'a2@student.school.example'),
+          ssAccount(
+              uid: 'jim', accountId: '3', mail: 'a3@student.school.example'),
+        ],
+        memberships: [
+          member('jane', '1A'),
+          member('joe', '2F ECO'),
+          member('jim', '2F MAW'),
+        ],
+      ),
+      azure: azSnap(
+        users: [
+          azUser(
+              id: 'az1',
+              upn: 'a1@student.school.example',
+              employeeId: '1',
+              displayName: 'Jane Doe'),
+          azUser(
+              id: 'az2',
+              upn: 'a2@student.school.example',
+              employeeId: '2',
+              displayName: 'Jane Doe'),
+          azUser(
+              id: 'az3',
+              upn: 'a3@student.school.example',
+              employeeId: '3',
+              displayName: 'Jane Doe'),
+        ],
+        groups: [
+          azClassGroup('1A', memberIds: const ['az1']),
+          if (withStaleGroup) azClassGroup('9Z'),
+        ],
+      ),
       ourSchoolIds: const {1},
     );
 
@@ -1166,13 +1282,28 @@ Future<InMemoryLinkedStore> seededLinkedStore(
 az.AzureSnapshot azSnap({
   DateTime? fetchedAt,
   List<az.AzureUser>? users,
+  List<az.AzureGroup> groups = const [],
   String? deltaToken,
 }) =>
     az.AzureSnapshot(
       fetchedAt: fetchedAt ?? kFixtureDate,
       deltaToken: deltaToken,
       users: users ?? [azUser()],
-      groups: const [],
+      groups: groups,
+    );
+
+/// An Office 365 **class** group as this app creates one (#228): a mail-enabled
+/// unified group whose display name and mail nickname are both `GBS-<class>`.
+az.AzureGroup azClassGroup(
+  String className, {
+  List<String> memberIds = const [],
+}) =>
+    az.AzureGroup(
+      id: 'az-GBS-$className',
+      displayName: 'GBS-$className',
+      mail: 'GBS-$className@student.school.example',
+      mailNickname: 'GBS-$className',
+      memberIds: memberIds,
     );
 
 /// Deterministic in-memory resolver (mirrors the linker's test fixture).

--- a/account_manager/test/reconcile/reconcile_live_settings_test.dart
+++ b/account_manager/test/reconcile/reconcile_live_settings_test.dart
@@ -1,0 +1,211 @@
+import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
+import 'package:account_state/account_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+import 'reconcile_fakes.dart';
+
+/// A settings document with a valid WISA profile and the given werkdatum pair /
+/// school marks.
+AppSettings _settings({
+  WorkDateSetting workDate = const WorkDateSetting(),
+  WorkDateSetting virtualWorkDate = const WorkDateSetting(),
+  List<WisaSchoolProfile> schools = const <WisaSchoolProfile>[],
+}) =>
+    AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: workDate,
+        virtualWorkDate: virtualWorkDate,
+      ),
+      wisaSchools: schools,
+    );
+
+WorkDateSetting _pinned(DateTime date) =>
+    WorkDateSetting(isNow: false, date: date);
+
+void main() {
+  group('the WISA pull reads the operator settings live (#238)', () {
+    test('a werkdatum saved after bootstrap reaches the very next pull',
+        () async {
+      // The reconcile stack bootstraps on a document pinned to the 2025 school
+      // year, exactly as a session opened before the rollover does.
+      final live =
+          LiveSettings(_settings(workDate: _pinned(DateTime(2025, 9, 1))));
+      final wire = RecordingWisaSoap();
+      final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+
+      await harness.controller.sync();
+      expect(wire.werkdatums, <String>['01/09/2025']);
+
+      // The operator advances the werkdatum in Instellingen and saves. Before
+      // #238 the syncer had closed over the bootstrap document, so this pull
+      // still asked WISA for 01/09/2025 — only a relaunch changed it.
+      live.publish(_settings(workDate: _pinned(DateTime(2026, 9, 1))));
+      await harness.controller.sync();
+
+      expect(wire.werkdatums, <String>['01/09/2025', '01/09/2026']);
+    });
+
+    test('a virtual school pulls with the saved virtuele werkdatum', () async {
+      // School 99 is marked virtual in Settings (#203), so its rows must come
+      // from the *virtual* werkdatum — and both dates are read live.
+      final live = LiveSettings(_settings(
+        workDate: _pinned(DateTime(2025, 9, 1)),
+        virtualWorkDate: _pinned(DateTime(2025, 9, 1)),
+      ));
+      final wire = RecordingWisaSoap(schools: const <(int, String, String)>[
+        (1, 'School 1', 'S1'),
+        (99, 'Virtuele school', 'V'),
+      ]);
+      final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+
+      live.publish(_settings(
+        workDate: _pinned(DateTime(2026, 9, 1)),
+        virtualWorkDate: _pinned(DateTime(2026, 10, 1)),
+        schools: const <WisaSchoolProfile>[
+          WisaSchoolProfile(
+              schoolId: 99, code: 'V', name: 'Virtuele school', virtual: true),
+        ],
+      ));
+      await harness.controller.sync();
+
+      // The ordinary school got the werkdatum, the virtual one the virtuele
+      // werkdatum — both as just saved.
+      final byWerkdatum = <String, Set<String>>{};
+      for (final q in wire.queries) {
+        if (q.$3.isEmpty) continue;
+        byWerkdatum.putIfAbsent(q.$2, () => <String>{}).add(q.$3);
+      }
+      expect(byWerkdatum['1'], <String>{'01/09/2026'});
+      expect(byWerkdatum['99'], <String>{'01/10/2026'});
+    });
+
+    test('the pull really lands the roster it asked for', () async {
+      final live =
+          LiveSettings(_settings(workDate: _pinned(DateTime(2026, 9, 1))));
+      final harness = ReconcileHarness(
+        wisaTransport: RecordingWisaSoap(),
+        liveSettings: live,
+      );
+
+      await harness.controller.sync();
+
+      final snapshot = harness.app.wisa.snapshot as wapi.WisaSnapshot;
+      expect(snapshot.students.single.wisaId.value, '1');
+      expect(snapshot.schools.single.id, 1);
+    });
+  });
+
+  group('Check for drift refuses a stale WISA roster (#238)', () {
+    test('is available while the WISA settings have not moved', () async {
+      final live =
+          LiveSettings(_settings(workDate: _pinned(DateTime(2025, 9, 1))));
+      final harness = ReconcileHarness(liveSettings: live);
+
+      expect(harness.controller.driftBlockedReason, isNull);
+      expect(harness.controller.canCheckDrift, isTrue);
+
+      // A save that touches nothing the WISA pull depends on leaves it open.
+      live.publish(_settings(workDate: _pinned(DateTime(2025, 9, 1)))
+          .copyWith(schoolPrefix: 'GBS'));
+      expect(harness.controller.canCheckDrift, isTrue);
+    });
+
+    test('a saved werkdatum blocks it, with a reason, until a sync runs',
+        () async {
+      final live =
+          LiveSettings(_settings(workDate: _pinned(DateTime(2025, 9, 1))));
+      final harness = ReconcileHarness(liveSettings: live);
+      await harness.controller.sync();
+      expect(harness.controller.canCheckDrift, isTrue);
+
+      live.publish(_settings(workDate: _pinned(DateTime(2026, 9, 1))));
+
+      expect(
+        harness.controller.driftBlockedReason,
+        'WISA-instellingen gewijzigd — synchroniseer eerst.',
+      );
+      expect(harness.controller.canCheckDrift, isFalse);
+
+      // And it is a real refusal, not just a disabled button: nothing is
+      // pulled, nothing is relinked, nothing is published to the other
+      // operators.
+      final ss = harness.ssSyncs;
+      final az = harness.azSyncs;
+      await harness.controller.checkDrift();
+      expect(harness.ssSyncs, ss);
+      expect(harness.azSyncs, az);
+      expect(
+        harness.log.entries.map((e) => e.message),
+        contains('WISA-instellingen gewijzigd — synchroniseer eerst.'),
+      );
+
+      // The Synchroniseer the message asks for clears it: WISA has now been
+      // pulled with the saved werkdatum.
+      await harness.controller.sync();
+      expect(harness.controller.driftBlockedReason, isNull);
+      expect(harness.controller.canCheckDrift, isTrue);
+    });
+
+    test('a virtual-school mark blocks it too', () async {
+      final live = LiveSettings(_settings());
+      final harness = ReconcileHarness(liveSettings: live);
+      await harness.controller.sync();
+
+      live.publish(_settings(schools: const <WisaSchoolProfile>[
+        WisaSchoolProfile(schoolId: 99, code: 'V', name: 'V', virtual: true),
+      ]));
+      expect(harness.controller.canCheckDrift, isFalse);
+    });
+
+    test('repaints the screen when a save arrives from Instellingen', () async {
+      final live = LiveSettings(_settings());
+      final harness = ReconcileHarness(liveSettings: live);
+      var notifications = 0;
+      harness.controller.addListener(() => notifications++);
+
+      live.publish(_settings(workDate: _pinned(DateTime(2026, 9, 1))));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(notifications, greaterThan(0),
+          reason: 'the reconcile screen is kept alive across tab switches, so '
+              'only a controller notification can disable its drift button');
+    });
+
+    test('a harness with no settings holder never arms the gate', () async {
+      final harness = ReconcileHarness();
+      await harness.controller.sync();
+      expect(harness.controller.driftBlockedReason, isNull);
+      expect(harness.controller.canCheckDrift, isTrue);
+    });
+  });
+
+  group('wisaSyncer', () {
+    test('reads the rules live too, so a DontImportFromWisa apply lands (#72)',
+        () async {
+      // The settings holder must not have cost the rules their liveness: both
+      // are read at pull time, so a rule accumulated between two passes still
+      // prunes the second one.
+      final wire = RecordingWisaSoap();
+      final rules = WisaImportRules();
+      final syncer = wisaSyncer(
+        wapi.WisaConnector.fromParts(
+          server: 'wisa.example',
+          port: 9000,
+          database: 'db',
+          username: 'u',
+          password: 'p',
+          transport: wire,
+        ),
+        settings: LiveSettings(_settings()),
+        rules: rules,
+      );
+
+      expect((await syncer(null)).classGroups, hasLength(1));
+      rules.add(const wapi.DontImportClass('3C'));
+      expect((await syncer(null)).classGroups, isEmpty);
+    });
+  });
+}

--- a/account_manager/test/reconcile/reconcile_live_settings_test.dart
+++ b/account_manager/test/reconcile/reconcile_live_settings_test.dart
@@ -182,6 +182,107 @@ void main() {
     });
   });
 
+  group('a WISA pull names the werkdatum it asked for (#239)', () {
+    test('names the resolved werkdatum, exactly as it went on the wire',
+        () async {
+      final live =
+          LiveSettings(_settings(workDate: _pinned(DateTime(2025, 9, 1))));
+      final wire = RecordingWisaSoap();
+      final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+
+      await harness.controller.sync();
+
+      // The date the operator can read matches the date WISA was asked for —
+      // the point of the line, and the only way an empty Acties can be told
+      // apart from a pull that landed on last year's roster.
+      expect(wire.werkdatums, <String>['01/09/2025']);
+      expect(
+        harness.log.entries.map((e) => e.message),
+        contains('Pulling WISA with werkdatum 01/09/2025.'),
+      );
+    });
+
+    test('names the date a "volg de huidige datum" werkdatum resolved to',
+        () async {
+      // The default setting, and the one that produces the reported symptom: a
+      // pass run before the school-year rollover silently pulls the previous
+      // year. The line has to name the *resolved* date, not "vandaag".
+      final harness = ReconcileHarness(
+        wisaTransport: RecordingWisaSoap(),
+        liveSettings: LiveSettings(_settings()),
+      );
+
+      await harness.controller.sync();
+
+      expect(
+        harness.log.entries.map((e) => e.message),
+        // The harness clock is fixed at kFixtureDate (2026-07-01).
+        contains('Pulling WISA with werkdatum 01/07/2026.'),
+      );
+    });
+
+    test('names the virtuele werkdatum, and the school that used it', () async {
+      final live = LiveSettings(_settings(
+        workDate: _pinned(DateTime(2026, 9, 1)),
+        virtualWorkDate: _pinned(DateTime(2026, 10, 1)),
+        schools: const <WisaSchoolProfile>[
+          WisaSchoolProfile(
+              schoolId: 99, code: 'V', name: 'Virtuele school', virtual: true),
+        ],
+      ));
+      final wire = RecordingWisaSoap(schools: const <(int, String, String)>[
+        (1, 'School 1', 'S1'),
+        (99, 'Virtuele school', 'V'),
+      ]);
+      final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+
+      await harness.controller.sync();
+
+      expect(wire.werkdatums, <String>['01/09/2026', '01/10/2026']);
+      expect(
+        harness.log.entries.map((e) => e.message),
+        contains('Pulling WISA with werkdatum 01/09/2026; virtuele werkdatum '
+            '01/10/2026 for V.'),
+      );
+    });
+
+    test('leaves the virtuele werkdatum unmentioned when no school used it',
+        () async {
+      // A second date no query carried would read as if some of the roster came
+      // from it. The pull says only what it asked.
+      final live = LiveSettings(_settings(
+        workDate: _pinned(DateTime(2026, 9, 1)),
+        virtualWorkDate: _pinned(DateTime(2026, 10, 1)),
+      ));
+      final harness = ReconcileHarness(
+        wisaTransport: RecordingWisaSoap(),
+        liveSettings: live,
+      );
+
+      await harness.controller.sync();
+
+      final messages = harness.log.entries.map((e) => e.message);
+      expect(messages, contains('Pulling WISA with werkdatum 01/09/2026.'));
+      expect(messages.where((m) => m.contains('virtuele werkdatum')), isEmpty);
+    });
+
+    test('falls back to the long name when a school carries no code', () {
+      expect(
+        wisaPullMessage(
+          schools: const <wapi.WisaSchool>[
+            wapi.WisaSchool(
+                id: 7, name: 'Virtuele school', code: '  ', isVirtual: true),
+            wapi.WisaSchool(id: 8, name: '', code: '', isVirtual: true),
+          ],
+          workDate: DateTime(2026, 9, 1),
+          virtualWorkDate: DateTime(2026, 10, 1),
+        ),
+        'Pulling WISA with werkdatum 01/09/2026; virtuele werkdatum '
+        '01/10/2026 for Virtuele school, school 8.',
+      );
+    });
+  });
+
   group('wisaSyncer', () {
     test('reads the rules live too, so a DontImportFromWisa apply lands (#72)',
         () async {

--- a/account_manager/test/screens/settings_fakes.dart
+++ b/account_manager/test/screens/settings_fakes.dart
@@ -15,6 +15,7 @@ class SettingsHarness {
     AppSettings initial = const AppSettings(),
     Map<SecretRef, String> secrets = const {},
     this.fetchWisaSchools,
+    this.liveSettings,
   })  : store = InMemorySettingsStore(initial),
         secrets = InMemorySecretProvider(secrets);
 
@@ -26,10 +27,17 @@ class SettingsHarness {
   /// to drive the fetch flow offline.
   final WisaSchoolFetcher? fetchWisaSchools;
 
+  /// The shared settings holder the screen publishes every loaded/saved
+  /// document into (#238). Pass a [ReconcileHarness]'s own holder to model what
+  /// production does — one instance behind both bootstraps — so a save in
+  /// Instellingen reaches the running reconcile stack.
+  final LiveSettings? liveSettings;
+
   SettingsServices get services => SettingsServices(
         store: store,
         secrets: secrets,
         fetchWisaSchools: fetchWisaSchools,
+        liveSettings: liveSettings,
       );
 
   /// A ready-made bootstrap closure for [SettingsScreen]/[AccountManagerApp].

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -158,6 +158,21 @@ class Membership {                // first-class many-to-many
 
 This fixes [PAIN-1](#8-pain-points-to-fix-during-the-port). See INV-30, INV-31.
 
+**Naming rule — the Office 365 class group (#228).** A class is addressable in
+Office 365 as a **unified** (Microsoft 365) group named `<PREFIX>-<KLAS>`, whose
+address is therefore `<PREFIX>-<KLAS>@<studentdomein>` (e.g.
+`SSM-2A@student.arcadiascholen.be`), reusing the school prefix and student
+domain the action config already carries. `<KLAS>` is the **bare** class name
+(`WisaClassGroup.name`), never the sub-grouped `fullName`: **sub-groups get no
+group of their own**, so `2F ECO` / `2F MAW` / `2F MOW` / `2F STEMW` all belong
+to `SSM-2F`, and the group's membership is the union of their rosters. Bare
+class names carry no spaces, so the name is used verbatim as the `mailNickname`
+— a name that would not survive as one yields no proposal rather than a mangled
+slug. Because `LinkedGroup` is keyed on the `fullName`, the bare name is carried
+alongside it as `LinkedGroup.className`, which is also what the Azure side of
+the group link matches on after stripping the prefix. Groups are never deleted
+automatically; a class that vanished leaves an informational notice.
+
 ### 3.8 `Snapshot`
 
 A per-system, **immutable** result of one sync.

--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -85,6 +85,14 @@ collision by suffixing, so the UPN that landed can differ from the one
 `describeChanges()` projected, and the Smartschool account would carry the wrong
 `mail`. The staff family has the same two-pass shape and is tracked as #240.
 
+`GroupAction.unlocks` is the same mechanism for the group family (#245), not a
+second one: `CreateAzureClassGroup.unlocks == {SyncAzureClassGroupMembers}`,
+because Graph creates a group **empty** — the roster is a separate write — so
+creating `SSM-2F` used to leave a class group with nobody in it until the
+operator clicked again. `StateApplier.applyGroup` chains it against the relinked
+record, which is the only place the id Graph just minted exists. The walk skips
+an informational follow-up, so a `canApply == false` action is never applied.
+
 `staffActions(snapshot, config)` does the same over the snapshot's staff
 records. The legacy staff parser writes the modify branch as `if (OK)` rather
 than `else`, but sets `OK = false` inside the missing branch, so the two
@@ -99,7 +107,10 @@ numeric `wisaId` becomes the copy-code.
 
 `groupActions(snapshot)` walks the snapshot's class groups, ported from the
 legacy `GroupActionParser`. The split is on the WISA/Smartschool **pair** rather
-than all three systems (there is no Azure group action):
+than all three systems; the Office 365 class-group actions added in #228
+(`CreateAzureClassGroup`, `SyncAzureClassGroupMembers`,
+`AzureClassGroupWithoutClass`) are orthogonal to a class's Smartschool state and
+ride alongside **both** branches:
 
 - **Missing from WISA or Smartschool** → the lifecycle-style actions, in legacy
   parser order: `DoNotImportFromWisa` (WISA-only class; adds a `DontImportClass`
@@ -174,6 +185,31 @@ placement guard the target the way legacy `MoveUserToClass` does — only an
 **official** class node is a valid destination (the ported `moveUserToClass`
 connector leaves that guard to the caller), so an ANS/BNS student whose
 "Leerlingen" target is non-official is correctly not moved.
+
+## Office 365 class placement (#245)
+
+`AzureClassGroupMembership` is the Azure counterpart of
+`MoveToSmartschoolClassGroup`: it reports, **on the student's own account**, that
+they are missing from their class's `<PREFIX>-<KLAS>` group, or still sitting in
+the group of a class they left — the per-account half of #228, which reported the
+roster diff only on the class row. It reads an injected `AzureClassPlacement`
+(target class, its group's display name, whether the group exists, whether they
+are in it, and which of our class groups they are in but should not be), wired
+through the opt-in `azurePlacementFor` callback of `studentActions` /
+`studentActionsFor`. Without the callback the dispatch is exactly as it was
+before #245.
+
+It is **informational** (`canApply == false`) — the first student action that is.
+Class-group membership is a class-level fact with exactly one automated remedy,
+`SyncAzureClassGroupMembers`, which rewrites the whole roster in one batched
+write; a per-account write would ask Graph to add the same member twice whenever
+an "apply all" pass ran both, and would count one unit of work twice. So the
+account row diagnoses and names the class, and the class row applies. Both are
+derived from the same `AzureClassGroupResolver` indexes in `account_state`, so
+they cannot disagree — and a class whose group does not exist yet, or a group
+whose class has vanished, is deliberately silent per student: neither has a
+per-student remedy (`CreateAzureClassGroup` and `AzureClassGroupWithoutClass`
+own those).
 
 ## Deferred (documented divergences)
 

--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -83,7 +83,7 @@ the operator's one apply provisions the student end to end. It must be the
 relinked record and never a projection — `createPrincipalName` resolves a UPN
 collision by suffixing, so the UPN that landed can differ from the one
 `describeChanges()` projected, and the Smartschool account would carry the wrong
-`mail`. The staff family has the same two-pass shape and is tracked as #240.
+`mail`.
 
 `GroupAction.unlocks` is the same mechanism for the group family (#245), not a
 second one: `CreateAzureClassGroup.unlocks == {SyncAzureClassGroupMembers}`,
@@ -92,6 +92,17 @@ creating `SSM-2F` used to leave a class group with nobody in it until the
 operator clicked again. `StateApplier.applyGroup` chains it against the relinked
 record, which is the only place the id Graph just minted exists. The walk skips
 an informational follow-up, so a `canApply == false` action is never applied.
+
+`StaffAction.unlocks` completes the set (#240): the staff family has the very
+same two-pass shape as the student one — `AddStaffToSmartschool` builds its
+account with the Azure UPN as the `mail` — so
+`AddStaffToAzure.unlocks == {AddStaffToSmartschool}` and
+`StateApplier.applyStaff` chains it exactly as `applyStudent` does. The applier
+runs **one** walk for all three families, parameterized by the typed dispatch it
+reads and the target identity; the bounds are therefore identical everywhere:
+nothing chains off a dry run or a failed write, each action type runs at most
+once per chain, an informational action is never run, and a failed link stops
+the chain.
 
 `staffActions(snapshot, config)` does the same over the snapshot's staff
 records. The legacy staff parser writes the modify branch as `if (OK)` rather

--- a/packages/account_actions/lib/account_actions.dart
+++ b/packages/account_actions/lib/account_actions.dart
@@ -21,6 +21,7 @@ library;
 export 'src/action_result.dart';
 export 'src/apply_options.dart';
 export 'src/azure_class_group.dart';
+export 'src/azure_class_placement.dart';
 export 'src/change_set.dart';
 export 'src/class_placement.dart';
 export 'src/connectors.dart';

--- a/packages/account_actions/lib/account_actions.dart
+++ b/packages/account_actions/lib/account_actions.dart
@@ -20,6 +20,7 @@ library;
 
 export 'src/action_result.dart';
 export 'src/apply_options.dart';
+export 'src/azure_class_group.dart';
 export 'src/change_set.dart';
 export 'src/class_placement.dart';
 export 'src/connectors.dart';

--- a/packages/account_actions/lib/src/action_result.dart
+++ b/packages/account_actions/lib/src/action_result.dart
@@ -57,6 +57,13 @@ class ActionResult {
   /// group delete (which sets [removed] instead).
   final Group? group;
 
+  /// The created/updated Azure **group** record — the Office 365 class group a
+  /// create or membership write produced (#228). Carried separately from
+  /// [group] (a Smartschool [Group]) and from [azure] (a user) so the State
+  /// layer knows which half of the Azure snapshot to patch. Null for every
+  /// other action.
+  final AzureGroup? azureGroup;
+
   /// True when the action deleted the record from [system] (so the State layer
   /// should drop it from the snapshot rather than patch it).
   final bool removed;
@@ -88,6 +95,7 @@ class ActionResult {
     this.smartschool,
     this.azure,
     this.group,
+    this.azureGroup,
     this.removed = false,
     this.wisaRule,
     this.generatedPassword,

--- a/packages/account_actions/lib/src/azure_class_group.dart
+++ b/packages/account_actions/lib/src/azure_class_group.dart
@@ -1,0 +1,81 @@
+import 'package:account_core/account_core.dart';
+
+/// The Office 365 class-group context for one linked class — everything the
+/// group actions need to create `<PREFIX>-<KLAS>` and keep its membership equal
+/// to the class roster, and which a [LinkedGroup] alone cannot answer (#228).
+///
+/// The analogue of [GroupPlacement] for the Azure side, and injected the same
+/// way: the State layer builds one per linked class from the WISA + Azure
+/// snapshots and the linked accounts, and the actions only ever *read* it. That
+/// keeps `account_actions` a pure function of its inputs — no snapshot walking
+/// inside an action.
+///
+/// Three things live here that a linked record cannot express:
+///
+/// - **The bare class name.** [LinkedGroup.wisa] is keyed and named by the WISA
+///   `fullName`, so the sub-grouped class `2F ECO` says nothing about the group
+///   `GBS-2F` its students belong to. [className] is the parent class.
+/// - **Ownership.** Four linked groups (`2F ECO`, `2F MAW`, `2F MOW`,
+///   `2F STEMW`) map to the **one** group `GBS-2F`, so exactly one of them must
+///   raise the create/membership actions or the operator sees four proposals
+///   for one write. The builder — which sees every class — nominates that
+///   record and marks it [owner]; every other record of the same class carries
+///   `owner: false` and raises nothing. When the parent class has a linked group
+///   of its own it is the owner; otherwise the first sub-group record is (the
+///   parent's `00` row is deduped away for a sub-grouped class, see #221), which
+///   is why the proposals name the class explicitly.
+/// - **The roster diff.** Membership is the union of the sub-groups' rosters,
+///   expressed as Azure object ids; deriving it needs the linked accounts, not
+///   this one record.
+class AzureClassGroupPlan {
+  const AzureClassGroupPlan({
+    required this.className,
+    required this.displayName,
+    required this.mailNickname,
+    required this.mail,
+    required this.owner,
+    required this.containsStudents,
+    this.membersToAdd = const [],
+    this.membersToRemove = const [],
+  });
+
+  /// The **bare** class name the group is named after — `2F`, never `2F ECO`.
+  final String className;
+
+  /// The group's display name, `<PREFIX>-<KLAS>`.
+  final String displayName;
+
+  /// The group's mail alias. Equal to [displayName]: bare class names carry no
+  /// spaces, so no slug rule is needed (a name that would *not* survive as a
+  /// nickname yields no plan at all — see [isValidMailNickname]).
+  final String mailNickname;
+
+  /// The address the group answers on, `<PREFIX>-<KLAS>@<studentdomein>`.
+  final String mail;
+
+  /// Whether this linked record is the one that raises this class's Office 365
+  /// actions. Exactly one record per distinct [className] carries `true`.
+  final bool owner;
+
+  /// Whether the class currently holds students of a school we manage — the
+  /// same signal [GroupPlacement.containsStudents] carries for Smartschool,
+  /// tallied over the **bare** class name so a sub-grouped class counts all its
+  /// sub-groups' students. An empty class gets no group, mirroring how an empty
+  /// WISA class is not created in Smartschool either.
+  final bool containsStudents;
+
+  /// Azure object ids on the class roster that the existing group does not have
+  /// as members yet. Empty when the group does not exist (nothing to diff
+  /// against) or when membership already matches.
+  final List<String> membersToAdd;
+
+  /// Azure object ids to remove: current members that are **students of ours**
+  /// no longer in this class. Deliberately never anybody else — staff and
+  /// titular membership of class groups are out of scope, so a member this app
+  /// cannot account for as one of its own students is left alone.
+  final List<String> membersToRemove;
+
+  /// Whether membership differs from the roster in either direction.
+  bool get membershipDiffers =>
+      membersToAdd.isNotEmpty || membersToRemove.isNotEmpty;
+}

--- a/packages/account_actions/lib/src/azure_class_placement.dart
+++ b/packages/account_actions/lib/src/azure_class_placement.dart
@@ -1,0 +1,55 @@
+/// One student's Office 365 class-group placement — where their Azure account
+/// *should* sit (`<PREFIX>-<KLAS>`) and where it actually sits today (#245).
+///
+/// The Azure counterpart of [ClassPlacement], and injected the same way: the
+/// State layer builds one per student from the linked view, and the action only
+/// ever *reads* it. That keeps `account_actions` a pure function of its inputs —
+/// no snapshot walking inside an action.
+///
+/// Everything here is derived from the **same** source as the class-level
+/// [AzureClassGroupPlan] — the linked groups' `memberIds` and the class rosters
+/// the linker's `wisaId ≡ employeeId` bridge produces — so the per-account view
+/// and the per-class view can never disagree about the same student. See
+/// `AzureClassGroupResolver` in `account_state`, which builds both.
+class AzureClassPlacement {
+  const AzureClassPlacement({
+    required this.className,
+    this.groupName,
+    this.groupExists = false,
+    this.isMember = false,
+    this.strayGroupNames = const [],
+  });
+
+  /// The **bare** WISA class the student belongs to — `2F`, never the
+  /// sub-grouped `2F ECO`, because sub-groups get no group of their own (#228).
+  /// Empty when the student carries no class at all.
+  final String className;
+
+  /// The display name of the class's Office 365 group, `<PREFIX>-<KLAS>`, or
+  /// `null` when no group can be named (no class, no configured prefix).
+  final String? groupName;
+
+  /// Whether that group actually exists in Azure today. When it does not, the
+  /// class-level `CreateAzureClassGroup` is the work — and since #245 it chains
+  /// straight into the roster sync — so nothing is reported per student.
+  final bool groupExists;
+
+  /// Whether the student's Azure account is already a member of [groupName].
+  final bool isMember;
+
+  /// The display names of **our** class groups the student is a member of but
+  /// should not be — the class group of a class they left.
+  ///
+  /// Deliberately limited to groups whose class still exists, which is exactly
+  /// the set the class-level `SyncAzureClassGroupMembers` can remove them from
+  /// (`AzureClassGroupPlan.membersToRemove`). The group of a class that vanished
+  /// is never touched automatically — that is `AzureClassGroupWithoutClass`'s
+  /// story, a manual cleanup — so naming it here would report work nobody can do.
+  final List<String> strayGroupNames;
+
+  /// Whether the student is missing from their own class's existing group.
+  bool get missingFromOwnGroup => groupExists && !isMember;
+
+  /// Whether the placement differs from the roster in either direction.
+  bool get differs => missingFromOwnGroup || strayGroupNames.isNotEmpty;
+}

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -80,6 +80,28 @@ sealed class GroupAction {
   /// [alternativeGroup]. Ignored when [alternativeGroup] is `null`.
   bool get isDefaultAlternative => false;
 
+  /// The action types this one **unlocks** on the same target (#245) — the
+  /// group family's half of the chaining [StudentAction.unlocks] introduced for
+  /// students (#230), and deliberately the same mechanism rather than a second
+  /// one.
+  ///
+  /// Provisioning a class group is a chain, not a single action:
+  /// [CreateAzureClassGroup] leaves an **empty** group, because Graph creates
+  /// the group and its membership in separate writes, so the roster only lands
+  /// once [SyncAzureClassGroupMembers] runs. The dispatch (§6.3) is a pure
+  /// function of the *current* record and can only offer the first link, which
+  /// is why creating `SSM-2F` used to need the operator's second click.
+  ///
+  /// Declaring the follow-up here lets the State layer run it immediately
+  /// against the **relinked** record — the created group with the id Graph
+  /// minted, spliced into the snapshot — and never against a projection.
+  ///
+  /// Pure and constant: it names what *may* follow, never what must. The
+  /// follow-up's own [evaluate] still decides (a class whose students have no
+  /// Office 365 account yet has nothing to add), and an informational follow-up
+  /// is never run.
+  Set<Type> get unlocks => const {};
+
   /// Performs the change on the target system. Impure. With
   /// [ApplyOptions.dryRun] set, performs **no** writes and returns the
   /// projected [ActionResult] (PAIN-3). Throws [UnsupportedError] when
@@ -587,6 +609,12 @@ class CreateAzureClassGroup extends GroupAction {
       group.wisa != null &&
       group.azure == null &&
       plan.containsStudents;
+
+  /// Creating the group unlocks the roster write that fills it (#245): Graph
+  /// creates a group empty, so without the chain the operator's click left an
+  /// `SSM-2F` with nobody in it and the enrolment waited for a second click.
+  @override
+  Set<Type> get unlocks => const {SyncAzureClassGroupMembers};
 
   @override
   ChangeSet describeChanges() => ChangeSet(

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -1,9 +1,11 @@
 import 'package:account_core/account_core.dart';
+import 'package:azure_api/azure_api.dart' as az;
 import 'package:smartschool_api/smartschool_api.dart' as ss;
 import 'package:wisa_api/wisa_api.dart' as wapi;
 
 import 'action_result.dart';
 import 'apply_options.dart';
+import 'azure_class_group.dart';
 import 'change_set.dart';
 import 'connectors.dart';
 import 'group_placement.dart';
@@ -22,17 +24,21 @@ import 'group_placement.dart';
 /// [group] or its snapshot records.
 ///
 /// **Group vs account families.** Three differences shape this family:
-/// - **No config.** Unlike [StudentAction]/[StaffAction], the shippable group
-///   actions derive everything from the WISA/Smartschool group pair — there is
-///   no domain, password, or uid to inject — so there is no `GroupActionConfig`.
-/// - **No Azure and no date.** Legacy has no Azure group action, and the group
-///   `Apply` takes no date; [LinkedGroup.azure] is ignored here.
+/// - **No config.** Unlike [StudentAction]/[StaffAction], the group actions
+///   derive everything from the linked record plus an injected placement —
+///   there is no domain, password, or uid to inject — so there is no
+///   `GroupActionConfig`. The Office 365 naming (`<PREFIX>-<KLAS>@<domein>`)
+///   that *would* need one arrives fully resolved on [AzureClassGroupPlan].
+/// - **No date.** The group `Apply` takes no date.
 /// - **Group record, not account.** A written group flows back through
-///   [ActionResult.group] (a [Group]), not [ActionResult.smartschool] (a
+///   [ActionResult.group] (a Smartschool [Group]) or [ActionResult.azureGroup]
+///   (an Azure group), not [ActionResult.smartschool] (a
 ///   `SmartschoolAccount`).
 ///
-/// **Scope.** The whole family ships here, plus one action legacy never had:
-/// [ClassExistsAsSmartschoolGroup] (informational, #225). [DoNotImportFromWisa],
+/// **Scope.** The whole legacy family ships here, plus the actions legacy never
+/// had: [ClassExistsAsSmartschoolGroup] (informational, #225) and the Office 365
+/// class-group trio [CreateAzureClassGroup] / [SyncAzureClassGroupMembers] /
+/// [AzureClassGroupWithoutClass] (#228). [DoNotImportFromWisa],
 /// [DoNotImportFromSmartschool] (informational), and [ModifySmartschoolData]
 /// derive everything from the WISA/Smartschool group pair (#54). The remaining
 /// three — [AddToSmartschool], [CreateInSmartschool] (informational), and
@@ -88,6 +94,10 @@ sealed class GroupAction {
   ss.SmartschoolConnector _requireSmartschool(Connectors c) =>
       c.smartschool ??
       (throw StateError('$runtimeType.apply needs a Smartschool connector'));
+
+  az.AzureConnector _requireAzure(Connectors c) =>
+      c.azure ??
+      (throw StateError('$runtimeType.apply needs an Azure connector'));
 
   ActionResult _failed(ChangeSet changes, Origin system, Object error) =>
       ActionResult(
@@ -537,4 +547,271 @@ class ModifySmartschoolData extends GroupAction {
       return _failed(changes, Origin.smartschool, e);
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Office 365 class groups (#228). Named `<PREFIX>-<KLAS>` after the **bare**
+// class name, so one group serves a class and all of its sub-groups. Everything
+// a [LinkedGroup] cannot answer — the bare name, which record owns the class's
+// proposals, and the roster diff — arrives on the injected
+// [AzureClassGroupPlan].
+// ---------------------------------------------------------------------------
+
+/// Create the Office 365 group for a class: `<PREFIX>-<KLAS>`, addressable at
+/// `<PREFIX>-<KLAS>@<studentdomein>` (#228).
+///
+/// Genuinely new — legacy never created a class group, only the handful of named
+/// staff groups. It is raised **once per distinct class**, on the record the
+/// plan marks as [AzureClassGroupPlan.owner], so a class split into sub-groups
+/// yields one proposal rather than one per sub-group.
+///
+/// Two guards keep it from proposing something that cannot land:
+/// - the class must currently hold students, mirroring how an empty WISA class
+///   is not created in Smartschool either ([CreateInSmartschool]);
+/// - a class name that would not survive as a Graph `mailNickname` yields no
+///   plan at all, so no create is offered rather than one Graph rejects.
+///
+/// [apply] re-asks Graph for the nickname before writing — the same "guard
+/// before create" the Azure account creates gained in #224. Graph does not
+/// reject a duplicate display name, so without the guard a stale snapshot (or a
+/// second operator) silently produces a second group.
+class CreateAzureClassGroup extends GroupAction {
+  /// The Office 365 naming + roster context, injected by the dispatch.
+  final AzureClassGroupPlan plan;
+
+  const CreateAzureClassGroup(super.group, this.plan);
+
+  @override
+  bool evaluate() =>
+      plan.owner &&
+      group.wisa != null &&
+      group.azure == null &&
+      plan.containsStudents;
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.azure,
+        summary: 'Maak de Office 365-groep ${plan.displayName} '
+            'voor klas ${plan.className}',
+        fields: [
+          FieldChange('displayName', after: plan.displayName),
+          FieldChange('mailNickname', after: plan.mailNickname),
+          FieldChange('mail', after: plan.mail),
+          const FieldChange('groupTypes', after: 'Unified'),
+        ],
+      );
+
+  /// The group as it will exist once created. Members are added by
+  /// [SyncAzureClassGroupMembers] on the next pass, so the projection is empty.
+  az.AzureGroup _created() => az.AzureGroup(
+        id: '',
+        displayName: plan.displayName,
+        mailNickname: plan.mailNickname,
+        mail: plan.mail,
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.azure,
+        azureGroup: _created(),
+      );
+    }
+
+    try {
+      final groups = _requireAzure(connectors).groups;
+      // Guard before create (#224's rule, applied to groups): the nickname is
+      // what makes the address unique, and Graph creates a second group under
+      // the same display name without complaint.
+      final existing = await groups.findByMailNickname(plan.mailNickname);
+      if (existing != null) {
+        return _failed(
+          changes,
+          Origin.azure,
+          StateError(
+            'Office 365 already has a group with mailNickname '
+            '${plan.mailNickname} (${existing.displayName}). Sync Azure again '
+            'so the existing group is linked instead of creating a duplicate.',
+          ),
+        );
+      }
+      final created = await groups.createGroup(
+        displayName: plan.displayName,
+        mailNickname: plan.mailNickname,
+        description: _wisa.description,
+      );
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.azure,
+        azureGroup: created,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.azure, e);
+    }
+  }
+}
+
+/// Bring an existing class group's membership in line with the class roster
+/// (#228): every student of the class is a member, and a student who left it is
+/// removed.
+///
+/// The diff arrives precomputed on the [AzureClassGroupPlan] because it is the
+/// union of the class's sub-group rosters expressed as Azure object ids —
+/// neither the roster nor the id mapping is on a [LinkedGroup]. The evaluation
+/// itself is offline: `listGroups` already loaded the members onto
+/// [LinkedGroup.azure], so no extra Graph read is needed to know a class is out
+/// of sync.
+///
+/// **Removals are limited to our own students.** Staff and titular membership of
+/// class groups are out of scope, so a member this app cannot account for as one
+/// of its students is never touched — see
+/// [AzureClassGroupPlan.membersToRemove].
+class SyncAzureClassGroupMembers extends GroupAction {
+  /// The Office 365 naming + roster context, injected by the dispatch.
+  final AzureClassGroupPlan plan;
+
+  const SyncAzureClassGroupMembers(super.group, this.plan);
+
+  az.AzureGroup get _azure => group.azure! as az.AzureGroup;
+
+  @override
+  bool evaluate() =>
+      plan.owner && group.azure != null && plan.membershipDiffers;
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.azure,
+        summary: 'Werk het ledenbestand van ${plan.displayName} bij '
+            '(${plan.membersToAdd.length} toevoegen, '
+            '${plan.membersToRemove.length} verwijderen)',
+        fields: [
+          if (plan.membersToAdd.isNotEmpty)
+            FieldChange('leden toevoegen',
+                after: '${plan.membersToAdd.length}'),
+          if (plan.membersToRemove.isNotEmpty)
+            FieldChange('leden verwijderen',
+                after: '${plan.membersToRemove.length}'),
+        ],
+      );
+
+  /// The group record as it will read once both writes have landed — what the
+  /// State layer splices into its Azure snapshot so the next relink sees the
+  /// class in sync without a re-pull.
+  az.AzureGroup _synced() {
+    final removed = plan.membersToRemove.toSet();
+    return _azure.withMembers(<String>[
+      for (final id in _azure.memberIds)
+        if (!removed.contains(id)) id,
+      ...plan.membersToAdd,
+    ]);
+  }
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.azure,
+        azureGroup: _synced(),
+      );
+    }
+
+    try {
+      final groups = _requireAzure(connectors).groups;
+      final results = <az.BatchResponse>[
+        ...await groups.addMembers(_azure.id, plan.membersToAdd),
+        ...await groups.removeMembers(_azure.id, plan.membersToRemove),
+      ];
+      final failures = results.where((r) => !r.isSuccess).length;
+      if (failures > 0) {
+        return _failed(
+          changes,
+          Origin.azure,
+          StateError(
+            '$failures of ${results.length} membership change(s) on '
+            '${plan.displayName} failed',
+          ),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.azure,
+        azureGroup: _synced(),
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.azure, e);
+    }
+  }
+}
+
+/// An Office 365 class group whose class no longer exists in WISA or
+/// Smartschool (#228). **Informational only** (`canApply == false`): groups are
+/// never deleted automatically — the mailbox and whatever is shared with it
+/// outlive the class — so this is the Azure analogue of the Smartschool orphan
+/// notice [DoNotImportFromSmartschool], and the cleanup stays a hand decision.
+///
+/// It is deliberately narrow. An unmatched Azure group is only reported when it
+/// is shaped exactly like one this app creates: inside the school's `<PREFIX>-`
+/// namespace, a mail-enabled Microsoft 365 group, and answering on a nickname
+/// equal to its display name. A security group, a hand-made Team, or anything
+/// outside the namespace is left unmentioned rather than filling the Klasgroepen
+/// list with rows nobody will act on (the clutter #209/#225 fixed).
+class AzureClassGroupWithoutClass extends GroupAction {
+  const AzureClassGroupWithoutClass(super.group);
+
+  az.AzureGroup? get _azure => group.azure as az.AzureGroup?;
+
+  @override
+  bool evaluate() {
+    final azure = _azure;
+    return group.wisa == null &&
+        group.smartschool == null &&
+        azure != null &&
+        group.className != null &&
+        azure.isUnified &&
+        _sameName(azure.mailNickname, azure.displayName);
+  }
+
+  @override
+  bool get canApply => false;
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.azure,
+        summary: 'De klas ${group.className} bestaat niet meer, maar de '
+            'Office 365-groep ${_azure?.displayName} nog wel. Verwijder ze '
+            'manueel als ze niet meer nodig is.',
+        fields: [
+          FieldChange('mail', before: _azure?.mail ?? ''),
+          FieldChange('leden', before: '${_azure?.memberIds.length ?? 0}'),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      throw UnsupportedError(
+        'AzureClassGroupWithoutClass is informational and cannot be applied '
+        '(canApply is false)',
+      );
+
+  static bool _sameName(String? a, String? b) =>
+      a != null &&
+      b != null &&
+      a.trim().toLowerCase() == b.trim().toLowerCase();
 }

--- a/packages/account_actions/lib/src/group_dispatch.dart
+++ b/packages/account_actions/lib/src/group_dispatch.dart
@@ -1,5 +1,6 @@
 import 'package:account_core/account_core.dart';
 
+import 'azure_class_group.dart';
 import 'group_action.dart';
 import 'group_placement.dart';
 
@@ -35,33 +36,55 @@ import 'group_placement.dart';
 /// have students?". It is only called for WISA-only classes; a both-present or
 /// Smartschool-only class never needs it.
 ///
+/// [azurePlanFor] wires the **Office 365 class-group** actions (#228). Unlike
+/// [placementFor] it is consulted for *every* record, not only the WISA-only
+/// ones: a class that is perfectly in sync between WISA and Smartschool still
+/// needs its `<PREFIX>-<KLAS>` group created and its membership kept equal to
+/// the roster, so [CreateAzureClassGroup] and [SyncAzureClassGroupMembers] are
+/// candidates in both branches. The builder returns `null` for a record that
+/// names no Office 365 class group (an orphan with no WISA class, or a class
+/// name that cannot form a mail nickname), and marks exactly one record per
+/// distinct bare class name as the [AzureClassGroupPlan.owner] so a sub-grouped
+/// class raises one proposal rather than one per sub-group. When omitted, the
+/// dispatch is exactly as it shipped before #228.
+///
 /// An Azure-only orphan group (`wisa == null && smartschool == null`, #52)
-/// yields no action.
+/// yields only the informational [AzureClassGroupWithoutClass], and only when it
+/// is shaped like a group this app created; anything else still yields nothing.
 ///
 /// Each candidate is constructed bound to [group] and kept only when its pure
 /// [GroupAction.evaluate] returns true. Pure and deterministic (INV-40): same
-/// group (+ same [placementFor]) ⇒ same list.
+/// group (+ same [placementFor] / [azurePlanFor]) ⇒ same list.
 List<GroupAction> groupActionsFor(
   LinkedGroup group, {
   GroupPlacement Function(LinkedGroup group)? placementFor,
+  AzureClassGroupPlan? Function(LinkedGroup group)? azurePlanFor,
 }) {
   final both = group.wisa != null && group.smartschool != null;
   final wisaOnly = group.wisa != null && group.smartschool == null;
 
   final placement =
       (placementFor != null && wisaOnly) ? placementFor(group) : null;
+  final azurePlan = azurePlanFor?.call(group);
 
-  final candidates = both
-      ? <GroupAction>[
-          ModifySmartschoolData(group),
-        ]
-      : <GroupAction>[
-          DoNotImportFromWisa(group),
-          ClassExistsAsSmartschoolGroup(group),
-          if (placement != null) AddToSmartschool(group, placement),
-          if (placement != null) CreateInSmartschool(group, placement),
-          DoNotImportFromSmartschool(group),
-        ];
+  final candidates = <GroupAction>[
+    if (both)
+      ModifySmartschoolData(group)
+    else ...[
+      DoNotImportFromWisa(group),
+      ClassExistsAsSmartschoolGroup(group),
+      if (placement != null) AddToSmartschool(group, placement),
+      if (placement != null) CreateInSmartschool(group, placement),
+      DoNotImportFromSmartschool(group),
+    ],
+    // The Office 365 group of a class is orthogonal to its Smartschool state,
+    // so these ride alongside both branches (#228).
+    if (azurePlan != null) ...[
+      CreateAzureClassGroup(group, azurePlan),
+      SyncAzureClassGroupMembers(group, azurePlan),
+    ],
+    AzureClassGroupWithoutClass(group),
+  ];
 
   return [
     for (final action in candidates)
@@ -74,12 +97,18 @@ List<GroupAction> groupActionsFor(
 ///
 /// Only [LinkedSnapshot.groups] are considered; students and staff are handled
 /// by their own families. [placementFor] is threaded through to
-/// [groupActionsFor] to enable the membership-dependent creation actions (#65).
+/// [groupActionsFor] to enable the membership-dependent creation actions (#65),
+/// and [azurePlanFor] to enable the Office 365 class-group actions (#228).
 List<GroupAction> groupActions(
   LinkedSnapshot snapshot, {
   GroupPlacement Function(LinkedGroup group)? placementFor,
+  AzureClassGroupPlan? Function(LinkedGroup group)? azurePlanFor,
 }) =>
     [
       for (final group in snapshot.groups)
-        ...groupActionsFor(group, placementFor: placementFor),
+        ...groupActionsFor(
+          group,
+          placementFor: placementFor,
+          azurePlanFor: azurePlanFor,
+        ),
     ];

--- a/packages/account_actions/lib/src/staff_action.dart
+++ b/packages/account_actions/lib/src/staff_action.dart
@@ -60,6 +60,40 @@ sealed class StaffAction {
   /// [alternativeGroup]. Ignored when [alternativeGroup] is `null`.
   bool get isDefaultAlternative => false;
 
+  /// Whether [apply] can perform a change. `false` for an informational action
+  /// (the legacy `CanBeApplied == false` case): it surfaces a diagnosis but has
+  /// no automated write, so calling [apply] throws. Every staff action is
+  /// applyable today, so this is always `true`; the getter exists so the UI's
+  /// apply affordance and the follow-up walk (#240) read the flag off the action
+  /// for every family instead of assuming it for this one. See
+  /// [StudentAction.canApply] and [GroupAction.canApply].
+  bool get canApply => true;
+
+  /// The action types this one **unlocks** on the same target (#240) — the staff
+  /// family's half of the chaining [StudentAction.unlocks] introduced for
+  /// students (#230) and extended to class groups in #245, deliberately the same
+  /// mechanism rather than a third one.
+  ///
+  /// Provisioning a brand-new staff member is a chain, not a single action: the
+  /// Smartschool account is built with the Azure UPN as its `mail`, so
+  /// [AddStaffToSmartschool] cannot even [evaluate] true until [AddStaffToAzure]
+  /// has run. The dispatch (§6.3) is a pure function of the *current* record and
+  /// can only ever offer the first link, which is why a WISA-only staff member
+  /// used to be offered one create and the operator had to apply, notice the
+  /// relink, and apply again.
+  ///
+  /// Declaring the follow-up here lets the State layer run it immediately
+  /// against the **freshly relinked** record. It must be the relinked record and
+  /// never a projection: `createPrincipalName` resolves a UPN collision by
+  /// suffixing, so the UPN that actually landed can differ from the one
+  /// [describeChanges] projected, and the Smartschool account would then carry
+  /// the wrong `mail`.
+  ///
+  /// Pure and constant — it names what *may* follow, never what must: the
+  /// follow-up's own [evaluate] still decides whether it applies, exactly as it
+  /// would on the next sync.
+  Set<Type> get unlocks => const {};
+
   /// Performs the change on the target system. Impure. With
   /// [ApplyOptions.dryRun] set, performs **no** writes and returns the
   /// projected [ActionResult] (PAIN-3).
@@ -100,6 +134,14 @@ class AddStaffToAzure extends StaffAction {
 
   @override
   bool evaluate() => staff.wisa != null && staff.azure == null;
+
+  /// Creating the Office 365 account unlocks the Smartschool create, which
+  /// needs the fresh UPN as the new account's `mail` (#240) — the staff twin of
+  /// [AddStudentToAzure]'s chain (#230). Without it a new staff member's second
+  /// create only appeared on the *next* pass, so Acties → Personeel never showed
+  /// the full provisioning intent.
+  @override
+  Set<Type> get unlocks => const {AddStaffToSmartschool};
 
   String get _displayName => '${_wisa.firstName} ${_wisa.lastName}'.trim();
 

--- a/packages/account_actions/lib/src/student_action.dart
+++ b/packages/account_actions/lib/src/student_action.dart
@@ -5,6 +5,7 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 
 import 'action_result.dart';
 import 'apply_options.dart';
+import 'azure_class_placement.dart';
 import 'change_set.dart';
 import 'class_placement.dart';
 import 'connectors.dart';
@@ -61,6 +62,16 @@ sealed class StudentAction {
   /// pre-selection. Exactly one alternative in a group should return `true`;
   /// ignored when [alternativeGroup] is `null`.
   bool get isDefaultAlternative => false;
+
+  /// Whether [apply] can perform a change. `false` for an informational action
+  /// (the legacy `CanBeApplied == false` case): it surfaces a diagnosis on the
+  /// account but has no automated write of its own, so calling [apply] throws.
+  /// Callers (UI / State layer) gate the "apply" affordance on this.
+  ///
+  /// The whole legacy student family is applyable; [AzureClassGroupMembership]
+  /// (#245) is the first member that is not, and it mirrors how the group family
+  /// has carried informational members since #54.
+  bool get canApply => true;
 
   /// The action types this one **unlocks** on the same target (#230).
   ///
@@ -1044,6 +1055,81 @@ class MoveToSmartschoolClassGroup extends StudentAction {
       return _failed(changes, Origin.smartschool, e);
     }
   }
+}
+
+/// The student's Office 365 class-group placement, when it disagrees with their
+/// WISA class (#245): they are missing from `<PREFIX>-<KLAS>`, or still sitting
+/// in the group of a class they left — or both.
+///
+/// The Azure counterpart of [MoveToSmartschoolClassGroup], and the per-account
+/// half of #228: the roster diff was previously reported only on the class row
+/// in Klasgroepen, so an operator looking at *one* student — the usual entry
+/// point when a parent phones about a class team — saw nothing about their group
+/// membership. It reads its [AzureClassPlacement] from the very same resolver
+/// that builds the class-level `AzureClassGroupPlan`, so the two views can never
+/// disagree about the same student.
+///
+/// **Informational** (`canApply == false`), deliberately. Class-group membership
+/// is a class-level fact with exactly one automated remedy —
+/// `SyncAzureClassGroupMembers`, which rewrites the whole roster in one batched
+/// write — and this action names it. Giving the account its own write would ask
+/// Graph to add the same member twice whenever an "apply all" pass ran both
+/// (the class plan is computed off the snapshot, so it cannot know the
+/// per-student write already landed), and would count one unit of work twice in
+/// the pending totals. So the per-account row diagnoses, the class row applies.
+class AzureClassGroupMembership extends StudentAction {
+  /// The Office 365 class-group context this action reads, injected by the
+  /// dispatch.
+  final AzureClassPlacement placement;
+
+  const AzureClassGroupMembership(
+    super.account,
+    super.config,
+    this.placement,
+  );
+
+  @override
+  bool evaluate() => account.azure != null && placement.differs;
+
+  @override
+  bool get canApply => false;
+
+  String get _strays => placement.strayGroupNames.join(', ');
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.azure,
+        summary: _summary(),
+        fields: [
+          FieldChange(
+            'Office 365-klasgroep',
+            before: _strays,
+            after: placement.groupName ?? '',
+          ),
+        ],
+      );
+
+  String _summary() {
+    final target = placement.groupName ?? placement.className;
+    if (!placement.missingFromOwnGroup) {
+      return 'Staat nog in de Office 365-klasgroep $_strays. Werk het '
+          'ledenbestand van die klas bij.';
+    }
+    if (placement.strayGroupNames.isEmpty) {
+      return 'Ontbreekt in de Office 365-klasgroep $target. Werk het '
+          'ledenbestand van klas ${placement.className} bij.';
+    }
+    return 'Zit in de verkeerde Office 365-klasgroep: $_strays in plaats van '
+        '$target. Werk het ledenbestand van beide klassen bij.';
+  }
+
+  @override
+  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) =>
+      throw UnsupportedError(
+        'AzureClassGroupMembership is informational and cannot be applied '
+        '(canApply is false) — the class-level SyncAzureClassGroupMembers '
+        'performs the membership write',
+      );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/account_actions/lib/src/student_dispatch.dart
+++ b/packages/account_actions/lib/src/student_dispatch.dart
@@ -1,5 +1,6 @@
 import 'package:account_core/account_core.dart';
 
+import 'azure_class_placement.dart';
 import 'class_placement.dart';
 import 'student_action.dart';
 import 'student_action_config.dart';
@@ -23,13 +24,25 @@ import 'student_action_config.dart';
 /// `account.wisa != null` records (the placement's target class comes from the
 /// WISA record); WISA-less lifecycle accounts never need it.
 ///
+/// [azurePlacementFor] wires the **Office 365 class-group** view of the same
+/// student (#245), the per-account half of #228. Like [placementFor] it is only
+/// called for `account.isInOurWisa` records — the target group is named after
+/// their WISA class — and it feeds a single action, [AzureClassGroupMembership],
+/// in the modify branch beside [MoveToSmartschoolClassGroup]: the two answer the
+/// same question ("is this student in the right class group?") for the two
+/// systems that have one, so they belong in the same branch. When omitted, the
+/// dispatch is exactly as it shipped before #245, because a [LinkedAccount]
+/// carries neither the group's membership nor the roster it should equal.
+///
 /// Each candidate is constructed bound to [account] and kept only when its
 /// pure [StudentAction.evaluate] returns true. Pure and deterministic
-/// (INV-40): same account + same [config] (+ same [placementFor]) ⇒ same list.
+/// (INV-40): same account + same [config] (+ same [placementFor] /
+/// [azurePlacementFor]) ⇒ same list.
 List<StudentAction> studentActionsFor(
   LinkedAccount account,
   StudentActionConfig config, {
   ClassPlacement Function(LinkedAccount account)? placementFor,
+  AzureClassPlacement Function(LinkedAccount account)? azurePlacementFor,
 }) {
   // "Complete" (modify branch) requires presence in *our* WISA, not merely
   // anywhere in the group (#134): a student who moved to a sibling group school
@@ -41,6 +54,9 @@ List<StudentAction> studentActionsFor(
 
   final placement = (placementFor != null && account.isInOurWisa)
       ? placementFor(account)
+      : null;
+  final azurePlacement = (azurePlacementFor != null && account.isInOurWisa)
+      ? azurePlacementFor(account)
       : null;
 
   final candidates = complete
@@ -54,6 +70,8 @@ List<StudentAction> studentActionsFor(
           ModifySmartschoolBirthPlace(account, config),
           if (placement != null)
             MoveToSmartschoolClassGroup(account, config, placement),
+          if (azurePlacement != null)
+            AzureClassGroupMembership(account, config, azurePlacement),
           ModifySmartschoolStudentEmail(account, config),
           ModifySmartschoolName(account, config),
         ]
@@ -80,8 +98,14 @@ List<StudentAction> studentActions(
   LinkedSnapshot snapshot,
   StudentActionConfig config, {
   ClassPlacement Function(LinkedAccount account)? placementFor,
+  AzureClassPlacement Function(LinkedAccount account)? azurePlacementFor,
 }) =>
     [
       for (final account in snapshot.accounts)
-        ...studentActionsFor(account, config, placementFor: placementFor),
+        ...studentActionsFor(
+          account,
+          config,
+          placementFor: placementFor,
+          azurePlacementFor: azurePlacementFor,
+        ),
     ];

--- a/packages/account_actions/test/azure_class_group_test.dart
+++ b/packages/account_actions/test/azure_class_group_test.dart
@@ -1,0 +1,391 @@
+import 'dart:convert';
+
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+/// Graph replies for the class-group writes: an empty `mailNickname` lookup
+/// (nothing exists yet), an echoed create, and `204` for the `$batch`
+/// membership calls.
+az.GraphResponse _classGroupGraph(az.GraphRequest request) {
+  if (request.method == 'GET') {
+    return az.GraphResponse(
+      statusCode: 200,
+      headers: const {'content-type': 'application/json'},
+      body: jsonEncode({'value': const <Object>[]}),
+    );
+  }
+  if (request.method == 'POST' && request.url.path.endsWith(r'/$batch')) {
+    final body = jsonDecode(request.body!) as Map<String, dynamic>;
+    final requests = (body['requests'] as List).cast<Map<String, dynamic>>();
+    return az.GraphResponse(
+      statusCode: 200,
+      headers: const {'content-type': 'application/json'},
+      body: jsonEncode({
+        'responses': [
+          for (final r in requests) {'id': r['id'], 'status': 204},
+        ],
+      }),
+    );
+  }
+  if (request.method == 'POST' && request.url.path.endsWith('/groups')) {
+    final body = Map<String, dynamic>.from(
+      jsonDecode(request.body!) as Map<String, dynamic>,
+    );
+    return az.GraphResponse(
+      statusCode: 201,
+      headers: const {'content-type': 'application/json'},
+      body: jsonEncode({
+        ...body,
+        'id': 'az-created',
+        'mail': '${body['mailNickname']}@student.school.example',
+      }),
+    );
+  }
+  return const az.GraphResponse(statusCode: 204);
+}
+
+void main() {
+  group('dispatch: one proposal per class, never per sub-group (#228)', () {
+    test('a class with no Office 365 group raises the create', () {
+      final actions = groupActionsFor(
+        linkedGroup(wisa: wisaGroup(), smartschool: ssGroup()),
+        azurePlanFor: (_) => azurePlan(),
+      );
+      expect(actions.map((a) => a.runtimeType), [CreateAzureClassGroup]);
+      expect(actions.single.canApply, isTrue);
+      expect(
+        actions.single.describeChanges().summary,
+        'Maak de Office 365-groep SSM-3A voor klas 3A',
+      );
+    });
+
+    test('the create rides alongside the Smartschool lifecycle actions', () {
+      // A WISA-only class needs both: a Smartschool class *and* its Office 365
+      // group. The two families are orthogonal, so neither branch swallows the
+      // other.
+      final actions = groupActionsFor(
+        linkedGroup(wisa: wisaGroup()),
+        placementFor: (_) => groupPlacement(containsStudents: true),
+        azurePlanFor: (_) => azurePlan(),
+      );
+      expect(
+        actions.map((a) => a.runtimeType),
+        [DoNotImportFromWisa, AddToSmartschool, CreateAzureClassGroup],
+      );
+    });
+
+    test('a sub-group record that does not own the class raises nothing', () {
+      // `3A ECO` maps to the same group as `3A`; only the nominated owner
+      // proposes the create, so the operator sees one row and not four.
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(name: '3A ECO'),
+          smartschool: ssGroup(code: '3A ECO', name: '3A ECO'),
+          className: '3A',
+        ),
+        azurePlanFor: (_) => azurePlan(owner: false),
+      );
+      expect(actions, isEmpty);
+    });
+
+    test('an empty class gets no group, mirroring CreateInSmartschool', () {
+      final actions = groupActionsFor(
+        linkedGroup(wisa: wisaGroup(), smartschool: ssGroup()),
+        azurePlanFor: (_) => azurePlan(containsStudents: false),
+      );
+      expect(actions, isEmpty);
+    });
+
+    test('a class whose group already exists raises no create', () {
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(),
+          smartschool: ssGroup(),
+          azure: azureClassGroup('3A'),
+        ),
+        azurePlanFor: (_) => azurePlan(),
+      );
+      expect(actions, isEmpty);
+    });
+
+    test('no plan at all ⇒ the dispatch is exactly as it was before #228', () {
+      expect(groupActionsFor(fullySyncedGroup()), isEmpty);
+      expect(
+        groupActionsFor(
+          linkedGroup(wisa: wisaGroup()),
+          placementFor: (_) => groupPlacement(containsStudents: true),
+        ).map((a) => a.runtimeType),
+        [DoNotImportFromWisa, AddToSmartschool],
+      );
+    });
+  });
+
+  group('membership follows the roster (#228)', () {
+    test('a roster difference raises the membership sync', () {
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(),
+          smartschool: ssGroup(),
+          azure: azureClassGroup('3A', memberIds: const ['az-old']),
+        ),
+        azurePlanFor: (_) => azurePlan(
+          membersToAdd: const ['az-new'],
+          membersToRemove: const ['az-old'],
+        ),
+      );
+      expect(actions.map((a) => a.runtimeType), [SyncAzureClassGroupMembers]);
+      expect(
+        actions.single.describeChanges().summary,
+        'Werk het ledenbestand van SSM-3A bij (1 toevoegen, 1 verwijderen)',
+      );
+    });
+
+    test('membership in sync raises nothing', () {
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(),
+          smartschool: ssGroup(),
+          azure: azureClassGroup('3A', memberIds: const ['az-1']),
+        ),
+        azurePlanFor: (_) => azurePlan(),
+      );
+      expect(actions, isEmpty);
+    });
+
+    test('the projected record adds and removes exactly the named members',
+        () async {
+      final action = SyncAzureClassGroupMembers(
+        linkedGroup(
+          wisa: wisaGroup(),
+          azure: azureClassGroup(
+            '3A',
+            memberIds: const ['az-teacher', 'az-left', 'az-stays'],
+          ),
+        ),
+        azurePlan(
+          membersToAdd: const ['az-joined'],
+          membersToRemove: const ['az-left'],
+        ),
+      );
+
+      final result = await action.apply(
+        const Connectors(),
+        const ApplyOptions(dryRun: true),
+      );
+
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(
+        (result.azureGroup! as az.AzureGroup).memberIds,
+        ['az-teacher', 'az-stays', 'az-joined'],
+        reason: 'the teacher this app cannot account for is left alone',
+      );
+    });
+  });
+
+  group('apply writes through Graph (#228)', () {
+    test('a create POSTs a unified group after asking for the nickname',
+        () async {
+      final transport = RecordingGraphTransport(handler: _classGroupGraph);
+      final action = CreateAzureClassGroup(
+        linkedGroup(wisa: wisaGroup(description: 'Klas 3A')),
+        azurePlan(),
+      );
+
+      final result = await action.apply(
+        Connectors(azure: azureConnector(transport)),
+        const ApplyOptions(),
+      );
+
+      expect(result.outcome, ActionOutcome.applied);
+      expect(transport.sent('GET', pathContains: '/groups'), isTrue,
+          reason: 'guard before create (#224\'s rule)');
+      final post = transport.requests
+          .firstWhere((r) => r.method == 'POST' && r.body != null);
+      final body = jsonDecode(post.body!) as Map<String, dynamic>;
+      expect(body['displayName'], 'SSM-3A');
+      expect(body['mailNickname'], 'SSM-3A');
+      expect(body['description'], 'Klas 3A');
+      expect(body['groupTypes'], ['Unified']);
+      expect((result.azureGroup! as az.AzureGroup).id, 'az-created');
+    });
+
+    test('a dry run writes nothing but projects the group', () async {
+      final transport = RecordingGraphTransport(handler: _classGroupGraph);
+      final action = CreateAzureClassGroup(
+        linkedGroup(wisa: wisaGroup()),
+        azurePlan(),
+      );
+
+      final result = await action.apply(
+        Connectors(azure: azureConnector(transport)),
+        const ApplyOptions(dryRun: true),
+      );
+
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(transport.requests, isEmpty);
+      expect(result.azureGroup!.mail, 'SSM-3A@student.school.example');
+    });
+
+    test('a nickname Graph already knows fails instead of duplicating',
+        () async {
+      final transport = RecordingGraphTransport(
+        handler: (request) {
+          if (request.method == 'GET') {
+            return az.GraphResponse(
+              statusCode: 200,
+              headers: const {'content-type': 'application/json'},
+              body: jsonEncode({
+                'value': [
+                  {
+                    'id': 'g-existing',
+                    'displayName': 'SSM-3A',
+                    'mailNickname': 'SSM-3A',
+                  },
+                ],
+              }),
+            );
+          }
+          return _classGroupGraph(request);
+        },
+      );
+      final action = CreateAzureClassGroup(
+        linkedGroup(wisa: wisaGroup()),
+        azurePlan(),
+      );
+
+      final result = await action.apply(
+        Connectors(azure: azureConnector(transport)),
+        const ApplyOptions(),
+      );
+
+      expect(result.outcome, ActionOutcome.failed);
+      expect('${result.error}', contains('already has a group'));
+      expect(transport.sent('POST', pathContains: '/groups'), isFalse);
+    });
+
+    test('a membership sync batches the adds and the removes', () async {
+      final transport = RecordingGraphTransport(handler: _classGroupGraph);
+      final action = SyncAzureClassGroupMembers(
+        linkedGroup(
+          wisa: wisaGroup(),
+          azure: azureClassGroup('3A', memberIds: const ['az-left']),
+        ),
+        azurePlan(
+          membersToAdd: const ['az-joined'],
+          membersToRemove: const ['az-left'],
+        ),
+      );
+
+      final result = await action.apply(
+        Connectors(azure: azureConnector(transport)),
+        const ApplyOptions(),
+      );
+
+      expect(result.outcome, ActionOutcome.applied);
+      final batches = transport.requests
+          .where((r) => r.url.path.endsWith(r'/$batch'))
+          .map((r) => jsonDecode(r.body!) as Map<String, dynamic>)
+          .expand((b) => (b['requests'] as List).cast<Map<String, dynamic>>())
+          .toList();
+      expect(batches.map((r) => r['method']), ['POST', 'DELETE']);
+      expect(
+        (result.azureGroup! as az.AzureGroup).memberIds,
+        ['az-joined'],
+      );
+    });
+  });
+
+  group('a vanished class is reported, never deleted (#228)', () {
+    LinkedGroup orphan(az.AzureGroup group, {String? className = '9Z'}) =>
+        linkedGroup(azure: group, className: className);
+
+    test('an app-shaped class group with no class raises the notice', () {
+      final actions = groupActionsFor(orphan(azureClassGroup('9Z')));
+      expect(actions.map((a) => a.runtimeType), [AzureClassGroupWithoutClass]);
+      final action = actions.single;
+      expect(action.canApply, isFalse,
+          reason: 'groups are never deleted automatically');
+      expect(
+        action.describeChanges().summary,
+        contains('De klas 9Z bestaat niet meer'),
+      );
+      expect(
+        () => action.apply(const Connectors(), const ApplyOptions()),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('a security group or a hand-made Team is left unmentioned', () {
+      // Not mail-enabled ⇒ not a group this app created.
+      expect(
+        groupActionsFor(orphan(az.AzureGroup(
+          id: 'g',
+          displayName: 'SSM-9Z',
+          securityEnabled: true,
+        ))),
+        isEmpty,
+      );
+      // Mail-enabled, but its nickname is not the display name — somebody made
+      // it by hand.
+      expect(
+        groupActionsFor(orphan(az.AzureGroup(
+          id: 'g',
+          displayName: 'SSM-Wiskunde',
+          mail: 'wiskunde@school.example',
+          mailNickname: 'wiskunde',
+        ))),
+        isEmpty,
+      );
+      // Outside our `<PREFIX>-` namespace ⇒ the linker never recovered a class
+      // name for it.
+      expect(
+        groupActionsFor(orphan(azureClassGroup('9Z'), className: null)),
+        isEmpty,
+      );
+    });
+
+    test('a class that still exists never raises the notice', () {
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(),
+          smartschool: ssGroup(),
+          azure: azureClassGroup('3A'),
+        ),
+        azurePlanFor: (_) => azurePlan(),
+      );
+      expect(actions, isEmpty);
+    });
+  });
+
+  group('purity (INV-40)', () {
+    test('evaluate and describeChanges are deterministic', () {
+      final group = linkedGroup(
+        wisa: wisaGroup(),
+        azure: azureClassGroup('3A', memberIds: const ['az-left']),
+      );
+      final plan = azurePlan(
+        membersToAdd: const ['az-joined'],
+        membersToRemove: const ['az-left'],
+      );
+      for (final action in <GroupAction>[
+        CreateAzureClassGroup(group, plan),
+        SyncAzureClassGroupMembers(group, plan),
+      ]) {
+        expect(action.evaluate(), action.evaluate());
+        expect(
+          action.describeChanges().summary,
+          action.describeChanges().summary,
+        );
+      }
+      // The bound record is untouched by evaluation.
+      expect(
+        (group.azure! as az.AzureGroup).memberIds,
+        ['az-left'],
+      );
+    });
+  });
+}

--- a/packages/account_actions/test/azure_class_group_test.dart
+++ b/packages/account_actions/test/azure_class_group_test.dart
@@ -124,6 +124,61 @@ void main() {
     });
   });
 
+  group('creating a class group is one chain, not two clicks (#245)', () {
+    test('the create declares the roster sync as its follow-up', () {
+      // Graph creates a group empty — membership is a separate write — so the
+      // dispatcher, a pure function of the current record, can only offer the
+      // create. Naming the follow-up here is what lets the State layer run the
+      // roster against the relinked record, which is the only place the id
+      // Graph minted exists.
+      final actions = groupActionsFor(
+        linkedGroup(wisa: wisaGroup(), smartschool: ssGroup()),
+        azurePlanFor: (_) => azurePlan(),
+      );
+      final create = actions.single as CreateAzureClassGroup;
+      expect(create.unlocks, <Type>{SyncAzureClassGroupMembers});
+    });
+
+    test('the roster sync ends the chain', () {
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(),
+          smartschool: ssGroup(),
+          azure: azureClassGroup('3A'),
+        ),
+        azurePlanFor: (_) => azurePlan(membersToAdd: const ['az-1']),
+      );
+      expect(actions.single.unlocks, isEmpty);
+    });
+
+    test('every other group action unlocks nothing', () {
+      // The chain is opt-in per action; a stray declaration would make the
+      // applier write beyond what the operator selected.
+      final groups = <LinkedGroup>[
+        linkedGroup(wisa: wisaGroup()),
+        linkedGroup(smartschool: ssGroup()),
+        linkedGroup(
+          wisa: wisaGroup(),
+          smartschool: ssGroup(untis: 'stale'),
+        ),
+        linkedGroup(
+          azure: azureClassGroup('9Z'),
+          className: '9Z',
+        ),
+      ];
+      for (final group in groups) {
+        for (final action in groupActionsFor(
+          group,
+          placementFor: (_) => groupPlacement(),
+          azurePlanFor: (_) => azurePlan(membersToAdd: const ['az-1']),
+        )) {
+          if (action is CreateAzureClassGroup) continue;
+          expect(action.unlocks, isEmpty, reason: '${action.runtimeType}');
+        }
+      }
+    });
+  });
+
   group('membership follows the roster (#228)', () {
     test('a roster difference raises the membership sync', () {
       final actions = groupActionsFor(

--- a/packages/account_actions/test/azure_class_membership_test.dart
+++ b/packages/account_actions/test/azure_class_membership_test.dart
@@ -1,0 +1,213 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+/// The per-student view of Office 365 class-group membership (#245) — the half
+/// of #228 that reports the roster diff on the *account* rather than only on the
+/// class row in Klasgroepen.
+///
+/// [AzureClassPlacement] arrives injected, exactly as [ClassPlacement] does, so
+/// these tests drive the action straight from a placement; the State layer test
+/// (`account_state/test/azure_class_groups_test.dart`) covers deriving one from
+/// a real linked view.
+AzureClassPlacement placement({
+  String className = '3A',
+  String? groupName = 'SSM-3A',
+  bool groupExists = true,
+  bool isMember = true,
+  List<String> strayGroupNames = const [],
+}) =>
+    AzureClassPlacement(
+      className: className,
+      groupName: groupName,
+      groupExists: groupExists,
+      isMember: isMember,
+      strayGroupNames: strayGroupNames,
+    );
+
+List<StudentAction> _dispatch(
+  LinkedAccount account,
+  AzureClassPlacement azure,
+) =>
+    studentActionsFor(
+      account,
+      config(),
+      placementFor: (_) => classPlacement(),
+      azurePlacementFor: (_) => azure,
+    );
+
+void main() {
+  group('the action reports the placement it is handed (#245)', () {
+    test('a student in their own class group raises nothing', () {
+      final action = AzureClassGroupMembership(
+        fullySynced(),
+        config(),
+        placement(),
+      );
+      expect(action.evaluate(), isFalse);
+    });
+
+    test('a student missing from their own class group is reported', () {
+      final action = AzureClassGroupMembership(
+        fullySynced(),
+        config(),
+        placement(isMember: false),
+      );
+      expect(action.evaluate(), isTrue);
+      final changes = action.describeChanges();
+      expect(changes.system, Origin.azure);
+      expect(changes.summary, contains('Ontbreekt in de Office 365-klasgroep'));
+      expect(changes.summary, contains('SSM-3A'));
+      expect(changes.fields.single.after, 'SSM-3A');
+    });
+
+    test('a student still in the group of a class they left is reported', () {
+      final action = AzureClassGroupMembership(
+        fullySynced(),
+        config(),
+        placement(strayGroupNames: const ['SSM-2B']),
+      );
+      expect(action.evaluate(), isTrue);
+      final changes = action.describeChanges();
+      expect(changes.summary, contains('Staat nog in de Office 365-klasgroep'));
+      expect(changes.summary, contains('SSM-2B'));
+      expect(changes.fields.single.before, 'SSM-2B');
+    });
+
+    test('the wrong-class case names both groups in one line', () {
+      final action = AzureClassGroupMembership(
+        fullySynced(),
+        config(),
+        placement(isMember: false, strayGroupNames: const ['SSM-2B']),
+      );
+      expect(action.evaluate(), isTrue);
+      final changes = action.describeChanges();
+      expect(changes.summary, contains('verkeerde Office 365-klasgroep'));
+      expect(changes.summary, contains('SSM-2B in plaats van SSM-3A'));
+      expect(changes.fields.single.before, 'SSM-2B');
+      expect(changes.fields.single.after, 'SSM-3A');
+    });
+
+    test('a class whose group does not exist yet raises nothing', () {
+      // The class-level CreateAzureClassGroup is the work there, and since #245
+      // it chains straight into the roster sync — reporting it once per student
+      // of the class would be pure noise.
+      final action = AzureClassGroupMembership(
+        fullySynced(),
+        config(),
+        placement(groupExists: false, isMember: false),
+      );
+      expect(action.evaluate(), isFalse);
+    });
+
+    test('a student with no Office 365 account raises nothing', () {
+      // AddStudentToAzure is their action; a group they cannot be a member of
+      // is not yet their account's problem.
+      final action = AzureClassGroupMembership(
+        linked(wisa: wisaStudent(), smartschool: ssAccount()),
+        config(),
+        placement(isMember: false),
+      );
+      expect(action.evaluate(), isFalse);
+    });
+  });
+
+  group('informational, so the class row stays the single write (#245)', () {
+    test('canApply is false and apply throws', () {
+      final action = AzureClassGroupMembership(
+        fullySynced(),
+        config(),
+        placement(isMember: false),
+      );
+      expect(action.canApply, isFalse);
+      expect(
+        () => action.apply(const Connectors(), const ApplyOptions()),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('every other student action stays applyable', () {
+      final actions = studentActionsFor(
+        linked(wisa: wisaStudent()),
+        config(),
+      );
+      expect(actions, isNotEmpty);
+      for (final action in actions) {
+        expect(action.canApply, isTrue, reason: '${action.runtimeType}');
+      }
+    });
+  });
+
+  group('dispatch wiring (#245)', () {
+    test('the modify branch raises it beside MoveToSmartschoolClassGroup', () {
+      final actions = _dispatch(fullySynced(), placement(isMember: false));
+      expect(
+        actions.map((a) => a.runtimeType),
+        contains(AzureClassGroupMembership),
+      );
+    });
+
+    test('a lifecycle account never gets one', () {
+      // A student with no Smartschool account falls to the lifecycle branch,
+      // where the class-placement actions of both systems are out of scope.
+      final actions = _dispatch(
+        linked(wisa: wisaStudent(), azure: azureUser()),
+        placement(isMember: false),
+      );
+      expect(
+        actions.map((a) => a.runtimeType),
+        isNot(contains(AzureClassGroupMembership)),
+      );
+    });
+
+    test('without the callback the dispatch is exactly as it was before #245',
+        () {
+      final actions = studentActionsFor(
+        fullySynced(),
+        config(),
+        placementFor: (_) => classPlacement(),
+      );
+      expect(
+        actions.map((a) => a.runtimeType),
+        isNot(contains(AzureClassGroupMembership)),
+      );
+    });
+
+    test('the callback is not consulted for a sibling-school student', () {
+      // A groupOnly student's class is not ours to place (#134/#222), so the
+      // resolver is never asked about them.
+      var calls = 0;
+      studentActionsFor(
+        linked(
+          wisa: wisaStudent(),
+          smartschool: ssAccount(),
+          azure: azureUser(),
+          wisaPresence: WisaPresence.groupOnly,
+        ),
+        config(),
+        azurePlacementFor: (_) {
+          calls++;
+          return placement();
+        },
+      );
+      expect(calls, 0);
+    });
+  });
+
+  group('purity (INV-40)', () {
+    test('evaluate and describeChanges are deterministic', () {
+      final action = AzureClassGroupMembership(
+        fullySynced(),
+        config(),
+        placement(isMember: false, strayGroupNames: const ['SSM-2B']),
+      );
+      expect(action.evaluate(), action.evaluate());
+      expect(
+        action.describeChanges().summary,
+        action.describeChanges().summary,
+      );
+    });
+  });
+}

--- a/packages/account_actions/test/staff_dispatch_test.dart
+++ b/packages/account_actions/test/staff_dispatch_test.dart
@@ -1,4 +1,5 @@
 import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
 import 'package:test/test.dart';
 
 import 'support/fixtures.dart';
@@ -159,6 +160,72 @@ void main() {
       expect(actions.whereType<AddStaffToAzure>(), isEmpty);
       expect(actions.whereType<RemoveStaffFromSmartschool>(), isEmpty);
       expect(actions.whereType<DontImportStaffFromWisa>(), isEmpty);
+    });
+  });
+
+  group('unlocked follow-ups (#240)', () {
+    test('the WISA-only create declares its Smartschool follow-up', () {
+      // Provisioning a new staff member is a chain the dispatcher cannot
+      // express: AddStaffToSmartschool needs the Azure UPN as the new account's
+      // mail, so it evaluates false until the Azure account exists. Naming the
+      // follow-up here is what lets the State layer run it straight after the
+      // create, against the relinked record — one click, both accounts.
+      final actions = staffActionsFor(linkedStaff(wisa: wisaStaff()), cfg);
+      final create = actions.whereType<AddStaffToAzure>().single;
+      expect(create.unlocks, <Type>{AddStaffToSmartschool});
+    });
+
+    test('the Smartschool create ends the chain', () {
+      // Nothing follows it: the record is complete afterwards, so the next pass
+      // is the ordinary modify branch, not another link of this chain.
+      final actions = staffActionsFor(
+        linkedStaff(wisa: wisaStaff(), azure: azureStaff()),
+        cfg,
+      );
+      expect(
+          actions.whereType<AddStaffToSmartschool>().single.unlocks, isEmpty);
+    });
+
+    test('every other staff action unlocks nothing', () {
+      // The chain is opt-in per action; a stray declaration would make the
+      // applier write beyond what the operator selected.
+      for (final staff in <LinkedStaff>[
+        linkedStaff(wisa: wisaStaff()),
+        linkedStaff(wisa: wisaStaff(), azure: azureStaff()),
+        linkedStaff(smartschool: ssStaff()),
+        linkedStaff(azure: azureStaff()),
+        linkedStaff(
+          wisa: wisaStaff(code: 'SMIT', wisaId: '42'),
+          smartschool: ssStaff(accountId: 'OLD', fax: '9999'),
+          azure: azureStaff(department: 'OTHER - Wiskunde'),
+        ),
+      ]) {
+        for (final action in staffActionsFor(staff, cfg)) {
+          if (action is AddStaffToAzure) continue;
+          expect(action.unlocks, isEmpty, reason: '${action.runtimeType}');
+        }
+      }
+    });
+
+    test('every staff action is applyable, and says so on the action', () {
+      // The walk skips a `canApply == false` follow-up. No staff action is
+      // informational today; the flag is read off the action rather than
+      // assumed, so adding one cannot silently make the applier run it.
+      for (final staff in <LinkedStaff>[
+        linkedStaff(wisa: wisaStaff()),
+        linkedStaff(wisa: wisaStaff(), azure: azureStaff()),
+        linkedStaff(smartschool: ssStaff()),
+        linkedStaff(azure: azureStaff()),
+        linkedStaff(
+          wisa: wisaStaff(code: 'SMIT', wisaId: '42'),
+          smartschool: ssStaff(accountId: 'OLD', fax: '9999'),
+          azure: azureStaff(department: 'OTHER - Wiskunde'),
+        ),
+      ]) {
+        for (final action in staffActionsFor(staff, cfg)) {
+          expect(action.canApply, isTrue, reason: '${action.runtimeType}');
+        }
+      }
     });
   });
 }

--- a/packages/account_actions/test/support/fixtures.dart
+++ b/packages/account_actions/test/support/fixtures.dart
@@ -381,12 +381,15 @@ GroupPlacement groupPlacement({
     );
 
 /// Builds a [LinkedGroup] from optional per-system records. Omit a system to
-/// simulate the class missing there.
+/// simulate the class missing there. [className] is the **bare** class name the
+/// Office 365 group is named after (#228); it defaults to the WISA name, which
+/// is right for every class that has no sub-groups.
 LinkedGroup linkedGroup({
   Group? wisa,
   Group? smartschool,
   Group? smartschoolNamesake,
   az.AzureGroup? azure,
+  String? className,
   LinkConfidence confidence = LinkConfidence.high,
 }) =>
     LinkedGroup(
@@ -394,7 +397,50 @@ LinkedGroup linkedGroup({
       smartschool: smartschool,
       smartschoolNamesake: smartschoolNamesake,
       azure: azure,
+      className: className ?? wisa?.name,
       confidence: confidence,
+    );
+
+/// An Office 365 **class** group as this app creates one (#228): a mail-enabled
+/// unified group whose display name and mail nickname are both
+/// `<prefix>-<class>`.
+az.AzureGroup azureClassGroup(
+  String className, {
+  String prefix = 'SSM',
+  String domain = 'student.school.example',
+  String? id,
+  List<String> memberIds = const [],
+}) =>
+    az.AzureGroup(
+      id: id ?? 'az-$prefix-$className',
+      displayName: '$prefix-$className',
+      mail: '$prefix-$className@$domain',
+      mailNickname: '$prefix-$className',
+      memberIds: memberIds,
+    );
+
+/// An [AzureClassGroupPlan] for one class. Defaults to the owner record of a
+/// populated class with membership already in sync; pass [membersToAdd] /
+/// [membersToRemove] to make the roster differ, or `owner: false` for a
+/// sub-group record that must raise nothing.
+AzureClassGroupPlan azurePlan({
+  String className = '3A',
+  String prefix = 'SSM',
+  String domain = 'student.school.example',
+  bool owner = true,
+  bool containsStudents = true,
+  List<String> membersToAdd = const [],
+  List<String> membersToRemove = const [],
+}) =>
+    AzureClassGroupPlan(
+      className: className,
+      displayName: '$prefix-$className',
+      mailNickname: '$prefix-$className',
+      mail: '$prefix-$className@$domain',
+      owner: owner,
+      containsStudents: containsStudents,
+      membersToAdd: membersToAdd,
+      membersToRemove: membersToRemove,
     );
 
 /// A class present and in sync in both WISA and Smartschool — no group action

--- a/packages/account_core/lib/src/group.dart
+++ b/packages/account_core/lib/src/group.dart
@@ -157,6 +157,69 @@ String? groupNameFingerprint(String? name) =>
 final RegExp _whitespaceRun =
     RegExp(r'[\s\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000]+');
 
+/// The Office 365 group name for a class: `<PREFIX>-<KLAS>` (#228).
+///
+/// [className] is the **bare** WISA class name \u2014 `2F`, never the sub-grouped
+/// `2F ECO`: sub-groups get no group of their own, so every one of their
+/// students belongs to the parent class's group. The same string is used as the
+/// group's `displayName` and its `mailNickname`, which makes the resulting
+/// address `<PREFIX>-<KLAS>@<studentdomein>`.
+///
+/// Returns `null` when either half is blank \u2014 there is no group to name then.
+String? azureClassGroupName(String? schoolPrefix, String? className) {
+  final prefix = schoolPrefix?.trim() ?? '';
+  final name = className?.trim() ?? '';
+  if (prefix.isEmpty || name.isEmpty) return null;
+  return '$prefix-$name';
+}
+
+/// The bare class name an Azure group's [displayName] stands for, given the
+/// school's [schoolPrefix] \u2014 the inverse of [azureClassGroupName] (#228).
+///
+/// The Azure side of the class-group bridge is **prefix-aware**: a group named
+/// `SSM-2A` is the Office 365 group of class `2A`, and matching its display name
+/// against the WISA class name directly never joins the two. Comparison of the
+/// prefix is case-insensitive (INV-12); the remainder is returned as written so
+/// it can be displayed.
+///
+/// Returns `null` when [displayName] is not in our `<PREFIX>-` namespace, or
+/// when nothing follows the separator.
+String? azureClassNameOf(String? displayName, String? schoolPrefix) {
+  final name = displayName?.trim() ?? '';
+  final prefix = schoolPrefix?.trim() ?? '';
+  if (name.isEmpty || prefix.isEmpty) return null;
+  final marker = '$prefix-';
+  if (name.length <= marker.length) return null;
+  if (name.substring(0, marker.length).toLowerCase() != marker.toLowerCase()) {
+    return null;
+  }
+  final bare = name.substring(marker.length).trim();
+  return bare.isEmpty ? null : bare;
+}
+
+/// Whether [nickname] is usable verbatim as a Graph `mailNickname` (#228).
+///
+/// Bare class names carry no spaces, so `<PREFIX>-<KLAS>` needs no slug rule \u2014
+/// but nothing *enforces* that on the WISA side, and Graph rejects a create
+/// whose nickname holds a space, a diacritic, or one of its reserved
+/// characters. The group actions consult this instead of silently mangling a
+/// name into something the operator never asked for: an unusable name means no
+/// create is proposed at all.
+///
+/// Graph accepts ASCII 0\u2013127 except ``@ ( ) \ [ ] " ; : < > ,`` and space.
+bool isValidMailNickname(String? nickname) {
+  final value = nickname ?? '';
+  if (value.isEmpty || value.trim().length != value.length) return false;
+  for (final unit in value.codeUnits) {
+    if (unit < 0x21 || unit > 0x7e) return false;
+    if (_reservedNicknameChars.contains(unit)) return false;
+  }
+  return true;
+}
+
+/// The characters Graph refuses inside a `mailNickname`, as code units.
+final Set<int> _reservedNicknameChars = '@()\\[]";:<>,'.codeUnits.toSet();
+
 /// First-class many-to-many link between a [Person] and a [Group].
 ///
 /// Replaces the legacy "groups own their members" model. Multiple memberships

--- a/packages/account_core/lib/src/linked.dart
+++ b/packages/account_core/lib/src/linked.dart
@@ -159,12 +159,29 @@ class LinkedGroup {
   /// explicit notice on this field instead of a create.
   final Group? smartschoolNamesake;
 
+  /// The **bare** class name behind this record — `2F` for the sub-grouped
+  /// class `2F ECO`, and simply the class name for a class without sub-groups
+  /// (#228).
+  ///
+  /// [wisa] is keyed and named by the WISA `fullName` (the cross-system match
+  /// key), which is what Smartschool spells a class by. The Office 365 group is
+  /// named after the *parent* class instead — sub-groups get no group of their
+  /// own — so without this the bare name is gone by the time an action sees the
+  /// record. Carrying it here keeps the linker the single place that knows how a
+  /// WISA class projects, rather than teaching every consumer to re-derive it.
+  ///
+  /// For an Azure-only orphan it is the name recovered from the group's
+  /// `<PREFIX>-` display name ([azureClassNameOf]); `null` for a record with
+  /// neither — a Smartschool-only orphan carries no WISA class to name.
+  final String? className;
+
   const LinkedGroup({
     this.wisa,
     this.smartschool,
     this.azure,
     required this.confidence,
     this.smartschoolNamesake,
+    this.className,
   });
 }
 

--- a/packages/account_core/lib/src/source_records.dart
+++ b/packages/account_core/lib/src/source_records.dart
@@ -42,4 +42,16 @@ abstract interface class AzureUser {
 abstract interface class AzureGroup {
   String get id;
   String get displayName;
+
+  /// The group's SMTP address, e.g. `SSM-2A@student.arcadiascholen.be`. Only a
+  /// mail-enabled (Microsoft 365 "unified") group has one; `null` for a plain
+  /// security group, and `null` on a record read back from a snapshot written
+  /// before the field was selected (#228).
+  String? get mail;
+
+  /// The group's mail alias — the local part [mail] is built from. Carried
+  /// beside [displayName] because two groups may share a display name while
+  /// addressing different mailboxes, and the class group is identified by the
+  /// address it answers on (#228).
+  String? get mailNickname;
 }

--- a/packages/account_core/test/group_test.dart
+++ b/packages/account_core/test/group_test.dart
@@ -177,4 +177,61 @@ void main() {
       expect(groupNameFingerprint(null), isNull);
     });
   });
+
+  group('Office 365 class-group naming (#228)', () {
+    test('a class group is <PREFIX>-<KLAS>', () {
+      expect(azureClassGroupName('SSM', '2A'), 'SSM-2A');
+      expect(azureClassGroupName(' SSM ', ' 2A '), 'SSM-2A');
+    });
+
+    test('a missing half names no group', () {
+      expect(azureClassGroupName('', '2A'), isNull);
+      expect(azureClassGroupName('SSM', '  '), isNull);
+      expect(azureClassGroupName(null, null), isNull);
+    });
+
+    test('the bare class name is recovered from the prefixed display name', () {
+      expect(azureClassNameOf('SSM-2A', 'SSM'), '2A');
+      // The prefix compares case-insensitively (INV-12); the class name is
+      // returned as written so it can be displayed.
+      expect(azureClassNameOf('ssm-2A', 'SSM'), '2A');
+      expect(azureClassNameOf('  SSM-2A  ', 'SSM'), '2A');
+    });
+
+    test('a name outside our namespace belongs to no class', () {
+      expect(azureClassNameOf('2A', 'SSM'), isNull);
+      expect(azureClassNameOf('OTHER-2A', 'SSM'), isNull);
+      expect(azureClassNameOf('SSM-', 'SSM'), isNull);
+      expect(azureClassNameOf('SSM-2A', ''), isNull);
+      expect(azureClassNameOf(null, 'SSM'), isNull);
+    });
+
+    test('naming round-trips for every plausible bare class name', () {
+      for (final className in ['1A', '2F', '7EW', 'OKAN', '3STW']) {
+        final name = azureClassGroupName('SSM', className)!;
+        expect(azureClassNameOf(name, 'SSM'), className);
+      }
+    });
+
+    test(
+        'bare class names need no slug rule \u2014 but a name that would break the '
+        'mail nickname is rejected rather than mangled', () {
+      // The decided rule: bare class names carry no spaces, so `<PREFIX>-<KLAS>`
+      // is used verbatim. This is the assertion that tells us early if a WISA
+      // class name ever stops honouring that.
+      for (final className in ['1A', '2F', '7EW', 'OKAN', '3STW']) {
+        expect(
+            isValidMailNickname(azureClassGroupName('SSM', className)), isTrue,
+            reason: '$className must survive as a mail nickname');
+      }
+      // \u2026and the shapes Graph refuses.
+      expect(isValidMailNickname('SSM-2F ECO'), isFalse, reason: 'space');
+      expect(isValidMailNickname('SSM-2\u00c9'), isFalse, reason: 'diacritic');
+      expect(isValidMailNickname('SSM-2A@x'), isFalse, reason: 'reserved @');
+      expect(isValidMailNickname('SSM-2A;1'), isFalse, reason: 'reserved ;');
+      expect(isValidMailNickname('SSM-2A\u00a0'), isFalse, reason: 'nbsp');
+      expect(isValidMailNickname(''), isFalse);
+      expect(isValidMailNickname(null), isFalse);
+    });
+  });
 }

--- a/packages/account_core/test/linked_test.dart
+++ b/packages/account_core/test/linked_test.dart
@@ -47,6 +47,10 @@ class _FakeAzureGroup implements AzureGroup {
   final String id;
   @override
   final String displayName;
+  @override
+  String? get mail => null;
+  @override
+  String? get mailNickname => null;
   const _FakeAzureGroup(this.id, this.displayName);
 }
 

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -140,6 +140,7 @@ LinkedSnapshot link(
     azureSnapshot,
     effectiveOurSchoolIds,
     virtualSchoolIds,
+    schoolPrefix,
     warnings,
   );
 
@@ -446,9 +447,20 @@ List<_StaffRecord> _buildStaffRecords(
 /// whitespace-insensitive [groupNameFingerprint], so a hand-typed `2 G` is
 /// recognised as the existing `2G` even though it is too loose a key to link on.
 ///
+/// The Azure side of the match is **prefix-aware** (#228). The Office 365 group
+/// of a class is named `<PREFIX>-<KLAS>` after the **bare** class name — `2F`,
+/// never the sub-grouped `2F ECO` — so `displayName` is stripped of the school
+/// prefix ([azureClassNameOf]) and matched against [LinkedGroup.className]
+/// rather than against the WISA `fullName`. Without that, `GBS-2A` would match
+/// no class at all and seed a spurious orphan *while* leaving `2A` reading as
+/// having no group; with it, one `GBS-2F` attaches to every one of that class's
+/// sub-group records, which is exactly what "sub-groups get no group of their
+/// own" means. The pre-#228 exact-`displayName` match is kept as a fallback so a
+/// hand-made, unprefixed group still links the way it used to.
+///
 /// Azure carries no `official`-style signal — [az.AzureGroup] is just
-/// `{id, displayName, securityEnabled}` — so an unmatched Azure group is kept
-/// as an orphan *unless* its name looks administrative (see
+/// `{id, displayName, securityEnabled, mail, mailNickname}` — so an unmatched
+/// Azure group is kept as an orphan *unless* its name looks administrative (see
 /// [_looksLikeClassGroup]); staff/directorate/secretariat groups are excluded
 /// by name rather than included by one, since there is no positive
 /// class-group signal to include by.
@@ -464,11 +476,17 @@ List<LinkedGroup> _linkGroups(
   az.AzureSnapshot azureSnapshot,
   Set<int> ourSchoolIds,
   Set<int> virtualSchoolIds,
+  String schoolPrefix,
   List<LinkWarning> warnings,
 ) {
   final records = <_GroupRecord>[];
   // Normalized fullName/name/displayName -> the record indexed under it.
   final byName = <String, _GroupRecord>{};
+  // Normalized **bare** class name -> every record of that class, in seed
+  // order (#228). A class split into sub-groups seeds one record per sub-group
+  // and they all share one Office 365 group, so this is a one-to-many index
+  // where [byName] is one-to-one.
+  final byClassName = <String, List<_GroupRecord>>{};
 
   // Every Smartschool group by name, official or not (#225) — the index the
   // "does this class already exist downstream?" guard consults after the link
@@ -502,6 +520,12 @@ List<LinkedGroup> _linkGroups(
     final rec = _GroupRecord(wisa: group);
     records.add(rec);
     byName[key] = rec;
+    // Index the same record under its bare class name for the prefix-aware
+    // Azure match (#228). `fullName == name` for a class without sub-groups, so
+    // the two indexes coincide there; a sub-grouped class contributes several
+    // records to the one bare name.
+    final bare = normalizeGroupName(group.name);
+    if (bare != null) (byClassName[bare] ??= <_GroupRecord>[]).add(rec);
   }
 
   // 2. Attach official Smartschool class groups by name; non-official
@@ -551,17 +575,35 @@ List<LinkedGroup> _linkGroups(
     );
   }
 
-  // 3. Attach Azure groups by displayName. An Azure group matching no
-  //    existing record becomes an orphan too (#52), but only when it looks
-  //    like a stale class rather than a staff/administrative group.
+  // 3. Attach Azure groups, prefix-aware (#228): `GBS-2F` is the Office 365
+  //    group of class `2F`, so the prefix is stripped and the remainder matched
+  //    against the **bare** class name — attaching to every sub-group record of
+  //    that class, since they share the one group. A group whose name is not in
+  //    our `<PREFIX>-` namespace falls back to the pre-#228 exact-`displayName`
+  //    match, so an unprefixed group somebody made by hand still links.
+  //
+  //    An Azure group matching no existing record becomes an orphan too (#52),
+  //    but only when it looks like a stale class rather than a
+  //    staff/administrative group.
   for (final group in azureSnapshot.groups) {
     final key = normalizeGroupName(group.displayName);
     if (key == null) continue;
+    final bare = azureClassNameOf(group.displayName, schoolPrefix);
+    final ofClass = bare == null ? null : byClassName[normalizeGroupName(bare)];
+    if (ofClass != null && ofClass.isNotEmpty) {
+      for (final rec in ofClass) {
+        rec.azure ??= group;
+      }
+      continue;
+    }
     final existing = byName[key];
     if (existing != null) {
       existing.azure ??= group;
     } else if (_looksLikeClassGroup(group.displayName)) {
-      final rec = _GroupRecord(azure: group);
+      // The denylist is checked against the *full* display name on purpose:
+      // `GBS-Personeel` only ends in a staff suffix before the prefix is
+      // stripped.
+      final rec = _GroupRecord(azure: group, className: bare);
       records.add(rec);
       byName[key] = rec;
     }
@@ -575,6 +617,7 @@ List<LinkedGroup> _linkGroups(
         smartschool: rec.smartschool,
         smartschoolNamesake: rec.smartschoolNamesake,
         azure: rec.azure,
+        className: rec.wisa?.name ?? rec.className,
         confidence:
             rec.wisa != null && rec.smartschool != null && rec.azure != null
                 ? LinkConfidence.high
@@ -668,7 +711,12 @@ class _GroupRecord {
   /// pass could not adopt (#225). See [LinkedGroup.smartschoolNamesake].
   Group? smartschoolNamesake;
 
-  _GroupRecord({this.wisa, this.smartschool, this.azure});
+  /// The bare class name for a record with **no** WISA anchor — recovered from
+  /// an orphan Azure group's `<PREFIX>-` display name (#228). A WISA-seeded
+  /// record reads its bare name off [wisa] instead.
+  final String? className;
+
+  _GroupRecord({this.wisa, this.smartschool, this.azure, this.className});
 }
 
 /// Whether a Smartschool [role] marks the account as staff (teacher or

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -355,6 +355,98 @@ void main() {
       },
     );
 
+    test(
+        'a prefixed Office 365 class group links to the bare class it is '
+        'named after (#228)', () {
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('2A')]),
+        ssSnap(const []),
+        azSnap(const [], groups: [azureClassGroup(_prefix, '2A')]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      // One record — the class — carrying its group, not a WISA class beside
+      // an unrelated Azure orphan.
+      expect(snapshot.groups, hasLength(1));
+      final g = snapshot.groups.single;
+      expect(g.wisa!.name, '2A');
+      expect(g.azure!.displayName, '$_prefix-2A');
+      expect(g.className, '2A');
+    });
+
+    test(
+        'one Office 365 group serves a sub-grouped class: every sub-group '
+        'record carries it, and they all report the bare class name (#228)',
+        () {
+      final snapshot = link(
+        wisaSnap(
+          const [],
+          classGroups: [
+            wisaClassGroup('2F', groupName: 'ECO', adminCode: 'a'),
+            wisaClassGroup('2F', groupName: 'MAW', adminCode: 'b'),
+            wisaClassGroup('2F', groupName: 'STEMW', adminCode: 'c'),
+          ],
+        ),
+        ssSnap(const []),
+        azSnap(const [], groups: [azureClassGroup(_prefix, '2F')]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      expect(snapshot.groups, hasLength(3));
+      expect(snapshot.groups.map((g) => g.wisa!.name),
+          ['2F ECO', '2F MAW', '2F STEMW']);
+      expect(snapshot.groups.map((g) => g.className), ['2F', '2F', '2F']);
+      expect(
+        snapshot.groups.map((g) => g.azure?.id),
+        everyElement('$_prefix-2F'),
+        reason: 'sub-groups get no group of their own — they share the parent',
+      );
+    });
+
+    test('a prefixed group whose class is gone stays an Azure orphan (#228)',
+        () {
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('2A')]),
+        ssSnap(const []),
+        azSnap(const [], groups: [azureClassGroup(_prefix, '9Z')]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final orphan = snapshot.groups.firstWhere((g) => g.wisa == null);
+      expect(orphan.azure!.displayName, '$_prefix-9Z');
+      expect(orphan.className, '9Z',
+          reason: 'the bare class name is recovered from the prefixed name');
+    });
+
+    test(
+        'the prefix strip never turns a staff group into a class orphan '
+        '(#228)', () {
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap(const []),
+        azSnap(const [], groups: [azureGroup('$_prefix-Personeel')]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+      expect(snapshot.groups, isEmpty);
+    });
+
+    test('an unprefixed Azure group still links by exact name (#228)', () {
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('5A')]),
+        ssSnap(const []),
+        azSnap(const [], groups: [azureGroup('5A')]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      expect(snapshot.groups, hasLength(1));
+      expect(snapshot.groups.single.azure!.displayName, '5A');
+    });
+
     test('WISA + Smartschool but no Azure → medium', () {
       final snapshot = link(
         wisaSnap(const [], classGroups: [wisaClassGroup('5A')]),

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -183,11 +183,40 @@ Group ssGroup(
       origin: Origin.smartschool,
     );
 
-/// An Azure group, matched to WISA by [displayName]. [id] defaults to
-/// [displayName].
-az.AzureGroup azureGroup(String displayName, {String? id}) => az.AzureGroup(
+/// An Azure group, matched to WISA by [displayName] — prefix-aware for a class
+/// group, so `Arcadia-2A` is the group of class `2A` (#228). [id] defaults to
+/// [displayName]. Pass [mail]/[mailNickname] to make it a *unified* group, the
+/// shape a class group has.
+az.AzureGroup azureGroup(
+  String displayName, {
+  String? id,
+  String? mail,
+  String? mailNickname,
+  List<String> memberIds = const [],
+}) =>
+    az.AzureGroup(
       id: id ?? displayName,
       displayName: displayName,
+      mail: mail,
+      mailNickname: mailNickname,
+      memberIds: memberIds,
+    );
+
+/// A *unified* (Microsoft 365) class group named the way this app creates one:
+/// `<prefix>-<class>` as both display name and mail nickname (#228).
+az.AzureGroup azureClassGroup(
+  String prefix,
+  String className, {
+  String? id,
+  String domain = 'student.s.be',
+  List<String> memberIds = const [],
+}) =>
+    azureGroup(
+      '$prefix-$className',
+      id: id ?? '$prefix-$className',
+      mail: '$prefix-$className@$domain',
+      mailNickname: '$prefix-$className',
+      memberIds: memberIds,
     );
 
 wapi.WisaSnapshot wisaSnap(

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -97,6 +97,7 @@ export 'src/realtime/signalr_transport.dart';
 export 'src/settings/app_settings.dart';
 export 'src/settings/connection.dart';
 export 'src/settings/import_rule_codec.dart';
+export 'src/settings/live_settings.dart';
 export 'src/settings/secret_provider.dart';
 export 'src/settings/settings_store.dart';
 export 'src/settings/wisa_school_label.dart';

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -73,6 +73,7 @@ export 'src/keyvault/key_vault_live_config.dart';
 export 'src/keyvault/key_vault_secret_provider.dart';
 export 'src/keyvault/key_vault_token_provider.dart';
 export 'src/keyvault/key_vault_transport.dart';
+export 'src/link/azure_class_groups.dart';
 export 'src/link/linked_state.dart';
 export 'src/link/placement.dart';
 export 'src/materialize/accepted_duplicates.dart';

--- a/packages/account_state/lib/src/apply/state_applier.dart
+++ b/packages/account_state/lib/src/apply/state_applier.dart
@@ -31,7 +31,8 @@ class ApplyResult {
   final LinkedState? linked;
 
   /// The results of the follow-up actions this write unlocked on the same
-  /// target and the applier ran straight away (#230), in the order they ran.
+  /// target and the applier ran straight away (#230 for students, #245 for
+  /// class groups), in the order they ran.
   ///
   /// Empty for every action that declares no `unlocks`, and for a dry run or a
   /// failed write (nothing was written, so nothing was unlocked). The caller
@@ -221,6 +222,7 @@ class StateApplier {
   ) {
     for (final candidate in linked.studentActions) {
       if (candidate.target.id == targetId &&
+          candidate.canApply &&
           unlocks.contains(candidate.runtimeType) &&
           !ran.contains(candidate.runtimeType)) {
         return candidate;
@@ -242,17 +244,105 @@ class StateApplier {
     );
   }
 
-  /// Applies a [GroupAction] and refreshes the snapshot on a real write.
+  /// Applies a [GroupAction] and refreshes the snapshot on a real write, then
+  /// runs whatever that write unlocked on the same class (#245).
   Future<ApplyResult> applyGroup(
     GroupAction action, {
     ApplyOptions options = const ApplyOptions(),
   }) async {
     final result = await action.apply(connectors, options);
-    return _refresh(
+    final applied = await _refresh(
       result,
       removedGroupId: action.target.smartschool?.id,
     );
+    return _chainGroupFollowUps(action, applied, options);
   }
+
+  /// Runs the follow-up actions [action]'s write unlocked on the same class,
+  /// against the **relinked** record (#245) — the group family's half of the
+  /// chaining [applyStudent] has done since #230, sharing its mechanism rather
+  /// than inventing a second one.
+  ///
+  /// Provisioning a class group is a two-link chain: Graph creates a group
+  /// empty, so `CreateAzureClassGroup` leaves `SSM-2F` with nobody in it and
+  /// `SyncAzureClassGroupMembers` is what enrols the class. The dispatcher is a
+  /// pure function of the current record and can only offer the first link, so
+  /// one click used to create the group and stop, leaving the roster to a second
+  /// pass the operator had to notice and trigger.
+  ///
+  /// Each link is taken from the freshly recomputed [LinkedState]'s own
+  /// dispatch — the same list the UI would show on the next render — so the
+  /// follow-up is bound to the record the previous write produced (the created
+  /// group carrying the id Graph minted, spliced into the Azure snapshot), and
+  /// its own `evaluate()` has already agreed it applies. Never a projection: the
+  /// created group's id is not knowable before the write.
+  ///
+  /// Bounded exactly as the student chain is, so no declaration can spin it:
+  /// nothing is unlocked when nothing was written, each action type runs at most
+  /// once per chain, an informational action is never run, and a failed link
+  /// stops it.
+  Future<ApplyResult> _chainGroupFollowUps(
+    GroupAction action,
+    ApplyResult applied,
+    ApplyOptions options,
+  ) async {
+    var linked = applied.linked;
+    if (linked == null || action.unlocks.isEmpty) return applied;
+
+    final targetKey = _groupKeyOf(action.target);
+    final ran = <Type>{action.runtimeType};
+    final followUps = <ActionResult>[];
+    var unlocks = action.unlocks;
+
+    while (unlocks.isNotEmpty) {
+      final next = _unlockedGroupAction(linked!, targetKey, unlocks, ran);
+      if (next == null) break;
+      ran.add(next.runtimeType);
+      final result = await next.apply(connectors, options);
+      followUps.add(result);
+      final refreshed = await _refresh(
+        result,
+        removedGroupId: next.target.smartschool?.id,
+      );
+      if (!refreshed.refreshed) break;
+      linked = refreshed.linked;
+      unlocks = next.unlocks;
+    }
+
+    if (followUps.isEmpty) return applied;
+    return ApplyResult(applied.result, linked, followUps: followUps);
+  }
+
+  /// The first action [linked]'s group dispatch raised for [targetKey] whose
+  /// type is named by [unlocks] and has not run yet this chain, or null when the
+  /// write unlocked nothing after all.
+  GroupAction? _unlockedGroupAction(
+    LinkedState linked,
+    String targetKey,
+    Set<Type> unlocks,
+    Set<Type> ran,
+  ) {
+    for (final candidate in linked.groupActions) {
+      if (_groupKeyOf(candidate.target) == targetKey &&
+          candidate.canApply &&
+          unlocks.contains(candidate.runtimeType) &&
+          !ran.contains(candidate.runtimeType)) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  /// The identity of a linked class record across a relink. A [core.LinkedGroup]
+  /// carries no id of its own, so this uses the keys the linker builds it from,
+  /// WISA first: the WISA `fullName` is what the linker keys records by (INV-20)
+  /// and is untouched by any Azure or Smartschool write, so the record that
+  /// raised the create is the same record after the relink.
+  static String _groupKeyOf(core.LinkedGroup group) =>
+      group.wisa?.id.value ??
+      group.smartschool?.id.value ??
+      group.azure?.id ??
+      '';
 
   /// Patches the owning snapshot from [result] and re-links, unless nothing was
   /// written. The `removed*` keys identify the record to drop for a delete

--- a/packages/account_state/lib/src/apply/state_applier.dart
+++ b/packages/account_state/lib/src/apply/state_applier.dart
@@ -297,6 +297,11 @@ class StateApplier {
         final current = app.azure.snapshot!;
         if (result.removed) {
           app.azure.patch(_dropAzureUser(current, removedAzureId));
+        } else if (result.azureGroup != null) {
+          // An Office 365 class group was created or had its membership
+          // rewritten (#228) — patch the snapshot's group list so the relink
+          // below sees the class as provisioned/in sync without a re-pull.
+          app.azure.patch(_putAzureGroup(current, result.azureGroup!));
         } else if (result.azure != null) {
           app.azure.patch(_putAzureUser(current, result.azure!));
         }
@@ -552,6 +557,27 @@ az.AzureSnapshot _putAzureUser(az.AzureSnapshot current, core.AzureUser user) {
     deltaToken: current.deltaToken,
     users: users,
     groups: current.groups,
+  );
+}
+
+az.AzureSnapshot _putAzureGroup(
+  az.AzureSnapshot current,
+  core.AzureGroup group,
+) {
+  final record = group as az.AzureGroup;
+  // Keyed by Azure object id, like the user splice. Only a real write reaches
+  // here (a dry run never refreshes), so a created group already carries the id
+  // Graph minted and a membership rewrite carries the group's own.
+  final groups = [
+    for (final g in current.groups)
+      if (g.id != record.id) g,
+    record,
+  ];
+  return az.AzureSnapshot(
+    fetchedAt: current.fetchedAt,
+    deltaToken: current.deltaToken,
+    users: current.users,
+    groups: groups,
   );
 }
 

--- a/packages/account_state/lib/src/apply/state_applier.dart
+++ b/packages/account_state/lib/src/apply/state_applier.dart
@@ -32,7 +32,7 @@ class ApplyResult {
 
   /// The results of the follow-up actions this write unlocked on the same
   /// target and the applier ran straight away (#230 for students, #245 for
-  /// class groups), in the order they ran.
+  /// class groups, #240 for staff), in the order they ran.
   ///
   /// Empty for every action that declares no `unlocks`, and for a dry run or a
   /// failed write (nothing was written, so nothing was unlocked). The caller
@@ -147,100 +147,41 @@ class StateApplier {
     StudentAction action, {
     ApplyOptions options = const ApplyOptions(),
   }) async {
-    final result = await action.apply(connectors, options);
-    final applied = await _refresh(
-      result,
-      removedSmartschoolUid: action.target.smartschool?.uid,
-      removedAzureId: action.target.azure?.id,
-    );
-    return _chainStudentFollowUps(action, applied, options);
-  }
-
-  /// Runs the follow-up actions [action]'s write unlocked on the same student,
-  /// against the **relinked** record (#230).
-  ///
-  /// Provisioning a new student is a two-link chain: `AddStudentToSmartschool`
-  /// builds the account with the Azure UPN as its `mail`, so it cannot evaluate
-  /// true until `AddStudentToAzure` has run. The dispatcher is a pure function
-  /// of the current record and can only offer the first link, so one click used
-  /// to create the Office 365 account and stop, leaving the Smartschool create
-  /// to a second pass the operator had to notice and trigger.
-  ///
-  /// Each link is taken from the freshly recomputed [LinkedState]'s own
-  /// dispatch — the same list the UI would show on the next render — so the
-  /// follow-up is bound to the record the previous write produced, placement
-  /// and all, and its own `evaluate()` has already agreed it applies. Never a
-  /// projection: `createPrincipalName` resolves a UPN collision by suffixing,
-  /// so the UPN that landed can differ from the projected one.
-  ///
-  /// The walk is bounded three ways, so no declaration can spin it: nothing is
-  /// unlocked when nothing was written (a dry run or a failure returns no
-  /// refreshed view), each action type runs at most once per chain, and a
-  /// failed link stops it — the failure is reported and the next sync re-offers
-  /// whatever is still missing.
-  Future<ApplyResult> _chainStudentFollowUps(
-    StudentAction action,
-    ApplyResult applied,
-    ApplyOptions options,
-  ) async {
-    var linked = applied.linked;
-    if (linked == null || action.unlocks.isEmpty) return applied;
-
+    final applied = await _applyStudentOnce(action, options);
     final targetId = action.target.id;
-    final ran = <Type>{action.runtimeType};
-    final followUps = <ActionResult>[];
-    var unlocks = action.unlocks;
-
-    while (unlocks.isNotEmpty) {
-      final next = _unlockedStudentAction(linked!, targetId, unlocks, ran);
-      if (next == null) break;
-      ran.add(next.runtimeType);
-      final result = await next.apply(connectors, options);
-      followUps.add(result);
-      final refreshed = await _refresh(
-        result,
-        removedSmartschoolUid: next.target.smartschool?.uid,
-        removedAzureId: next.target.azure?.id,
-      );
-      if (!refreshed.refreshed) break;
-      linked = refreshed.linked;
-      unlocks = next.unlocks;
-    }
-
-    if (followUps.isEmpty) return applied;
-    return ApplyResult(applied.result, linked, followUps: followUps);
+    return _chainFollowUps<StudentAction>(
+      action,
+      applied,
+      options,
+      dispatch: (linked) => linked.studentActions,
+      sameTarget: (candidate) => candidate.target.id == targetId,
+      canApply: (candidate) => candidate.canApply,
+      unlocksOf: (candidate) => candidate.unlocks,
+      run: _applyStudentOnce,
+    );
   }
 
-  /// The first action [linked]'s dispatch raised for [targetId] whose type is
-  /// named by [unlocks] and has not run yet this chain, or null when the write
-  /// unlocked nothing after all.
-  StudentAction? _unlockedStudentAction(
-    LinkedState linked,
-    core.LinkedAccountId targetId,
-    Set<Type> unlocks,
-    Set<Type> ran,
-  ) {
-    for (final candidate in linked.studentActions) {
-      if (candidate.target.id == targetId &&
-          candidate.canApply &&
-          unlocks.contains(candidate.runtimeType) &&
-          !ran.contains(candidate.runtimeType)) {
-        return candidate;
-      }
-    }
-    return null;
-  }
-
-  /// Applies a [StaffAction] and refreshes the snapshot on a real write.
+  /// Applies a [StaffAction] and refreshes the snapshot on a real write, then
+  /// runs whatever that write unlocked on the same staff member (#240).
   Future<ApplyResult> applyStaff(
     StaffAction action, {
     ApplyOptions options = const ApplyOptions(),
   }) async {
-    final result = await action.apply(connectors, options);
-    return _refresh(
-      result,
-      removedSmartschoolUid: action.target.smartschool?.uid,
-      removedAzureId: action.target.azure?.id,
+    final applied = await _applyStaffOnce(action, options);
+    final targetId = action.target.id;
+    return _chainFollowUps<StaffAction>(
+      action,
+      applied,
+      options,
+      dispatch: (linked) => linked.staffActions,
+      // A staff member's [core.LinkedAccountId] comes from the resolver's
+      // natural key (`wisaId`, else the staff `code`), and an Azure create
+      // stamps that same `wisaId` as the account's `employeeId` — so the record
+      // that raised the create is the same record after the relink.
+      sameTarget: (candidate) => candidate.target.id == targetId,
+      canApply: (candidate) => candidate.canApply,
+      unlocksOf: (candidate) => candidate.unlocks,
+      run: _applyStaffOnce,
     );
   }
 
@@ -250,81 +191,139 @@ class StateApplier {
     GroupAction action, {
     ApplyOptions options = const ApplyOptions(),
   }) async {
+    final applied = await _applyGroupOnce(action, options);
+    final targetKey = _groupKeyOf(action.target);
+    return _chainFollowUps<GroupAction>(
+      action,
+      applied,
+      options,
+      dispatch: (linked) => linked.groupActions,
+      sameTarget: (candidate) => _groupKeyOf(candidate.target) == targetKey,
+      canApply: (candidate) => candidate.canApply,
+      unlocksOf: (candidate) => candidate.unlocks,
+      run: _applyGroupOnce,
+    );
+  }
+
+  /// Runs one student action and refreshes the snapshot — the single link the
+  /// chain repeats.
+  Future<ApplyResult> _applyStudentOnce(
+    StudentAction action,
+    ApplyOptions options,
+  ) async {
     final result = await action.apply(connectors, options);
-    final applied = await _refresh(
+    return _refresh(
+      result,
+      removedSmartschoolUid: action.target.smartschool?.uid,
+      removedAzureId: action.target.azure?.id,
+    );
+  }
+
+  /// Runs one staff action and refreshes the snapshot.
+  Future<ApplyResult> _applyStaffOnce(
+    StaffAction action,
+    ApplyOptions options,
+  ) async {
+    final result = await action.apply(connectors, options);
+    return _refresh(
+      result,
+      removedSmartschoolUid: action.target.smartschool?.uid,
+      removedAzureId: action.target.azure?.id,
+    );
+  }
+
+  /// Runs one group action and refreshes the snapshot.
+  Future<ApplyResult> _applyGroupOnce(
+    GroupAction action,
+    ApplyOptions options,
+  ) async {
+    final result = await action.apply(connectors, options);
+    return _refresh(
       result,
       removedGroupId: action.target.smartschool?.id,
     );
-    return _chainGroupFollowUps(action, applied, options);
   }
 
-  /// Runs the follow-up actions [action]'s write unlocked on the same class,
-  /// against the **relinked** record (#245) — the group family's half of the
-  /// chaining [applyStudent] has done since #230, sharing its mechanism rather
-  /// than inventing a second one.
+  /// Runs the follow-up actions [action]'s write unlocked on the same target,
+  /// against the **relinked** record — one walk, shared by all three families
+  /// (students #230, class groups #245, staff #240) rather than a copy per
+  /// family. Only the typed dispatch it reads and the target identity differ,
+  /// so those arrive as parameters.
   ///
-  /// Provisioning a class group is a two-link chain: Graph creates a group
-  /// empty, so `CreateAzureClassGroup` leaves `SSM-2F` with nobody in it and
-  /// `SyncAzureClassGroupMembers` is what enrols the class. The dispatcher is a
-  /// pure function of the current record and can only offer the first link, so
-  /// one click used to create the group and stop, leaving the roster to a second
-  /// pass the operator had to notice and trigger.
+  /// Provisioning is a two-link chain in every family, and dispatch (§6.3) is a
+  /// pure function of the record *as it stands*, so it can only ever offer the
+  /// first link. `AddStudentToSmartschool` / [AddStaffToSmartschool] build their
+  /// account with the Azure UPN as its `mail` and evaluate false until the
+  /// Office 365 account exists; `CreateAzureClassGroup` leaves an empty group
+  /// because Graph writes the roster separately. In each case one click used to
+  /// perform the first write and stop, leaving the rest to a second pass the
+  /// operator had to notice and trigger.
   ///
   /// Each link is taken from the freshly recomputed [LinkedState]'s own
-  /// dispatch — the same list the UI would show on the next render — so the
-  /// follow-up is bound to the record the previous write produced (the created
-  /// group carrying the id Graph minted, spliced into the Azure snapshot), and
-  /// its own `evaluate()` has already agreed it applies. Never a projection: the
-  /// created group's id is not knowable before the write.
+  /// [dispatch] — the same list the UI would show on the next render — so the
+  /// follow-up is bound to the record the previous write produced, placement and
+  /// all, and its own `evaluate()` has already agreed it applies. Never a
+  /// projection: `createPrincipalName` resolves a UPN collision by suffixing, so
+  /// the UPN that landed can differ from the projected one, and a created
+  /// group's id is not knowable before the write at all.
   ///
-  /// Bounded exactly as the student chain is, so no declaration can spin it:
-  /// nothing is unlocked when nothing was written, each action type runs at most
-  /// once per chain, an informational action is never run, and a failed link
-  /// stops it.
-  Future<ApplyResult> _chainGroupFollowUps(
-    GroupAction action,
+  /// The walk is bounded four ways, so no declaration can spin it: nothing is
+  /// unlocked when nothing was written (a dry run or a failure returns no
+  /// refreshed view), each action type runs at most once per chain, an
+  /// informational action ([canApply] false) is never run, and a failed link
+  /// stops it — the failure is reported and the next sync re-offers whatever is
+  /// still missing.
+  Future<ApplyResult> _chainFollowUps<A extends Object>(
+    A action,
     ApplyResult applied,
-    ApplyOptions options,
-  ) async {
+    ApplyOptions options, {
+    required List<A> Function(LinkedState linked) dispatch,
+    required bool Function(A candidate) sameTarget,
+    required bool Function(A candidate) canApply,
+    required Set<Type> Function(A candidate) unlocksOf,
+    required Future<ApplyResult> Function(A action, ApplyOptions options) run,
+  }) async {
     var linked = applied.linked;
-    if (linked == null || action.unlocks.isEmpty) return applied;
+    var unlocks = unlocksOf(action);
+    if (linked == null || unlocks.isEmpty) return applied;
 
-    final targetKey = _groupKeyOf(action.target);
     final ran = <Type>{action.runtimeType};
     final followUps = <ActionResult>[];
-    var unlocks = action.unlocks;
 
     while (unlocks.isNotEmpty) {
-      final next = _unlockedGroupAction(linked!, targetKey, unlocks, ran);
+      final next = _firstUnlocked(
+        dispatch(linked!),
+        unlocks,
+        ran,
+        sameTarget,
+        canApply,
+      );
       if (next == null) break;
       ran.add(next.runtimeType);
-      final result = await next.apply(connectors, options);
-      followUps.add(result);
-      final refreshed = await _refresh(
-        result,
-        removedGroupId: next.target.smartschool?.id,
-      );
+      final refreshed = await run(next, options);
+      followUps.add(refreshed.result);
       if (!refreshed.refreshed) break;
       linked = refreshed.linked;
-      unlocks = next.unlocks;
+      unlocks = unlocksOf(next);
     }
 
     if (followUps.isEmpty) return applied;
     return ApplyResult(applied.result, linked, followUps: followUps);
   }
 
-  /// The first action [linked]'s group dispatch raised for [targetKey] whose
-  /// type is named by [unlocks] and has not run yet this chain, or null when the
+  /// The first of [candidates] that targets the same record, is applyable, has a
+  /// type named by [unlocks], and has not run yet this chain — or null when the
   /// write unlocked nothing after all.
-  GroupAction? _unlockedGroupAction(
-    LinkedState linked,
-    String targetKey,
+  A? _firstUnlocked<A extends Object>(
+    List<A> candidates,
     Set<Type> unlocks,
     Set<Type> ran,
+    bool Function(A candidate) sameTarget,
+    bool Function(A candidate) canApply,
   ) {
-    for (final candidate in linked.groupActions) {
-      if (_groupKeyOf(candidate.target) == targetKey &&
-          candidate.canApply &&
+    for (final candidate in candidates) {
+      if (sameTarget(candidate) &&
+          canApply(candidate) &&
           unlocks.contains(candidate.runtimeType) &&
           !ran.contains(candidate.runtimeType)) {
         return candidate;

--- a/packages/account_state/lib/src/link/azure_class_groups.dart
+++ b/packages/account_state/lib/src/link/azure_class_groups.dart
@@ -1,0 +1,155 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:account_core/account_core.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+/// Builds the [AzureClassGroupPlan] the Office 365 class-group actions need
+/// (#228), from the linked snapshot the pure `link()` just produced.
+///
+/// The Azure counterpart of [PlacementResolver]: it walks the linked records
+/// **once** in its constructor and exposes one tear-off, [planFor], that the
+/// State layer hands to the group dispatcher as its `azurePlanFor` callback.
+/// Keeping the walk here is what lets `account_actions` stay a pure function of
+/// its inputs.
+///
+/// Three questions live here that no single [LinkedGroup] can answer:
+///
+/// - **Which class is this?** A record is keyed and named by the WISA
+///   `fullName`, so `2F ECO` must be resolved back to the parent class `2F`
+///   — the name the one shared group `<PREFIX>-2F` is built from.
+///   [LinkedGroup.className] carries that, stamped by the linker.
+/// - **Who raises the proposals?** Every sub-group record of `2F` maps to the
+///   same group, so exactly one of them is nominated
+///   ([AzureClassGroupPlan.owner]). The class's *own* record wins when it
+///   exists; otherwise the first record of that class in snapshot order does,
+///   because a sub-grouped class often has no parent record at all (its `00`
+///   row is deduped away, #221).
+/// - **What is the roster?** The class's students as **Azure object ids** — the
+///   union over its sub-groups, since a student's [wapi.WisaStudent.classGroup]
+///   is the bare class name. Only students present in a school we manage
+///   ([LinkedAccount.isInOurWisa]) count, mirroring how the linker seeds class
+///   groups (#205) and how the placement resolver tallies `containsStudents`
+///   (#222).
+///
+/// Removals are computed narrowly on purpose: a member is only ever proposed for
+/// removal when it is one of *our* students' Azure accounts and that student is
+/// no longer in this class. Staff, titulars, and anything else in the group are
+/// left alone — they are out of the issue's scope, and a class group that has
+/// been shared with a teacher must not quietly lose them.
+class AzureClassGroupResolver {
+  AzureClassGroupResolver({
+    required LinkedSnapshot linked,
+    required this.schoolPrefix,
+    required this.studentDomain,
+  }) {
+    // 1. Roster per bare class name, as Azure object ids, plus the set of every
+    //    Azure id we can account for as one of our students (the removal
+    //    safety net) and which classes hold students at all.
+    for (final account in linked.accounts) {
+      if (!account.isInOurWisa) continue;
+      final wisa = account.wisa;
+      if (wisa is! wapi.WisaStudent) continue;
+      final className = normalizeGroupName(wisa.classGroup);
+      if (className == null) continue;
+      _classesWithStudents.add(className);
+      final azureId = account.azure?.id.trim();
+      if (azureId == null || azureId.isEmpty) continue;
+      _ourStudentAzureIds.add(azureId);
+      (_rosterByClass[className] ??= <String>{}).add(azureId);
+    }
+
+    // 2. Nominate the record that raises each class's Office 365 proposals.
+    //    Two passes so the class's own record always wins over a sub-group's,
+    //    regardless of snapshot order.
+    for (final group in linked.groups) {
+      final key = _ownerKeyOf(group);
+      final className = normalizeGroupName(group.className);
+      if (key == null || className == null || group.wisa == null) continue;
+      if (normalizeGroupName(group.wisa!.name) == className) {
+        _ownerKeyByClass[className] = key;
+      }
+    }
+    for (final group in linked.groups) {
+      final key = _ownerKeyOf(group);
+      final className = normalizeGroupName(group.className);
+      if (key == null || className == null || group.wisa == null) continue;
+      _ownerKeyByClass.putIfAbsent(className, () => key);
+    }
+  }
+
+  /// The Azure `companyName`/group-name prefix the school stamps on its own
+  /// objects — the `<PREFIX>` half of `<PREFIX>-<KLAS>`.
+  final String schoolPrefix;
+
+  /// The student mail domain, e.g. `student.arcadiascholen.be`. Only used to
+  /// render the address the created group will answer on.
+  final String studentDomain;
+
+  /// Normalized bare class name -> the Azure object ids of its students.
+  final Map<String, Set<String>> _rosterByClass = {};
+
+  /// Every Azure object id belonging to a student of ours — the only ids a
+  /// membership removal may ever name.
+  final Set<String> _ourStudentAzureIds = {};
+
+  /// Normalized bare class names that hold at least one student of ours,
+  /// whether or not that student already has an Azure account.
+  final Set<String> _classesWithStudents = {};
+
+  /// Normalized bare class name -> the [_ownerKeyOf] of the record that raises
+  /// that class's Office 365 actions.
+  final Map<String, String> _ownerKeyByClass = {};
+
+  /// The plan for one linked class, or `null` when the record names no Office
+  /// 365 class group: it carries no WISA class (an orphan), the school prefix
+  /// is unconfigured, or the resulting name would not survive as a Graph
+  /// `mailNickname` (a class name with a space or a diacritic — see
+  /// [isValidMailNickname]). Returning `null` is what keeps a create from being
+  /// proposed that Graph would reject.
+  AzureClassGroupPlan? planFor(LinkedGroup group) {
+    if (group.wisa == null) return null;
+    final rawName = group.className?.trim();
+    final className = normalizeGroupName(rawName);
+    if (rawName == null || className == null) return null;
+
+    final displayName = azureClassGroupName(schoolPrefix, rawName);
+    if (displayName == null || !isValidMailNickname(displayName)) return null;
+
+    final owner = _ownerKeyByClass[className] == _ownerKeyOf(group);
+    final roster = _rosterByClass[className] ?? const <String>{};
+    final current = _memberIdsOf(group.azure);
+    final currentSet = current.toSet();
+
+    return AzureClassGroupPlan(
+      className: rawName,
+      displayName: displayName,
+      mailNickname: displayName,
+      mail: '$displayName@$studentDomain',
+      owner: owner,
+      containsStudents: _classesWithStudents.contains(className),
+      membersToAdd: group.azure == null
+          ? const <String>[]
+          : <String>[
+              for (final id in roster)
+                if (!currentSet.contains(id)) id,
+            ],
+      membersToRemove: <String>[
+        for (final id in current)
+          if (_ourStudentAzureIds.contains(id) && !roster.contains(id)) id,
+      ],
+    );
+  }
+
+  /// The stable identity of a linked class record, used to nominate one owner
+  /// per class. The WISA `fullName` is exactly that: the linker keys records by
+  /// it and collapses duplicates to the first (INV-20), so no two records of one
+  /// snapshot share it.
+  static String? _ownerKeyOf(LinkedGroup group) => group.wisa?.id.value;
+
+  /// A group's current members. `account_core`'s [AzureGroup] interface carries
+  /// only the linking keys, so the member list is read off the concrete
+  /// connector record — the same downcast the State layer makes elsewhere.
+  /// `listGroups` loads them with the group, so this needs no extra Graph call.
+  static List<String> _memberIdsOf(AzureGroup? group) =>
+      group is az.AzureGroup ? group.memberIds.toList() : const <String>[];
+}

--- a/packages/account_state/lib/src/link/azure_class_groups.dart
+++ b/packages/account_state/lib/src/link/azure_class_groups.dart
@@ -7,10 +7,15 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 /// (#228), from the linked snapshot the pure `link()` just produced.
 ///
 /// The Azure counterpart of [PlacementResolver]: it walks the linked records
-/// **once** in its constructor and exposes one tear-off, [planFor], that the
-/// State layer hands to the group dispatcher as its `azurePlanFor` callback.
-/// Keeping the walk here is what lets `account_actions` stay a pure function of
-/// its inputs.
+/// **once** in its constructor and exposes two tear-offs — [planFor], which the
+/// State layer hands to the group dispatcher as its `azurePlanFor` callback, and
+/// [placementFor] (#245), which it hands to the *student* dispatcher as its
+/// `azurePlacementFor` callback. Keeping the walk here is what lets
+/// `account_actions` stay a pure function of its inputs.
+///
+/// One resolver serving both is the point: the per-class roster diff and the
+/// per-account "are you in your class's group?" are the same fact read two ways,
+/// so they are derived from the same indexes rather than computed twice.
 ///
 /// Three questions live here that no single [LinkedGroup] can answer:
 ///
@@ -75,6 +80,24 @@ class AzureClassGroupResolver {
       if (key == null || className == null || group.wisa == null) continue;
       _ownerKeyByClass.putIfAbsent(className, () => key);
     }
+
+    // 3. The per-student view of the same facts (#245): which classes have a
+    //    group today, and which of those groups each Azure account sits in.
+    //
+    //    Only a class that still exists is indexed (`wisa != null`), which is
+    //    exactly the set the class-level `SyncAzureClassGroupMembers` can act
+    //    on — so every membership this reports has a remedy. A sub-grouped
+    //    class contributes several records that all carry the one group, and
+    //    they collapse onto the single bare-name key.
+    for (final group in linked.groups) {
+      final className = normalizeGroupName(group.className);
+      final azure = group.azure;
+      if (className == null || group.wisa == null || azure == null) continue;
+      _groupNameByClass.putIfAbsent(className, () => azure.displayName);
+      for (final memberId in _memberIdsOf(azure)) {
+        (_classesByMemberId[memberId] ??= <String>{}).add(className);
+      }
+    }
   }
 
   /// The Azure `companyName`/group-name prefix the school stamps on its own
@@ -99,6 +122,17 @@ class AzureClassGroupResolver {
   /// Normalized bare class name -> the [_ownerKeyOf] of the record that raises
   /// that class's Office 365 actions.
   final Map<String, String> _ownerKeyByClass = {};
+
+  /// Normalized bare class name -> the display name of the Office 365 group
+  /// that class **has today**, for the classes that still exist (#245). In
+  /// linked-snapshot order, so the per-student report is deterministic.
+  final Map<String, String> _groupNameByClass = {};
+
+  /// Azure object id -> the normalized bare class names of the class groups it
+  /// is currently a member of (#245). Built from the very same `memberIds`
+  /// [planFor] diffs the roster against, so the per-account and per-class views
+  /// of one student cannot disagree.
+  final Map<String, Set<String>> _classesByMemberId = {};
 
   /// The plan for one linked class, or `null` when the record names no Office
   /// 365 class group: it carries no WISA class (an orphan), the school prefix
@@ -136,6 +170,43 @@ class AzureClassGroupResolver {
       membersToRemove: <String>[
         for (final id in current)
           if (_ourStudentAzureIds.contains(id) && !roster.contains(id)) id,
+      ],
+    );
+  }
+
+  /// The Office 365 class-group placement of one student (#245) — the
+  /// per-account view of the membership [planFor] reports per class.
+  ///
+  /// The State layer hands this to the student dispatcher as its
+  /// `azurePlacementFor` callback, exactly as [planFor] is handed to the group
+  /// dispatcher. Both read the same two indexes, so a student the class plan
+  /// wants added is the same student this reports as missing.
+  ///
+  /// A record with no WISA student, no class, or no Azure account yields an
+  /// inert placement: their class group is not their account's problem yet —
+  /// `AddStudentToAzure` is.
+  AzureClassPlacement placementFor(LinkedAccount account) {
+    final wisa = account.wisa;
+    final rawName = wisa is wapi.WisaStudent ? wisa.classGroup.trim() : '';
+    final className = normalizeGroupName(rawName);
+    final groupName = _groupNameByClass[className] ??
+        azureClassGroupName(schoolPrefix, rawName);
+
+    final azureId = account.azure?.id.trim();
+    final memberOf = (azureId == null || azureId.isEmpty)
+        ? const <String>{}
+        : (_classesByMemberId[azureId] ?? const <String>{});
+
+    return AzureClassPlacement(
+      className: rawName,
+      groupName: groupName,
+      groupExists:
+          className != null && _groupNameByClass.containsKey(className),
+      isMember: className != null && memberOf.contains(className),
+      strayGroupNames: <String>[
+        for (final entry in _groupNameByClass.entries)
+          if (entry.key != className && memberOf.contains(entry.key))
+            entry.value,
       ],
     );
   }

--- a/packages/account_state/lib/src/link/linked_state.dart
+++ b/packages/account_state/lib/src/link/linked_state.dart
@@ -6,6 +6,7 @@ import 'package:smartschool_api/smartschool_api.dart' as ss;
 import 'package:wisa_api/wisa_api.dart' as wapi;
 
 import '../sync/application_state.dart';
+import 'azure_class_groups.dart';
 import 'placement.dart';
 
 /// The State layer's **derived** view of one link+dispatch pass: the pure
@@ -99,6 +100,15 @@ class LinkedState {
       ourSchoolIds: ourSchoolIds,
     );
 
+    // The Office 365 class-group plans are derived from the *linked* view, not
+    // the raw snapshots (#228): the roster is expressed as Azure object ids, and
+    // the `wisaId ≡ employeeId` bridge that produces them is the linker's.
+    final azureClassGroups = AzureClassGroupResolver(
+      linked: snapshot,
+      schoolPrefix: studentConfig.schoolPrefix,
+      studentDomain: studentConfig.studentDomain,
+    );
+
     return LinkedState(
       snapshot: snapshot,
       studentActions: actions.studentActions(
@@ -110,6 +120,7 @@ class LinkedState {
       groupActions: actions.groupActions(
         snapshot,
         placementFor: placements.groupPlacementFor,
+        azurePlanFor: azureClassGroups.planFor,
       ),
     );
   }

--- a/packages/account_state/lib/src/link/linked_state.dart
+++ b/packages/account_state/lib/src/link/linked_state.dart
@@ -102,7 +102,9 @@ class LinkedState {
 
     // The Office 365 class-group plans are derived from the *linked* view, not
     // the raw snapshots (#228): the roster is expressed as Azure object ids, and
-    // the `wisaId ≡ employeeId` bridge that produces them is the linker's.
+    // the `wisaId ≡ employeeId` bridge that produces them is the linker's. The
+    // same resolver feeds the per-student view of that membership (#245), so
+    // the class row and the account row read one set of facts.
     final azureClassGroups = AzureClassGroupResolver(
       linked: snapshot,
       schoolPrefix: studentConfig.schoolPrefix,
@@ -115,6 +117,7 @@ class LinkedState {
         snapshot,
         studentConfig,
         placementFor: placements.classPlacementFor,
+        azurePlacementFor: azureClassGroups.placementFor,
       ),
       staffActions: actions.staffActions(snapshot, staffConfig),
       groupActions: actions.groupActions(

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -43,8 +43,10 @@ MaterializedView materialize(
   }
   final byStaff = <String, List<CandidateAction>>{};
   for (final a in linked.staffActions) {
+    // Read off the action like the other two families since #240: every staff
+    // action is applyable today, but nothing here should assume it.
     (byStaff[a.target.id.value] ??= <CandidateAction>[])
-        .add(_candidate('staff', a, a.describeChanges(), canApply: true));
+        .add(_candidate('staff', a, a.describeChanges(), canApply: a.canApply));
   }
 
   // Account-scoped warnings, keyed by the Smartschool uid they name.

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -34,8 +34,12 @@ MaterializedView materialize(
   // Group the dispatched actions by the account/staff they target.
   final byAccount = <String, List<CandidateAction>>{};
   for (final a in linked.studentActions) {
-    (byAccount[a.target.id.value] ??= <CandidateAction>[])
-        .add(_candidate('student', a, a.describeChanges(), canApply: true));
+    // Since #245 the student family has an informational member too
+    // (`AzureClassGroupMembership`), so the flag is read off the action rather
+    // than assumed — a diagnosis must not count as pending work or offer an
+    // apply the action would throw on.
+    (byAccount[a.target.id.value] ??= <CandidateAction>[]).add(
+        _candidate('student', a, a.describeChanges(), canApply: a.canApply));
   }
   final byStaff = <String, List<CandidateAction>>{};
   for (final a in linked.staffActions) {

--- a/packages/account_state/lib/src/settings/live_settings.dart
+++ b/packages/account_state/lib/src/settings/live_settings.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'app_settings.dart';
+import 'work_date.dart';
+
+/// A mutable holder for the operator's [AppSettings], shared between the
+/// Settings view — which publishes the document it just loaded or saved — and
+/// the reconcile stack, which reads it back at pull time.
+///
+/// ## Why this exists (#238)
+///
+/// `bootstrapReconcile` reads the settings document exactly once and is
+/// memoized for the life of the process, while the Settings view writes through
+/// its own separately-memoized store. So a saved werkdatum reached the WISA
+/// connector only after a relaunch: the syncer had closed over an immutable
+/// `AppSettings` captured at bootstrap. This is the same seam
+/// `WisaImportRules` already provides for the `DontImportFromWisa` rules —
+/// build it once, wire the readers to consult it *live*, and hand the same
+/// instance to whoever writes it:
+///
+/// ```dart
+/// final live = LiveSettings();                  // in main(), one per process
+/// bootstrapReconcile(liveSettings: live, ...);  // reads it at pull time
+/// bootstrapSettings(liveSettings: live);        // publishes on load/save
+/// ```
+///
+/// [changes] lets a listener repaint on a save it did not make itself — the
+/// reconcile screen keeps its widget alive across tab switches, so nothing else
+/// would tell it the WISA pull inputs moved under it.
+class LiveSettings {
+  LiveSettings([AppSettings initial = const AppSettings()])
+      : _current = initial;
+
+  AppSettings _current;
+
+  final StreamController<AppSettings> _changes =
+      StreamController<AppSettings>.broadcast();
+
+  /// The settings as last published. Read this at the moment a value is needed
+  /// (pull time), never once at wiring time — that is the whole point.
+  AppSettings get current => _current;
+
+  /// Emits every published document, so a live view can react to a save made
+  /// elsewhere in the app.
+  Stream<AppSettings> get changes => _changes.stream;
+
+  /// Adopts [next] as the current settings and notifies [changes].
+  void publish(AppSettings next) {
+    _current = next;
+    if (!_changes.isClosed) _changes.add(next);
+  }
+
+  /// Closes [changes]. Optional — the holder normally lives as long as the
+  /// process does.
+  Future<void> close() => _changes.close();
+}
+
+/// A stable identity for the settings a WISA pull depends on: the werkdatum
+/// pair and the operator's virtual-school marks (#238).
+///
+/// Fingerprints the **settings**, not the resolved dates: `isNow: true`
+/// resolves to a different instant on every pull and would make two identical
+/// configurations compare unequal, which would leave "Check for drift"
+/// permanently blocked. Two settings documents with the same fingerprint
+/// therefore produce the same WISA query for the same instant.
+String wisaPullFingerprint(AppSettings settings) {
+  final virtualSchools = settings.virtualWisaSchoolIds.toList()..sort();
+  return 'werkdatum=${_workDateKey(settings.wisa.workDate)};'
+      'virtueleWerkdatum=${_workDateKey(settings.wisa.virtualWorkDate)};'
+      'virtueleScholen=${virtualSchools.join(',')}';
+}
+
+String _workDateKey(WorkDateSetting setting) =>
+    setting.isNow ? 'now' : (setting.date?.toIso8601String() ?? 'unset');

--- a/packages/account_state/test/azure_class_groups_test.dart
+++ b/packages/account_state/test/azure_class_groups_test.dart
@@ -78,6 +78,34 @@ az.AzureGroup _classGroup(String className,
       memberIds: memberIds,
     );
 
+/// A Smartschool account bridged to a WISA student by `accountId ≡ wisaId`, so
+/// the linked record is complete and the student dispatch takes its modify
+/// branch — where the per-account class-group view lives (#245).
+ss.SmartschoolAccount _ssAccount(String uid, {required String accountId}) =>
+    ss.SmartschoolAccount(
+      uid: uid,
+      accountId: accountId,
+      mail: '$uid@$_domain',
+      registerId: '',
+      stemId: 0,
+      role: core.PersonRole.student,
+      givenName: 'Jane',
+      surname: 'Doe',
+      extraNames: '',
+      initials: '',
+      preferredName: '',
+      gender: core.Gender.female,
+      birthDate: _d,
+      birthPlace: '',
+      birthCountry: '',
+      address: _addr,
+      mobilePhone: '',
+      homePhone: '',
+      fax: '',
+      untisId: '',
+      status: 'actief',
+    );
+
 class _SeqResolver implements core.PersonIdResolver {
   final Map<String, String> _seen = {};
 
@@ -92,6 +120,7 @@ LinkedState _recompute({
   List<az.AzureUser> azureUsers = const [],
   List<az.AzureGroup> azureGroups = const [],
   List<core.Group> ssGroups = const [],
+  List<ss.SmartschoolAccount> ssAccounts = const [],
 }) =>
     LinkedState.recompute(
       wisa: wapi.WisaSnapshot(
@@ -104,7 +133,7 @@ LinkedState _recompute({
       smartschool: ss.SmartschoolSnapshot(
         fetchedAt: _d,
         groups: ssGroups,
-        accounts: const [],
+        accounts: ssAccounts,
         memberships: const [],
       ),
       azure: az.AzureSnapshot(
@@ -355,6 +384,194 @@ void main() {
       expect(notices, hasLength(1));
       expect(notices.single.canApply, isFalse);
       expect(notices.single.target.className, '9Z');
+    });
+  });
+
+  group('the same membership, read per account (#245)', () {
+    /// The per-student class-group actions of a linked view, keyed by the
+    /// account they target.
+    Map<String, actions.AzureClassGroupMembership> memberships(
+      LinkedState linked,
+    ) =>
+        {
+          for (final a in linked.studentActions
+              .whereType<actions.AzureClassGroupMembership>())
+            a.target.id.value: a,
+        };
+
+    test('a student missing from their own class group says so on the account',
+        () {
+      // The very state the class row reports as "1 toevoegen": w2 is on the
+      // roster of 2A but not in GBS-2A.
+      final linked = _recompute(
+        classGroups: [_wClass('2A')],
+        students: [
+          _student(wisaId: 'w1', classGroup: '2A'),
+          _student(wisaId: 'w2', classGroup: '2A'),
+        ],
+        ssAccounts: [
+          _ssAccount('jane', accountId: 'w1'),
+          _ssAccount('joe', accountId: 'w2'),
+        ],
+        azureUsers: [
+          _azUser('az-1', employeeId: 'w1'),
+          _azUser('az-2', employeeId: 'w2'),
+        ],
+        azureGroups: [
+          _classGroup('2A', memberIds: const ['az-1'])
+        ],
+      );
+
+      final sync =
+          _actionsOfType<actions.SyncAzureClassGroupMembers>(linked).single;
+      expect(sync.plan.membersToAdd, ['az-2'],
+          reason: 'the class row still reports the same one student');
+
+      final byAccount = memberships(linked);
+      expect(byAccount, hasLength(1),
+          reason: 'only the student the class row would add reports anything');
+      final action = byAccount.values.single;
+      expect(action.placement.className, '2A');
+      expect(action.placement.groupName, 'GBS-2A');
+      expect(action.placement.missingFromOwnGroup, isTrue);
+      expect(action.placement.strayGroupNames, isEmpty);
+      expect(action.canApply, isFalse,
+          reason: 'the class-level sync performs the one write');
+      expect(action.describeChanges().summary, contains('GBS-2A'));
+    });
+
+    test('a student left in their old class group names that group', () {
+      final linked = _recompute(
+        classGroups: [_wClass('2A'), _wClass('2B')],
+        students: [_student(wisaId: 'w1', classGroup: '2B')],
+        ssAccounts: [_ssAccount('jane', accountId: 'w1')],
+        azureUsers: [_azUser('az-1', employeeId: 'w1')],
+        azureGroups: [
+          _classGroup('2A', memberIds: const ['az-1']),
+          _classGroup('2B', memberIds: const ['az-1']),
+        ],
+      );
+
+      final action = memberships(linked).values.single;
+      expect(action.placement.isMember, isTrue,
+          reason: 'they are already in their own 2B group');
+      expect(action.placement.missingFromOwnGroup, isFalse);
+      expect(action.placement.strayGroupNames, ['GBS-2A']);
+      expect(action.describeChanges().summary, contains('GBS-2A'));
+    });
+
+    test('the wrong class group is reported once, in both directions', () {
+      final linked = _recompute(
+        classGroups: [_wClass('2A'), _wClass('2B')],
+        students: [_student(wisaId: 'w1', classGroup: '2B')],
+        ssAccounts: [_ssAccount('jane', accountId: 'w1')],
+        azureUsers: [_azUser('az-1', employeeId: 'w1')],
+        azureGroups: [
+          _classGroup('2A', memberIds: const ['az-1']),
+          _classGroup('2B'),
+        ],
+      );
+
+      final action = memberships(linked).values.single;
+      expect(action.placement.missingFromOwnGroup, isTrue);
+      expect(action.placement.strayGroupNames, ['GBS-2A']);
+      final summary = action.describeChanges().summary;
+      expect(summary, contains('GBS-2A in plaats van GBS-2B'));
+
+      // And it is the same fact the two class rows report, not a third one.
+      final syncs = {
+        for (final s
+            in _actionsOfType<actions.SyncAzureClassGroupMembers>(linked))
+          s.plan.className: s.plan,
+      };
+      expect(syncs['2A']!.membersToRemove, ['az-1']);
+      expect(syncs['2B']!.membersToAdd, ['az-1']);
+    });
+
+    test('a sub-grouped class reports the parent group, not the sub-group', () {
+      final linked = _recompute(
+        classGroups: [
+          _wClass('2F', groupName: 'ECO', adminCode: 'a'),
+          _wClass('2F', groupName: 'MAW', adminCode: 'b'),
+        ],
+        students: [
+          _student(wisaId: 'w1', classGroup: '2F', classSubGroup: 'ECO'),
+          _student(wisaId: 'w2', classGroup: '2F', classSubGroup: 'MAW'),
+        ],
+        ssAccounts: [
+          _ssAccount('jane', accountId: 'w1'),
+          _ssAccount('joe', accountId: 'w2'),
+        ],
+        azureUsers: [
+          _azUser('az-1', employeeId: 'w1'),
+          _azUser('az-2', employeeId: 'w2'),
+        ],
+        azureGroups: [
+          _classGroup('2F', memberIds: const ['az-1'])
+        ],
+      );
+
+      final byAccount = memberships(linked);
+      expect(byAccount, hasLength(1));
+      final action = byAccount.values.single;
+      expect(action.placement.groupName, 'GBS-2F',
+          reason: 'sub-groups share the parent class\'s one group');
+      expect(action.placement.strayGroupNames, isEmpty,
+          reason: 'their own group is not a stray one');
+    });
+
+    test('a class with no group yet reports nothing per student', () {
+      // CreateAzureClassGroup is the work, and it chains the roster (#245);
+      // repeating it on every student of the class would be pure noise.
+      final linked = _recompute(
+        classGroups: [_wClass('2A')],
+        students: [_student(wisaId: 'w1', classGroup: '2A')],
+        ssAccounts: [_ssAccount('jane', accountId: 'w1')],
+        azureUsers: [_azUser('az-1', employeeId: 'w1')],
+      );
+
+      expect(
+          _actionsOfType<actions.CreateAzureClassGroup>(linked), hasLength(1));
+      expect(memberships(linked), isEmpty);
+    });
+
+    test('the group of a vanished class is never reported as a stray', () {
+      // Nothing removes a member from it — AzureClassGroupWithoutClass is a
+      // manual-cleanup notice — so naming it per student would be work nobody
+      // can do.
+      final linked = _recompute(
+        classGroups: [_wClass('2A')],
+        students: [_student(wisaId: 'w1', classGroup: '2A')],
+        ssAccounts: [_ssAccount('jane', accountId: 'w1')],
+        azureUsers: [_azUser('az-1', employeeId: 'w1')],
+        azureGroups: [
+          _classGroup('2A', memberIds: const ['az-1']),
+          _classGroup('9Z', memberIds: const ['az-1']),
+        ],
+      );
+
+      expect(_actionsOfType<actions.AzureClassGroupWithoutClass>(linked),
+          hasLength(1));
+      expect(memberships(linked), isEmpty);
+    });
+
+    test('a member this app cannot account for gets no per-account report', () {
+      // The class titular sitting in GBS-2A is not one of our students, so
+      // neither the class plan nor the per-account view names them.
+      final linked = _recompute(
+        classGroups: [_wClass('2A')],
+        students: [_student(wisaId: 'w1', classGroup: '2A')],
+        ssAccounts: [_ssAccount('jane', accountId: 'w1')],
+        azureUsers: [
+          _azUser('az-1', employeeId: 'w1'),
+          _azUser('az-teacher', employeeId: 'staff'),
+        ],
+        azureGroups: [
+          _classGroup('2A', memberIds: const ['az-1', 'az-teacher']),
+        ],
+      );
+
+      expect(memberships(linked), isEmpty);
     });
   });
 }

--- a/packages/account_state/test/azure_class_groups_test.dart
+++ b/packages/account_state/test/azure_class_groups_test.dart
@@ -1,0 +1,360 @@
+import 'package:account_actions/account_actions.dart' as actions;
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart';
+import 'package:azure_api/azure_api.dart' as az;
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart' as wapi;
+
+/// The Office 365 class-group slice of the derived view (#228), driven through
+/// the real `LinkedState.recompute` so the linker's prefix-aware group match,
+/// the [AzureClassGroupResolver], and the group dispatch are exercised the way
+/// the app wires them.
+const String _prefix = 'GBS';
+const String _domain = 'student.school.example';
+final DateTime _d = DateTime.utc(2026);
+
+const core.Address _addr = core.Address(
+  street: '',
+  houseNumber: '',
+  postalCode: '',
+  city: '',
+  country: '',
+);
+
+wapi.WisaStudent _student({
+  required String wisaId,
+  required String classGroup,
+  String classSubGroup = '00',
+  int schoolId = 1,
+}) =>
+    wapi.WisaStudent(
+      wisaId: core.WisaId(wisaId),
+      classGroup: classGroup,
+      classSubGroup: classSubGroup,
+      name: 'Doe',
+      firstName: 'Jane',
+      preferredName: '',
+      birthDate: _d,
+      stemId: '',
+      gender: core.Gender.female,
+      nationalId: '',
+      birthPlace: '',
+      nationality: '',
+      address: _addr,
+      classChange: _d,
+      schoolId: schoolId,
+    );
+
+wapi.WisaClassGroup _wClass(
+  String name, {
+  String groupName = '00',
+  String adminCode = '',
+  int schoolId = 1,
+}) =>
+    wapi.WisaClassGroup(
+      name: name,
+      groupName: groupName,
+      description: 'Klas $name',
+      adminCode: adminCode,
+      schoolCode: '123',
+      schoolId: schoolId,
+    );
+
+az.AzureUser _azUser(String id, {required String employeeId}) => az.AzureUser(
+      id: id,
+      upn: '$id@$_domain',
+      employeeId: employeeId,
+      companyName: _prefix,
+    );
+
+az.AzureGroup _classGroup(String className,
+        {List<String> memberIds = const []}) =>
+    az.AzureGroup(
+      id: 'az-$_prefix-$className',
+      displayName: '$_prefix-$className',
+      mail: '$_prefix-$className@$_domain',
+      mailNickname: '$_prefix-$className',
+      memberIds: memberIds,
+    );
+
+class _SeqResolver implements core.PersonIdResolver {
+  final Map<String, String> _seen = {};
+
+  @override
+  core.PersonId resolve(String naturalKey) =>
+      core.PersonId(_seen.putIfAbsent(naturalKey, () => 'p${_seen.length}'));
+}
+
+LinkedState _recompute({
+  List<wapi.WisaStudent> students = const [],
+  List<wapi.WisaClassGroup> classGroups = const [],
+  List<az.AzureUser> azureUsers = const [],
+  List<az.AzureGroup> azureGroups = const [],
+  List<core.Group> ssGroups = const [],
+}) =>
+    LinkedState.recompute(
+      wisa: wapi.WisaSnapshot(
+        fetchedAt: _d,
+        students: students,
+        staff: const [],
+        classGroups: classGroups,
+        schools: const [],
+      ),
+      smartschool: ss.SmartschoolSnapshot(
+        fetchedAt: _d,
+        groups: ssGroups,
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: az.AzureSnapshot(
+        fetchedAt: _d,
+        users: azureUsers,
+        groups: azureGroups,
+      ),
+      resolver: _SeqResolver(),
+      studentConfig: actions.StudentActionConfig(
+        schoolPrefix: _prefix,
+        azureDomain: 'school.example',
+        studentDomain: _domain,
+      ),
+      staffConfig: actions.StaffActionConfig(
+        schoolPrefix: _prefix,
+        azureDomain: 'school.example',
+      ),
+    );
+
+List<T> _actionsOfType<T>(LinkedState linked) =>
+    linked.groupActions.whereType<T>().toList();
+
+void main() {
+  group('creating the class group (#228)', () {
+    test('a populated class with no group raises exactly one create', () {
+      final linked = _recompute(
+        classGroups: [_wClass('2A')],
+        students: [_student(wisaId: 'w1', classGroup: '2A')],
+        azureUsers: [_azUser('az-1', employeeId: 'w1')],
+      );
+
+      final creates = _actionsOfType<actions.CreateAzureClassGroup>(linked);
+      expect(creates, hasLength(1));
+      expect(creates.single.plan.displayName, 'GBS-2A');
+      expect(creates.single.plan.mail, 'GBS-2A@$_domain');
+      expect(creates.single.plan.className, '2A');
+    });
+
+    test(
+        'a sub-grouped class raises one create for the parent, not one per '
+        'sub-group', () {
+      final linked = _recompute(
+        classGroups: [
+          _wClass('2F', groupName: 'ECO', adminCode: 'a'),
+          _wClass('2F', groupName: 'MAW', adminCode: 'b'),
+          _wClass('2F', groupName: 'MOW', adminCode: 'c'),
+          _wClass('2F', groupName: 'STEMW', adminCode: 'd'),
+        ],
+        students: [
+          _student(wisaId: 'w1', classGroup: '2F', classSubGroup: 'ECO'),
+          _student(wisaId: 'w2', classGroup: '2F', classSubGroup: 'MAW'),
+        ],
+        azureUsers: [
+          _azUser('az-1', employeeId: 'w1'),
+          _azUser('az-2', employeeId: 'w2'),
+        ],
+      );
+
+      // Four linked groups (one per sub-group) but one Office 365 proposal.
+      expect(linked.snapshot.groups, hasLength(4));
+      final creates = _actionsOfType<actions.CreateAzureClassGroup>(linked);
+      expect(creates, hasLength(1));
+      expect(creates.single.plan.displayName, 'GBS-2F');
+      expect(creates.single.target.wisa!.name, '2F ECO',
+          reason: 'the parent class has no record of its own, so the first '
+              'sub-group carries the proposal');
+    });
+
+    test("the parent class's own record owns the proposal when it exists", () {
+      final linked = _recompute(
+        classGroups: [
+          _wClass('2F', groupName: 'ECO', adminCode: 'a'),
+          _wClass('2F', adminCode: 'b'),
+        ],
+        students: [_student(wisaId: 'w1', classGroup: '2F')],
+        azureUsers: [_azUser('az-1', employeeId: 'w1')],
+      );
+
+      final creates = _actionsOfType<actions.CreateAzureClassGroup>(linked);
+      expect(creates, hasLength(1));
+      expect(creates.single.target.wisa!.name, '2F');
+    });
+
+    test('an empty class gets no group', () {
+      final linked = _recompute(classGroups: [_wClass('2A')]);
+      expect(_actionsOfType<actions.CreateAzureClassGroup>(linked), isEmpty);
+    });
+
+    test('a class whose students have no Office 365 account yet still counts',
+        () {
+      // `containsStudents` is a WISA fact: the class is real and populated even
+      // though nobody has an account to put in the group yet.
+      final linked = _recompute(
+        classGroups: [_wClass('2A')],
+        students: [_student(wisaId: 'w1', classGroup: '2A')],
+      );
+      final creates = _actionsOfType<actions.CreateAzureClassGroup>(linked);
+      expect(creates, hasLength(1));
+      expect(creates.single.plan.containsStudents, isTrue);
+    });
+
+    test('an existing group is adopted, not created again', () {
+      final linked = _recompute(
+        classGroups: [_wClass('2A')],
+        students: [_student(wisaId: 'w1', classGroup: '2A')],
+        azureUsers: [_azUser('az-1', employeeId: 'w1')],
+        azureGroups: [
+          _classGroup('2A', memberIds: const ['az-1'])
+        ],
+      );
+
+      expect(_actionsOfType<actions.CreateAzureClassGroup>(linked), isEmpty);
+      expect(linked.snapshot.groups.single.azure!.displayName, 'GBS-2A');
+    });
+
+    test(
+        'a class name that cannot form a mail nickname is never proposed '
+        '(#228)', () {
+      // Bare class names carry no spaces; if one ever does, Graph would refuse
+      // the create — so nothing is offered rather than something that fails.
+      final linked = _recompute(
+        classGroups: [_wClass('2 F')],
+        students: [_student(wisaId: 'w1', classGroup: '2 F')],
+        azureUsers: [_azUser('az-1', employeeId: 'w1')],
+      );
+      expect(_actionsOfType<actions.CreateAzureClassGroup>(linked), isEmpty);
+    });
+  });
+
+  group('membership follows the roster (#228)', () {
+    test('a student missing from their own class group is added', () {
+      final linked = _recompute(
+        classGroups: [_wClass('2A')],
+        students: [
+          _student(wisaId: 'w1', classGroup: '2A'),
+          _student(wisaId: 'w2', classGroup: '2A'),
+        ],
+        azureUsers: [
+          _azUser('az-1', employeeId: 'w1'),
+          _azUser('az-2', employeeId: 'w2'),
+        ],
+        azureGroups: [
+          _classGroup('2A', memberIds: const ['az-1'])
+        ],
+      );
+
+      final sync =
+          _actionsOfType<actions.SyncAzureClassGroupMembers>(linked).single;
+      expect(sync.plan.membersToAdd, ['az-2']);
+      expect(sync.plan.membersToRemove, isEmpty);
+    });
+
+    test('a student who moved to another class is removed from the old group',
+        () {
+      final linked = _recompute(
+        classGroups: [_wClass('2A'), _wClass('2B')],
+        students: [
+          _student(wisaId: 'w1', classGroup: '2B'),
+        ],
+        azureUsers: [_azUser('az-1', employeeId: 'w1')],
+        azureGroups: [
+          _classGroup('2A', memberIds: const ['az-1']),
+          _classGroup('2B'),
+        ],
+      );
+
+      final syncs = {
+        for (final s
+            in _actionsOfType<actions.SyncAzureClassGroupMembers>(linked))
+          s.plan.className: s.plan,
+      };
+      expect(syncs['2A']!.membersToRemove, ['az-1']);
+      expect(syncs['2B']!.membersToAdd, ['az-1']);
+    });
+
+    test('a member this app cannot account for is never removed', () {
+      // The class titular, a shared mailbox, a guest — all out of scope, and
+      // all indistinguishable from each other here: not one of our students.
+      final linked = _recompute(
+        classGroups: [_wClass('2A')],
+        students: [_student(wisaId: 'w1', classGroup: '2A')],
+        azureUsers: [_azUser('az-1', employeeId: 'w1')],
+        azureGroups: [
+          _classGroup('2A', memberIds: const ['az-1', 'az-teacher']),
+        ],
+      );
+
+      expect(
+        _actionsOfType<actions.SyncAzureClassGroupMembers>(linked),
+        isEmpty,
+        reason: 'membership already matches the roster; the teacher stays',
+      );
+    });
+
+    test("membership is the union of a sub-grouped class's rosters", () {
+      final linked = _recompute(
+        classGroups: [
+          _wClass('2F', groupName: 'ECO', adminCode: 'a'),
+          _wClass('2F', groupName: 'MAW', adminCode: 'b'),
+        ],
+        students: [
+          _student(wisaId: 'w1', classGroup: '2F', classSubGroup: 'ECO'),
+          _student(wisaId: 'w2', classGroup: '2F', classSubGroup: 'MAW'),
+        ],
+        azureUsers: [
+          _azUser('az-1', employeeId: 'w1'),
+          _azUser('az-2', employeeId: 'w2'),
+        ],
+        azureGroups: [_classGroup('2F')],
+      );
+
+      final syncs = _actionsOfType<actions.SyncAzureClassGroupMembers>(linked);
+      expect(syncs, hasLength(1), reason: 'one group, one membership action');
+      expect(syncs.single.plan.membersToAdd, ['az-1', 'az-2']);
+    });
+
+    test('membership already in sync raises nothing', () {
+      final linked = _recompute(
+        classGroups: [_wClass('2A')],
+        students: [_student(wisaId: 'w1', classGroup: '2A')],
+        azureUsers: [_azUser('az-1', employeeId: 'w1')],
+        azureGroups: [
+          _classGroup('2A', memberIds: const ['az-1'])
+        ],
+      );
+      // The Smartschool side of this fixture still has work to do; the Office
+      // 365 side has none.
+      expect(
+          _actionsOfType<actions.SyncAzureClassGroupMembers>(linked), isEmpty);
+      expect(_actionsOfType<actions.CreateAzureClassGroup>(linked), isEmpty);
+    });
+  });
+
+  group('a vanished class (#228)', () {
+    test('its group is reported for manual cleanup, never deleted', () {
+      final linked = _recompute(
+        classGroups: [_wClass('2A')],
+        students: [_student(wisaId: 'w1', classGroup: '2A')],
+        azureUsers: [_azUser('az-1', employeeId: 'w1')],
+        azureGroups: [
+          _classGroup('2A', memberIds: const ['az-1']),
+          _classGroup('9Z'),
+        ],
+      );
+
+      final notices =
+          _actionsOfType<actions.AzureClassGroupWithoutClass>(linked);
+      expect(notices, hasLength(1));
+      expect(notices.single.canApply, isFalse);
+      expect(notices.single.target.className, '9Z');
+    });
+  });
+}

--- a/packages/account_state/test/live_settings_test.dart
+++ b/packages/account_state/test/live_settings_test.dart
@@ -1,0 +1,127 @@
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+
+AppSettings _settings({
+  WorkDateSetting workDate = const WorkDateSetting(),
+  WorkDateSetting virtualWorkDate = const WorkDateSetting(),
+  List<WisaSchoolProfile> schools = const <WisaSchoolProfile>[],
+}) =>
+    AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.local',
+        port: '9000',
+        workDate: workDate,
+        virtualWorkDate: virtualWorkDate,
+      ),
+      wisaSchools: schools,
+    );
+
+void main() {
+  group('LiveSettings', () {
+    test('hands back whatever was published last (#238)', () {
+      final live = LiveSettings(_settings());
+      expect(live.current.wisa.workDate.isNow, isTrue);
+
+      final pinned = _settings(
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2026, 9, 1)),
+      );
+      live.publish(pinned);
+      expect(live.current.wisa.workDate.date, DateTime(2026, 9, 1));
+    });
+
+    test('notifies listeners of every publish (#238)', () async {
+      final live = LiveSettings();
+      final seen = <String>[];
+      final sub = live.changes.listen((s) => seen.add(s.schoolPrefix));
+      addTearDown(sub.cancel);
+
+      live.publish(const AppSettings(schoolPrefix: 'A'));
+      live.publish(const AppSettings(schoolPrefix: 'B'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(seen, <String>['A', 'B']);
+    });
+
+    test('defaults to an empty document so a caller can wire it early', () {
+      expect(LiveSettings().current.schoolPrefix, '');
+    });
+  });
+
+  group('wisaPullFingerprint', () {
+    test('changes when the werkdatum is pinned to a new date (#238)', () {
+      final before = wisaPullFingerprint(_settings());
+      final after = wisaPullFingerprint(_settings(
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2026, 9, 1)),
+      ));
+      expect(after, isNot(before));
+    });
+
+    test('changes when the virtuele werkdatum moves (#238)', () {
+      final before = wisaPullFingerprint(_settings(
+        virtualWorkDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9)),
+      ));
+      final after = wisaPullFingerprint(_settings(
+        virtualWorkDate: WorkDateSetting(isNow: false, date: DateTime(2026, 9)),
+      ));
+      expect(after, isNot(before));
+    });
+
+    test("changes when a school's virtual mark is flipped (#238)", () {
+      const school = WisaSchoolProfile(schoolId: 99, code: 'V', name: 'V');
+      final before = wisaPullFingerprint(_settings(schools: const [school]));
+      final after = wisaPullFingerprint(
+        _settings(schools: const [
+          WisaSchoolProfile(
+            schoolId: 99,
+            code: 'V',
+            name: 'V',
+            virtual: true,
+          )
+        ]),
+      );
+      expect(after, isNot(before));
+    });
+
+    test('is stable for "volg de huidige datum" across two reads (#238)', () {
+      // The whole reason this fingerprints the *setting* and not the resolved
+      // date: `isNow: true` resolves to a different instant every pull, so
+      // fingerprinting the resolved value would leave a drift check blocked
+      // forever even though nothing was ever changed.
+      final settings = _settings();
+      expect(wisaPullFingerprint(settings), wisaPullFingerprint(settings));
+      expect(
+        wisaPullFingerprint(settings),
+        wisaPullFingerprint(_settings()),
+      );
+    });
+
+    test('ignores settings a WISA pull does not depend on (#238)', () {
+      // The managed (`ours`) mark feeds the linker, not the pull, and the school
+      // prefix feeds Azure — neither may arm the drift gate.
+      final plain = _settings(
+        schools: const [WisaSchoolProfile(schoolId: 1, code: 'A', name: 'A')],
+      );
+      final managed = _settings(
+        schools: const [
+          WisaSchoolProfile(schoolId: 1, code: 'A', name: 'A', ours: true),
+        ],
+      );
+      expect(wisaPullFingerprint(managed), wisaPullFingerprint(plain));
+      expect(
+        wisaPullFingerprint(plain.copyWith(schoolPrefix: 'GBS')),
+        wisaPullFingerprint(plain),
+      );
+    });
+
+    test('is insensitive to the order the virtual schools are stored in', () {
+      const a =
+          WisaSchoolProfile(schoolId: 1, code: 'A', name: 'A', virtual: true);
+      const b =
+          WisaSchoolProfile(schoolId: 2, code: 'B', name: 'B', virtual: true);
+      expect(
+        wisaPullFingerprint(_settings(schools: const [a, b])),
+        wisaPullFingerprint(_settings(schools: const [b, a])),
+      );
+    });
+  });
+}

--- a/packages/account_state/test/state_applier_test.dart
+++ b/packages/account_state/test/state_applier_test.dart
@@ -79,6 +79,16 @@ class _RecordingGraph implements az.GraphTransport {
       );
       return _ok({...body, 'id': 'az-created-${++_created}'}, 201);
     }
+    if (request.method == 'POST' && request.url.path.endsWith('/groups')) {
+      final body = Map<String, dynamic>.from(
+        jsonDecode(request.body ?? '{}') as Map,
+      );
+      return _ok({
+        ...body,
+        'id': 'az-group-${++_created}',
+        'mail': '${body['mailNickname']}@student.school.example',
+      }, 201);
+    }
     return const az.GraphResponse(statusCode: 204);
   }
 
@@ -193,12 +203,13 @@ az.AzureUser _azUser({
 wapi.WisaSnapshot _wSnap({
   List<wapi.WisaStudent> students = const [],
   List<wapi.WisaStaff> staff = const [],
+  List<wapi.WisaClassGroup> classGroups = const [],
 }) =>
     wapi.WisaSnapshot(
       fetchedAt: _d,
       students: students,
       staff: staff,
-      classGroups: const [],
+      classGroups: classGroups,
       schools: const [],
     );
 
@@ -211,8 +222,11 @@ ss.SmartschoolSnapshot _sSnap(
       memberships: const [],
     );
 
-az.AzureSnapshot _aSnap({List<az.AzureUser> users = const []}) =>
-    az.AzureSnapshot(fetchedAt: _d, users: users, groups: const []);
+az.AzureSnapshot _aSnap({
+  List<az.AzureUser> users = const [],
+  List<az.AzureGroup> groups = const [],
+}) =>
+    az.AzureSnapshot(fetchedAt: _d, users: users, groups: groups);
 
 core.LinkedAccount _linkedStudent({
   wapi.WisaStudent? wisa,
@@ -608,6 +622,101 @@ void main() {
       expect(
         harness.app.smartschool.snapshot!.accounts.map((a) => a.uid),
         containsAll(['jan.peeters', 'jan.peeters1', 'jan.peeters2']),
+      );
+    });
+  });
+
+  group('Office 365 class groups (#228)', () {
+    /// A WISA class with one enrolled student who already has an Office 365
+    /// account — the state that raises the class-group create.
+    _Harness classHarness({List<az.AzureGroup> groups = const []}) => _Harness(
+          wisa: _wSnap(
+            students: [_wStudent(wisaId: 'W1', classGroup: '2A')],
+            classGroups: [
+              const wapi.WisaClassGroup(
+                name: '2A',
+                groupName: '00',
+                description: 'Klas 2A',
+                adminCode: '',
+                schoolCode: '123',
+                schoolId: 1,
+              ),
+            ],
+          ),
+          azure: _aSnap(
+            users: [_azUser(id: 'az-1', employeeId: 'W1')],
+            groups: groups,
+          ),
+        );
+
+    test('a create patches the Azure snapshot, so the relink sees the group',
+        () async {
+      final harness = classHarness();
+      final before = await harness.applier.link();
+      final create = before.groupActions.whereType<CreateAzureClassGroup>();
+      expect(create, hasLength(1),
+          reason: 'the class has students and no Office 365 group yet');
+
+      final applied = await harness.applier.applyGroup(create.single);
+
+      expect(applied.result.outcome, ActionOutcome.applied);
+      expect(applied.refreshed, isTrue);
+      expect(
+        harness.app.azure.snapshot!.groups.map((g) => g.displayName),
+        ['SSM-2A'],
+        reason: 'no re-sync — the created group is spliced in (#72)',
+      );
+      expect(harness.counts, [0, 0, 0], reason: 'nothing was re-pulled');
+      // The relinked view no longer offers the create; the class is provisioned.
+      expect(applied.linked!.groupActions.whereType<CreateAzureClassGroup>(),
+          isEmpty);
+    });
+
+    test('a membership sync patches the members in place', () async {
+      final harness = classHarness(groups: [
+        az.AzureGroup(
+          id: 'az-2A',
+          displayName: 'SSM-2A',
+          mail: 'SSM-2A@student.school.example',
+          mailNickname: 'SSM-2A',
+        ),
+      ]);
+      final before = await harness.applier.link();
+      final sync =
+          before.groupActions.whereType<SyncAzureClassGroupMembers>().single;
+      expect(sync.plan.membersToAdd, ['az-1']);
+
+      final applied = await harness.applier.applyGroup(sync);
+
+      expect(applied.result.outcome, ActionOutcome.applied);
+      expect(
+        (harness.app.azure.snapshot!.groups.single).memberIds,
+        ['az-1'],
+      );
+      expect(
+        applied.linked!.groupActions.whereType<SyncAzureClassGroupMembers>(),
+        isEmpty,
+        reason: 'the class reads as in sync straight after the write',
+      );
+    });
+
+    test('a dry run writes nothing and patches nothing', () async {
+      final harness = classHarness();
+      final before = await harness.applier.link();
+      final create =
+          before.groupActions.whereType<CreateAzureClassGroup>().single;
+
+      final applied = await harness.applier.applyGroup(
+        create,
+        options: const ApplyOptions(dryRun: true),
+      );
+
+      expect(applied.result.outcome, ActionOutcome.dryRun);
+      expect(applied.refreshed, isFalse);
+      expect(harness.app.azure.snapshot!.groups, isEmpty);
+      expect(
+        harness.graph.requests.where((r) => r.method == 'POST'),
+        isEmpty,
       );
     });
   });

--- a/packages/account_state/test/state_applier_test.dart
+++ b/packages/account_state/test/state_applier_test.dart
@@ -590,6 +590,162 @@ void main() {
     });
   });
 
+  group('provisioning a new staff member is one chain, not two passes (#240)',
+      () {
+    /// A staff member who exists only in WISA — a new hire with neither a
+    /// Smartschool nor an Office 365 account. The dispatch can only offer the
+    /// Azure create: `AddStaffToSmartschool` builds its account with the Azure
+    /// UPN as the `mail`, so it evaluates false until that account exists.
+    _Harness newHire({int soapResultCode = 0}) => _Harness(
+          wisa: _wSnap(staff: [_wStaff(code: 'SMIT', wisaId: '42')]),
+          wisaBaseStaff: [_wStaff(code: 'SMIT', wisaId: '42')],
+          soapResultCode: soapResultCode,
+        );
+
+    test('the Azure create chains the Smartschool create it unlocked',
+        () async {
+      final harness = newHire();
+      final before = await harness.applier.link();
+      final create = before.staffActions.whereType<AddStaffToAzure>().single;
+
+      final applied = await harness.applier.applyStaff(create);
+
+      // Both writes happened, off one apply.
+      expect(applied.result.outcome, ActionOutcome.applied);
+      expect(applied.result.system, core.Origin.azure);
+      expect(applied.followUps.map((r) => r.changes.summary),
+          ['Maak een nieuw Smartschool account']);
+      expect(applied.followUps.single.outcome, ActionOutcome.applied);
+
+      // And both records are in the snapshots the pass left behind.
+      final azure = harness.app.azure.snapshot!.users.single;
+      expect(azure.employeeId, '42');
+      final smartschool = harness.app.smartschool.snapshot!.accounts.single;
+      expect(smartschool.accountId, 'SMIT',
+          reason: 'staff bridge to Smartschool by their WISA code, not wisaId');
+      expect(smartschool.mail, azure.upn,
+          reason: 'the follow-up read the UPN that actually landed, not the '
+              'projected one');
+      expect(harness.counts, [0, 0, 0],
+          reason: 'the chain rides the incremental refresh — no re-sync');
+    });
+
+    test('the chained account is what the linker now sees', () async {
+      final harness = newHire();
+      final create = (await harness.applier.link())
+          .staffActions
+          .whereType<AddStaffToAzure>()
+          .single;
+
+      final applied = await harness.applier.applyStaff(create);
+
+      final linked = applied.linked!.snapshot.staff.single;
+      expect(linked.wisa, isNotNull);
+      expect(linked.azure, isNotNull);
+      expect(linked.smartschool, isNotNull,
+          reason: 'the returned view is the one the *last* link produced');
+      expect(
+          applied.linked!.staffActions.whereType<AddStaffToAzure>(), isEmpty);
+      expect(applied.linked!.staffActions.whereType<AddStaffToSmartschool>(),
+          isEmpty);
+    });
+
+    test('a dry run projects the first write and chains nothing', () async {
+      final harness = newHire();
+      final create = (await harness.applier.link())
+          .staffActions
+          .whereType<AddStaffToAzure>()
+          .single;
+
+      final applied =
+          await harness.applier.applyStaff(create, options: ApplyOptions.dry);
+
+      expect(applied.result.outcome, ActionOutcome.dryRun);
+      expect(applied.followUps, isEmpty,
+          reason: 'nothing was written, so nothing was unlocked');
+      expect(harness.soap.soapActions, isEmpty);
+      expect(harness.graph.requests.where((r) => r.method == 'POST'), isEmpty);
+      expect(harness.app.smartschool.snapshot!.accounts, isEmpty);
+    });
+
+    test('a failing follow-up stops the chain and is reported', () async {
+      // Smartschool refuses the create (non-zero return code); the Azure
+      // account it followed still exists and must stay in the snapshot, so the
+      // next pass offers exactly the one create that is still missing.
+      final harness = newHire(soapResultCode: 1);
+      final create = (await harness.applier.link())
+          .staffActions
+          .whereType<AddStaffToAzure>()
+          .single;
+
+      final applied = await harness.applier.applyStaff(create);
+
+      expect(applied.result.outcome, ActionOutcome.applied);
+      expect(applied.followUps.single.outcome, ActionOutcome.failed);
+      expect(applied.linked, isNotNull,
+          reason: 'the successful Azure write is still reflected');
+      expect(harness.app.azure.snapshot!.users, hasLength(1));
+      expect(harness.app.smartschool.snapshot!.accounts, isEmpty);
+      expect(
+        applied.linked!.staffActions.whereType<AddStaffToSmartschool>(),
+        hasLength(1),
+      );
+    });
+
+    test('an unrelated staff action chains nothing', () async {
+      // The chain is opt-in per action: applying the copy-code repair on a
+      // complete record must stay one write.
+      final staff = _linkedStaff(
+        wisa: _wStaff(code: 'SMIT', wisaId: '42'),
+        smartschool: _ssAccount(
+          uid: 'anna.smit',
+          accountId: 'SMIT',
+          mail: 'anna.smit@school.example',
+          role: core.PersonRole.teacher,
+        ),
+        azure: _azUser(id: 'az-9', upn: 'anna.smit@school.example'),
+      );
+      final harness = _Harness(
+        wisa: _wSnap(staff: [_wStaff(code: 'SMIT', wisaId: '42')]),
+        smartschool:
+            _sSnap(accounts: [staff.smartschool! as ss.SmartschoolAccount]),
+        azure: _aSnap(users: [staff.azure! as az.AzureUser]),
+      );
+      final action = SetStaffCopyCode(staff, harness.applier.staffConfig);
+
+      final applied = await harness.applier.applyStaff(action);
+
+      expect(applied.result.outcome, ActionOutcome.applied);
+      expect(applied.followUps, isEmpty);
+    });
+
+    test('both minted passwords land on one password sheet (#105)', () async {
+      final queue = InMemoryPasswordQueueStore();
+      final harness = newHire();
+      final applier = StateApplier(
+        app: harness.app,
+        connectors: Connectors(
+          smartschool: _ssConn(harness.soap),
+          azure: _azConn(harness.graph),
+        ),
+        resolver: _SeqResolver(),
+        wisaRules: harness.rules,
+        studentConfig: _studentConfig(),
+        staffConfig: _staffConfig(),
+        passwordQueue: queue,
+      );
+
+      await applier.applyStaff(
+        (await applier.link()).staffActions.whereType<AddStaffToAzure>().single,
+      );
+
+      final entry = (await queue.load()).single;
+      expect(entry.azurePassword, isNotNull);
+      expect(entry.smartschoolPassword, isNotNull,
+          reason: 'the chained create merges onto the entry the first left');
+    });
+  });
+
   group('Smartschool uid uniqueness for created accounts (#72)', () {
     test(
         'suffixes a colliding login and stays unique across sequential creates',

--- a/packages/account_state/test/state_applier_test.dart
+++ b/packages/account_state/test/state_applier_test.dart
@@ -719,5 +719,116 @@ void main() {
         isEmpty,
       );
     });
+
+    group('provisioning a class group is one apply, not two (#245)', () {
+      test('the create chains the roster sync it unlocked', () async {
+        // Graph creates a group empty, so #228 left `SSM-2A` with nobody in it
+        // and the enrolment waited for the operator's second click. The chain
+        // runs the roster against the **relinked** record — the only place the
+        // id Graph just minted exists.
+        final harness = classHarness();
+        final before = await harness.applier.link();
+        final create =
+            before.groupActions.whereType<CreateAzureClassGroup>().single;
+
+        final applied = await harness.applier.applyGroup(create);
+
+        expect(applied.result.outcome, ActionOutcome.applied);
+        expect(applied.followUps, hasLength(1));
+        expect(applied.followUps.single.outcome, ActionOutcome.applied);
+        expect(
+          applied.followUps.single.changes.summary,
+          contains('Werk het ledenbestand van SSM-2A bij'),
+        );
+        expect(
+          harness.app.azure.snapshot!.groups.single.memberIds,
+          ['az-1'],
+          reason: 'the created group holds the class straight away',
+        );
+        expect(harness.counts, [0, 0, 0], reason: 'nothing was re-pulled');
+        expect(
+          applied.linked!.groupActions.whereType<CreateAzureClassGroup>(),
+          isEmpty,
+        );
+        expect(
+          applied.linked!.groupActions.whereType<SyncAzureClassGroupMembers>(),
+          isEmpty,
+          reason: 'the class is provisioned and in sync after the one apply',
+        );
+      });
+
+      test('a dry run projects the create and chains nothing', () async {
+        final harness = classHarness();
+        final before = await harness.applier.link();
+        final create =
+            before.groupActions.whereType<CreateAzureClassGroup>().single;
+
+        final applied = await harness.applier.applyGroup(
+          create,
+          options: const ApplyOptions(dryRun: true),
+        );
+
+        expect(applied.result.outcome, ActionOutcome.dryRun);
+        expect(applied.followUps, isEmpty,
+            reason: 'nothing was written, so nothing was unlocked');
+      });
+
+      test('a class whose students have no Office 365 account chains nothing',
+          () async {
+        // The follow-up's own evaluate() still decides: there is no roster to
+        // add, so the created group is simply left empty.
+        final harness = _Harness(
+          wisa: _wSnap(
+            students: [_wStudent(wisaId: 'W1', classGroup: '2A')],
+            classGroups: [
+              const wapi.WisaClassGroup(
+                name: '2A',
+                groupName: '00',
+                description: 'Klas 2A',
+                adminCode: '',
+                schoolCode: '123',
+                schoolId: 1,
+              ),
+            ],
+          ),
+        );
+        final before = await harness.applier.link();
+        final create =
+            before.groupActions.whereType<CreateAzureClassGroup>().single;
+
+        final applied = await harness.applier.applyGroup(create);
+
+        expect(applied.result.outcome, ActionOutcome.applied);
+        expect(applied.followUps, isEmpty);
+        expect(harness.app.azure.snapshot!.groups.single.memberIds, isEmpty);
+      });
+
+      test('an informational group action is never chained', () async {
+        // The orphan notice throws on apply; the walk must skip it whatever a
+        // future `unlocks` declaration says.
+        final harness = classHarness(groups: [
+          az.AzureGroup(
+            id: 'az-9Z',
+            displayName: 'SSM-9Z',
+            mail: 'SSM-9Z@student.school.example',
+            mailNickname: 'SSM-9Z',
+          ),
+        ]);
+        final before = await harness.applier.link();
+        expect(
+          before.groupActions.whereType<AzureClassGroupWithoutClass>(),
+          hasLength(1),
+        );
+        final create =
+            before.groupActions.whereType<CreateAzureClassGroup>().single;
+
+        final applied = await harness.applier.applyGroup(create);
+
+        expect(
+          applied.followUps.map((r) => r.changes.summary),
+          everyElement(contains('ledenbestand')),
+        );
+      });
+    });
   });
 }

--- a/packages/azure_api/lib/src/group_manager.dart
+++ b/packages/azure_api/lib/src/group_manager.dart
@@ -63,6 +63,77 @@ class GroupManager {
     return groups;
   }
 
+  /// The group answering on [mailNickname], or `null` when the tenant has none.
+  ///
+  /// The pre-create guard for [createGroup], mirroring
+  /// `UserManager.findByEmployeeId` (#224): the nickname is what makes the
+  /// address unique, and Graph does **not** reject a second group that reuses a
+  /// display name — it happily creates a duplicate whose address it then
+  /// suffixes. Asking first is the only way a create stays idempotent across a
+  /// retry or a second operator.
+  ///
+  /// [listGroups] cannot answer this: it is scoped to the school prefix and
+  /// matches on `displayName`, so a class group somebody renamed by hand still
+  /// holds the nickname a create would collide with.
+  Future<AzureGroup?> findByMailNickname(String mailNickname) async {
+    final nickname = mailNickname.trim();
+    if (nickname.isEmpty) return null;
+    final url = _graph.uri(
+      'groups',
+      query: {
+        r'$select': _select,
+        r'$count': 'true',
+        r'$filter': "mailNickname eq '${_escapeODataString(nickname)}'",
+      },
+    );
+    final rows =
+        await _graph.getCollection(url, headers: _advancedQueryHeaders);
+    if (rows.isEmpty) return null;
+    return AzureGroup.fromGraphJson(rows.first);
+  }
+
+  /// Creates a **unified** (Microsoft 365) group — the shape a class group must
+  /// have to be mailed and attached to a Team (#228).
+  ///
+  /// Deliberately not the security group legacy created for its staff groups
+  /// (`{prefix}-Personeel` and friends): `groupTypes: ["Unified"]` +
+  /// `mailEnabled: true` + `securityEnabled: false` is what gives the group a
+  /// mailbox at `<mailNickname>@<tenant mail domain>`.
+  ///
+  /// The created group is returned with **no members**; membership is a separate
+  /// write ([addMembers]), so a create that lands but whose membership pass
+  /// fails leaves a correct, empty group rather than a half-populated one.
+  Future<AzureGroup> createGroup({
+    required String displayName,
+    required String mailNickname,
+    String description = '',
+    String visibility = 'Private',
+  }) async {
+    final body = <String, dynamic>{
+      'displayName': displayName,
+      'mailNickname': mailNickname,
+      if (description.trim().isNotEmpty) 'description': description,
+      'groupTypes': const ['Unified'],
+      'mailEnabled': true,
+      'securityEnabled': false,
+      'visibility': visibility,
+    };
+    final json = await _graph.postJson(_graph.uri('groups'), body);
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: created Microsoft 365 group $displayName ($mailNickname).',
+    );
+    // The create response echoes the new resource; fall back to the request
+    // values for anything Graph left out of its echo (as `createUser` does).
+    return AzureGroup(
+      id: (json['id'] as String?) ?? '',
+      displayName: (json['displayName'] as String?) ?? displayName,
+      securityEnabled: (json['securityEnabled'] as bool?) ?? false,
+      mail: json['mail'] as String?,
+      mailNickname: (json['mailNickname'] as String?) ?? mailNickname,
+    );
+  }
+
   /// Returns the object ids of a group's members, following pagination.
   Future<List<String>> loadMemberIds(String groupId) async {
     final url = _graph.uri(

--- a/packages/azure_api/lib/src/models/azure_group.dart
+++ b/packages/azure_api/lib/src/models/azure_group.dart
@@ -24,6 +24,18 @@ class AzureGroup implements core.AzureGroup {
   /// legacy `SecurityEnabled` flag used by `FindGroupByName`.
   final bool securityEnabled;
 
+  /// The group's SMTP address, e.g. `GBS-2A@student.school.example`. Only a
+  /// mail-enabled ("unified", Microsoft 365) group carries one; `null` for a
+  /// plain security group such as the legacy staff groups (#228).
+  @override
+  final String? mail;
+
+  /// The group's mail alias — the local part of [mail]. Carried beside
+  /// [displayName] so a class group can be told apart from a same-named group
+  /// answering on a different address (#228).
+  @override
+  final String? mailNickname;
+
   /// Azure object ids of the group's members.
   final UnmodifiableListView<String> memberIds;
 
@@ -31,6 +43,8 @@ class AzureGroup implements core.AzureGroup {
     required this.id,
     required this.displayName,
     this.securityEnabled = false,
+    this.mail,
+    this.mailNickname,
     List<String> memberIds = const [],
   }) : memberIds = UnmodifiableListView(List.of(memberIds));
 
@@ -39,7 +53,15 @@ class AzureGroup implements core.AzureGroup {
     'id',
     'displayName',
     'securityEnabled',
+    'mail',
+    'mailNickname',
   ];
+
+  /// Whether this group is a mail-enabled Microsoft 365 ("unified") group —
+  /// the shape a class group must have to be mailed and attached to a Team
+  /// (#228). Read off the two fields Graph gives us: a security group is not
+  /// mail-enabled and carries no address.
+  bool get isUnified => !securityEnabled && (mail ?? '').trim().isNotEmpty;
 
   /// Whether [userId] is a member, by Azure object id.
   bool hasMember(String userId) => memberIds.contains(userId);
@@ -54,6 +76,8 @@ class AzureGroup implements core.AzureGroup {
         id: (json['id'] as String?) ?? '',
         displayName: (json['displayName'] as String?) ?? '',
         securityEnabled: (json['securityEnabled'] as bool?) ?? false,
+        mail: json['mail'] as String?,
+        mailNickname: json['mailNickname'] as String?,
         memberIds: members,
       );
 
@@ -63,6 +87,8 @@ class AzureGroup implements core.AzureGroup {
         id: id,
         displayName: displayName,
         securityEnabled: securityEnabled,
+        mail: mail,
+        mailNickname: mailNickname,
         memberIds: members,
       );
 
@@ -70,6 +96,8 @@ class AzureGroup implements core.AzureGroup {
         'id': id,
         'displayName': displayName,
         'securityEnabled': securityEnabled,
+        if (mail != null) 'mail': mail,
+        if (mailNickname != null) 'mailNickname': mailNickname,
         'memberIds': memberIds.toList(),
       };
 
@@ -77,6 +105,8 @@ class AzureGroup implements core.AzureGroup {
         id: json['id'] as String,
         displayName: (json['displayName'] as String?) ?? '',
         securityEnabled: (json['securityEnabled'] as bool?) ?? false,
+        mail: json['mail'] as String?,
+        mailNickname: json['mailNickname'] as String?,
         memberIds:
             ((json['memberIds'] as List<dynamic>?) ?? const []).cast<String>(),
       );
@@ -87,6 +117,8 @@ class AzureGroup implements core.AzureGroup {
       other.id == id &&
       other.displayName == displayName &&
       other.securityEnabled == securityEnabled &&
+      other.mail == mail &&
+      other.mailNickname == mailNickname &&
       _listEquals(other.memberIds, memberIds);
 
   @override
@@ -94,6 +126,8 @@ class AzureGroup implements core.AzureGroup {
         id,
         displayName,
         securityEnabled,
+        mail,
+        mailNickname,
         Object.hashAll(memberIds),
       );
 

--- a/packages/azure_api/test/group_manager_test.dart
+++ b/packages/azure_api/test/group_manager_test.dart
@@ -34,7 +34,7 @@ void main() {
       );
       expect(
         groupCall.url.queryParameters[r'$select'],
-        'id,displayName,securityEnabled',
+        'id,displayName,securityEnabled,mail,mailNickname',
       );
       expect(groupCall.headers['ConsistencyLevel'], 'eventual');
     });
@@ -88,6 +88,89 @@ void main() {
         log.messages.where((m) => m.contains('groepen opgehaald')),
         isEmpty,
       );
+    });
+  });
+
+  group('class-group creation (#228)', () {
+    test('creates a mail-enabled unified group, not a security group',
+        () async {
+      final transport = FakeGraphTransport((req) => jsonOk({
+            'id': 'g-new',
+            'displayName': req.body == null
+                ? ''
+                : (jsonDecode(req.body!)
+                    as Map<String, dynamic>)['displayName'],
+            'mail': 'GBS-2A@student.school.example',
+            'mailNickname': 'GBS-2A',
+          }));
+      final groups = GroupManager(clientWith(transport));
+
+      final created = await groups.createGroup(
+        displayName: 'GBS-2A',
+        mailNickname: 'GBS-2A',
+        description: 'Tweede jaar A',
+      );
+
+      expect(transport.last.method, 'POST');
+      expect(transport.last.url.path, endsWith('/groups'));
+      final body = jsonDecode(transport.last.body!) as Map<String, dynamic>;
+      expect(body['groupTypes'], ['Unified']);
+      expect(body['mailEnabled'], isTrue);
+      expect(body['securityEnabled'], isFalse);
+      expect(body['displayName'], 'GBS-2A');
+      expect(body['mailNickname'], 'GBS-2A');
+      expect(body['description'], 'Tweede jaar A');
+
+      expect(created.id, 'g-new');
+      expect(created.mail, 'GBS-2A@student.school.example');
+      expect(created.mailNickname, 'GBS-2A');
+      expect(created.isUnified, isTrue);
+      expect(created.memberIds, isEmpty,
+          reason: 'membership is a separate write');
+    });
+
+    test('an empty description is left out of the body entirely', () async {
+      final transport = FakeGraphTransport((_) => jsonOk({'id': 'g-new'}));
+      final groups = GroupManager(clientWith(transport));
+      await groups.createGroup(displayName: 'GBS-2A', mailNickname: 'GBS-2A');
+      final body = jsonDecode(transport.last.body!) as Map<String, dynamic>;
+      expect(body.containsKey('description'), isFalse);
+    });
+
+    test('findByMailNickname filters on the nickname and returns the group',
+        () async {
+      final transport = FakeGraphTransport((_) => jsonOk({
+            'value': [
+              {
+                'id': 'g-1',
+                'displayName': 'GBS-2A',
+                'mail': 'GBS-2A@student.school.example',
+                'mailNickname': 'GBS-2A',
+              },
+            ],
+          }));
+      final groups = GroupManager(clientWith(transport));
+
+      final found = await groups.findByMailNickname('GBS-2A');
+
+      expect(transport.last.url.queryParameters[r'$filter'],
+          "mailNickname eq 'GBS-2A'");
+      expect(transport.last.headers['ConsistencyLevel'], 'eventual');
+      expect(found?.id, 'g-1');
+    });
+
+    test('findByMailNickname returns null when the tenant has none', () async {
+      final transport =
+          FakeGraphTransport((_) => jsonOk({'value': const <Object>[]}));
+      final groups = GroupManager(clientWith(transport));
+      expect(await groups.findByMailNickname('GBS-2A'), isNull);
+    });
+
+    test('a blank nickname short-circuits without a call', () async {
+      final transport = FakeGraphTransport.constant(noContent());
+      final groups = GroupManager(clientWith(transport));
+      expect(await groups.findByMailNickname('  '), isNull);
+      expect(transport.requests, isEmpty);
     });
   });
 

--- a/packages/azure_api/test/models_test.dart
+++ b/packages/azure_api/test/models_test.dart
@@ -131,5 +131,45 @@ void main() {
       );
       expect(AzureGroup.fromJson(group.toJson()), group);
     });
+
+    test('carries the address a class group is identified by (#228)', () {
+      final group = AzureGroup.fromGraphJson(const <String, dynamic>{
+        'id': 'g1',
+        'displayName': 'GBS-2A',
+        'securityEnabled': false,
+        'mail': 'GBS-2A@student.school.example',
+        'mailNickname': 'GBS-2A',
+      });
+      expect(group.mail, 'GBS-2A@student.school.example');
+      expect(group.mailNickname, 'GBS-2A');
+      expect(group.isUnified, isTrue);
+      expect(AzureGroup.fromJson(group.toJson()), group);
+      expect(group.withMembers(const ['m1']).mail, group.mail);
+    });
+
+    test('a security group is not unified, whatever it is named (#228)', () {
+      final group = AzureGroup(
+        id: 'g',
+        displayName: 'GBS-Personeel',
+        securityEnabled: true,
+      );
+      expect(group.isUnified, isFalse);
+      // Nor is a mail-less group that merely is not security-enabled.
+      expect(AzureGroup(id: 'g2', displayName: 'GBS-2A').isUnified, isFalse);
+    });
+
+    test('two groups differing only in address are not equal (#228)', () {
+      final a = AzureGroup(
+        id: 'g',
+        displayName: 'GBS-2A',
+        mail: 'GBS-2A@student.school.example',
+      );
+      final b = AzureGroup(
+        id: 'g',
+        displayName: 'GBS-2A',
+        mail: 'GBS-2A@other.example',
+      );
+      expect(a, isNot(b));
+    });
   });
 }

--- a/packages/smartschool_api/lib/smartschool_api.dart
+++ b/packages/smartschool_api/lib/smartschool_api.dart
@@ -46,7 +46,8 @@ export 'src/rules/import_rules.dart'
         DiscardSmartschoolGroup,
         NoSmartschoolSubgroups,
         SmartschoolImportRule,
-        applyImportRules;
+        applyImportRules,
+        unmatchedImportRules;
 export 'src/snapshot.dart' show SmartschoolSnapshot;
 export 'src/soap/credentials.dart' show SmartschoolCredentials, SoapArg;
 export 'src/soap/soap_envelope.dart'

--- a/packages/smartschool_api/lib/src/connector.dart
+++ b/packages/smartschool_api/lib/src/connector.dart
@@ -100,11 +100,14 @@ class SmartschoolConnector {
   /// surviving group.
   ///
   /// [rules] are applied to the group tree at construction time
-  /// ([DiscardSmartschoolGroup], [NoSmartschoolSubgroups]). Disabled
-  /// (`uitgeschakeld`) accounts are dropped. One [SmartschoolMembership] is
-  /// emitted per (account, group) pair, so an account appearing in several
-  /// subtrees produces several membership rows (PAIN-1); the account record
-  /// itself is deduplicated by `uid`.
+  /// ([DiscardSmartschoolGroup], [NoSmartschoolSubgroups]), matching a group by
+  /// its normalized name and naming in the log any rule that matched nothing at
+  /// all (#241).
+  ///
+  /// Disabled (`uitgeschakeld`) accounts are dropped. One
+  /// [SmartschoolMembership] is emitted per (account, group) pair, so an
+  /// account appearing in several subtrees produces several membership rows
+  /// (PAIN-1); the account record itself is deduplicated by `uid`.
   ///
   /// Smartschool's internal group ids are backfilled onto the projected
   /// groups from the `groups` arrays the account payloads carry (#138) — the
@@ -120,7 +123,9 @@ class SmartschoolConnector {
       [_access],
     );
     final payload = decodeReturn(treeXml).text;
-    final forest = applyImportRules(parseGroupTree(payload), rules);
+    final parsed = parseGroupTree(payload);
+    _reportUnmatchedRules(parsed, rules);
+    final forest = applyImportRules(parsed, rules);
 
     final visited = <SmartschoolGroup>[];
     final accountsByUid = <String, SmartschoolAccount>{};
@@ -147,6 +152,32 @@ class SmartschoolConnector {
       accounts: accountsByUid.values.toList(),
       memberships: memberships,
     );
+  }
+
+  /// Names every import rule that matched no group in this pull (#241).
+  ///
+  /// A rule is matched on the normalized group name now, so case and stray
+  /// whitespace no longer decide whether it fires; what is left when a rule
+  /// still matches nothing is a name Smartschool does not carry — a typo, or a
+  /// group renamed since the rule was written. That was indistinguishable from
+  /// a rule that matched an already-empty subtree, and both looked like the
+  /// rule simply having no effect, so each unmatched rule gets a line of its
+  /// own. Reported before the tree is pruned, because pruning rebuilds it.
+  void _reportUnmatchedRules(
+    List<SmartschoolGroup> forest,
+    Iterable<SmartschoolImportRule> rules,
+  ) {
+    for (final rule in unmatchedImportRules(forest, rules)) {
+      final effect = switch (rule) {
+        DiscardSmartschoolGroup() => 'nothing was discarded',
+        NoSmartschoolSubgroups() => 'no subgroups were pruned',
+      };
+      _log?.addMessage(
+        core.Origin.smartschool,
+        'Import rule "${rule.groupName}" matched no Smartschool group in this '
+        'pull — $effect. Check the group name.',
+      );
+    }
   }
 
   /// Depth-first walk over [nodes], collecting the visited nodes in tree order

--- a/packages/smartschool_api/lib/src/rules/import_rules.dart
+++ b/packages/smartschool_api/lib/src/rules/import_rules.dart
@@ -11,16 +11,26 @@
 /// once, up front.
 library;
 
+import 'package:account_core/account_core.dart' show normalizeGroupName;
+
 import '../models/smartschool_group.dart';
 
 /// Base sealed type for the two Smartschool import rules.
 sealed class SmartschoolImportRule {
   const SmartschoolImportRule();
+
+  /// The Smartschool group this rule applies to, spelled the way the operator
+  /// typed it in Instellingen (#202).
+  ///
+  /// Never compared raw: it is matched on [normalizeGroupName], the key the
+  /// rest of the port joins group names on (#241).
+  String get groupName;
 }
 
 /// Removes the group named [groupName] **and its entire subtree** from the
 /// snapshot. Mirrors legacy `DiscardSmartschoolGroup` (`RuleAction.Discard`).
 class DiscardSmartschoolGroup extends SmartschoolImportRule {
+  @override
   final String groupName;
   const DiscardSmartschoolGroup(this.groupName);
 }
@@ -30,9 +40,15 @@ class DiscardSmartschoolGroup extends SmartschoolImportRule {
 /// where `Find`, `GetTreeAsList`, account loading, and counting all stop
 /// descending into a named group's children.
 class NoSmartschoolSubgroups extends SmartschoolImportRule {
+  @override
   final String groupName;
   const NoSmartschoolSubgroups(this.groupName);
 }
+
+/// The match key of [rule]'s group name, or `null` when the rule names nothing
+/// (a blank name, which can never match a group).
+String? _ruleKey(SmartschoolImportRule rule) =>
+    normalizeGroupName(rule.groupName);
 
 /// Applies all [rules] to [forest], returning a new top-level list.
 ///
@@ -41,26 +57,38 @@ class NoSmartschoolSubgroups extends SmartschoolImportRule {
 ///   - otherwise a matching [NoSmartschoolSubgroups] prunes its children;
 ///   - surviving groups recurse.
 ///
+/// A rule matches a group when their names share a [normalizeGroupName] key
+/// (#241): both sides are operator-typed — the rule in Instellingen, the group
+/// in Smartschool — so `leerlingen` is the same rule target as `Leerlingen`,
+/// and a name carrying a double or non-breaking space is the same as the one
+/// without. Matching them raw made a rule that read as correct do nothing at
+/// all. A rule whose name is blank matches nothing.
+///
 /// The node objects are reused; their `children` lists are rebuilt. Callers
 /// pass a freshly parsed forest, so in-place reuse is safe.
 List<SmartschoolGroup> applyImportRules(
   List<SmartschoolGroup> forest,
   Iterable<SmartschoolImportRule> rules,
 ) {
-  final discardNames = <String>{
-    for (final r in rules)
-      if (r is DiscardSmartschoolGroup) r.groupName,
-  };
-  final noSubgroupNames = <String>{
-    for (final r in rules)
-      if (r is NoSmartschoolSubgroups) r.groupName,
-  };
+  final discardNames = <String>{};
+  final noSubgroupNames = <String>{};
+  for (final rule in rules) {
+    final key = _ruleKey(rule);
+    if (key == null) continue;
+    switch (rule) {
+      case DiscardSmartschoolGroup():
+        discardNames.add(key);
+      case NoSmartschoolSubgroups():
+        noSubgroupNames.add(key);
+    }
+  }
 
   List<SmartschoolGroup> walk(List<SmartschoolGroup> groups) {
     final kept = <SmartschoolGroup>[];
     for (final g in groups) {
-      if (discardNames.contains(g.name)) continue;
-      final children = noSubgroupNames.contains(g.name)
+      final key = normalizeGroupName(g.name);
+      if (key != null && discardNames.contains(key)) continue;
+      final children = key != null && noSubgroupNames.contains(key)
           ? const <SmartschoolGroup>[]
           : walk(g.children);
       g.children
@@ -72,4 +100,43 @@ List<SmartschoolGroup> applyImportRules(
   }
 
   return walk(forest);
+}
+
+/// The [rules] that match no group anywhere in [forest] — the rules this pull
+/// will do nothing for (#241).
+///
+/// Since [applyImportRules] matches on the normalized name, a rule still
+/// matching nothing means Smartschool carries no group by that name at all: a
+/// typo, or a group renamed since the rule was written. Reporting these is what
+/// lets an operator tell such a rule apart from one that matched a subtree
+/// which was already empty — the two used to be equally silent.
+///
+/// Membership is decided over the **whole** parsed forest, not the pruned
+/// result, so a rule shadowed by another rule's discard is not reported as a
+/// typo: its group does exist. Call this *before* [applyImportRules], which
+/// rebuilds the nodes' `children` lists in place.
+///
+/// Rules are returned in the order given, one entry per rule — two rules naming
+/// the same missing group are two findings, because they are two mistakes.
+List<SmartschoolImportRule> unmatchedImportRules(
+  List<SmartschoolGroup> forest,
+  Iterable<SmartschoolImportRule> rules,
+) {
+  final present = <String>{};
+  void collect(List<SmartschoolGroup> groups) {
+    for (final g in groups) {
+      final key = normalizeGroupName(g.name);
+      if (key != null) present.add(key);
+      collect(g.children);
+    }
+  }
+
+  collect(forest);
+
+  final unmatched = <SmartschoolImportRule>[];
+  for (final rule in rules) {
+    final key = _ruleKey(rule);
+    if (key == null || !present.contains(key)) unmatched.add(rule);
+  }
+  return unmatched;
 }

--- a/packages/smartschool_api/test/connector_test.dart
+++ b/packages/smartschool_api/test/connector_test.dart
@@ -300,6 +300,54 @@ void main() {
           .toList();
       expect(codes, isNot(contains('GSPORT')));
     });
+
+    test('applies a rule whose name differs in case and whitespace (#241)',
+        () async {
+      // The tree names the group `Sport`; the operator typed ` sport `. It is
+      // the same group, so the same subtree goes.
+      final t = _FakeTransport();
+      final log = _RecordingLog();
+      final snap = await _connector(t, log: log).sync(
+        rules: const [DiscardSmartschoolGroup(' sport ')],
+      );
+      expect(snap.groups.map((g) => g.id.value), ['SCH', 'C1A', 'C1B']);
+      // A rule that matched must not be reported as doing nothing.
+      expect(
+        log.messages,
+        isNot(contains(contains('matched no Smartschool group'))),
+      );
+    });
+
+    test('names an import rule that matched no group in this pull (#241)',
+        () async {
+      // A typo (or a group renamed in Smartschool since the rule was written).
+      // The pull is unpruned — as before — but no longer silently so.
+      final t = _FakeTransport();
+      final log = _RecordingLog();
+      final snap = await _connector(t, log: log).sync(
+        rules: const [
+          DiscardSmartschoolGroup('Sprot'),
+          NoSmartschoolSubgroups('Sport'),
+        ],
+      );
+      expect(
+        snap.groups.map((g) => g.id.value),
+        ['SCH', 'C1A', 'C1B', 'GSPORT'],
+      );
+      expect(
+        log.messages,
+        contains(
+          'Import rule "Sprot" matched no Smartschool group in this pull — '
+          'nothing was discarded. Check the group name.',
+        ),
+      );
+      // The rule that did match is not named, even though pruning an empty
+      // subtree changed nothing either — that is the distinction #241 is about.
+      expect(
+        log.messages.where((m) => m.contains('matched no Smartschool group')),
+        hasLength(1),
+      );
+    });
   });
 
   group('saveAccount', () {

--- a/packages/smartschool_api/test/rules/import_rules_test.dart
+++ b/packages/smartschool_api/test/rules/import_rules_test.dart
@@ -84,4 +84,133 @@ void main() {
     );
     expect(_codes(result), ['Root', 'A']);
   });
+
+  // ---------------------------------------------------------------------------
+  // Normalized matching (#241)
+  // ---------------------------------------------------------------------------
+
+  group('matches on the normalized group name (#241)', () {
+    test('DiscardSmartschoolGroup ignores case', () {
+      final result = applyImportRules(
+        _forest(),
+        const [DiscardSmartschoolGroup('a')],
+      );
+      expect(_codes(result), ['Root', 'B']);
+    });
+
+    test('DiscardSmartschoolGroup ignores surrounding whitespace', () {
+      final result = applyImportRules(
+        _forest(),
+        const [DiscardSmartschoolGroup('  A ')],
+      );
+      expect(_codes(result), ['Root', 'B']);
+    });
+
+    test('NoSmartschoolSubgroups ignores case', () {
+      final result = applyImportRules(
+        _forest(),
+        const [NoSmartschoolSubgroups('a')],
+      );
+      expect(_codes(result), ['Root', 'A', 'B']);
+    });
+
+    test('a non-breaking space in the Smartschool name still matches', () {
+      // Smartschool carries the name with the non-breaking space a copy-paste
+      // left behind; the operator typed a plain one.
+      final forest = [
+        SmartschoolGroup(
+          name: 'Klassen\u00a01',
+          code: 'K1',
+          type: core.GroupType.group,
+        ),
+      ];
+      final result = applyImportRules(
+        forest,
+        const [DiscardSmartschoolGroup('Klassen 1')],
+      );
+      expect(result, isEmpty);
+    });
+
+    test('a blank rule name matches nothing', () {
+      // Not even the group whose name is itself blank — an empty key must never
+      // index or match anything (INV-12 / #225).
+      final forest = [
+        SmartschoolGroup(name: '', code: 'X', type: core.GroupType.group),
+        SmartschoolGroup(name: 'A', code: 'A', type: core.GroupType.group),
+      ];
+      final result = applyImportRules(
+        forest,
+        const [DiscardSmartschoolGroup('   ')],
+      );
+      expect(_codes(result), ['X', 'A']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unmatched rules (#241)
+  // ---------------------------------------------------------------------------
+
+  group('unmatchedImportRules', () {
+    List<String> names(List<SmartschoolImportRule> rules) =>
+        [for (final r in rules) r.groupName];
+
+    test('reports a rule naming a group the tree does not carry', () {
+      expect(
+        names(unmatchedImportRules(
+          _forest(),
+          const [DiscardSmartschoolGroup('Sport')],
+        )),
+        ['Sport'],
+      );
+    });
+
+    test('reports nothing when the name differs only in case or whitespace',
+        () {
+      expect(
+        unmatchedImportRules(
+          _forest(),
+          const [DiscardSmartschoolGroup(' a '), NoSmartschoolSubgroups('B')],
+        ),
+        isEmpty,
+      );
+    });
+
+    test('reports a blank rule name, which can never match', () {
+      expect(
+        names(unmatchedImportRules(
+          _forest(),
+          const [NoSmartschoolSubgroups('  ')],
+        )),
+        ['  '],
+      );
+    });
+
+    test('does not report a rule shadowed by another rule', () {
+      // `A1` lives inside the subtree `A` discards. The rule does nothing this
+      // pull, but its group exists — that is a rule interaction, not a typo,
+      // and calling it out would send the operator hunting a name that is
+      // spelled correctly.
+      expect(
+        unmatchedImportRules(
+          _forest(),
+          const [DiscardSmartschoolGroup('A'), NoSmartschoolSubgroups('A1')],
+        ),
+        isEmpty,
+      );
+    });
+
+    test('keeps one entry per rule, in the order given', () {
+      expect(
+        names(unmatchedImportRules(
+          _forest(),
+          const [
+            DiscardSmartschoolGroup('Sport'),
+            NoSmartschoolSubgroups('A'),
+            NoSmartschoolSubgroups('Sport'),
+          ],
+        )),
+        ['Sport', 'Sport'],
+      );
+    });
+  });
 }

--- a/packages/wisa_api/lib/wisa_api.dart
+++ b/packages/wisa_api/lib/wisa_api.dart
@@ -12,6 +12,10 @@ library;
 export 'src/config/live_config.dart' show WisaLiveConfig;
 export 'src/connector.dart' show WisaConnector, WisaQuery;
 export 'src/csv/csv_parser.dart' show CsvHeaderMismatch, CsvRowParseException;
+// The `Werkdatum` SOAP parameter's own formatter. Exported so an operator-facing
+// message can name the date exactly as it went on the wire, instead of
+// re-deriving a format that could drift from it (#239).
+export 'src/csv/date_format.dart' show formatWerkdatum;
 // The canonical `SMAGetInst` row decoder — the one place that untangles WISA's
 // inverted NAME/DESCRIPTION columns. Exported so the convention can be pinned
 // against the real CSV from outside this package (#208).


### PR DESCRIPTION
Batch chunk B — six issues, one commit each, each individually green on the full local gates. Follows chunk A (#242).

The headline is #228: Office 365 groups per class, which is new capability rather than a port — the legacy WPF app only ever touched the handful of named staff groups.

## What changed

**`e5bd9fd` — #228 an Office 365 group per class, with roster-driven membership**
`<PREFIX>-<KLAS>@<studentdomein>` (e.g. `SSM-2A@student.arcadiascholen.be`), created and kept in sync from the WISA roster.

- `account_core`: `azureClassGroupName` / `azureClassNameOf` / `isValidMailNickname`; `AzureGroup` gains `mail` + `mailNickname`; **`LinkedGroup.className`** — the bare class name, which is the structural gap the issue named (records are keyed on the WISA `fullName`, so the bare name was unavailable where the actions run).
- `account_linker`: the Azure pass is prefix-aware — strip `<PREFIX>-`, match the remainder against the bare class name, and attach the one group to *every* sub-group record of that class. Without this, `GBS-2A` would never match class `2A` and would seed a false orphan.
- `azure_api`: `GroupManager.createGroup` (unified — `groupTypes:["Unified"]`, `mailEnabled`, not `securityEnabled`, so it can be mailed and attached to a Team) with `findByMailNickname` as the pre-create guard, following #224's guard-before-create pattern.
- `account_actions`: `CreateAzureClassGroup` raised **once per distinct bare class** (not once per sub-group — sub-groups get no group of their own), `SyncAzureClassGroupMembers` diffing the roster offline from `AzureGroup.memberIds`, and the informational `AzureClassGroupWithoutClass`. Removals are limited to Azure accounts identifiable as our own students, so staff and titulars are never touched, and no group is ever deleted automatically.
- `account_state`: `AzureClassGroupResolver` built off the linked view, so the roster resolves to Azure object ids through the linker's `employeeId ≡ wisaId` bridge. `MaterializedGroup.inAzure` is now meaningful — the column #227 will render.

A class name that cannot form a valid Graph `mailNickname` yields **no plan at all** rather than a mangled slug, and an empty class gets no group (mirroring `CreateInSmartschool`).

**`81bad7f` — #245 report class-group membership per student**
The other half of "Accounts should check the student is in the correct Office 365 group". `AzureClassGroupMembership` reads the *same* resolver and the same roster indexes the class-level plan uses, so the account row and the class row cannot disagree. It is deliberately **informational** (`canApply == false`) with a pointer to the class-level roster sync: the diff has exactly one automated remedy, and making the per-account row applyable too would have Graph add the same member twice on an "apply all" pass and double-count the work in the pending totals. Also gave `GroupAction` the `unlocks` chaining students got in #230, so creating a class group enrols its roster in the same apply.

**`ee4fc6c` — #241 a Smartschool import rule differing in case or whitespace silently does nothing**
`applyImportRules` compared raw group names, and the tree parser does not trim — so `leerlingen` never matched `Leerlingen`. Both rule kinds now key on the shared `normalizeGroupName` from #225, and a rule matching **no group anywhere in the parsed forest** is named in the sync log, beside #225's skipped namesakes and #230's skipped students. The sibling `WisaImportRule` was checked and deliberately left on raw `==`: those rules are generated from WISA's own snapshot values and never hand-typed.

**`e8177ef` — #238 the WISA werkdatum needs a relaunch to take effect**
Two causes. The WISA syncer closed over an `AppSettings` read **once at bootstrap**, and the two memoized bootstraps each held their own frozen copy — fixed with a shared `LiveSettings` holder wired into both and read at pull time. Separately, "Check for drift" never re-pulls WISA, so it would have relinked a stale roster against the new setting and broadcast it; it is now refused with a visible on-screen reason until a Synchroniseer has pulled with the saved settings. The fingerprint covers the *settings*, not the resolved date, so `isNow: true` cannot block it forever.

**`31ff29e` — #239 a sync never says which werkdatum it pulled**
One named line per pass — `Pulling WISA with werkdatum 01/09/2025.` — rendered with the connector's own formatter so it cannot drift from the `Werkdatum` SOAP parameter. Written after the school list resolves but before the row queries, so a pull that then fails has still said what it asked for. The virtuele werkdatum is named only when a school in that pull actually used it.

**`8a545d3` — #240 the staff one-click provisioning chain**
`AddStaffToAzure.unlocks == {AddStaffToSmartschool}`. Rather than a third copy of the walk, the student/group/staff chains are now one generic `_chainFollowUps`, so the bounds are literally shared: no chain off a dry run or failed write, one run per action type, informational actions skipped, a failed link stops the chain.

## Test plan

Every commit was verified individually before landing; the numbers below are the final state of the branch.

- `dart format --set-exit-if-changed .` — clean, 298 files, 0 changed
- `dart analyze --fatal-infos --fatal-warnings` — clean
- `dart test` per package — account_core 82, wisa_api 127, smartschool_api 147, azure_api 110, account_linker 72, account_actions 185, account_state 419, account_store 8 — all pass; the ~11 skipped throughout are the opt-in live tests, deliberately not run
- `flutter test` (account_manager widget) — 326 pass
- `flutter test integration_test/app_launch_test.dart -d windows` — 69 pass, including new e2e cases for #228, #238, #239, #240, #241 and #245
- Each issue's new test was confirmed **failing on unpatched code**. For #241 that failure is the reported bug verbatim: `Expected: ['SCH','KLA'] Actual: ['SCH','ORG','HID','KLA','C1A']` — the rules did nothing at all.

No live WISA / Smartschool / Azure hosts were contacted.

## Follow-ups filed during this chunk

Queued for the next chunk: **#246**, **#247**, **#248**.

**#248 is worth reading before the next release** even though it is out of scope here: a WISA-only staff member raises both `AddStaffToAzure` and `DontImportStaffFromWisa`, neither declares an `alternativeGroup`, and `applyEntry` runs every selected choice — so one click provisions the teacher *and* blacklists them from future WISA imports. The new #240 e2e records the behaviour verbatim with a pointer to the issue.

Closes #228
Closes #238
Closes #239
Closes #240
Closes #241
Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)
