### PR TITLE
Batch: mutually exclusive action choices, apply feedback, and Acties tree state (#234 #235 #236 #243 #244 #248 #251)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2050,6 +2050,90 @@ void main() {
   });
 
   testWidgets(
+      'applying a class\'s work updates its Acties badge on the way back to '
+      'the overview, without a re-sync end-to-end (#236)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. The badges are read from the
+    // materialized rollups, which only a sync used to rewrite, so a class whose
+    // work had just been applied kept advertising it — and since #226 that same
+    // stale count decides whether the class is in the tree at all.
+    //
+    // This is the layer that sees it: the overview and the drilled-in list are
+    // two projections composed by different halves of the screen, and the bug is
+    // precisely that they disagree. Only a run that syncs, drills in, applies,
+    // and comes back out puts both on screen in that order.
+    useTallWindow(tester);
+    final harness = appliedClassWorkHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    expect(harness.controller.error, isNull);
+
+    final jaar3 = find.byKey(const ValueKey('rollup-grade-grades|3'));
+    final klas3C = find.byKey(const ValueKey('rollup-class-class|1|3|3C'));
+    final klasgroepen = find.byKey(const ValueKey('rollup-groups'));
+
+    // Sam's stale Office 365 name is the only student work: 3C carries it,
+    // badged 1, and the class groups carry four writes of their own.
+    await tester.ensureVisible(jaar3);
+    await tester.tap(jaar3);
+    await tester.pumpAndSettle();
+    expect(
+        find.descendant(of: klas3C, matching: find.text('1')), findsOneWidget);
+    expect(find.descendant(of: klasgroepen, matching: find.text('4')),
+        findsOneWidget);
+
+    // Drill into 3C and apply that one entry, confirmation dialog and all.
+    await tester.ensureVisible(klas3C);
+    await tester.tap(klas3C);
+    await tester.pumpAndSettle();
+    final entry = harness.controller.classroomPendingEntries.single;
+    await tester.tap(find.byKey(ValueKey('entry-student-${entry.targetId}')));
+    await tester.pumpAndSettle();
+    final applyEntry = find.byKey(ValueKey('entry-apply-${entry.targetId}'));
+    await tester.ensureVisible(applyEntry);
+    await tester.tap(applyEntry);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+    expect(find.text('Apply result'), findsWidgets);
+    expect(harness.controller.classroomPendingEntries, isEmpty,
+        reason: 'the live list drops the work immediately — it always did');
+
+    // Overzicht: the class is done, so under the work-list filter it is gone,
+    // and with 3D already clean the whole year goes with it.
+    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
+    await tester.pumpAndSettle();
+    expect(klas3C, findsNothing,
+        reason: 'the class used to come back still badged 1');
+    expect(jaar3, findsNothing);
+    // …while the work nobody touched is untouched: a re-derivation of what
+    // changed, not a blanket reset.
+    expect(find.descendant(of: klasgroepen, matching: find.text('4')),
+        findsOneWidget);
+
+    // Off the filter, the class is back in the inventory — now ticked off
+    // rather than badged, with no sync between.
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(jaar3);
+    if (klas3C.evaluate().isEmpty) {
+      await tester.tap(jaar3);
+      await tester.pumpAndSettle();
+    }
+    expect(find.descendant(of: klas3C, matching: find.text('1')), findsNothing);
+    expect(find.descendant(of: klas3C, matching: find.byIcon(Icons.check)),
+        findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'a single-group class whose name another school shares raises no class '
       'change, and "00" never reaches a class name end-to-end (#221)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -4592,6 +4592,98 @@ void main() {
   });
 
   testWidgets(
+      'the apply-confirmation dialog names the system the pass really writes, '
+      'in Dutch (#234)', (WidgetTester tester) async {
+    // The report, reproduced through the real app: a student whose WISA name
+    // differs from their Azure displayName raises exactly one action —
+    // ModifyAzureName, a single Graph PATCH — and the confirmation used to
+    // announce it as "This writes 1 change(s) to Smartschool and Azure AD".
+    // Both halves of that were wrong: the wrong systems, and English on a Dutch
+    // screen.
+    //
+    // This is the layer that sees it. The sentence is assembled from the
+    // *selected* option of every choice the operator's drill-down left standing
+    // (#110/#244/#248), so what it claims depends on the dispatch, the entry
+    // grouping and the per-row selection all agreeing — a widget test of the
+    // dialog in isolation would only ever prove the formatter.
+    useTallWindow(tester);
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(wisaId: '1', classGroup: '3C')],
+        schools: [wisaSchool(1)],
+        classGroups: [wisaClassGroup('3C', adminCode: 'a3')],
+      ),
+      smartschool: ssSnap(
+        groups: [ssGroup('3C', code: '3C_ss', untis: '3C')],
+        accounts: [ssAccount()],
+        memberships: [member('jane', '3C_ss')],
+      ),
+      // displayName left empty — the single thing out of step with WISA.
+      azure: azSnap(users: [azUser()]),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('3C'));
+    await tester.tap(find.text('3C'));
+    await tester.pumpAndSettle();
+
+    final entry = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student');
+    expect(
+      entry.choices.map((c) => c.selected.changes.summary),
+      <String>['Wijzig de naam in Azure'],
+      reason: 'the class holds exactly the action the report names',
+    );
+    final id = entry.targetId;
+    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.pumpAndSettle();
+
+    // One system, the one the action targets, under a Dutch title with Dutch
+    // buttons.
+    final dialog = find.byType(AlertDialog);
+    Finder inDialog(Finder matching) =>
+        find.descendant(of: dialog, matching: matching);
+    expect(find.text('Toepassen voor ${entry.target}?'), findsOneWidget);
+    expect(
+      inDialog(find.textContaining('Dit schrijft 1 wijziging naar '
+          'Office 365.')),
+      findsOneWidget,
+    );
+    expect(inDialog(find.textContaining('Smartschool')), findsNothing,
+        reason: 'nothing in this pass goes near Smartschool');
+    expect(inDialog(find.text('Annuleer')), findsOneWidget);
+    expect(inDialog(find.text('Toepassen')), findsOneWidget);
+
+    // And confirming really does write only there: one Graph PATCH, no SOAP.
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+    expect(find.text('Apply result'), findsOneWidget);
+    expect(
+      harness.graph.requests.where((r) => r.method == 'PATCH'),
+      hasLength(1),
+    );
+    expect(harness.soap.soapActions, isEmpty);
+  });
+
+  testWidgets(
       'a WISA-only student reaches Acties under their own class, and one '
       'apply provisions both of their accounts (#230)',
       (WidgetTester tester) async {
@@ -4664,6 +4756,22 @@ void main() {
     await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
     await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
     await tester.pumpAndSettle();
+
+    // The confirmation names the chained system before the write (#234). The
+    // visible action targets Office 365, but this apply goes on to create the
+    // Smartschool account its chain unlocks, and the operator is told so — as a
+    // follow-up that *may* run (its own evaluate decides), never as a second
+    // counted change.
+    expect(
+      find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.textContaining('Dit schrijft 1 wijziging naar '
+            'Office 365. Een vervolgactie kan ook naar Smartschool '
+            'schrijven.'),
+      ),
+      findsOneWidget,
+    );
+
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
     expect(find.text('Apply result'), findsOneWidget);

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1560,6 +1560,117 @@ void main() {
   });
 
   testWidgets(
+      'the Acties badges count one pending item per either/or, so the '
+      'Klasgroepen node agrees with the list it opens end-to-end (#251)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. Two brand-new WISA classes,
+    // each carrying the create-or-ignore either/or of #244 plus an Office 365
+    // group to create: four decisions in all.
+    //
+    // The badge counted *actions*, so it read 6 — both halves of both choices —
+    // while the list behind it offered four resolutions and Apply to all wrote
+    // four. The overview and the list disagreed about how much work there was,
+    // and since #226 that same count decides whether a node is in the tree at
+    // all.
+    //
+    // This is the layer that sees it: the badge is derived from the persisted
+    // rollups, the list from the live dispatch, and they are composed by
+    // different halves of the screen — only a full run puts both on screen in
+    // that order.
+    useTallWindow(tester);
+    final harness = newClassChoiceHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    expect(harness.controller.error, isNull);
+
+    final klasgroepen = find.byKey(const ValueKey('rollup-groups'));
+    await tester.ensureVisible(klasgroepen);
+    expect(find.descendant(of: klasgroepen, matching: find.text('4')),
+        findsOneWidget,
+        reason: 'two classes × (one either/or + one Office 365 group)');
+    expect(find.descendant(of: klasgroepen, matching: find.text('6')),
+        findsNothing,
+        reason: 'the badge used to count both halves of both choices');
+
+    // Each student's own class carries one action and is badged once, so the
+    // collapse did not simply deflate every count.
+    final jaar1 = find.byKey(const ValueKey('rollup-grade-grades|1'));
+    await tester.ensureVisible(jaar1);
+    await tester.tap(jaar1);
+    await tester.pumpAndSettle();
+    final klas1A = find.byKey(const ValueKey('rollup-class-class|1|1|1A'));
+    await tester.ensureVisible(klas1A);
+    expect(
+        find.descendant(of: klas1A, matching: find.text('1')), findsOneWidget);
+
+    // The number on the node is exactly what a confirmed apply of that list
+    // would write — the claim the badge and the dialog used to disagree on.
+    await tester.ensureVisible(klasgroepen);
+    await tester.tap(klasgroepen);
+    await tester.pumpAndSettle();
+    final groups = harness.controller.groupPendingEntries;
+    expect(groups, hasLength(2));
+    expect(harness.controller.applyScope(groups).systems, hasLength(4));
+    expect(find.text('Voeg deze klas toe aan Smartschool (keuze)'),
+        findsNWidgets(2));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'a new hire is one pending item on the Personeel badge, not two '
+      'end-to-end (#251/#248)', (WidgetTester tester) async {
+    // The staff twin of the class case, and the crisp version of the count: two
+    // freshly hired teachers, each raising the provision-or-ignore either/or of
+    // #248 and nothing else. Two people, two decisions — the node read 4.
+    //
+    // The Personeel tree is the deeper one (school → jaar → klas), so this also
+    // proves the collapse survives every level of the aggregation rather than
+    // only the leaf the operator drills into.
+    useTallWindow(tester);
+    final harness = newStaffChoiceHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    expect(harness.controller.error, isNull);
+
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+    final staffSchool =
+        find.byKey(const ValueKey('rollup-school-school|staff'));
+    await tester.ensureVisible(staffSchool);
+    await tester.tap(staffSchool);
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
+    await tester.pumpAndSettle();
+
+    final staffClass = find
+        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
+    await tester.ensureVisible(staffClass);
+    expect(find.descendant(of: staffClass, matching: find.text('2')),
+        findsOneWidget,
+        reason: 'two hires, one either/or each');
+    expect(
+        find.descendant(of: staffClass, matching: find.text('4')), findsNothing,
+        reason: 'the opt-out is the alternative, never a second to-do');
+
+    // The Personeel tab badge is derived the same way and agrees.
+    expect(harness.controller.staffPendingCount, 2);
+    expect(harness.controller.applyableCount, 2,
+        reason: 'an apply writes one resolution per hire');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'a class without an Office 365 group is proposed once — named after the '
       'parent class — and applying it creates a unified group end-to-end '
       '(#228)', (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1088,7 +1088,9 @@ void main() {
     // Our own populated class is the only proposal on the list…
     expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
     expect(find.text('1A'), findsOneWidget);
-    expect(find.text('Voeg deze klas toe aan Smartschool'), findsOneWidget);
+    // …reading as the create side of the either/or choice of #244.
+    expect(find.text('Voeg deze klas toe aan Smartschool (keuze)'),
+        findsOneWidget);
     // …and no class of the school we do not manage is anywhere near it.
     expect(find.text('9Z'), findsNothing,
         reason: 'creating another school\'s class is never ours to propose');
@@ -1201,12 +1203,29 @@ void main() {
         find.textContaining('Voeg deze klas toe aan Smartschool'), findsNothing,
         reason: 'nobody of ours is in 1A — creating + enrolling is not due');
 
-    // The notice is marked manual — there is nothing to write for an empty
-    // class — while the only applyable line stays the "ignore this class"
-    // opt-out every WISA-only class carries.
-    expect(find.textContaining('(manueel)'), findsOneWidget);
+    // The notice leads the either/or choice of #244 — the "ignore this class"
+    // opt-out is its alternative, not a second to-do — so the collapsed row
+    // reads as a choice, and the opt-out is not on it.
+    expect(find.textContaining('(keuze)'), findsOneWidget);
+    expect(find.textContaining('(manueel)'), findsNothing);
     expect(find.textContaining('Negeer deze klas bij het importeren uit WISA'),
+        findsNothing,
+        reason: 'blacklisting is the alternative, not a second to-do');
+
+    // Expanding it offers both readings as radios, the notice pre-selected —
+    // and the entry has nothing to apply until the operator picks the opt-out.
+    await tester.tap(find.byKey(const ValueKey('entry-group-1A')));
+    await tester.pumpAndSettle();
+    expect(find.text('Kies één oplossing:'), findsOneWidget);
+    expect(find.text('Negeer deze klas bij het importeren uit WISA'),
         findsOneWidget);
+    expect(
+      tester
+          .widget<FilledButton>(find.byKey(const ValueKey('entry-apply-1A')))
+          .onPressed,
+      isNull,
+      reason: 'there is nothing to write for an empty class',
+    );
 
     // And the pass itself never constructed the create-and-enrol action for it.
     final kinds = harness.controller.pendingEntries
@@ -1288,6 +1307,90 @@ void main() {
     final lines = harness.log.entries.map((e) => e.message).join('\n');
     expect(lines, contains('Klas "2G" niet gekoppeld'));
     expect(lines, contains('G2G'));
+  });
+
+  testWidgets(
+      'a new class offers one either/or choice, and "apply to all" creates '
+      'every class without blacklisting any end-to-end (#244)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation, over the real Smartschool
+    // write path. Two brand-new WISA classes, neither known to Smartschool.
+    //
+    // Each used to carry "Voeg deze klas toe aan Smartschool" *and* "Negeer
+    // deze klas bij het importeren uit WISA" as two independent to-dos, both
+    // selected — so the situation header's **Apply to all** created every new
+    // class of the year and then wrote a DontImportClass rule on the very name
+    // it had just created. The class dropped out of the next WISA snapshot
+    // while the group survived downstream, unmanaged.
+    //
+    // This is the layer that sees it: the contradiction is what the operator
+    // reads off the bulk header and clicks, and the fix has to reach it through
+    // the dispatch, the entry grouping and the drill-down.
+    useTallWindow(tester);
+    final harness = newClassChoiceHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+
+    // Both new classes are on the list, each reading as *one* choice…
+    expect(find.byKey(const ValueKey('entry-group-1A')), findsOneWidget);
+    expect(find.byKey(const ValueKey('entry-group-1B')), findsOneWidget);
+    expect(find.text('Voeg deze klas toe aan Smartschool (keuze)'),
+        findsNWidgets(2));
+    // …and no row carries the opt-out as a line of its own: it is the
+    // alternative the operator can switch to, not a second thing that also
+    // runs. (The bulk header below names both sides of the one choice.)
+    expect(find.text('Negeer deze klas bij het importeren uit WISA'),
+        findsNothing);
+
+    // The bulk header offers the one resolution for both classes.
+    final key = harness.controller.groupPendingEntries
+        .firstWhere((e) => e.targetId == '1A')
+        .situationKey;
+    final bulk = find.byKey(ValueKey('situation-apply-$key'));
+    await tester.ensureVisible(bulk);
+    expect(
+      find.textContaining('Voeg deze klas toe aan Smartschool / Negeer deze '
+          'klas bij het importeren uit WISA'),
+      findsOneWidget,
+      reason: 'the header names one either/or, not two independent to-dos',
+    );
+
+    final pulls = harness.wisaSyncs;
+    await tester.tap(bulk);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    // Both classes were created in Smartschool…
+    final saved =
+        harness.soap.soapActions.where((a) => a.endsWith('#saveClass')).length;
+    expect(saved, 2);
+    // …and not one of them was blacklisted on the way out. A DontImportClass
+    // rule re-pulls WISA, so an untouched pull count is the proof.
+    expect(harness.wisaSyncs, pulls);
+    final summaries =
+        harness.controller.applyResults!.map((r) => r.changes.summary).toList();
+    expect(summaries.where((s) => s == 'Voeg deze klas toe aan Smartschool'),
+        hasLength(2));
+    expect(
+      summaries,
+      isNot(contains('Negeer deze klas bij het importeren uit WISA')),
+      reason: 'the rule would drop the classes this same pass just created',
+    );
   });
 
   testWidgets(

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1722,17 +1722,14 @@ void main() {
     await tester.tap(toggle);
     await tester.pumpAndSettle();
 
-    // Closing a classroom rebuilds — and so collapses — the tree, so the year
-    // is re-opened for each of the two students.
-    Future<void> openYear() async {
-      final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
-      await tester.ensureVisible(yearNode);
-      await tester.tap(yearNode);
-      await tester.pumpAndSettle();
-    }
+    // The year is opened once and stays open across both drill-downs: since
+    // #235 pressing Overzicht comes back to the grade-year it was opened from.
+    final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
+    await tester.ensureVisible(yearNode);
+    await tester.tap(yearNode);
+    await tester.pumpAndSettle();
 
     // Sam, in 1B: one line, naming both groups, and marked as a manual fix.
-    await openYear();
     await tester
         .ensureVisible(find.byKey(const ValueKey('rollup-class-class|1|1|1B')));
     await tester.tap(find.byKey(const ValueKey('rollup-class-class|1|1|1B')));
@@ -1747,10 +1744,10 @@ void main() {
     expect(find.textContaining('(manueel)'), findsWidgets,
         reason: 'the class row performs the write, so this one diagnoses');
 
-    // Jane, in 1A: the plain "missing from her own group" reading.
+    // Jane, in 1A: the plain "missing from her own group" reading. Overzicht
+    // lands back on the still-open year, with her class already listed.
     await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
     await tester.pumpAndSettle();
-    await openYear();
     await tester
         .ensureVisible(find.byKey(const ValueKey('rollup-class-class|1|1|1A')));
     await tester.tap(find.byKey(const ValueKey('rollup-class-class|1|1|1A')));
@@ -1980,17 +1977,76 @@ void main() {
     expect(tester.widget<Switch>(toggle).value, isTrue);
     expect(find.byKey(const ValueKey('rollup-grade-grades|1')), findsNothing);
 
-    // Switched off, the full inventory is back — every year, every class.
+    // Switched off, the full inventory is back — every year, every class. Jaar
+    // 3 was left open above and, being visible under either filter setting,
+    // stays open across the switch (#235), so its ticked-off class simply
+    // reappears beside the one with work.
     await tester.ensureVisible(toggle);
     await tester.tap(toggle);
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('rollup-grade-grades|1')), findsOneWidget);
     expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
     expect(find.byKey(const ValueKey('actions-filter-hidden')), findsNothing);
-    await tester.tap(find.byKey(const ValueKey('rollup-grade-grades|3')));
-    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-class-class|1|3|3C')),
+        findsOneWidget);
     expect(find.byKey(const ValueKey('rollup-class-class|1|3|3D')),
         findsOneWidget);
+  });
+
+  testWidgets(
+      'the Acties tree is a single-open accordion whose grade-year survives a '
+      'drill into a class end-to-end (#235)', (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. This bug is a composition one:
+    // while a class is open the drill-down is not built at all, so the
+    // expansion held inside the ExpansionTiles died with them and **Overzicht**
+    // came back to a fully collapsed tree. Only an end-to-end run navigates the
+    // way that breaks it — a widget test of the tree alone never leaves it.
+    useTallWindow(tester);
+    final harness = twoSchoolHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+
+    final jaar1 = find.byKey(const ValueKey('rollup-grade-grades|1'));
+    final jaar3 = find.byKey(const ValueKey('rollup-grade-grades|3'));
+    final klas1A = find.byKey(const ValueKey('rollup-class-class|1|1|1A'));
+    final klas3C = find.byKey(const ValueKey('rollup-class-class|1|3|3C'));
+
+    // Open Jaar 1…
+    await tester.ensureVisible(jaar1);
+    await tester.tap(jaar1);
+    await tester.pumpAndSettle();
+    expect(klas1A, findsOneWidget);
+
+    // …then Jaar 3: one open node per level, so Jaar 1 shuts behind it.
+    await tester.ensureVisible(jaar3);
+    await tester.tap(jaar3);
+    await tester.pumpAndSettle();
+    expect(klas3C, findsOneWidget);
+    expect(klas1A, findsNothing,
+        reason: 'several years could stand open at once before #235');
+
+    // Drill into 3C and press Overzicht: the year the operator came from is
+    // still open, with its class in view rather than behind a re-expand.
+    await tester.ensureVisible(klas3C);
+    await tester.tap(klas3C);
+    await tester.pumpAndSettle();
+    expect(harness.controller.selectedClassroom?.classroom, '3C');
+    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
+    await tester.pumpAndSettle();
+    expect(klas3C, findsOneWidget,
+        reason: 'the tree used to come back fully collapsed');
+    expect(klas1A, findsNothing);
+    expect(harness.controller.expandedPath, <String>['rollup-grade-grades|3']);
   });
 
   testWidgets(
@@ -2042,20 +2098,15 @@ void main() {
     );
 
     // Browse it the way the operator does: the merged first year holds both
-    // schools' `1C`, each still keyed to its own school partition. Closing a
-    // classroom rebuilds — and so collapses — the drill-down tree, so the year
-    // is re-opened for each school.
+    // schools' `1C`, each still keyed to its own school partition. The year is
+    // opened once — since #235 Overzicht comes back to it still open.
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
 
-    Future<void> openYear() async {
-      final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
-      await tester.ensureVisible(yearNode);
-      await tester.tap(yearNode);
-      await tester.pumpAndSettle();
-    }
-
-    await openYear();
+    final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
+    await tester.ensureVisible(yearNode);
+    await tester.tap(yearNode);
+    await tester.pumpAndSettle();
     expect(find.text('1C 00'), findsNothing,
         reason: 'the sentinel never names a class in the drill-down either');
 
@@ -2064,7 +2115,6 @@ void main() {
       if (harness.controller.selectedClassroom != null) {
         await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
         await tester.pumpAndSettle();
-        await openYear();
       }
       final classNode = find.byKey(ValueKey('rollup-class-class|$school|1|1C'));
       expect(classNode, findsOneWidget);

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -4470,8 +4470,10 @@ void main() {
     expect(find.text('Maak een nieuw Office 365 account'), findsNothing,
         reason: 'the account already exists — creating one duplicates it');
     // The record is now WISA + Azure, so the only thing left to build is the
-    // Smartschool side — the proposal the adoption unlocks.
-    expect(find.text('Maak een nieuw Smartschool account'), findsOneWidget);
+    // Smartschool side — the proposal the adoption unlocks, reading as the
+    // create side of the #248 choice it shares with the WISA opt-out.
+    expect(find.text('Maak een nieuw Smartschool account (keuze)'),
+        findsOneWidget);
   });
 
   testWidgets(
@@ -4757,7 +4759,10 @@ void main() {
         find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
     expect(find.text('Anna Smit'), findsWidgets,
         reason: 'a staff member with no downstream account is still listed');
-    expect(find.text('Maak een nieuw Office 365 account'), findsOneWidget);
+    // …reading as the create side of the either/or choice of #248: the WISA
+    // opt-out this family also raises is its alternative, not a second to-do.
+    expect(
+        find.text('Maak een nieuw Office 365 account (keuze)'), findsOneWidget);
     expect(find.text('Maak een nieuw Smartschool account'), findsNothing,
         reason: 'the dispatch can only see the first link of the chain');
 
@@ -4777,15 +4782,14 @@ void main() {
 
     // Both accounts exist now, off that single click, and both writes are
     // reported — the second is a real write the operator must see, not a silent
-    // extra. The third row is the entry's *other* pending item, the WISA ignore
-    // rule this family also offers for a staff member with no Smartschool
-    // account; it is not part of the chain (tracked as #248).
+    // extra. And *only* those two: the WISA ignore rule this family also raises
+    // is the alternative of the same choice since #248, so it no longer rides
+    // along on the apply that just provisioned her.
     expect(
       harness.controller.applyResults!.map((r) => r.changes.summary),
       <String>[
         'Maak een nieuw Office 365 account',
         'Maak een nieuw Smartschool account',
-        'Negeer dit account bij het importeren uit WISA',
       ],
     );
     expect(
@@ -4807,6 +4811,126 @@ void main() {
     final messages = harness.log.entries.map((e) => e.message);
     expect(messages, contains(contains('Maak een nieuw Office 365 account')));
     expect(messages, contains(contains('Maak een nieuw Smartschool account')));
+  });
+
+  testWidgets(
+      'a new staff member offers one either/or choice, and "apply to all" '
+      'provisions every hire without blacklisting any end-to-end (#248)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation, over the real Graph and
+    // Smartschool write paths. Two freshly hired teachers, present in WISA only.
+    //
+    // Each used to carry "Maak een nieuw Office 365 account" *and* "Negeer dit
+    // account bij het importeren uit WISA" as two independent to-dos, both
+    // selected — so one click provisioned the teacher end to end (the #240
+    // chain) and then wrote a DontImportUserFromWisa rule on the very code it
+    // had just provisioned. The rule set is persisted and re-applied on every
+    // WISA pull, so the next sync dropped the staff member the operator had
+    // just given two accounts, and those accounts went unmanaged.
+    //
+    // This is the layer that sees it: the contradiction is what the operator
+    // reads off Acties → Personeel and clicks, and the fix has to reach it
+    // through the dispatch, the entry grouping and the drill-down.
+    useTallWindow(tester);
+    final harness = newStaffChoiceHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // Browse Acties → Personeel, where the operator met this.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+    final staffSchool =
+        find.byKey(const ValueKey('rollup-school-school|staff'));
+    await tester.ensureVisible(staffSchool);
+    await tester.tap(staffSchool);
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
+    await tester.pumpAndSettle();
+    final staffClass = find
+        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
+    await tester.ensureVisible(staffClass);
+    await tester.tap(staffClass);
+    await tester.pumpAndSettle();
+    expect(
+        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+
+    // Both new hires are on the list, each reading as *one* choice…
+    expect(find.text('Anna Smit'), findsWidgets);
+    expect(find.text('Bram Jansen'), findsWidgets);
+    expect(find.text('Maak een nieuw Office 365 account (keuze)'),
+        findsNWidgets(2));
+    // …and no row carries the opt-out as a line of its own: it is the
+    // alternative the operator can switch to, not a second thing that also
+    // runs. (The bulk header below names both sides of the one choice.)
+    expect(find.text('Negeer dit account bij het importeren uit WISA'),
+        findsNothing);
+
+    // Expanding one offers both readings as radios, the create pre-selected.
+    final entries = harness.controller.pendingEntries
+        .where((e) => e.family == 'staff')
+        .toList();
+    expect(entries, hasLength(2));
+    final first = find.byKey(ValueKey('entry-staff-${entries.first.targetId}'));
+    await tester.ensureVisible(first);
+    await tester.tap(first);
+    await tester.pumpAndSettle();
+    expect(find.text('Kies één oplossing:'), findsOneWidget);
+    expect(find.text('Negeer dit account bij het importeren uit WISA'),
+        findsOneWidget);
+    await tester.tap(first);
+    await tester.pumpAndSettle();
+
+    // The bulk header offers the one resolution for both hires.
+    final key = entries.first.situationKey;
+    final bulk = find.byKey(ValueKey('situation-apply-$key'));
+    await tester.ensureVisible(bulk);
+    expect(
+      find.textContaining('Maak een nieuw Office 365 account / Negeer dit '
+          'account bij het importeren uit WISA'),
+      findsOneWidget,
+      reason: 'the header names one either/or, not two independent to-dos',
+    );
+
+    final pulls = harness.wisaSyncs;
+    await tester.tap(bulk);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    // Both teachers were provisioned end to end — Office 365 and, off the #240
+    // chain, Smartschool…
+    expect(harness.graph.createdUsers, hasLength(2));
+    final summaries =
+        harness.controller.applyResults!.map((r) => r.changes.summary).toList();
+    expect(summaries.where((s) => s == 'Maak een nieuw Office 365 account'),
+        hasLength(2));
+    expect(summaries.where((s) => s == 'Maak een nieuw Smartschool account'),
+        hasLength(2));
+    // …and not one of them was blacklisted on the way out. A
+    // DontImportUserFromWisa rule re-pulls WISA, so an untouched pull count is
+    // the proof.
+    expect(
+      summaries,
+      isNot(contains('Negeer dit account bij het importeren uit WISA')),
+      reason: 'the rule would drop the hires this same pass just provisioned',
+    );
+    expect(harness.wisaSyncs, pulls);
+    expect(
+      harness.controller.applyResults!.map((r) => r.outcome.name),
+      everyElement('applied'),
+    );
   });
 }
 

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -291,6 +291,172 @@ void main() {
     expect(harness.controller.busy, isFalse);
   });
 
+  /// Two departed Smartschool-only students with different names, each raising
+  /// the unregister/delete choice — a two-action pass whose steps are told
+  /// apart by the account they name. [gate] parks every action so the pass can
+  /// be observed frozen exactly where the operator waits (#243).
+  ReconcileHarness twoDepartedHarness(Future<void> Function() gate) =>
+      ReconcileHarness(
+        applyGate: gate,
+        wisa: wisaSnap(students: const []),
+        smartschool: ssSnap(
+          groups: const [],
+          accounts: [
+            ssAccount(
+              uid: 'user0',
+              accountId: '0',
+              mail: 'user0@student.school.example',
+              givenName: 'Jan',
+              surname: 'Peeters',
+            ),
+            ssAccount(
+              uid: 'user1',
+              accountId: '1',
+              mail: 'user1@student.school.example',
+              givenName: 'Sofie',
+              surname: 'Claes',
+            ),
+          ],
+          memberships: const [],
+        ),
+        azure: azSnap(users: const []),
+      );
+
+  /// Syncs on Reconcile and lands on the Actions tab, the way the operator gets
+  /// to the apply affordances.
+  Future<void> syncThenOpenActions(WidgetTester tester) async {
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+  }
+
+  /// The text of one line of the modal progress dialog.
+  String progressLine(WidgetTester tester, String key) =>
+      tester.widget<Text>(find.byKey(ValueKey(key))).data!;
+
+  final Finder progressDialog =
+      find.byKey(const ValueKey('actions-progress-dialog'));
+
+  testWidgets(
+      'an apply pass holds the operator in a modal progress dialog naming the '
+      'account and action in flight, and clears when the pass ends (#243)',
+      (WidgetTester tester) async {
+    // The real app over the offline harness, with the pass parked one action at
+    // a time. An "Apply to all" over a September situation group writes
+    // hundreds of accounts sequentially and runs for minutes; its only feedback
+    // used to be greyed-out buttons and an indeterminate bar in a page header
+    // the operator had scrolled past, and nothing stopped them navigating away
+    // mid-write. Composition is the point here: the dialog has to sit over the
+    // real shell, in the real font, above a page that is still scrollable.
+    useTallWindow(tester);
+    final gates = <Completer<void>>[];
+    final harness = twoDepartedHarness(() async {
+      final gate = Completer<void>();
+      gates.add(gate);
+      await gate.future;
+    });
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+
+    // Idle: no dialog.
+    expect(progressDialog, findsNothing);
+
+    await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
+    await tester.tap(find.byKey(const ValueKey('actions-apply')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    // Parked on the first action: the dialog names how far along the pass is
+    // and whose account is being written right now.
+    expect(progressDialog, findsOneWidget);
+    expect(gates, hasLength(1));
+    expect(find.text('Acties toepassen…'), findsOneWidget);
+    expect(progressLine(tester, 'actions-progress-count'), 'Actie 1 van 2');
+    expect(progressLine(tester, 'actions-progress-step'),
+        startsWith('Jan Peeters —'));
+    expect(
+      tester
+          .widget<LinearProgressIndicator>(
+            find.byKey(const ValueKey('actions-progress-bar')),
+          )
+          .value,
+      isNotNull,
+      reason: 'determinate, not the motionless sweep this replaces',
+    );
+
+    // Modal: the barrier is there and a tap outside does not dismiss it, so the
+    // operator cannot scroll or navigate away mid-write.
+    await tester.tapAt(const Offset(5, 5));
+    await tester.pumpAndSettle();
+    expect(progressDialog, findsOneWidget);
+
+    // The text follows the pass onto the second account.
+    gates[0].complete();
+    await tester.pumpAndSettle();
+    expect(progressLine(tester, 'actions-progress-count'), 'Actie 2 van 2');
+    expect(progressLine(tester, 'actions-progress-step'),
+        startsWith('Sofie Claes —'));
+
+    // The pass finishes: the dialog closes by itself, leaving the results.
+    gates[1].complete();
+    await tester.pumpAndSettle();
+    expect(progressDialog, findsNothing);
+    expect(find.text('Apply result'), findsOneWidget);
+    expect(harness.soap.soapActions, isNotEmpty);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'a pass whose writes fail still clears the progress dialog (#243)',
+      (WidgetTester tester) async {
+    // The worst case for a modal: leaving it up after a failed pass would lock
+    // the operator out of the whole app, so its lifetime is bound to the pass's
+    // future rather than to anything observed about the results.
+    useTallWindow(tester);
+    final gate = Completer<void>();
+    final harness = twoDepartedHarness(() async {
+      await gate.future;
+      throw StateError('Smartschool weigerde de schrijfactie');
+    });
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+
+    await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
+    await tester.tap(find.byKey(const ValueKey('actions-apply')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+    expect(progressDialog, findsOneWidget);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+
+    expect(progressDialog, findsNothing);
+    expect(find.text('Apply result'), findsOneWidget);
+    expect(
+      find.textContaining('Smartschool weigerde de schrijfactie'),
+      findsWidgets,
+      reason: 'the failure is reported on the page, not behind a stuck modal',
+    );
+    // The app is usable again: the affordances are live and reachable.
+    await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets(
       'a completed sync logs a terminal "Sync complete … Ready." line and the '
       'last-sync box renders a row per system end-to-end (#162/#188)',

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -1693,6 +1693,7 @@ class ReconcileController extends ChangeNotifier {
       } else {
         _applyResults = results;
         _dryRunResults = null;
+        _refreshRollups();
       }
       _applyStep = null;
       _finish(ReconcilePhase.ready);
@@ -1703,6 +1704,9 @@ class ReconcileController extends ChangeNotifier {
         _dryRunResults = results;
       } else {
         _applyResults = results;
+        // A pass that broke halfway still wrote whatever it got through, so the
+        // overview owes the operator those counts too (#236).
+        _refreshRollups();
       }
       // Nothing is in flight any more, however the pass ended (#243).
       _applyStep = null;
@@ -1817,6 +1821,49 @@ class ReconcileController extends ChangeNotifier {
         '${ss.official ? 'met een andere schrijfwijze' : 'maar geen '
             'officiële klas'}.',
       );
+    }
+  }
+
+  /// Re-derives the overview rollups from the refreshed linked view after a
+  /// **real** apply (#236) — the badge counts, and since #226 which nodes the
+  /// tree shows at all.
+  ///
+  /// Until this, `_rollups` was assigned by [_persist] alone, which only ever
+  /// runs from [_relink]. An apply patches the snapshot and adopts the refreshed
+  /// `_linked` but never re-materialized, so the two halves of the Acties screen
+  /// disagreed the moment a pass finished: the drilled-in list (derived from the
+  /// live view) had dropped the work, while the overview kept advertising it —
+  /// and under the default filter kept a finished class in the tree — until the
+  /// next Synchroniseer. [materialize] is pure and already derives exactly these
+  /// aggregates from a [LinkedState], so the correction is the same computation
+  /// the sync path runs, minus the store write.
+  ///
+  /// Deliberately **local-only**. Nothing is written back and the generation is
+  /// not bumped, for three reasons: the stored view is ~9.6k documents and
+  /// rewriting it per apply is not affordable ([LinkedStore.writeMaterialized]
+  /// is the sync path's tool, not an apply's); this session's generation must
+  /// stay behind the store's so a later [onStoreChanged] still wins over this
+  /// correction rather than being gated out as stale; and there is no narrow
+  /// per-account write seam to do it properly. So other operators keep the
+  /// pre-apply counts until someone syncs — the shared half of the bug, filed
+  /// separately (#254) because it needs that seam plus a [ChangeSignal] shard.
+  ///
+  /// Never called from the dry-run path: a projection writes nothing, so it must
+  /// leave every count exactly as it found it.
+  void _refreshRollups() {
+    final linked = _linked;
+    if (linked == null) return;
+    try {
+      _rollups = materialize(
+        linked,
+        generation: _syncState.generation,
+        schoolLabels: _schoolLabels(),
+      ).rollups;
+    } on Object catch (e) {
+      // A correction that fails must not turn a successful apply into a failed
+      // pass; the counts then simply stay as stale as they were before.
+      log.addError(
+          core.Origin.all, 'Could not refresh the overview counts: $e');
     }
   }
 

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -156,6 +156,53 @@ class ApplyScope {
       ApplyScope(systems: <core.Origin>[], chained: <core.Origin>{});
 }
 
+/// The action a running dry-run/apply pass is on **right now** (#243) — what the
+/// modal progress dialog names while the operator waits.
+///
+/// Published by [ReconcileController._run] straight off the list it is walking:
+/// the selected, applyable option of each choice, which is the very same
+/// resolution [ReconcileController.applyScope] summarised for the confirmation
+/// dialog a moment earlier. The progress dialog therefore counts exactly the
+/// actions the operator just agreed to, rather than resolving the work a second
+/// way that could disagree with what they were shown.
+class ApplyStep {
+  const ApplyStep({
+    required this.dry,
+    required this.index,
+    required this.total,
+    required this.target,
+    required this.summary,
+    this.followUps = 0,
+  });
+
+  /// Whether this pass is a dry-run (nothing is written) rather than an apply.
+  final bool dry;
+
+  /// 1-based position of the action in flight within the planned list.
+  final int index;
+
+  /// How many actions the pass set out to run.
+  ///
+  /// The *planned* actions only, and deliberately so. A chained follow-up
+  /// (#230/#240/#245) is not in the pending list at all: dispatch is a pure
+  /// function of the record as it stands, so the second link only exists once
+  /// the first write has landed and relinked, and its own `evaluate` decides
+  /// then whether it runs. It can never be counted up front — so it is reported
+  /// separately in [followUps] instead of quietly inflating a total the operator
+  /// was already shown.
+  final int total;
+
+  /// Human label of the record this action targets ("Jan Peeters").
+  final String target;
+
+  /// The action's one-line change summary ("Maak een nieuw Office 365 account").
+  final String summary;
+
+  /// Extra writes that chained off already-finished steps of this pass — the
+  /// follow-ups [total] structurally cannot include.
+  final int followUps;
+}
+
 /// One decision point within a [PendingAccountEntry]: either a lone action or a
 /// set of mutually-exclusive alternatives, exactly one of which is [selected].
 ///
@@ -418,6 +465,7 @@ class ReconcileController extends ChangeNotifier {
 
   ReconcilePhase _phase = ReconcilePhase.idle;
   double _progress = 0.0;
+  ApplyStep? _applyStep;
   LinkedState? _linked;
   bool _noChangesNeeded = false;
   String? _error;
@@ -483,6 +531,24 @@ class ReconcileController extends ChangeNotifier {
     final next = value.clamp(0.0, 1.0);
     if (next <= _progress) return;
     _progress = next;
+    notifyListeners();
+  }
+
+  /// The action the running dry-run/apply pass is on, or `null` when no pass is
+  /// walking actions (#243). Drives the modal progress dialog's text, so a pass
+  /// that writes hundreds of accounts says which account and which action it is
+  /// on instead of leaving the operator with greyed-out buttons for minutes.
+  ApplyStep? get applyStep => _applyStep;
+
+  /// Publishes the pass's current step and repaints.
+  ///
+  /// Its own notification rather than something riding along with
+  /// [_setProgress]: that one ignores any value not greater than the current
+  /// one, so a step published through it would be dropped exactly when the bar
+  /// does not move — the first action of every pass, and every action of a pass
+  /// of one.
+  void _setApplyStep(ApplyStep step) {
+    _applyStep = step;
     notifyListeners();
   }
 
@@ -1561,6 +1627,18 @@ class ReconcileController extends ChangeNotifier {
 
     try {
       for (final (index, option) in selected.indexed) {
+        // Name the action *before* it runs, so the modal progress dialog says
+        // what is in flight rather than what just finished (#243). `results`
+        // already holds one row per write performed, so anything in it beyond
+        // the [index] steps that completed is a chained follow-up.
+        _setApplyStep(ApplyStep(
+          dry: dry,
+          index: index + 1,
+          total: selected.length,
+          target: option.target,
+          summary: option.changes.summary,
+          followUps: results.length - index,
+        ));
         results.addAll(await _applyOne(
           () => _applyAny(option.action, options),
           option.target,
@@ -1584,6 +1662,7 @@ class ReconcileController extends ChangeNotifier {
         _applyResults = results;
         _dryRunResults = null;
       }
+      _applyStep = null;
       _finish(ReconcilePhase.ready);
     } on Object catch (e) {
       // _applyOne swallows per-action failures; reaching here means the pass
@@ -1593,6 +1672,8 @@ class ReconcileController extends ChangeNotifier {
       } else {
         _applyResults = results;
       }
+      // Nothing is in flight any more, however the pass ended (#243).
+      _applyStep = null;
       _fail(e);
     }
   }
@@ -1848,6 +1929,7 @@ class ReconcileController extends ChangeNotifier {
   void _begin(ReconcilePhase phase) {
     _phase = phase;
     _progress = 0.0;
+    _applyStep = null;
     _error = null;
     _noChangesNeeded = false;
     _dryRunResults = null;

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -475,6 +475,7 @@ class ReconcileController extends ChangeNotifier {
   SyncState _syncState = SyncState.initial;
   List<Rollup> _rollups = const [];
   Rollup? _selectedClassroom;
+  List<String> _expandedPath = const <String>[];
   List<MaterializedAccount>? _classroomAccounts;
   bool _loadingClassroom = false;
   bool _showingGroups = false;
@@ -1209,6 +1210,37 @@ class ReconcileController extends ChangeNotifier {
   /// Whether a classroom drill-down read is in flight.
   bool get loadingClassroom => _loadingClassroom;
 
+  /// Which accordion nodes the Acties drill-down has open, outermost first
+  /// (#235) — `['rollup-grade-grades|3']` on the flat Leerlingen tree, and
+  /// `['rollup-school-school|staff', 'rollup-grade-grade|staff|Personeel']` on
+  /// the nested Personeel one. Empty means a fully collapsed tree.
+  ///
+  /// It lives up here beside [selectedClassroom] for the reason the bug existed:
+  /// while a class is open the tree is not built at all, so expansion kept
+  /// inside the `ExpansionTile`s themselves died with them and **Overzicht**
+  /// came back fully collapsed. Held one level above the widgets it survives the
+  /// detail view — and a family tab change, which closes the drill-down but
+  /// leaves the other tab's path untouched, the two trees sharing no node key.
+  ///
+  /// One entry **per depth** is what makes it an accordion without breaking the
+  /// nested staff tree: opening a node replaces whichever sibling sat at its
+  /// depth and drops everything below, while its ancestors stay open.
+  List<String> get expandedPath => _expandedPath;
+
+  set expandedPath(List<String> path) {
+    if (_samePath(_expandedPath, path)) return;
+    _expandedPath = List<String>.unmodifiable(path);
+    notifyListeners();
+  }
+
+  static bool _samePath(List<String> a, List<String> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+
   /// The three category summaries the Reconcile overview renders (#163), summed
   /// from the stored rollups so they read in a passive session too: students are
   /// every school rollup *except* the synthetic staff bucket, staff is that
@@ -1854,8 +1886,12 @@ class ReconcileController extends ChangeNotifier {
       // Nudge every passive session to refetch: the whole view was rewritten,
       // so the signal names no narrower shard (#116).
       await _publish(ChangeSignal.viewChanged(generation: view.generation));
-      // A re-sync invalidates any open drill-down; the next open re-reads.
+      // A re-sync invalidates any open drill-down; the next open re-reads. The
+      // remembered accordion path goes with it (#235), so it can never point at
+      // a node this new generation no longer has. Written straight to the field:
+      // the pass notifies once when it finishes.
       _selectedClassroom = null;
+      _expandedPath = const <String>[];
       _classroomAccounts = null;
       _showingGroups = false;
       _groupDocs = null;

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -817,34 +817,43 @@ class ReconcileController extends ChangeNotifier {
   /// non-null [PendingActionOption.group] become one mutually-exclusive choice
   /// (its selection honoured from [_choices], defaulting to the group default);
   /// every other option is a choice of one.
+  ///
+  /// The partition itself is `account_actions`' [actions.collapseAlternatives]
+  /// (#251) — the one definition of "these actions are one either/or", shared
+  /// with the materializer so the badges and this list cannot disagree about
+  /// what a decision is. Only the operator's session-local pick is layered on
+  /// here; a passive session has no picks to apply.
   List<PendingChoice> _choicesFor(
     String targetId,
     List<PendingActionOption> options,
+  ) =>
+      [
+        for (final choice in actions.collapseAlternatives<PendingActionOption>(
+          options,
+          groupOf: (o) => o.group,
+          isDefault: (o) => o.isDefault,
+        ))
+          PendingChoice(
+            alternatives: choice.options,
+            selected: _chosen(targetId, choice),
+          ),
+      ];
+
+  /// The option the operator picked for [choice] on [targetId] (#110), or the
+  /// group's pre-selected default when they have not picked one — or picked a
+  /// kind this pass no longer offers.
+  PendingActionOption _chosen(
+    String targetId,
+    actions.Alternatives<PendingActionOption> choice,
   ) {
-    final choices = <PendingChoice>[];
-    final groupOrder = <String>[];
-    final byGroup = <String, List<PendingActionOption>>{};
-    for (final o in options) {
-      final g = o.group;
-      if (g == null) {
-        choices.add(PendingChoice(alternatives: [o], selected: o));
-      } else {
-        if (!byGroup.containsKey(g)) groupOrder.add(g);
-        (byGroup[g] ??= <PendingActionOption>[]).add(o);
-      }
-    }
-    for (final g in groupOrder) {
-      final alts = byGroup[g]!;
-      final defaultKind =
-          alts.firstWhere((a) => a.isDefault, orElse: () => alts.first).kind;
-      final chosenKind = _choices['$targetId|$g'] ?? defaultKind;
-      final selected = alts.firstWhere(
-        (a) => a.kind == chosenKind,
-        orElse: () => alts.firstWhere((a) => a.kind == defaultKind),
-      );
-      choices.add(PendingChoice(alternatives: alts, selected: selected));
-    }
-    return choices;
+    final group = choice.options.first.group;
+    if (group == null) return choice.selected;
+    final kind = _choices['$targetId|$group'];
+    if (kind == null) return choice.selected;
+    return choice.options.firstWhere(
+      (a) => a.kind == kind,
+      orElse: () => choice.selected,
+    );
   }
 
   /// Records the operator's pick of a mutually-exclusive alternative (#110):

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -89,6 +89,7 @@ class PendingActionOption {
     required this.target,
     required this.changes,
     required this.canApply,
+    this.unlockedSystems = const {},
   });
 
   /// The live `StudentAction` / `StaffAction` / `GroupAction` this option runs.
@@ -115,6 +116,44 @@ class PendingActionOption {
 
   /// Whether an apply pass would actually write this option.
   final bool canApply;
+
+  /// The systems only a **chained follow-up** of this option would write to
+  /// (`StudentAction.unlockedSystems` et al., #234) — never the option's own
+  /// [changes] system.
+  ///
+  /// Read off the action rather than derived from the pending list, because the
+  /// follow-up is not in it: the dispatcher is a pure function of the record as
+  /// it stands, so `AddStudentToSmartschool` only appears once the Azure create
+  /// has run and relinked. The confirmation dialog has to name that second
+  /// system *before* the write.
+  final Set<core.Origin> unlockedSystems;
+}
+
+/// What a confirmed apply of a selection would write, for the confirmation
+/// dialog (#234).
+///
+/// Built by [ReconcileController.applyScope] from the **selected**, applyable
+/// option of each choice — exactly the actions `applyAll` / `applySituation` /
+/// `applyEntry` would run — so the dialog names the systems the pass genuinely
+/// reaches instead of the hard-coded "Smartschool and Azure AD" it used to
+/// claim for every action.
+class ApplyScope {
+  const ApplyScope({required this.systems, required this.chained});
+
+  /// One entry per action the pass would run: the system that action writes to.
+  /// A list, not a set — its length is the change count the dialog quotes, and
+  /// two Azure patches are two changes to one system.
+  final List<core.Origin> systems;
+
+  /// Systems only a chained follow-up would reach, with everything already in
+  /// [systems] removed. Non-empty only for the provisioning chains whose second
+  /// write lands in another system (a new student's / staff member's Office 365
+  /// create pulls the Smartschool create in behind it).
+  final Set<core.Origin> chained;
+
+  /// Nothing selected — a dialog built from this claims no write at all.
+  static const ApplyScope empty =
+      ApplyScope(systems: <core.Origin>[], chained: <core.Origin>{});
 }
 
 /// One decision point within a [PendingAccountEntry]: either a lone action or a
@@ -525,6 +564,7 @@ class ReconcileController extends ChangeNotifier {
       // (`AzureClassGroupMembership`), so the apply affordance is gated on the
       // action rather than assumed, exactly as the group family's is.
       canApply: (a) => a.canApply,
+      unlockedSystems: (a) => a.unlockedSystems,
     ));
     entries.addAll(_entriesFor(
       family: 'staff',
@@ -537,6 +577,7 @@ class ReconcileController extends ChangeNotifier {
       // Read off the action like the other two families since #240: every staff
       // action is applyable today, but nothing here should assume it.
       canApply: (a) => a.canApply,
+      unlockedSystems: (a) => a.unlockedSystems,
     ));
     entries.addAll(_entriesFor(
       family: 'group',
@@ -547,6 +588,7 @@ class ReconcileController extends ChangeNotifier {
       isDefault: (a) => a.isDefaultAlternative,
       changes: (a) => a.describeChanges(),
       canApply: (a) => a.canApply,
+      unlockedSystems: (a) => a.unlockedSystems,
     ));
     _pendingCacheKey = l;
     _pendingCacheChoicesVersion = _choicesVersion;
@@ -665,6 +707,7 @@ class ReconcileController extends ChangeNotifier {
     required bool Function(T) isDefault,
     required actions.ChangeSet Function(T) changes,
     required bool Function(T) canApply,
+    required Set<core.Origin> Function(T) unlockedSystems,
   }) {
     final order = <String>[];
     final byTarget = <String, List<T>>{};
@@ -695,6 +738,7 @@ class ReconcileController extends ChangeNotifier {
                   target: labels[id]!,
                   changes: changes(a),
                   canApply: canApply(a),
+                  unlockedSystems: unlockedSystems(a),
                 ),
             ],
           ),
@@ -1161,6 +1205,28 @@ class ReconcileController extends ChangeNotifier {
   /// counts once (the chosen resolution), not twice, and the informational group
   /// actions are excluded.
   int get applyableCount => _selectedActions(pendingEntries).length;
+
+  /// What a confirmed apply of [entries] would actually write (#234) — the
+  /// systems the apply-confirmation dialog names, derived from the very options
+  /// [applyAll] / [applySituation] / [applyEntry] would run.
+  ///
+  /// Two halves, because they are not the same claim. [ApplyScope.systems] is
+  /// what the selected actions write themselves, one entry per action.
+  /// [ApplyScope.chained] is what only a follow-up would reach — an
+  /// `AddStudentToAzure` writes Office 365 and then, off the same click, writes
+  /// the Smartschool account its chain unlocks (#230/#240), which is a system
+  /// the visible action never names. The follow-up cannot be counted, because
+  /// its own `evaluate` decides at apply time whether it runs at all; it can
+  /// only be named.
+  ApplyScope applyScope(Iterable<PendingAccountEntry> entries) {
+    final selected = _selectedActions(entries);
+    if (selected.isEmpty) return ApplyScope.empty;
+    final systems = <core.Origin>[for (final o in selected) o.changes.system];
+    final chained = <core.Origin>{
+      for (final o in selected) ...o.unlockedSystems,
+    }..removeAll(systems);
+    return ApplyScope(systems: systems, chained: chained);
+  }
 
   /// The live actions to run for [entries]: the selected, applyable option of
   /// every choice, in order.

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -33,6 +33,12 @@ import '../search/name_query.dart';
 /// back is counted and named, so a year the operator expected is explained
 /// rather than merely absent.
 ///
+/// The tree is a single-open accordion whose open path outlives the detail view
+/// (#235): drilling into a class and pressing **Overzicht** comes back to the
+/// grade-year it was opened from, and opening another year closes the one that
+/// was open. The path is held on the [ReconcileController], because while a
+/// class is open the tree is not built at all.
+///
 /// A session with no linked view — passive, or one whose pass failed before it
 /// linked — can only show the stored documents, so both drill-downs say so out
 /// loud rather than quietly swapping in static cards (#214).
@@ -172,6 +178,29 @@ class _FilteredTree {
   final int hidden;
 }
 
+/// The seam the drill-down's expandable nodes are driven through (#235): where
+/// a node's persistent [ExpansibleController] comes from, whether it is the open
+/// one at its depth, and where a tap on it is recorded.
+///
+/// Passed down rather than reached for, so [_DrillDownSection] and [_GradeNode]
+/// stay the stateless projections of the rollups they already were — the open
+/// path itself lives on the [ReconcileController], one level above the tree.
+class _Accordion {
+  const _Accordion({
+    required this.controllerFor,
+    required this.isOpen,
+    required this.onToggled,
+  });
+
+  final ExpansibleController Function(String node) controllerFor;
+
+  /// Whether [node] is the open node at that depth of the tree — 0 for a
+  /// top-level node, 1 for a grade-year nested under the staff school.
+  final bool Function(String node, int depth) isOpen;
+
+  final void Function(String node, int depth, bool open) onToggled;
+}
+
 class _ActionsBody extends StatefulWidget {
   const _ActionsBody({required this.controller});
 
@@ -205,6 +234,19 @@ class _ActionsBodyState extends State<_ActionsBody>
   /// cleared on every family tab change.
   final TextEditingController _search = TextEditingController();
 
+  /// One [ExpansibleController] per accordion node the operator has met this
+  /// session, keyed by [_rollupNodeKey] (#235).
+  ///
+  /// An `ExpansionTile` reads [ExpansionTile.initiallyExpanded] once, in its
+  /// `initState`, and thereafter owns its own open/closed state — so nothing
+  /// declarative can close the year that was open when another is tapped, and
+  /// nothing survives the tile being disposed. Both halves of #235 need a handle
+  /// that outlives the tile, which is exactly what an injected controller is:
+  /// held here, it carries a node's expansion across the detail view, and it is
+  /// the one thing that can collapse a sibling on demand.
+  final Map<String, ExpansibleController> _tiles =
+      <String, ExpansibleController>{};
+
   ReconcileController get controller => widget.controller;
 
   @override
@@ -213,10 +255,18 @@ class _ActionsBodyState extends State<_ActionsBody>
     _tabs = TabController(length: _ActionFamilyTab.values.length, vsync: this)
       ..addListener(_onTabChanged);
     _search.addListener(_onSearchChanged);
+    // Anything that moves the open path without going through a tap — a re-sync
+    // clearing it (#235) — is picked up here and pushed into the tiles.
+    controller.addListener(_syncExpansion);
   }
 
   @override
   void dispose() {
+    controller.removeListener(_syncExpansion);
+    for (final ExpansibleController tile in _tiles.values) {
+      tile.dispose();
+    }
+    _tiles.clear();
     _tabs
       ..removeListener(_onTabChanged)
       ..dispose();
@@ -228,6 +278,96 @@ class _ActionsBodyState extends State<_ActionsBody>
 
   void _onSearchChanged() {
     if (mounted) setState(() {});
+  }
+
+  /// The drill-down tree's accordion seam (#235), handed to the widgets that
+  /// build the expandable nodes.
+  _Accordion get _accordion => _Accordion(
+        controllerFor: _tileFor,
+        isOpen: _isNodeOpen,
+        onToggled: _onNodeToggled,
+      );
+
+  /// The persistent controller of one accordion node, created on first render.
+  /// Safe to call from `build`: a controller nobody is listening to yet cannot
+  /// schedule a rebuild.
+  ExpansibleController _tileFor(String node) => _tiles.putIfAbsent(node, () {
+        final ExpansibleController tile = ExpansibleController();
+        if (_isNodeOpenKey(node)) tile.expand();
+        return tile;
+      });
+
+  /// Whether [node] is the open node at [depth] of
+  /// [ReconcileController.expandedPath].
+  bool _isNodeOpen(String node, int depth) {
+    final List<String> path = controller.expandedPath;
+    return path.length > depth && path[depth] == node;
+  }
+
+  bool _isNodeOpenKey(String node) => controller.expandedPath.contains(node);
+
+  /// Records the operator opening or closing one accordion node.
+  ///
+  /// Opening replaces whatever sat at that depth — which is what makes the tree
+  /// single-open — and truncates everything below it, since a node's children
+  /// go away with it. Closing truncates from that depth. The path setter
+  /// notifies, so [_syncExpansion] does the actual collapsing of the sibling
+  /// that just lost its place.
+  void _onNodeToggled(String node, int depth, bool open) {
+    final List<String> path = controller.expandedPath;
+    if (open) {
+      controller.expandedPath = <String>[...path.take(depth), node];
+    } else if (_isNodeOpen(node, depth)) {
+      controller.expandedPath = path.take(depth).toList();
+    }
+  }
+
+  /// Brings every tile controller back in line with the open path. Idempotent —
+  /// [ExpansibleController.expand] / [ExpansibleController.collapse] are no-ops
+  /// on a controller that already agrees — so it is safe to run on every
+  /// controller notification.
+  void _syncExpansion() {
+    if (!mounted) return;
+    final Set<String> open = controller.expandedPath.toSet();
+    for (final MapEntry<String, ExpansibleController> tile in _tiles.entries) {
+      if (open.contains(tile.key)) {
+        tile.value.expand();
+      } else {
+        tile.value.collapse();
+      }
+    }
+  }
+
+  /// Forgets the tail of the open path the global filter has just stopped
+  /// rendering (#226/#235).
+  ///
+  /// Without this, a year the operator opened with the filter off would come
+  /// back open — and, having been invisible in between, unexpectedly so — the
+  /// next time they switched the filter off again.
+  void _pruneExpansion() {
+    final List<String> path = controller.expandedPath;
+    if (path.isEmpty) return;
+    final Set<String> visible = _visibleNodeKeys();
+    var keep = 0;
+    while (keep < path.length && visible.contains(path[keep])) {
+      keep++;
+    }
+    if (keep < path.length) controller.expandedPath = path.take(keep).toList();
+  }
+
+  /// The keys of every accordion node either family tree would render under the
+  /// current filter — both tabs, because the open path outlives a tab change.
+  Set<String> _visibleNodeKeys() {
+    final keys = <String>{
+      for (final root in _studentTree().roots) _rollupNodeKey(root),
+    };
+    for (final root in _staffTree().roots) {
+      keys.add(_rollupNodeKey(root));
+      for (final grade in controller.childrenOf(root.key)) {
+        if (_keepGrade(grade)) keys.add(_rollupNodeKey(grade));
+      }
+    }
+    return keys;
   }
 
   /// Whether the Personeel family tab is the selected one — the only tab that
@@ -408,7 +548,12 @@ class _ActionsBodyState extends State<_ActionsBody>
       // governs both tabs, the drill-down, and every classroom opened from it.
       _section(_ActionsFilterBar(
         onlyWithActions: _onlyWithActions,
-        onChanged: (v) => setState(() => _onlyWithActions = v),
+        onChanged: (v) {
+          setState(() => _onlyWithActions = v);
+          // Pruned after the flag has flipped, against the tree the operator is
+          // about to see (#235).
+          _pruneExpansion();
+        },
       )),
       _gap(PlinkSpacing.s4),
       _section(_FamilyTabBar(controller: controller, tabs: _tabs)),
@@ -428,6 +573,7 @@ class _ActionsBodyState extends State<_ActionsBody>
       slivers.add(_section(staffTab
           ? _DrillDownSection(
               controller: controller,
+              accordion: _accordion,
               roots: tree.roots,
               groups: null,
               hidden: tree.hidden,
@@ -438,6 +584,7 @@ class _ActionsBodyState extends State<_ActionsBody>
                   if (_keepGrade(grade))
                     _GradeNode(
                       controller: controller,
+                      accordion: _accordion,
                       grade: grade,
                       onlyWithActions: _onlyWithActions,
                     ),
@@ -445,6 +592,7 @@ class _ActionsBodyState extends State<_ActionsBody>
             )
           : _DrillDownSection(
               controller: controller,
+              accordion: _accordion,
               roots: tree.roots,
               groups: tree.groups,
               hidden: tree.hidden,
@@ -1225,6 +1373,7 @@ String _rollupNodeKey(Rollup r) => switch (r.level) {
 class _DrillDownSection extends StatelessWidget {
   const _DrillDownSection({
     required this.controller,
+    required this.accordion,
     required this.roots,
     required this.groups,
     required this.emptyLabel,
@@ -1234,6 +1383,10 @@ class _DrillDownSection extends StatelessWidget {
   });
 
   final ReconcileController controller;
+
+  /// Drives the top-level nodes as a single-open accordion whose open node
+  /// outlives a drill-down (#235).
+  final _Accordion accordion;
 
   /// The top-level accordion nodes: the merged grade-years plus
   /// "Niet toegewezen" on the Leerlingen tab, the single staff school node on
@@ -1269,6 +1422,33 @@ class _DrillDownSection extends StatelessWidget {
   String get _allHiddenNote =>
       'Alles is verborgen door de filter: $hidden zonder openstaande acties. '
       'Zet de filter af voor het volledige overzicht.';
+
+  /// One top-level accordion node (depth 0), driven by [accordion] rather than
+  /// by the `ExpansionTile`'s own state (#235) — so the year the operator drilled
+  /// a class out of is still open when they come back, and opening another one
+  /// closes it.
+  Widget _rootTile(BuildContext context, Rollup root, Color hairline) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final String node = _rollupNodeKey(root);
+    return Container(
+      margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
+      decoration: BoxDecoration(
+        border: Border.all(color: hairline),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: ExpansionTile(
+        key: ValueKey(node),
+        controller: accordion.controllerFor(node),
+        initiallyExpanded: accordion.isOpen(node, 0),
+        onExpansionChanged: (open) => accordion.onToggled(node, 0, open),
+        shape: const Border(),
+        collapsedShape: const Border(),
+        title: Text(root.label, style: text.bodyLarge),
+        trailing: _PendingBadge(count: root.pendingCount),
+        children: childrenOf(root),
+      ),
+    );
+  }
 
   String? _freshness() {
     final state = controller.syncState;
@@ -1308,23 +1488,7 @@ class _DrillDownSection extends StatelessWidget {
                 )
               : Text(emptyLabel, style: text.bodyMedium)
         else ...<Widget>[
-          for (final root in roots)
-            Container(
-              margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
-              decoration: BoxDecoration(
-                border: Border.all(color: hairline),
-                borderRadius:
-                    const BorderRadius.all(Radius.circular(PlinkRadius.base)),
-              ),
-              child: ExpansionTile(
-                key: ValueKey(_rollupNodeKey(root)),
-                shape: const Border(),
-                collapsedShape: const Border(),
-                title: Text(root.label, style: text.bodyLarge),
-                trailing: _PendingBadge(count: root.pendingCount),
-                children: childrenOf(root),
-              ),
-            ),
+          for (final root in roots) _rootTile(context, root, hairline),
           if (groupsNode != null)
             Container(
               margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
@@ -1372,11 +1536,19 @@ class _DrillDownSection extends StatelessWidget {
 class _GradeNode extends StatelessWidget {
   const _GradeNode({
     required this.controller,
+    required this.accordion,
     required this.grade,
     required this.onlyWithActions,
   });
 
   final ReconcileController controller;
+
+  /// Drives this node at depth 1 (#235). The depth is what keeps the staff tree
+  /// usable: opening a grade-year replaces its *sibling* year, never the school
+  /// node above it — which single-open on one flat key would have collapsed out
+  /// from under the year the operator just opened.
+  final _Accordion accordion;
+
   final Rollup grade;
 
   /// Whether the global filter is on, in which case only the classrooms of this
@@ -1386,8 +1558,12 @@ class _GradeNode extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
+    final String node = _rollupNodeKey(grade);
     return ExpansionTile(
-      key: ValueKey(_rollupNodeKey(grade)),
+      key: ValueKey(node),
+      controller: accordion.controllerFor(node),
+      initiallyExpanded: accordion.isOpen(node, 1),
+      onExpansionChanged: (open) => accordion.onToggled(node, 1, open),
       shape: const Border(),
       collapsedShape: const Border(),
       tilePadding: const EdgeInsets.only(left: PlinkSpacing.s5, right: 16),

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -721,7 +721,12 @@ class _ActionsHeader extends StatelessWidget {
               key: const ValueKey('actions-dry-run'),
               onPressed: controller.busy || controller.applyableCount == 0
                   ? null
-                  : controller.dryRun,
+                  : () => _runWithProgress(
+                        context,
+                        controller: controller,
+                        dry: true,
+                        run: controller.dryRun,
+                      ),
               icon: const Icon(Icons.visibility_outlined),
               label: const Text('Dry-run alles'),
             ),
@@ -731,6 +736,7 @@ class _ActionsHeader extends StatelessWidget {
                   ? null
                   : () => _confirmAndApply(
                         context,
+                        controller: controller,
                         title: 'Openstaande acties toepassen?',
                         scope: controller.applyScope(controller.pendingEntries),
                         apply: controller.applyAll,
@@ -742,7 +748,13 @@ class _ActionsHeader extends StatelessWidget {
         ),
         if (controller.busy) ...<Widget>[
           const SizedBox(height: PlinkSpacing.s4),
-          const LinearProgressIndicator(),
+          // Determinate, like the Reconcile header's (#176/#243): the value
+          // exists on the very same controller, and an indeterminate sweep here
+          // was a motionless bar that read as a hung app.
+          LinearProgressIndicator(
+            key: const ValueKey('actions-progress'),
+            value: controller.progress,
+          ),
         ],
       ],
     );
@@ -1019,14 +1031,16 @@ String applyConfirmationMessage(ApplyScope scope) {
       'bekijken.';
 }
 
-/// Shows the apply-confirmation dialog and, on confirm, runs [apply] (#110).
-/// Shared by the global, per-situation, and per-entry apply affordances so a
-/// write is always one deliberate confirmation.
+/// Shows the apply-confirmation dialog and, on confirm, runs [apply] behind the
+/// modal progress dialog (#110/#243). Shared by the global, per-situation, and
+/// per-entry apply affordances so a write is always one deliberate confirmation
+/// followed by one visible pass.
 ///
 /// [scope] is what that particular confirmation covers (#234) — the systems the
 /// pass will really reach, not a fixed pair.
 Future<void> _confirmAndApply(
   BuildContext context, {
+  required ReconcileController controller,
   required String title,
   required ApplyScope scope,
   required Future<void> Function() apply,
@@ -1049,8 +1063,145 @@ Future<void> _confirmAndApply(
       ],
     ),
   );
-  if (confirmed ?? false) await apply();
+  if (!(confirmed ?? false)) return;
+  if (!context.mounted) return;
+  await _runWithProgress(
+    context,
+    controller: controller,
+    dry: false,
+    run: apply,
+  );
 }
+
+/// Runs one dry-run/apply pass behind a **modal** progress dialog (#243).
+///
+/// An "Apply to all" over the September "zonder klas" bucket is sequential, one
+/// connector round-trip per action, and runs for minutes. Its only feedback used
+/// to be greyed-out buttons and an indeterminate bar in a page header the
+/// operator had usually scrolled past — so the app looked hung, and nothing
+/// stopped them scrolling, switching family tab, or navigating away mid-write.
+///
+/// Every affordance goes through here — global, per-situation, per-entry, and
+/// dry-run as well as apply — so the pass behaves the same wherever it is
+/// started. A dry-run over hundreds of accounts is exactly as slow and was
+/// exactly as silent.
+///
+/// The dialog's lifetime is bound to [run]'s future rather than to any observed
+/// controller state: it is dismissed in a `finally`, so a pass that fails — or
+/// one that returns immediately because another is already running — can never
+/// strand the operator behind a modal barrier.
+Future<void> _runWithProgress(
+  BuildContext context, {
+  required ReconcileController controller,
+  required bool dry,
+  required Future<void> Function() run,
+}) async {
+  final NavigatorState navigator = Navigator.of(context, rootNavigator: true);
+  unawaited(showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) =>
+        _ApplyProgressDialog(controller: controller, dry: dry),
+  ));
+  try {
+    await run();
+  } finally {
+    if (navigator.mounted) navigator.pop();
+  }
+}
+
+/// The modal dialog a pass runs behind (#243): how far along it is, and the
+/// account and action in flight right now.
+///
+/// Rebuilt from [ReconcileController.applyStep], which the pass publishes before
+/// each action off the very list the confirmation dialog was built from, so the
+/// count here and the change count the operator just agreed to are the same
+/// resolution of the work.
+class _ApplyProgressDialog extends StatelessWidget {
+  const _ApplyProgressDialog({required this.controller, required this.dry});
+
+  final ReconcileController controller;
+
+  /// Whether this pass writes nothing, which is the one thing the operator most
+  /// wants confirmed while staring at a progress dialog for two minutes.
+  final bool dry;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    // Non-dismissible: the pass is a sequence of live writes, so there is
+    // nothing useful to do behind it and plenty of harm in navigating away.
+    return PopScope(
+      canPop: false,
+      child: AlertDialog(
+        key: const ValueKey('actions-progress-dialog'),
+        title: Text(dry ? 'Dry-run bezig…' : 'Acties toepassen…'),
+        content: SizedBox(
+          // A [LinearProgressIndicator] demands all the width it is offered, so
+          // without a bound the dialog stretches across a desktop window. Fixed
+          // at a readable measure, clamped so a narrow window cannot overflow.
+          width: (MediaQuery.sizeOf(context).width - 112).clamp(240.0, 400.0),
+          child: ListenableBuilder(
+            listenable: controller,
+            builder: (context, _) {
+              final ApplyStep? step = controller.applyStep;
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  // Always determinate — an indeterminate sweep is what #176
+                  // replaced on Reconcile, and is what this dialog exists to
+                  // stop showing.
+                  LinearProgressIndicator(
+                    key: const ValueKey('actions-progress-bar'),
+                    value: step == null ? 0.0 : (step.index - 1) / step.total,
+                  ),
+                  const SizedBox(height: PlinkSpacing.s4),
+                  Text(
+                    key: const ValueKey('actions-progress-count'),
+                    step == null
+                        ? 'Bezig…'
+                        : 'Actie ${step.index} van ${step.total}',
+                    style: text.titleSmall,
+                  ),
+                  if (step != null) ...<Widget>[
+                    const SizedBox(height: PlinkSpacing.s1),
+                    Text(
+                      key: const ValueKey('actions-progress-step'),
+                      '${step.target} — ${step.summary}',
+                      style: text.bodyMedium,
+                    ),
+                  ],
+                  if (step != null && step.followUps > 0) ...<Widget>[
+                    const SizedBox(height: PlinkSpacing.s2),
+                    Text(
+                      key: const ValueKey('actions-progress-followups'),
+                      // Named, never folded into the count: a follow-up is not
+                      // in the pending list, so it cannot be part of the total
+                      // the operator was shown (#230/#240/#245).
+                      '+ ${_followUpCount(step.followUps)} gestart door een '
+                      'eerdere actie.',
+                      style: text.bodySmall,
+                    ),
+                  ],
+                  const SizedBox(height: PlinkSpacing.s3),
+                  Text(
+                    dry
+                        ? 'Er wordt niets geschreven.'
+                        : 'Sluit het venster niet tot de reeks klaar is.',
+                    style: text.bodySmall,
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _followUpCount(int n) => n == 1 ? '1 vervolgactie' : '$n vervolgacties';
 
 /// The stable widget key of one rollup node, by level — so a test (and the
 /// element tree) names a node the same way wherever it is rendered.
@@ -1543,7 +1694,12 @@ class _SituationHeader extends StatelessWidget {
             key: ValueKey('situation-dry-run-$key'),
             onPressed: controller.busy || applyable == 0
                 ? null
-                : () => controller.dryRunSituation(key),
+                : () => _runWithProgress(
+                      context,
+                      controller: controller,
+                      dry: true,
+                      run: () => controller.dryRunSituation(key),
+                    ),
             child: const Text('Dry-run alles'),
           ),
           const SizedBox(width: PlinkSpacing.s2),
@@ -1553,6 +1709,7 @@ class _SituationHeader extends StatelessWidget {
                 ? null
                 : () => _confirmAndApply(
                       context,
+                      controller: controller,
                       title: 'Toepassen op ${entries.length} accounts?',
                       // Scoped exactly as [ReconcileController.applySituation]
                       // scopes the pass — every entry in this situation, not
@@ -1636,7 +1793,12 @@ class _PendingEntryTile extends StatelessWidget {
                 key: ValueKey('entry-dry-run-${entry.targetId}'),
                 onPressed: controller.busy || !entry.canApply
                     ? null
-                    : () => controller.dryRunEntry(entry),
+                    : () => _runWithProgress(
+                          context,
+                          controller: controller,
+                          dry: true,
+                          run: () => controller.dryRunEntry(entry),
+                        ),
                 child: const Text('Dry-run'),
               ),
               const SizedBox(width: PlinkSpacing.s2),
@@ -1646,6 +1808,7 @@ class _PendingEntryTile extends StatelessWidget {
                     ? null
                     : () => _confirmAndApply(
                           context,
+                          controller: controller,
                           title: 'Toepassen voor ${entry.target}?',
                           scope: controller.applyScope(<PendingAccountEntry>[
                             entry,

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -3,7 +3,14 @@ import 'dart:async';
 import 'package:account_actions/account_actions.dart' as actions;
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart'
-    show MaterializedAccount, MaterializedGroup, Rollup, RollupLevel;
+    show
+        CandidateAction,
+        MaterializedAccount,
+        MaterializedGroup,
+        Rollup,
+        RollupLevel,
+        candidateChoices,
+        pendingDecisionCount;
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
@@ -1734,8 +1741,7 @@ class _AccountTile extends StatelessWidget {
               Expanded(child: Text(account.label, style: text.bodyLarge)),
               const _ReadOnlyLock(),
               const SizedBox(width: PlinkSpacing.s2),
-              _PendingBadge(
-                  count: account.candidates.where((c) => c.canApply).length),
+              _PendingBadge(count: pendingDecisionCount(account.candidates)),
             ],
           ),
           const SizedBox(height: PlinkSpacing.s2),
@@ -1748,11 +1754,16 @@ class _AccountTile extends StatelessWidget {
               padding: const EdgeInsets.only(top: PlinkSpacing.s1),
               child: Text(w, style: text.bodySmall),
             ),
-          for (final c in account.candidates)
+          // One line per *decision* (#251): a departed student's unregister /
+          // delete pair is one either/or, so it reads as the single choice the
+          // interactive tile shows — never as two bullets that both look due.
+          for (final c in candidateChoices(account.candidates))
             Padding(
               padding: const EdgeInsets.only(top: PlinkSpacing.s1),
               child: Text(
-                '• ${c.summary}',
+                c.isChoice
+                    ? '• ${c.selected.summary} (keuze)'
+                    : '• ${c.selected.summary}',
                 style: text.bodySmall?.copyWith(color: muted),
               ),
             ),
@@ -1777,6 +1788,16 @@ class _ReadOnlyLock extends StatelessWidget {
           color: Theme.of(context).disabledColor,
         ),
       );
+}
+
+/// One read-only candidate line of a passive-session group tile, worded exactly
+/// as the interactive [_PendingEntryTile]'s: an either/or reads as one "(keuze)"
+/// on its pre-selected half (#251), an informational notice keeps its
+/// "(manueel)" marker (#225), and an ordinary action is its bare summary.
+String _readOnlyCandidateLine(actions.Alternatives<CandidateAction> choice) {
+  final summary = choice.selected.summary;
+  if (choice.isChoice) return '• $summary (keuze)';
+  return choice.selected.canApply ? '• $summary' : '• $summary (manueel)';
 }
 
 /// One class group's read-only summary in a passive-session group drill-down,
@@ -1812,8 +1833,7 @@ class _GroupTile extends StatelessWidget {
               Expanded(child: Text(group.label, style: text.bodyLarge)),
               const _ReadOnlyLock(),
               const SizedBox(width: PlinkSpacing.s2),
-              _PendingBadge(
-                  count: group.candidates.where((c) => c.canApply).length),
+              _PendingBadge(count: pendingDecisionCount(group.candidates)),
             ],
           ),
           const SizedBox(height: PlinkSpacing.s2),
@@ -1821,11 +1841,14 @@ class _GroupTile extends StatelessWidget {
             spacing: PlinkSpacing.s2,
             children: <Widget>[for (final s in systems) PlinkBadge(s)],
           ),
-          for (final c in group.candidates)
+          // One line per *decision* (#251), marked exactly as the interactive
+          // tile marks it: since #244 a new class is one "create it or stop
+          // importing it" either/or, which used to read as two separate to-dos.
+          for (final c in candidateChoices(group.candidates))
             Padding(
               padding: const EdgeInsets.only(top: PlinkSpacing.s1),
               child: Text(
-                c.canApply ? '• ${c.summary}' : '• ${c.summary} (manueel)',
+                _readOnlyCandidateLine(c),
                 style: text.bodySmall?.copyWith(color: muted),
               ),
             ),

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:account_actions/account_actions.dart' as actions;
+import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart'
     show MaterializedAccount, MaterializedGroup, Rollup, RollupLevel;
 import 'package:flutter/material.dart';
@@ -722,7 +723,7 @@ class _ActionsHeader extends StatelessWidget {
                   ? null
                   : controller.dryRun,
               icon: const Icon(Icons.visibility_outlined),
-              label: const Text('Dry-run all'),
+              label: const Text('Dry-run alles'),
             ),
             TextButton.icon(
               key: const ValueKey('actions-apply'),
@@ -730,12 +731,12 @@ class _ActionsHeader extends StatelessWidget {
                   ? null
                   : () => _confirmAndApply(
                         context,
-                        title: 'Apply pending actions?',
-                        count: controller.applyableCount,
+                        title: 'Openstaande acties toepassen?',
+                        scope: controller.applyScope(controller.pendingEntries),
                         apply: controller.applyAll,
                       ),
               icon: const Icon(Icons.play_arrow_outlined),
-              label: const Text('Apply all'),
+              label: const Text('Alles toepassen'),
             ),
           ],
         ),
@@ -951,32 +952,99 @@ class _EmptyLine extends StatelessWidget {
       Text(message, style: Theme.of(context).textTheme.bodyMedium);
 }
 
+/// The Dutch name the operator knows a system by — the same names the action
+/// summaries and the rest of the screen use (#234). Azure AD is "Office 365"
+/// throughout this app, so the dialog says that and not the tenant's technical
+/// name.
+String systemLabel(core.Origin system) => switch (system) {
+      core.Origin.azure => 'Office 365',
+      core.Origin.smartschool => 'Smartschool',
+      core.Origin.wisa => 'WISA',
+      core.Origin.all => 'alle systemen',
+      core.Origin.other => 'een ander systeem',
+    };
+
+/// Joins system names the way Dutch reads them: "a", "a en b", "a, b en c".
+String _joinSystems(Iterable<core.Origin> systems) {
+  final names = <String>[
+    // Pinned order (WISA → Smartschool → Office 365) so the same selection
+    // always reads the same way, whatever order the actions were dispatched in.
+    for (final s in systems.toSet().toList()..sort((a, b) => a.index - b.index))
+      systemLabel(s),
+  ];
+  if (names.length <= 1) return names.join();
+  return '${names.take(names.length - 1).join(', ')} en ${names.last}';
+}
+
+String _changeCount(int n) => n == 1 ? '1 wijziging' : '$n wijzigingen';
+
+String _ruleCount(int n) => n == 1 ? '1 importregel' : '$n importregels';
+
+/// The body of the apply-confirmation dialog: what this particular pass will
+/// write, and where (#234).
+///
+/// It used to be one hard-coded sentence claiming "Smartschool and Azure AD"
+/// for every action, so a single Graph `PATCH` on one display name announced a
+/// write to a system it never touched. Everything needed to say it correctly is
+/// on the actions themselves; [ApplyScope] carries it here.
+///
+/// Three things it is careful about:
+/// - **WISA is never written.** The `DontImportFromWisa` family's `ChangeSet`
+///   carries `Origin.wisa`, but what it produces is a local import rule — the
+///   connector is read-only. So those are counted as import rules and the
+///   sentence says outright that nothing is written to WISA.
+/// - **Chained follow-ups are named, not counted.** A new student's Office 365
+///   create writes Smartschool too (#230/#240). Whether the follow-up runs is
+///   decided by its own `evaluate` after the first write, so it gets its own
+///   "kan ook" sentence rather than being folded into the count.
+/// - **A chain that stays inside a system it already named adds nothing** — a
+///   class group's create and its roster write are both Office 365 (#245), so
+///   there is no second system to announce.
+String applyConfirmationMessage(ApplyScope scope) {
+  final writes = scope.systems.where((s) => s != core.Origin.wisa).toList();
+  final rules = scope.systems.length - writes.length;
+  final clauses = <String>[
+    if (writes.isNotEmpty)
+      'schrijft ${_changeCount(writes.length)} naar ${_joinSystems(writes)}',
+    if (rules > 0)
+      'legt ${_ruleCount(rules)} vast (er wordt niets naar WISA geschreven)',
+  ];
+  final what =
+      clauses.isEmpty ? 'Dit schrijft niets.' : 'Dit ${clauses.join(' en ')}.';
+  final follow = scope.chained.isEmpty
+      ? ''
+      : ' Een vervolgactie kan ook naar ${_joinSystems(scope.chained)} '
+          'schrijven.';
+  return '$what$follow Doe eerst een dry-run om de exacte wijzigingen te '
+      'bekijken.';
+}
+
 /// Shows the apply-confirmation dialog and, on confirm, runs [apply] (#110).
 /// Shared by the global, per-situation, and per-entry apply affordances so a
 /// write is always one deliberate confirmation.
+///
+/// [scope] is what that particular confirmation covers (#234) — the systems the
+/// pass will really reach, not a fixed pair.
 Future<void> _confirmAndApply(
   BuildContext context, {
   required String title,
-  required int count,
+  required ApplyScope scope,
   required Future<void> Function() apply,
 }) async {
   final confirmed = await showDialog<bool>(
     context: context,
     builder: (context) => AlertDialog(
       title: Text(title),
-      content: Text(
-        'This writes $count change(s) to Smartschool and Azure AD. '
-        'Run a dry-run first to preview the exact changes.',
-      ),
+      content: Text(applyConfirmationMessage(scope)),
       actions: <Widget>[
         TextButton(
           onPressed: () => Navigator.of(context).pop(false),
-          child: const Text('Cancel'),
+          child: const Text('Annuleer'),
         ),
         FilledButton(
           key: const ValueKey('actions-apply-confirm'),
           onPressed: () => Navigator.of(context).pop(true),
-          child: const Text('Apply'),
+          child: const Text('Toepassen'),
         ),
       ],
     ),
@@ -1476,7 +1544,7 @@ class _SituationHeader extends StatelessWidget {
             onPressed: controller.busy || applyable == 0
                 ? null
                 : () => controller.dryRunSituation(key),
-            child: const Text('Dry-run all'),
+            child: const Text('Dry-run alles'),
           ),
           const SizedBox(width: PlinkSpacing.s2),
           FilledButton(
@@ -1485,11 +1553,18 @@ class _SituationHeader extends StatelessWidget {
                 ? null
                 : () => _confirmAndApply(
                       context,
-                      title: 'Apply to ${entries.length} accounts?',
-                      count: applyable,
+                      title: 'Toepassen op ${entries.length} accounts?',
+                      // Scoped exactly as [ReconcileController.applySituation]
+                      // scopes the pass — every entry in this situation, not
+                      // only the ones this classroom happens to render — so the
+                      // dialog names what will actually be written (#234).
+                      scope: controller.applyScope(
+                        controller.pendingEntries
+                            .where((e) => e.situationKey == key),
+                      ),
                       apply: () => controller.applySituation(key),
                     ),
-            child: Text('Apply to all ($applyable)'),
+            child: Text('Alles toepassen ($applyable)'),
           ),
         ],
       ),
@@ -1571,13 +1646,13 @@ class _PendingEntryTile extends StatelessWidget {
                     ? null
                     : () => _confirmAndApply(
                           context,
-                          title: 'Apply for ${entry.target}?',
-                          count: entry.choices
-                              .where((c) => c.selected.canApply)
-                              .length,
+                          title: 'Toepassen voor ${entry.target}?',
+                          scope: controller.applyScope(<PendingAccountEntry>[
+                            entry,
+                          ]),
                           apply: () => controller.applyEntry(entry),
                         ),
-                child: const Text('Apply'),
+                child: const Text('Toepassen'),
               ),
             ],
           ),

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -1644,12 +1644,20 @@ class _ChoiceControl extends StatelessWidget {
               ),
             ),
           ),
+        // What the picked resolution will actually write. Collapsing two
+        // actions into one choice (#244) must not cost the operator the diff
+        // they used to read off the second row — a class create names the class,
+        // its description and its Smartschool parent, and that is exactly what
+        // decides whether the create or the opt-out is right.
+        const SizedBox(height: PlinkSpacing.s2),
+        _OptionDetail(option: choice.selected),
       ],
     );
   }
 }
 
-/// The per-field diff (or a lifecycle note) for a single, non-choice option.
+/// The per-field diff (or a lifecycle note) for a single option — the one that
+/// stands alone, or the one selected inside a [_ChoiceControl].
 class _OptionDetail extends StatelessWidget {
   const _OptionDetail({required this.option});
 

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -9,6 +9,19 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 
 import 'reconcile_fakes.dart';
 
+/// Collects every distinct [ApplyStep] [controller] publishes from now on — the
+/// sequence the modal progress dialog renders as a pass walks its actions
+/// (#243). A step is notified separately from the progress value, so listening
+/// is the only way to see the ones a pass passed through.
+List<ApplyStep> recordSteps(ReconcileController controller) {
+  final steps = <ApplyStep>[];
+  controller.addListener(() {
+    final step = controller.applyStep;
+    if (step != null && !identical(steps.lastOrNull, step)) steps.add(step);
+  });
+  return steps;
+}
+
 /// A [SignalPublisher] whose every publish throws — to prove a broadcast
 /// failure is swallowed and never fails the pass that triggered it (#116).
 class _ThrowingPublisher implements SignalPublisher {
@@ -591,6 +604,62 @@ void main() {
       );
       expect(h.graph.createdUsers, isEmpty);
       expect(h.soap.soapActions, isEmpty);
+    });
+
+    test(
+        'the published step counts planned actions and reports the chained '
+        'write apart from them (#243)', () async {
+      // The progress dialog's total can only ever be the *planned* actions:
+      // dispatch is a pure function of the record as it stands, so the
+      // Smartschool create does not exist until the Azure create has landed and
+      // relinked. Folding it into the total would mean promising a number
+      // nobody could know — so it is reported as a follow-up instead.
+      final h = newIntakeHarness();
+      await h.controller.sync();
+
+      final steps = recordSteps(h.controller);
+      await h.controller.applyAll();
+
+      expect(steps.map((s) => s.total).toSet(), <int>{steps.length},
+          reason: 'the planned total never moves mid-pass');
+      expect(
+          steps.map((s) => s.index), List.generate(steps.length, (i) => i + 1));
+      expect(steps.first.summary, 'Maak een nieuw Office 365 account');
+      expect(steps.first.followUps, 0);
+      expect(steps.first.dry, isFalse);
+      // The Azure create pulled the Smartschool create in behind it, so the
+      // pass performed one write more than it planned actions.
+      expect(h.controller.applyResults!.length, steps.length + 1);
+      expect(steps.skip(1).map((s) => s.followUps), everyElement(1));
+      // Nothing is in flight once the pass is over.
+      expect(h.controller.applyStep, isNull);
+    });
+  });
+
+  group('the pass publishes the step it is on (#243)', () {
+    test('a dry-run names each action before it runs, and clears at the end',
+        () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+
+      final steps = recordSteps(h.controller);
+      await h.controller.dryRun();
+
+      expect(steps, isNotEmpty);
+      expect(steps.map((s) => s.dry), everyElement(isTrue));
+      expect(steps.map((s) => s.target), everyElement(isNotEmpty));
+      expect(steps.map((s) => s.summary), everyElement(isNotEmpty));
+      expect(steps.last.index, steps.last.total);
+      expect(h.controller.applyStep, isNull);
+    });
+
+    test('a sync publishes no step — it walks no actions', () async {
+      final h = ReconcileHarness();
+      final steps = recordSteps(h.controller);
+      await h.controller.sync();
+
+      expect(steps, isEmpty);
+      expect(h.controller.applyStep, isNull);
     });
   });
 

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -487,6 +487,126 @@ void main() {
           reason: 'a real write re-links from the patched snapshot');
     });
 
+    /// Every node of the overview tree keyed by its rollup key, with the count
+    /// the badge renders — the whole projection #236 is about, in one map.
+    Map<String, int> pendingByNode(ReconcileController c) => <String, int>{
+          for (final root in c.studentRollups) ...<String, int>{
+            root.key: root.pendingCount,
+            for (final klas in c.studentChildrenOf(root))
+              klas.key: klas.pendingCount,
+          },
+          if (c.groupRollup case final groups?) groups.key: groups.pendingCount,
+        };
+
+    /// The classroom node whose badge the fixture's one student action sits
+    /// under: Sam's class, 3C of school 1.
+    Rollup klas3C(ReconcileController c) => c
+        .studentChildrenOf(
+            c.studentRollups.singleWhere((r) => r.gradeYear == '3'))
+        .singleWhere((r) => r.classroom == '3C');
+
+    /// Sam's pending entry — the one applyable student action in the fixture.
+    PendingAccountEntry samEntry(ReconcileController c) =>
+        c.pendingEntries.singleWhere((e) => e.family == 'student');
+
+    test('re-derives the counts the pass just changed, and only those (#236)',
+        () async {
+      // The badges read `Rollup.pendingCount` off `_rollups`, which only
+      // [_persist] assigned — and that runs from `_relink()` alone. So an apply
+      // left the drilled-in list (live, derived from `_linked`) and the overview
+      // disagreeing until the next Synchroniseer.
+      final h = appliedClassWorkHarness();
+      await h.controller.sync();
+      expect(klas3C(h.controller).pendingCount, 1);
+      expect(h.controller.groupRollup!.pendingCount, 4);
+
+      await h.controller.applyEntry(samEntry(h.controller));
+
+      expect(h.controller.error, isNull);
+      expect(klas3C(h.controller).pendingCount, 0,
+          reason: 'the badge used to keep its pre-apply count until a re-sync');
+      expect(
+        h.controller.studentRollups
+            .singleWhere((r) => r.gradeYear == '3')
+            .pendingCount,
+        0,
+        reason: 'the grade-year above it is summed from the same rollups',
+      );
+      expect(h.controller.groupRollup!.pendingCount, 4,
+          reason: 'a re-derivation of what changed, not a blanket reset');
+    });
+
+    test('a dry-run leaves every count exactly as it found it (#236)',
+        () async {
+      // The correction is gated on a *real* write: a projection changes nothing,
+      // so it must not move a single badge.
+      final h = appliedClassWorkHarness();
+      await h.controller.sync();
+      final before = pendingByNode(h.controller);
+      expect(before.values, contains(greaterThan(0)));
+
+      await h.controller.dryRun();
+
+      expect(pendingByNode(h.controller), before);
+      expect(h.soap.soapActions, isEmpty, reason: 'nothing was written');
+      expect(h.graph.requests, isEmpty, reason: 'nothing was written');
+    });
+
+    test(
+        'a pass with a refused write clears only what really went through '
+        '(#236)', () async {
+      // The counts must follow the writes, not the pass: the first action is
+      // refused, the rest land. Sam's class keeps its badge while the class
+      // groups lose theirs.
+      var calls = 0;
+      final h = appliedClassWorkHarness(applyGate: () async {
+        if (++calls == 1) throw StateError('Office 365 weigerde dit');
+      });
+      await h.controller.sync();
+      expect(klas3C(h.controller).pendingCount, 1);
+
+      await h.controller.applyAll();
+
+      expect(
+        h.controller.applyResults!.map((r) => r.outcome),
+        containsAll(<actions.ActionOutcome>[
+          actions.ActionOutcome.failed,
+          actions.ActionOutcome.applied,
+        ]),
+      );
+      expect(klas3C(h.controller).pendingCount, 1,
+          reason: "the refused write left Sam's name as it was");
+      expect(h.controller.groupRollup, isNull,
+          reason: 'the class-group work that did land is gone');
+    });
+
+    test(
+        'the refreshed counts are local — the shared store keeps its generation '
+        '(#236, shared half in #254)', () async {
+      // A deliberate choice, not an oversight: rewriting ~9.6k documents per
+      // apply is not affordable, and bumping this session's generation would
+      // gate out the very `onStoreChanged` that should overrule this
+      // correction. Other operators catch up on the next sync.
+      final h = appliedClassWorkHarness();
+      Future<Rollup> stored3C() async => (await h.linkedStore.readRollups())
+          .singleWhere((r) => r.classroom == '3C' && r.school == '1');
+
+      await h.controller.sync();
+      final before = await h.linkedStore.readSyncState();
+
+      await h.controller.applyEntry(samEntry(h.controller));
+
+      expect(
+          (await h.linkedStore.readSyncState()).generation, before.generation,
+          reason: 'no write, so no new generation');
+      expect(h.controller.syncState.generation, before.generation,
+          reason: 'the session must stay behind the store, never ahead of it');
+      expect((await stored3C()).pendingCount, 1,
+          reason: 'the stored view stays pre-apply until someone syncs (#254)');
+      expect(klas3C(h.controller).pendingCount, 0,
+          reason: '…while this session already reads the corrected count');
+    });
+
     test('informational group actions are listed but never applied', () async {
       // An orphan Smartschool class (no WISA counterpart) surfaces the
       // informational DoNotImportFromSmartschool — visible in the pending

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -1063,13 +1063,16 @@ void main() {
     test('departed students sum across the unassigned bucket, not staff',
         () async {
       // Three WISA-departed, Smartschool-only accounts, all in the synthetic
-      // "unassigned" school — never the staff bucket. Each carries two applyable
-      // candidates (the unregister + delete alternatives), so the rollup
-      // pendingCount is 3 × 2.
+      // "unassigned" school — never the staff bucket. Each raises the
+      // unregister/delete pair, which is one either/or the operator resolves
+      // once — so the rollup pendingCount is 3, not the 3 × 2 it counted before
+      // #251 (an apply pass writes one resolution per student, never both).
       final h = manyDepartedHarness(count: 3);
       await h.controller.sync();
 
-      expectSummary(h.controller.studentSummary, total: 3, pending: 6);
+      expectSummary(h.controller.studentSummary, total: 3, pending: 3);
+      expect(h.controller.applyableCount, 3,
+          reason: 'the badge and the live list agree on what is pending');
       expectSummary(h.controller.staffSummary, total: 0, pending: 0);
     });
 

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1881,6 +1881,67 @@ CosmosLinkedStore cosmosLinkedStoreOver(
 // The harness: the real State layer over scripted syncers.
 // ---------------------------------------------------------------------------
 
+/// The real [StateApplier] with one seam: an optional [gate] awaited before
+/// every action a pass runs (#243).
+///
+/// A dry-run touches no connector and a scripted apply answers on the microtask
+/// queue, so an entire pass otherwise completes inside a single `tester.pump()`
+/// — leaving no frame in which the modal progress dialog exists to be asserted
+/// on. Parking on the gate freezes the pass exactly where the operator sees it:
+/// mid-flight, on a named account and a named action.
+///
+/// With no gate wired this is the plain applier, so the harness builds it
+/// unconditionally rather than duplicating the (long) construction twice.
+class GatedApplier extends StateApplier {
+  GatedApplier({
+    required this.gate,
+    required super.app,
+    required super.connectors,
+    required super.resolver,
+    required super.wisaRules,
+    required super.studentConfig,
+    required super.staffConfig,
+    super.classTree,
+    super.passwordQueue,
+    super.ourSchoolIds,
+  });
+
+  /// Awaited before each action; `null` for the ordinary harness.
+  final Future<void> Function()? gate;
+
+  Future<void> _park() async {
+    final g = gate;
+    if (g != null) await g();
+  }
+
+  @override
+  Future<ApplyResult> applyStudent(
+    actions.StudentAction action, {
+    actions.ApplyOptions options = const actions.ApplyOptions(),
+  }) async {
+    await _park();
+    return super.applyStudent(action, options: options);
+  }
+
+  @override
+  Future<ApplyResult> applyStaff(
+    actions.StaffAction action, {
+    actions.ApplyOptions options = const actions.ApplyOptions(),
+  }) async {
+    await _park();
+    return super.applyStaff(action, options: options);
+  }
+
+  @override
+  Future<ApplyResult> applyGroup(
+    actions.GroupAction action, {
+    actions.ApplyOptions options = const actions.ApplyOptions(),
+  }) async {
+    await _park();
+    return super.applyGroup(action, options: options);
+  }
+}
+
 /// One assembled reconcile stack against fakes: scripted per-system syncers
 /// (with call counters), a [StateApplier] wired to recording connectors, and
 /// the [ReconcileController] under test.
@@ -1900,6 +1961,7 @@ class ReconcileHarness {
     ss.SmartschoolSnapshot? ssInitial,
     az.AzureSnapshot? azureInitial,
     this.azureGate,
+    this.applyGate,
     this.azureTransport,
     this.smartschoolTransport,
     this.smartschoolRules = const <ss.SmartschoolImportRule>[],
@@ -2084,7 +2146,10 @@ class ReconcileHarness {
       ),
     );
 
-    applier = StateApplier(
+    applier = GatedApplier(
+      // Null unless a test wants the pass frozen mid-flight (#243); with no
+      // gate this is the plain StateApplier the app wires.
+      gate: applyGate,
       app: app,
       connectors: actions.Connectors(
         smartschool: ss.SmartschoolConnector.fromParts(
@@ -2186,6 +2251,12 @@ class ReconcileHarness {
   /// it — a seam to freeze a sync mid-pass (WISA + Smartschool already pulled)
   /// so a widget test can observe the busy progress bar (#176).
   final Completer<void>? azureGate;
+
+  /// When set, every action of a dry-run/apply pass parks here before it runs —
+  /// the seam that freezes a pass mid-flight so a test can observe the modal
+  /// progress dialog naming the account and action in flight (#243). Unlike
+  /// [azureGate] it covers dry-runs too, which touch no connector at all.
+  final Future<void> Function()? applyGate;
 
   /// When set, the Azure pull is the **production** one — a real
   /// [az.AzureConnector] + [azureSyncer] over this transport — instead of the

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1298,6 +1298,59 @@ ReconcileHarness nonOfficialSmartschoolClassHarness() => ReconcileHarness(
       ourSchoolIds: const {1},
     );
 
+/// A harness for the start-of-year "new class" choice (#244). Our school 1 runs
+/// two brand-new classes, `1A` and `1B`, each holding a student and neither
+/// known to Smartschool — the shape that raised "Voeg deze klas toe aan
+/// Smartschool" and "Negeer deze klas bij het importeren uit WISA" as two
+/// independent to-dos on the same class. Both landed in the selection, so one
+/// **Apply to all** created every new class of the year and then wrote a
+/// `DontImportClass` rule on each name it had just created: the groups survived
+/// in Smartschool, but the classes dropped out of the next WISA snapshot and
+/// were no longer managed.
+///
+/// Two classes on purpose — that is what puts them in one "same situation"
+/// subset and lights up the bulk **Apply to all** the report describes.
+/// Smartschool holds only the `Leerlingen` root the classes hang under, named
+/// by [ReconcileHarness.classTree], so the create actually lands.
+ReconcileHarness newClassChoiceHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(wisaId: '1', classGroup: '1A'),
+          wisaStudent(wisaId: '2', classGroup: '1B'),
+        ],
+        schools: [wisaSchool(1)],
+        classGroups: [
+          wisaClassGroup(
+            '1A',
+            description: 'Onze eerste klas',
+            schoolCode: '111',
+            schoolId: 1,
+          ),
+          wisaClassGroup(
+            '1B',
+            description: 'Onze tweede klas',
+            schoolCode: '111',
+            schoolId: 1,
+          ),
+        ],
+      ),
+      smartschool: ssSnap(
+        groups: [
+          ssGroup(
+            'Leerlingen',
+            code: 'SCHOOL',
+            official: false,
+            type: core.GroupType.group,
+          ),
+        ],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+      ourSchoolIds: const {1},
+      classTree: const SmartschoolClassTree(path: 'SCHOOL'),
+    );
+
 /// A harness for the `00` sub-group sentinel (#221). Two managed schools that
 /// each have their own `1C`, and each of those is a **single-group** class: one
 /// `SyncKlas` row with `KLASGROEP = 00` and — because `ADMINGROEP` is only
@@ -1816,6 +1869,7 @@ class ReconcileHarness {
     this.azureTransport,
     this.smartschoolTransport,
     this.smartschoolRules = const <ss.SmartschoolImportRule>[],
+    this.classTree = const SmartschoolClassTree(),
     this.wisaTransport,
     this.passwordGraph,
     this.syncedBy = 'operator@school.example',
@@ -2017,6 +2071,10 @@ class ReconcileHarness {
       ),
       resolver: SeqResolver(),
       wisaRules: wisaRules,
+      // The Smartschool group tree a freshly created class hangs under. Left
+      // unconfigured by default (no parent resolves, as in a bare tenant); a
+      // fixture that applies `AddToSmartschool` for real names the root here.
+      classTree: classTree,
       studentConfig: actions.StudentActionConfig(
         schoolPrefix: 'GBS',
         azureDomain: 'school.example',
@@ -2130,6 +2188,14 @@ class ReconcileHarness {
   /// Read at sync time, like [ssResult]: assign between passes to model the
   /// session that bootstraps on rules the operator has just saved in Settings.
   List<ss.SmartschoolImportRule> smartschoolRules;
+
+  /// The Smartschool class-tree live-config the placement resolver reads to
+  /// find the group a freshly created official class hangs under — the
+  /// `classTreeFrom(settings.smartschool)` the real bootstrap injects.
+  /// Unconfigured by default, so no parent resolves and `AddToSmartschool`
+  /// fails the way it does against a bare tenant; a fixture that wants the
+  /// create to land names the root here.
+  final SmartschoolClassTree classTree;
 
   /// When set, the Passwords screen writes through the **production**
   /// [ConnectorPasswordBackends] over this transport instead of the recording

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -958,6 +958,80 @@ ReconcileHarness twoSchoolHarness() => ReconcileHarness(
       ourSchoolIds: const {1, 2},
     );
 
+/// A harness for the post-apply overview counts (#236). One managed school with
+/// two third-year classes, both correctly placed in Smartschool, so the only
+/// **student** work anywhere is Sam's stale Office 365 display name — one
+/// applyable action, on 3C, which a real apply genuinely clears (the applier
+/// patches the Azure record and re-links, so the refreshed view no longer raises
+/// it). 3D carries nothing.
+///
+/// The two classes also carry group work of their own (Smartschool class data,
+/// and the Office 365 groups the empty tenant has neither of). That is the point:
+/// applying *the class's* work must drop 3C's badge to nothing while the
+/// Klasgroepen node keeps its own count — a re-derivation of what changed, not a
+/// blanket reset.
+///
+/// [applyGate] is awaited before every action, as everywhere else — a test that
+/// needs one write refused throws from it on the call it picks.
+ReconcileHarness appliedClassWorkHarness({
+  Future<void> Function()? applyGate,
+}) =>
+    ReconcileHarness(
+      applyGate: applyGate,
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(
+              wisaId: '3', classGroup: '3C', firstName: 'Sam', name: 'Sels'),
+          wisaStudent(
+              wisaId: '4', classGroup: '3D', firstName: 'Tom', name: 'Tas'),
+        ],
+        schools: [wisaSchool(1)],
+        classGroups: [
+          wisaClassGroup('3C', adminCode: 'a3', schoolCode: '111'),
+          wisaClassGroup('3D', adminCode: 'a4', schoolCode: '111'),
+        ],
+      ),
+      smartschool: ssSnap(
+        groups: [
+          ssGroup('3C', code: '3C_ss', untis: '3C'),
+          ssGroup('3D', code: '3D_ss', untis: '3D'),
+        ],
+        accounts: [
+          ssAccount(
+            uid: 'sam',
+            accountId: '3',
+            mail: 'sam.sels@student.school.example',
+            givenName: 'Sam',
+            surname: 'Sels',
+          ),
+          ssAccount(
+            uid: 'tom',
+            accountId: '4',
+            mail: 'tom.tas@student.school.example',
+            givenName: 'Tom',
+            surname: 'Tas',
+          ),
+        ],
+        memberships: [member('sam', '3C_ss'), member('tom', '3D_ss')],
+      ),
+      // Sam's display name is left blank (stale) so `ModifyAzureName` fires;
+      // Tom's already carries his WISA name, so his class is done.
+      azure: azSnap(users: [
+        azUser(
+          id: 'az3',
+          upn: 'sam.sels@student.school.example',
+          employeeId: '3',
+        ),
+        azUser(
+          id: 'az4',
+          upn: 'tom.tas@student.school.example',
+          employeeId: '4',
+          displayName: 'Tom Tas',
+        ),
+      ]),
+      ourSchoolIds: const {1},
+    );
+
 /// A harness for the managed-school class-group scope (#205). WISA hands the
 /// session class groups from two schools, and the sibling school's arrive
 /// *first* in the pull: `1A` and `9Z` of school 2 (which we do not manage),

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1351,6 +1351,40 @@ ReconcileHarness newClassChoiceHarness() => ReconcileHarness(
       classTree: const SmartschoolClassTree(path: 'SCHOOL'),
     );
 
+/// A harness for the "new staff member" choice (#248) — the staff twin of
+/// [newClassChoiceHarness]. Two freshly hired teachers exist in WISA only, so
+/// each raises `AddStaffToAzure` (which since #240 chains the Smartschool
+/// create) **and** `DontImportStaffFromWisa` on the same target.
+///
+/// Neither declared an `alternativeGroup`, so both landed in the selection and
+/// one click provisioned the teacher *and* wrote a `DontImportUserFromWisa` rule
+/// on the very code it had just provisioned. The rule set is persisted and
+/// re-applied on every WISA pull, so the next sync dropped the staff member the
+/// operator had just given two accounts.
+///
+/// Two staff members on purpose — that is what puts them in one "same
+/// situation" subset and lights up the bulk **Apply to all**.
+ReconcileHarness newStaffChoiceHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: const [],
+        staff: [
+          wisaStaff(),
+          wisaStaff(
+            code: 'JANS',
+            wisaId: '43',
+            firstName: 'Bram',
+            lastName: 'Jansen',
+          ),
+        ],
+      ),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+    );
+
 /// A harness for the `00` sub-group sentinel (#221). Two managed schools that
 /// each have their own `1C`, and each of those is a **single-group** class: one
 /// `SyncKlas` row with `KLASGROEP = 00` and — because `ADMINGROEP` is only

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1553,10 +1553,34 @@ ReconcileHarness namedSchoolHarness() => ReconcileHarness(
 // seeded straight into an [InMemoryLinkedStore] a passive session reads back.
 // ---------------------------------------------------------------------------
 
+/// The pair of mutually-exclusive candidates a WISA-departed student's account
+/// doc carries (#110), as the materializer writes them since #251: both halves
+/// applyable, sharing one `alternativeGroup`, the unregister pre-selected. One
+/// decision, two readings — the shape whose badge used to read 2.
+List<CandidateAction> departureChoice() => const <CandidateAction>[
+      CandidateAction(
+        family: 'student',
+        kind: 'UnregisterStudentFromSmartschool',
+        system: core.Origin.smartschool,
+        summary: 'Schrijf de leerling uit in Smartschool',
+        alternativeGroup: actions.smartschoolDepartureAlternative,
+        isDefaultAlternative: true,
+      ),
+      CandidateAction(
+        family: 'student',
+        kind: 'DeleteStudentFromSmartschool',
+        system: core.Origin.smartschool,
+        summary: 'Verwijder dit account uit Smartschool',
+        alternativeGroup: actions.smartschoolDepartureAlternative,
+      ),
+    ];
+
 /// One [MaterializedAccount] for a passive-session classroom, placed in
 /// [school]/[gradeYear]/[classroom]. [withAction] decides whether it carries an
 /// applyable candidate — i.e. whether [MaterializedAccount.hasPending] is true,
-/// the "has actions" predicate the toggle filters on.
+/// the "has actions" predicate the toggle filters on. [candidates] overrides it
+/// outright for a doc that needs a specific candidate set (e.g. the either/or of
+/// [departureChoice]).
 MaterializedAccount matAccount({
   required String id,
   required String label,
@@ -1566,6 +1590,7 @@ MaterializedAccount matAccount({
   String classroom = '3C',
   bool isStaff = false,
   bool withAction = false,
+  List<CandidateAction>? candidates,
 }) =>
     MaterializedAccount(
       id: core.LinkedAccountId(id),
@@ -1580,16 +1605,17 @@ MaterializedAccount matAccount({
       inWisa: true,
       inSmartschool: true,
       inAzure: true,
-      candidates: withAction
-          ? <CandidateAction>[
-              CandidateAction(
-                family: isStaff ? 'staff' : 'student',
-                kind: 'MoveToSmartschoolClassGroup',
-                system: core.Origin.smartschool,
-                summary: 'Wijzig de klas in Smartschool',
-              ),
-            ]
-          : const <CandidateAction>[],
+      candidates: candidates ??
+          (withAction
+              ? <CandidateAction>[
+                  CandidateAction(
+                    family: isStaff ? 'staff' : 'student',
+                    kind: 'MoveToSmartschoolClassGroup',
+                    system: core.Origin.smartschool,
+                    summary: 'Wijzig de klas in Smartschool',
+                  ),
+                ]
+              : const <CandidateAction>[]),
     );
 
 /// A staff [MaterializedAccount] in the synthetic "Personeel" school/class the

--- a/account_manager/test/reconcile/reconcile_pending_choice_test.dart
+++ b/account_manager/test/reconcile/reconcile_pending_choice_test.dart
@@ -1,4 +1,5 @@
 import 'package:account_actions/account_actions.dart' as actions;
+import 'package:account_manager/src/reconcile/reconcile_controller.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'reconcile_fakes.dart';
@@ -323,6 +324,105 @@ void main() {
         choice.alternatives.map((a) => a.kind),
         containsAll(<String>['CreateInSmartschool', 'DoNotImportFromWisa']),
       );
+    });
+  });
+
+  group('a new staff member is one choice, not two to-dos (#248)', () {
+    const String createAzure = 'Maak een nieuw Office 365 account';
+    const String createSs = 'Maak een nieuw Smartschool account';
+    const String ignore = 'Negeer dit account bij het importeren uit WISA';
+
+    List<String> summariesOf(ReconcileHarness h) =>
+        h.controller.applyResults!.map((r) => r.changes.summary).toList();
+
+    List<PendingAccountEntry> staffEntries(ReconcileHarness h) =>
+        h.controller.pendingEntries.where((e) => e.family == 'staff').toList();
+
+    test('the create and the blacklist collapse into one choice, create first',
+        () async {
+      final h = newStaffChoiceHarness();
+      await h.controller.sync();
+
+      final entry = staffEntries(h).first;
+      final choice = entry.choices.singleWhere(
+        (c) => c.situationId == actions.staffImportAlternative,
+      );
+
+      expect(entry.choices, hasLength(1),
+          reason: 'the two contradictory actions are one decision, not two');
+      expect(choice.isChoice, isTrue,
+          reason: 'either provision them or stop importing them — never both');
+      expect(
+        choice.alternatives.map((a) => a.kind),
+        ['AddStaffToAzure', 'DontImportStaffFromWisa'],
+        reason: 'the create leads the radio pair',
+      );
+      expect(choice.selected.kind, 'AddStaffToAzure',
+          reason: 'provisioning a new hire is the normal operation');
+    });
+
+    test('applying the default provisions both accounts and blacklists nothing',
+        () async {
+      // The #240 chain still runs: the Azure create unlocks the Smartschool
+      // create. What must not follow is the WISA opt-out that used to ride
+      // along on the same click.
+      final h = newStaffChoiceHarness();
+      await h.controller.sync();
+      final pulls = h.wisaSyncs;
+
+      await h.controller.applyEntry(staffEntries(h).first);
+
+      expect(summariesOf(h), <String>[createAzure, createSs]);
+      expect(summariesOf(h), isNot(contains(ignore)),
+          reason: 'the rule would drop the teacher we just provisioned');
+      expect(h.graph.createdUsers, hasLength(1));
+      expect(h.wisaSyncs, pulls,
+          reason: 'no import rule was added, so WISA was never re-pulled');
+    });
+
+    test('choosing the blacklist applies it alone, provisioning nothing',
+        () async {
+      final h = newStaffChoiceHarness();
+      await h.controller.sync();
+      final entry = staffEntries(h).first;
+
+      h.controller.chooseAlternative(
+        entry: entry,
+        group: actions.staffImportAlternative,
+        kind: 'DontImportStaffFromWisa',
+      );
+      await h.controller.applyEntry(
+        staffEntries(h).firstWhere((e) => e.targetId == entry.targetId),
+      );
+
+      expect(summariesOf(h), contains(ignore));
+      expect(summariesOf(h), isNot(contains(createAzure)));
+      expect(h.graph.createdUsers, isEmpty);
+    });
+
+    test(
+        '"apply to all" over the situation provisions every new hire and '
+        'blacklists none', () async {
+      final h = newStaffChoiceHarness();
+      await h.controller.sync();
+      final entries = staffEntries(h);
+      expect(entries, hasLength(2));
+
+      final key = entries.first.situationKey;
+      expect(
+        entries.where((e) => e.situationKey == key),
+        hasLength(2),
+        reason: 'both new hires are the same situation, bulk-applied at once',
+      );
+      final pulls = h.wisaSyncs;
+
+      await h.controller.applySituation(key);
+
+      final summaries = summariesOf(h);
+      expect(summaries.where((s) => s == createAzure), hasLength(2));
+      expect(summaries.where((s) => s == createSs), hasLength(2));
+      expect(summaries, isNot(contains(ignore)));
+      expect(h.wisaSyncs, pulls);
     });
   });
 }

--- a/account_manager/test/reconcile/reconcile_pending_choice_test.dart
+++ b/account_manager/test/reconcile/reconcile_pending_choice_test.dart
@@ -199,4 +199,130 @@ void main() {
           reason: 'a fresh linked view must not serve a stale cached list');
     });
   });
+
+  group('a new class is one choice, not two to-dos (#244)', () {
+    const String create = 'Voeg deze klas toe aan Smartschool';
+    const String ignore = 'Negeer deze klas bij het importeren uit WISA';
+
+    List<String> summariesOf(ReconcileHarness h) =>
+        h.controller.applyResults!.map((r) => r.changes.summary).toList();
+
+    /// Whether the pass actually asked Smartschool to save a class. The
+    /// recorded SOAP action is the fully-qualified `…V3#saveClass`.
+    bool savedAClass(ReconcileHarness h) =>
+        h.soap.soapActions.any((a) => a.endsWith('#saveClass'));
+
+    test('the create and the blacklist collapse into one choice, create first',
+        () async {
+      final h = newClassChoiceHarness();
+      await h.controller.sync();
+
+      final entry = h.controller.groupPendingEntries
+          .firstWhere((e) => e.targetId == '1A');
+      final choice = entry.choices.singleWhere(
+        (c) => c.situationId == actions.classImportAlternative,
+      );
+
+      expect(choice.isChoice, isTrue,
+          reason: 'either import the class or stop offering it — never both');
+      expect(
+        choice.alternatives.map((a) => a.kind),
+        ['AddToSmartschool', 'DoNotImportFromWisa'],
+        reason: 'the create leads the radio pair',
+      );
+      expect(choice.selected.kind, 'AddToSmartschool',
+          reason: 'adding new classes is the normal start-of-year operation');
+    });
+
+    test('applying the default creates the class and blacklists nothing',
+        () async {
+      final h = newClassChoiceHarness();
+      await h.controller.sync();
+      final pulls = h.wisaSyncs;
+      final entry = h.controller.groupPendingEntries
+          .firstWhere((e) => e.targetId == '1A');
+
+      await h.controller.applyEntry(entry);
+
+      expect(summariesOf(h), contains(create));
+      expect(summariesOf(h), isNot(contains(ignore)),
+          reason: 'the rule would drop the class we just created');
+      expect(savedAClass(h), isTrue);
+      expect(h.wisaSyncs, pulls,
+          reason: 'no import rule was added, so WISA was never re-pulled');
+    });
+
+    test('choosing the blacklist applies it alone, creating nothing', () async {
+      final h = newClassChoiceHarness();
+      await h.controller.sync();
+      final entry = h.controller.groupPendingEntries
+          .firstWhere((e) => e.targetId == '1A');
+
+      h.controller.chooseAlternative(
+        entry: entry,
+        group: actions.classImportAlternative,
+        kind: 'DoNotImportFromWisa',
+      );
+      final chosen = h.controller.groupPendingEntries
+          .firstWhere((e) => e.targetId == '1A');
+      await h.controller.applyEntry(chosen);
+
+      expect(summariesOf(h), contains(ignore));
+      expect(summariesOf(h), isNot(contains(create)));
+      expect(savedAClass(h), isFalse);
+    });
+
+    test(
+        '"apply to all" over the situation creates every class and '
+        'blacklists none', () async {
+      // The report's headline: 21 new classes were created and then, in the
+      // same pass, each had a DontImportClass rule written on the very name it
+      // had just been created under.
+      final h = newClassChoiceHarness();
+      await h.controller.sync();
+      final entries = h.controller.groupPendingEntries;
+      expect(entries.map((e) => e.targetId), containsAll(<String>['1A', '1B']));
+
+      final key = entries.firstWhere((e) => e.targetId == '1A').situationKey;
+      expect(
+        entries.where((e) => e.situationKey == key).map((e) => e.targetId),
+        containsAll(<String>['1A', '1B']),
+        reason: 'both new classes are the same situation, bulk-applied at once',
+      );
+      final pulls = h.wisaSyncs;
+
+      await h.controller.applySituation(key);
+
+      final summaries = summariesOf(h);
+      expect(summaries.where((s) => s == create), hasLength(2));
+      expect(summaries, isNot(contains(ignore)));
+      expect(h.wisaSyncs, pulls);
+    });
+
+    test(
+        'an empty class defaults to its notice, so a bulk apply writes '
+        'nothing for it', () async {
+      // The empty-class reading takes the create's place inside the same
+      // choice. It is informational, so the entry offers no apply at all until
+      // the operator deliberately picks "ignore this class".
+      final h = siblingPopulatedClassHarness();
+      await h.controller.sync();
+
+      final entry = h.controller.groupPendingEntries
+          .firstWhere((e) => e.targetId == '1A');
+      final choice = entry.choices.singleWhere(
+        (c) => c.situationId == actions.classImportAlternative,
+      );
+
+      expect(choice.selected.kind, 'CreateInSmartschool');
+      expect(choice.selected.canApply, isFalse);
+      expect(entry.canApply, isFalse,
+          reason: 'nothing to write for an empty class until the operator '
+              'picks the opt-out');
+      expect(
+        choice.alternatives.map((a) => a.kind),
+        containsAll(<String>['CreateInSmartschool', 'DoNotImportFromWisa']),
+      );
+    });
+  });
 }

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -771,9 +771,11 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('rollup-groups')));
     await tester.pumpAndSettle();
 
-    // Our own populated class is the one and only proposal…
+    // Our own populated class is the one and only proposal… and it reads as
+    // the create side of the either/or choice #244 collapsed it into.
     expect(find.text('1A'), findsOneWidget);
-    expect(find.text('Voeg deze klas toe aan Smartschool'), findsOneWidget);
+    expect(find.text('Voeg deze klas toe aan Smartschool (keuze)'),
+        findsOneWidget);
     // …and the sibling school's class is never offered: applying it would
     // create another school's class in our Smartschool.
     expect(find.text('9Z'), findsNothing);

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:account_actions/account_actions.dart' show ActionOutcome;
 import 'package:account_core/account_core.dart' show Address, Origin;
 import 'package:account_manager/src/reconcile/reconcile_controller.dart'
     show ApplyScope;
@@ -5,6 +8,7 @@ import 'package:account_manager/src/screens/actions_screen.dart';
 import 'package:account_state/account_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:smartschool_api/smartschool_api.dart' show SmartschoolAccount;
 
 import '../reconcile/reconcile_fakes.dart';
 
@@ -1159,5 +1163,244 @@ void main() {
     expect(tester.widget<FilledButton>(readOnlySync).onPressed, isNull);
     expect(find.textContaining('mieke@school'), findsOneWidget,
         reason: 'a dead button needs its reason on screen too');
+  });
+
+  group('a pass runs behind a modal progress dialog (#243)', () {
+    // An "Apply to all" over a September situation group writes hundreds of
+    // accounts, one connector round-trip at a time, for minutes. Its only
+    // feedback used to be greyed-out buttons plus an indeterminate bar in a
+    // page header the operator had long scrolled past — so a running pass was
+    // indistinguishable from a hung app, nothing named the account being
+    // written, and nothing stopped them scrolling away mid-write.
+
+    /// Two departed Smartschool-only students with **different names**, so an
+    /// assertion that the dialog names the account in flight is a real one.
+    ReconcileHarness twoDeparted({Future<void> Function()? gate}) =>
+        ReconcileHarness(
+          applyGate: gate,
+          wisa: wisaSnap(students: const []),
+          smartschool: ssSnap(
+            groups: const [],
+            accounts: <SmartschoolAccount>[
+              ssAccount(
+                uid: 'user0',
+                accountId: '0',
+                mail: 'user0@student.school.example',
+                givenName: 'Jan',
+                surname: 'Peeters',
+              ),
+              ssAccount(
+                uid: 'user1',
+                accountId: '1',
+                mail: 'user1@student.school.example',
+                givenName: 'Sofie',
+                surname: 'Claes',
+              ),
+            ],
+            memberships: const [],
+          ),
+          azure: azSnap(users: const []),
+        );
+
+    /// The text of one line of the progress dialog.
+    String line(WidgetTester tester, String key) =>
+        tester.widget<Text>(find.byKey(ValueKey(key))).data!;
+
+    final Finder dialog = find.byKey(const ValueKey('actions-progress-dialog'));
+
+    testWidgets(
+        'an apply holds the operator in a non-dismissible dialog that names '
+        'each account and action as it goes, and closes itself when the pass '
+        'ends', (WidgetTester tester) async {
+      _useTallWindow(tester);
+      // One fresh gate per action, so the pass can be walked step by step and
+      // the text observed on each — the bug is precisely that nobody could see
+      // which account was being written.
+      final gates = <Completer<void>>[];
+      final harness = twoDeparted(gate: () async {
+        final gate = Completer<void>();
+        gates.add(gate);
+        await gate.future;
+      });
+      await harness.controller.sync();
+      await tester
+          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+
+      // Idle: no dialog.
+      expect(dialog, findsNothing);
+
+      await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
+      await tester.tap(find.byKey(const ValueKey('actions-apply')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      await tester.pumpAndSettle();
+
+      // Parked on the first action: the dialog is up, headed as an apply, and
+      // says how far along it is and on whom.
+      expect(dialog, findsOneWidget);
+      expect(gates, hasLength(1));
+      expect(find.text('Acties toepassen…'), findsOneWidget);
+      expect(line(tester, 'actions-progress-count'), 'Actie 1 van 2');
+      expect(
+          line(tester, 'actions-progress-step'), startsWith('Jan Peeters —'));
+      expect(line(tester, 'actions-progress-step'), contains('Smartschool'));
+
+      // Determinate, and it is a real bar — the motionless indeterminate sweep
+      // is exactly what this replaces (#176).
+      final bar = tester.widget<LinearProgressIndicator>(
+        find.byKey(const ValueKey('actions-progress-bar')),
+      );
+      expect(bar.value, 0.0);
+
+      // Modal: tapping the barrier does not get rid of it.
+      await tester.tapAt(const Offset(5, 5));
+      await tester.pumpAndSettle();
+      expect(dialog, findsOneWidget);
+
+      // The second action: the text follows the pass to the next account.
+      gates[0].complete();
+      await tester.pumpAndSettle();
+      expect(gates, hasLength(2));
+      expect(dialog, findsOneWidget);
+      expect(line(tester, 'actions-progress-count'), 'Actie 2 van 2');
+      expect(
+          line(tester, 'actions-progress-step'), startsWith('Sofie Claes —'));
+      expect(
+        tester
+            .widget<LinearProgressIndicator>(
+              find.byKey(const ValueKey('actions-progress-bar')),
+            )
+            .value,
+        0.5,
+      );
+
+      // The pass ends: the dialog closes by itself, leaving the results.
+      gates[1].complete();
+      await tester.pumpAndSettle();
+      expect(dialog, findsNothing);
+      expect(find.text('Apply result'), findsOneWidget);
+      expect(harness.controller.applyResults, hasLength(2));
+      expect(harness.soap.soapActions, isNotEmpty);
+    });
+
+    testWidgets(
+        'a dry-run gets the same dialog — just as slow, and it used to be just '
+        'as silent', (WidgetTester tester) async {
+      _useTallWindow(tester);
+      final gate = Completer<void>();
+      final harness = twoDeparted(gate: () => gate.future);
+      await harness.controller.sync();
+      await tester
+          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+
+      // A dry-run needs no confirmation, so it goes straight into the pass.
+      await tester.ensureVisible(find.byKey(const ValueKey('actions-dry-run')));
+      await tester.tap(find.byKey(const ValueKey('actions-dry-run')));
+      await tester.pumpAndSettle();
+
+      expect(dialog, findsOneWidget);
+      expect(find.text('Dry-run bezig…'), findsOneWidget);
+      expect(find.text('Er wordt niets geschreven.'), findsOneWidget);
+      expect(line(tester, 'actions-progress-count'), 'Actie 1 van 2');
+      expect(
+          line(tester, 'actions-progress-step'), startsWith('Jan Peeters —'));
+
+      gate.complete();
+      await tester.pumpAndSettle();
+      expect(dialog, findsNothing);
+      expect(find.text('Dry-run result'), findsOneWidget);
+      expect(harness.soap.soapActions, isEmpty);
+    });
+
+    testWidgets('a pass whose writes fail still clears the dialog',
+        (WidgetTester tester) async {
+      _useTallWindow(tester);
+      // The worst case for a modal: the pass blows up. Leaving the dialog up
+      // would lock the operator out of the app entirely, so its lifetime is
+      // bound to the pass's future, not to anything observed about the results.
+      final gate = Completer<void>();
+      final harness = twoDeparted(gate: () async {
+        await gate.future;
+        throw StateError('Smartschool weigerde de schrijfactie');
+      });
+      await harness.controller.sync();
+      await tester
+          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
+      await tester.tap(find.byKey(const ValueKey('actions-apply')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      await tester.pumpAndSettle();
+      expect(dialog, findsOneWidget);
+
+      gate.complete();
+      await tester.pumpAndSettle();
+
+      expect(dialog, findsNothing,
+          reason: 'a failed pass must not trap anyone');
+      expect(find.text('Apply result'), findsOneWidget);
+      expect(
+        harness.controller.applyResults!.map((r) => r.outcome),
+        everyElement(ActionOutcome.failed),
+      );
+      expect(
+        find.textContaining('Smartschool weigerde de schrijfactie'),
+        findsWidgets,
+      );
+    });
+
+    testWidgets('the per-situation and per-entry affordances run behind it too',
+        (WidgetTester tester) async {
+      _useTallWindow(tester);
+      var gate = Completer<void>();
+      final harness = twoDeparted(gate: () => gate.future);
+      await harness.controller.sync();
+      await tester
+          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+      await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
+
+      // The same-situation bulk dry-run.
+      final key = harness.controller.pendingEntries
+          .firstWhere((e) => e.family == 'student')
+          .situationKey;
+      final bulkDryRun = find.byKey(ValueKey('situation-dry-run-$key'));
+      await tester.ensureVisible(bulkDryRun);
+      await tester.tap(bulkDryRun);
+      await tester.pumpAndSettle();
+      expect(dialog, findsOneWidget);
+      expect(find.text('Dry-run bezig…'), findsOneWidget);
+      expect(line(tester, 'actions-progress-count'), 'Actie 1 van 2');
+      gate.complete();
+      await tester.pumpAndSettle();
+      expect(dialog, findsNothing);
+
+      // The per-entry apply, which is a pass of exactly one.
+      gate = Completer<void>();
+      final entry = harness.controller.pendingEntries
+          .firstWhere((e) => e.target == 'Sofie Claes');
+      final id = entry.targetId;
+      await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
+      await tester.tap(find.byKey(ValueKey('entry-student-$id')));
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+      await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(dialog, findsOneWidget);
+      expect(line(tester, 'actions-progress-count'), 'Actie 1 van 1');
+      expect(
+          line(tester, 'actions-progress-step'), startsWith('Sofie Claes —'));
+      gate.complete();
+      await tester.pumpAndSettle();
+      expect(dialog, findsNothing);
+      expect(find.text('Apply result'), findsOneWidget);
+    });
   });
 }

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -1135,6 +1135,49 @@ void main() {
   });
 
   testWidgets(
+      'a read-only session badges an either/or once and lists it as the one '
+      'choice it is (#251)', (WidgetTester tester) async {
+    // A passive session over a departed student's stored doc: it carries the
+    // unregister *and* the delete, which are two readings of one situation the
+    // operator resolves once. The class node used to advertise 2 and the card
+    // listed both as separate bullets, so a class with one leaver read as two
+    // pieces of work — and since #226 that same count decides what is visible.
+    _useTallWindow(tester);
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(
+        id: 's1',
+        label: 'Jane Doe',
+        classroom: '3C',
+        candidates: departureChoice(),
+      ),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The class node in the tree: one decision, badged once.
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    final klas3C = find.byKey(const ValueKey('rollup-class-class|1|3|3C'));
+    await tester.ensureVisible(klas3C);
+    expect(
+        find.descendant(of: klas3C, matching: find.text('1')), findsOneWidget,
+        reason: 'one leaver is one pending decision, not two');
+    expect(find.descendant(of: klas3C, matching: find.text('2')), findsNothing);
+
+    // Drilling in, the card says the same thing: one line, marked as the choice
+    // it is, with the alternative behind it rather than beside it.
+    await tester.ensureVisible(find.text('3C'));
+    await tester.tap(find.text('3C'));
+    await tester.pumpAndSettle();
+    expect(harness.controller.linked, isNull, reason: 'passive session');
+    expect(find.text('• Schrijf de leerling uit in Smartschool (keuze)'),
+        findsOneWidget);
+    expect(find.text('• Verwijder dit account uit Smartschool'), findsNothing,
+        reason: 'the delete is the alternative, not a second to-do');
+  });
+
+  testWidgets(
       "a generation bump refetches the passive Actions overview's freshness "
       '(#108)', (WidgetTester tester) async {
     final linkedStore = InMemoryLinkedStore();

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -790,6 +790,176 @@ void main() {
         find.byKey(const ValueKey('actions-filter-all-hidden')), findsNothing);
   });
 
+  // --- The single-open accordion and its open path (#235) ------------------
+
+  testWidgets(
+      'drilling into a class and pressing Overzicht comes back to the '
+      'grade-year it was opened from, still expanded (#235)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = twoSchoolHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+    expect(harness.controller.selectedClassroom?.classroom, '3C');
+
+    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
+    await tester.pumpAndSettle();
+    expect(
+        find.byKey(const ValueKey('rollup-class-class|1|3|3C')), findsOneWidget,
+        reason: 'Overzicht used to come back to a fully collapsed tree');
+    expect(
+        find.byKey(const ValueKey('rollup-class-class|1|1|1A')), findsNothing,
+        reason: 'the years that were closed stay closed');
+    // The open node is remembered a level above the tiles, which is what let it
+    // survive them being disposed for the detail view.
+    expect(harness.controller.expandedPath, <String>['rollup-grade-grades|3']);
+  });
+
+  testWidgets('opening a grade-year closes the one that was open (#235)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = twoSchoolHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Jaar 1'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-class-class|1|1|1A')),
+        findsOneWidget);
+
+    await tester.ensureVisible(find.text('Jaar 3'));
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-class-class|1|3|3C')),
+        findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('rollup-class-class|1|1|1A')), findsNothing,
+        reason: 'several grade-years could be open at once before #235');
+    expect(harness.controller.expandedPath, <String>['rollup-grade-grades|3']);
+
+    // Tapping the open year again shuts it, leaving nothing open.
+    await tester.ensureVisible(find.text('Jaar 3'));
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    expect(harness.controller.expandedPath, isEmpty);
+    expect(
+        find.byKey(const ValueKey('rollup-class-class|1|3|3C')), findsNothing);
+  });
+
+  testWidgets(
+      'the nested Personeel tree keeps the school open under an opened '
+      'grade-year, and both open across a drill-down (#235)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // The staff tree is school → grade-year → class, so "one open node" has to
+    // mean one per level: a flat single-open key would collapse the school out
+    // from under the very year it was used to reach.
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(students: [wisaStudent()], staff: [wisaStaff()]),
+    );
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
+    await tester.pumpAndSettle();
+
+    final school = find.byKey(const ValueKey('rollup-school-school|staff'));
+    await tester.ensureVisible(school);
+    await tester.tap(school);
+    await tester.pumpAndSettle();
+    final grade =
+        find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel'));
+    await tester.ensureVisible(grade);
+    await tester.tap(grade);
+    await tester.pumpAndSettle();
+
+    final klas = find
+        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
+    expect(klas, findsOneWidget,
+        reason: 'the school stayed open under the grade-year it revealed');
+    expect(harness.controller.expandedPath, <String>[
+      'rollup-school-school|staff',
+      'rollup-grade-grade|staff|Personeel',
+    ]);
+
+    await tester.ensureVisible(klas);
+    await tester.tap(klas);
+    await tester.pumpAndSettle();
+    expect(harness.controller.selectedClassroom?.classroom, 'Personeel');
+
+    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
+    await tester.pumpAndSettle();
+    expect(klas, findsOneWidget,
+        reason: 'both levels of the staff path come back open');
+  });
+
+  testWidgets(
+      'a grade-year the filter hides is forgotten rather than re-opening when '
+      'the filter goes off again (#226/#235)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = await filterTreeHarness();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // Filter off: the full inventory, including the years with nothing to do.
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('rollup-grade-grades|4')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.expandedPath, <String>['rollup-grade-grades|4']);
+
+    // Filter back on: Jaar 4 has nothing pending, so it is gone — and with it
+    // the memory of it being open.
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-grade-grades|4')), findsNothing);
+    expect(harness.controller.expandedPath, isEmpty);
+
+    // Off once more: Jaar 4 is back, collapsed like every other node.
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-grade-grades|4')), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('rollup-class-class|1|4|4A')), findsNothing,
+        reason: 'a node hidden in between must not resurrect its open state');
+  });
+
+  testWidgets(
+      "a re-sync forgets the open node instead of aiming it at a generation "
+      'that no longer has it (#235)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = ReconcileHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    expect(harness.controller.expandedPath, <String>['rollup-grade-grades|3']);
+
+    // WISA moved the student, so this pass really re-links and re-materializes
+    // rather than taking the unchanged shortcut.
+    harness.wisaResult = wisaSnap(
+      students: [wisaStudent(classGroup: '3D')],
+      fetchedAt: kFixtureDate.add(const Duration(hours: 1)),
+    );
+    await harness.controller.sync();
+    await tester.pumpAndSettle();
+
+    expect(harness.controller.expandedPath, isEmpty);
+    expect(
+        find.byKey(const ValueKey('rollup-class-class|1|3|3D')), findsNothing,
+        reason: 'the tree comes back collapsed, not half-open');
+  });
+
   // --- Address diff in the drill-down (#153) -------------------------------
   const wisaAddr = Address(
     street: 'Koophandelstraat',

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -1,4 +1,6 @@
-import 'package:account_core/account_core.dart' show Address;
+import 'package:account_core/account_core.dart' show Address, Origin;
+import 'package:account_manager/src/reconcile/reconcile_controller.dart'
+    show ApplyScope;
 import 'package:account_manager/src/screens/actions_screen.dart';
 import 'package:account_state/account_state.dart';
 import 'package:flutter/material.dart';
@@ -97,7 +99,7 @@ void main() {
     await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
     await tester.tap(find.byKey(const ValueKey('actions-apply')));
     await tester.pumpAndSettle();
-    expect(find.text('Apply pending actions?'), findsOneWidget);
+    expect(find.text('Openstaande acties toepassen?'), findsOneWidget);
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
     expect(find.text('Apply result'), findsOneWidget);
@@ -115,11 +117,143 @@ void main() {
     await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
     await tester.tap(find.byKey(const ValueKey('actions-apply')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Cancel'));
+    await tester.tap(find.text('Annuleer'));
     await tester.pumpAndSettle();
 
     expect(harness.soap.soapActions, isEmpty);
     expect(find.text('Apply result'), findsNothing);
+  });
+
+  group('the apply-confirmation dialog says what the pass really writes (#234)',
+      () {
+    // The sentence used to be hard-coded — "This writes N change(s) to
+    // Smartschool and Azure AD" — for every action, so a single Graph PATCH on
+    // one display name announced a write to a system it never touches. These
+    // pin the sentence itself; the widget/e2e cases below prove the screen
+    // feeds it the right scope.
+    ApplyScope scope(List<Origin> systems, {Set<Origin> chained = const {}}) =>
+        ApplyScope(systems: systems, chained: chained);
+
+    test('one Azure change names Office 365 only', () {
+      expect(
+        applyConfirmationMessage(scope(<Origin>[Origin.azure])),
+        'Dit schrijft 1 wijziging naar Office 365. Doe eerst een dry-run om '
+        'de exacte wijzigingen te bekijken.',
+      );
+    });
+
+    test('a mixed selection names each system it really targets', () {
+      expect(
+        applyConfirmationMessage(
+          scope(<Origin>[Origin.azure, Origin.smartschool, Origin.azure]),
+        ),
+        startsWith('Dit schrijft 3 wijzigingen naar Smartschool en '
+            'Office 365.'),
+      );
+    });
+
+    test('the WISA opt-out family claims no write at all', () {
+      // DontImportStaffFromWisa & co carry Origin.wisa on their ChangeSet, but
+      // WISA is read-only here: what they produce is a local import rule.
+      final message = applyConfirmationMessage(scope(<Origin>[Origin.wisa]));
+      expect(
+        message,
+        startsWith('Dit legt 1 importregel vast (er wordt niets naar WISA '
+            'geschreven).'),
+      );
+      expect(message, isNot(contains('schrijft 1 wijziging')));
+    });
+
+    test('a rule beside a real write is counted apart from it', () {
+      expect(
+        applyConfirmationMessage(scope(<Origin>[Origin.azure, Origin.wisa])),
+        startsWith('Dit schrijft 1 wijziging naar Office 365 en legt 1 '
+            'importregel vast (er wordt niets naar WISA geschreven).'),
+      );
+    });
+
+    test('a chained follow-up names its system, without inflating the count',
+        () {
+      // A new student's Office 365 create writes Smartschool too (#230/#240).
+      // Whether it runs is decided by the follow-up's own evaluate after the
+      // first write, so it is named, never counted.
+      expect(
+        applyConfirmationMessage(
+          scope(<Origin>[Origin.azure], chained: <Origin>{Origin.smartschool}),
+        ),
+        startsWith('Dit schrijft 1 wijziging naar Office 365. Een vervolgactie '
+            'kan ook naar Smartschool schrijven.'),
+      );
+    });
+
+    test('nothing selected claims nothing', () {
+      expect(
+        applyConfirmationMessage(ApplyScope.empty),
+        startsWith('Dit schrijft niets.'),
+      );
+    });
+  });
+
+  /// A student who is in all three systems and in sync except for their Azure
+  /// `displayName` — the exact report in #234: one `ModifyAzureName`, a single
+  /// Graph `PATCH`, and nothing whatsoever for Smartschool.
+  ReconcileHarness nameDriftHarness() => ReconcileHarness(
+        wisa: wisaSnap(
+          students: [wisaStudent(wisaId: '1', classGroup: '3C')],
+          schools: [wisaSchool(1)],
+          classGroups: [wisaClassGroup('3C', adminCode: 'a3')],
+        ),
+        smartschool: ssSnap(
+          groups: [ssGroup('3C', code: '3C_ss', untis: '3C')],
+          accounts: [ssAccount()],
+          memberships: [member('jane', '3C_ss')],
+        ),
+        // displayName left empty — the one thing that differs from WISA.
+        azure: azSnap(users: [azUser()]),
+      );
+
+  testWidgets(
+      'applying one Azure-only action announces Office 365, not "Smartschool '
+      'and Azure AD" (#234)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = nameDriftHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+
+    final entry = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student');
+    expect(
+      entry.choices.map((c) => c.selected.changes.summary),
+      <String>['Wijzig de naam in Azure'],
+      reason: 'the fixture raises exactly the action the bug report names',
+    );
+
+    final id = entry.targetId;
+    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.pumpAndSettle();
+
+    final dialog = find.byType(AlertDialog);
+    expect(find.text('Toepassen voor ${entry.target}?'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: dialog,
+        matching:
+            find.textContaining('Dit schrijft 1 wijziging naar Office 365.'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: dialog, matching: find.textContaining('Smartschool')),
+      findsNothing,
+      reason: 'the pass never touches Smartschool',
+    );
   });
 
   /// A WISA-departed scenario: [count] Smartschool-only active accounts (no

--- a/packages/account_actions/lib/account_actions.dart
+++ b/packages/account_actions/lib/account_actions.dart
@@ -19,6 +19,7 @@
 library;
 
 export 'src/action_result.dart';
+export 'src/alternatives.dart';
 export 'src/apply_options.dart';
 export 'src/azure_class_group.dart';
 export 'src/azure_class_placement.dart';

--- a/packages/account_actions/lib/src/alternatives.dart
+++ b/packages/account_actions/lib/src/alternatives.dart
@@ -1,0 +1,74 @@
+/// The mutually-exclusive-alternative collapse (#110), as one shared primitive.
+///
+/// Two layers have to answer the same question — "what are the *decisions* this
+/// pile of actions really represents?" — over two different representations of
+/// the same actions: the live `StudentAction` / `StaffAction` / `GroupAction`
+/// the reconcile controller holds, and the flattened `CandidateAction` the
+/// materialized view persists. Both partition on [StudentAction.alternativeGroup]
+/// and pre-select [StudentAction.isDefaultAlternative]; #251 is what happens when
+/// only one of them does it.
+///
+/// Pure and family-agnostic: the keys are read through the callers' accessors,
+/// so nothing here knows about actions, candidates, or any concrete family.
+library;
+
+/// One decision point: a set of mutually-exclusive [options] of which exactly
+/// one — [selected] — is the resolution that will actually run.
+///
+/// A departed student's "unregister *vs* delete" pair is one [Alternatives] with
+/// two options; an ordinary modify action is one with a single option. The
+/// distinction is [isChoice].
+class Alternatives<T> {
+  Alternatives({required this.options, required this.selected})
+      : assert(options.isNotEmpty);
+
+  /// The mutually-exclusive options (at least one), in first-seen order.
+  final List<T> options;
+
+  /// The pre-selected option — the declared default of the group, or the lone
+  /// option. Callers that let an operator pick may substitute their own choice.
+  final T selected;
+
+  /// True when this is a real either/or the operator resolves, false for a lone
+  /// action.
+  bool get isChoice => options.length > 1;
+}
+
+/// Collapses [items] into the decision points they represent (#110/#251).
+///
+/// Items whose [groupOf] key is the same non-null string are alternatives of one
+/// choice, ordered by where the group was first seen; every item with a `null`
+/// key is a choice of its own, in place. Each group's [Alternatives.selected] is
+/// the item [isDefault] marks — or, if a family ever forgets to mark one, the
+/// first item of the group, which every dispatch keeps as the provisioning half
+/// rather than the opt-out.
+///
+/// Counting the result — rather than the raw items — is what makes one either/or
+/// one pending decision instead of two.
+List<Alternatives<T>> collapseAlternatives<T>(
+  Iterable<T> items, {
+  required String? Function(T) groupOf,
+  required bool Function(T) isDefault,
+}) {
+  final choices = <Alternatives<T>>[];
+  final order = <String>[];
+  final byGroup = <String, List<T>>{};
+  for (final item in items) {
+    final group = groupOf(item);
+    if (group == null) {
+      choices.add(Alternatives<T>(options: <T>[item], selected: item));
+      continue;
+    }
+    if (!byGroup.containsKey(group)) order.add(group);
+    (byGroup[group] ??= <T>[]).add(item);
+  }
+  for (final group in order) {
+    final alternatives = byGroup[group]!;
+    choices.add(Alternatives<T>(
+      options: alternatives,
+      selected:
+          alternatives.firstWhere(isDefault, orElse: () => alternatives.first),
+    ));
+  }
+  return choices;
+}

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -71,9 +71,9 @@ sealed class GroupAction {
   bool get canApply => true;
 
   /// The key shared by mutually-exclusive alternatives resolving the same
-  /// situation (#110). No group action has alternatives today, so this is always
-  /// `null`; the getter exists so the pending-list grouping treats every family
-  /// uniformly. See [StudentAction.alternativeGroup].
+  /// situation (#110). `null` (the default) means the action stands on its own.
+  /// The group family's one key is [classImportAlternative] (#244). See
+  /// [StudentAction.alternativeGroup].
   String? get alternativeGroup => null;
 
   /// Whether this action is the default alternative within its
@@ -134,6 +134,42 @@ sealed class GroupAction {
 // Actions for when the group is missing from one system (§6.3).
 // ---------------------------------------------------------------------------
 
+/// The [GroupAction.alternativeGroup] key shared by the mutually exclusive
+/// readings of a WISA class Smartschool does not have (#244): import the class
+/// ([AddToSmartschool] when it holds students, [CreateInSmartschool]'s
+/// wait-or-delete notice when it does not) *or* stop offering it
+/// ([DoNotImportFromWisa]).
+///
+/// They are opposite decisions, so they are one choice and never two to-dos.
+/// Applying both created the Smartschool class and then wrote a
+/// [wapi.DontImportClass] rule on the very name it had just created —
+/// blacklisting the class, which then vanished from the next WISA snapshot
+/// while the group survived downstream, unmanaged. "Apply to all" did that to
+/// every new class of the year at once.
+///
+/// The two create actions never fire together (the [GroupPlacement] membership
+/// signal picks exactly one), so all three can share the single key and exactly
+/// one default is ever offered.
+///
+/// **The default is the create action, deliberately the opposite polarity from
+/// [smartschoolDepartureAlternative]**, where the conservative "keep the
+/// account" option leads. Adding new classes is the normal start-of-year bulk
+/// operation; a mis-defaulted bulk apply that silently blacklists a year's
+/// worth of classes is far worse than one that creates them. For an empty class
+/// the default is the informational [CreateInSmartschool], so the bulk apply
+/// writes nothing at all and the operator has to pick "ignore this class"
+/// deliberately.
+///
+/// The mechanism itself is family-agnostic: the pending-list grouping reads
+/// [alternativeGroup] / [isDefaultAlternative] off whatever action it is given,
+/// so a family with the same "provision it *or* stop importing it" pair — the
+/// staff [AddStaffToAzure] versus [DontImportStaffFromWisa] of #248 — declares
+/// its own key the same way and needs no further plumbing. Keep the
+/// provisioning action ahead of the "do not import" one in its dispatch, so it
+/// leads the radio list and is also what the grouping falls back to if a
+/// default is ever forgotten.
+const String classImportAlternative = 'class-import';
+
 /// Stop importing a class from WISA. Ported from `Action\Group\DoNotImportFromWisa`:
 /// the class exists in WISA but not Smartschool, and the operator judges it need
 /// not exist downstream, so a [wapi.DontImportClass] rule is added keyed on the
@@ -154,6 +190,12 @@ class DoNotImportFromWisa extends GroupAction {
 
   @override
   bool evaluate() => group.wisa != null && group.smartschool == null;
+
+  /// Blacklisting the class is one half of the [classImportAlternative] choice
+  /// (#244) — never a to-do beside the create it contradicts. It is not the
+  /// default: an operator has to pick it.
+  @override
+  String? get alternativeGroup => classImportAlternative;
 
   wapi.DontImportClass _rule() => wapi.DontImportClass(_wisa.name);
 
@@ -214,6 +256,15 @@ class AddToSmartschool extends GroupAction {
       group.smartschool == null &&
       group.smartschoolNamesake == null &&
       placement.containsStudents;
+
+  /// Creating the class is the leading half of the [classImportAlternative]
+  /// choice (#244), and its **default**: importing a new class is the normal
+  /// start-of-year operation, so a bulk apply provisions rather than blacklists.
+  @override
+  String? get alternativeGroup => classImportAlternative;
+
+  @override
+  bool get isDefaultAlternative => true;
 
   /// The official Smartschool class to create, derived from the WISA class and
   /// the resolved parent. Untis is set to the class name (legacy
@@ -329,6 +380,17 @@ class CreateInSmartschool extends GroupAction {
       group.smartschool == null &&
       group.smartschoolNamesake == null &&
       !placement.containsStudents;
+
+  /// The empty-class reading stands in for [AddToSmartschool] inside the
+  /// [classImportAlternative] choice (#244), and is the default in its place —
+  /// the two never fire together, so exactly one default is ever offered. Being
+  /// informational, that default makes a bulk apply write **nothing** for an
+  /// empty class: blacklisting it stays a deliberate pick.
+  @override
+  String? get alternativeGroup => classImportAlternative;
+
+  @override
+  bool get isDefaultAlternative => true;
 
   @override
   bool get canApply => false;

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -102,6 +102,12 @@ sealed class GroupAction {
   /// is never run.
   Set<Type> get unlocks => const {};
 
+  /// The systems the [unlocks] chain would write to, beyond the one
+  /// [describeChanges] already names (#234) — the group half of
+  /// [StudentAction.unlockedSystems], which documents why the UI cannot derive
+  /// this from a pending action.
+  Set<Origin> get unlockedSystems => const {};
+
   /// Performs the change on the target system. Impure. With
   /// [ApplyOptions.dryRun] set, performs **no** writes and returns the
   /// projected [ActionResult] (PAIN-3). Throws [UnsupportedError] when
@@ -677,6 +683,12 @@ class CreateAzureClassGroup extends GroupAction {
   /// `SSM-2F` with nobody in it and the enrolment waited for a second click.
   @override
   Set<Type> get unlocks => const {SyncAzureClassGroupMembers};
+
+  /// The roster write lands in Office 365 too, so the chain reaches no system
+  /// this action does not already name — the confirmation dialog has nothing
+  /// extra to announce for it (#234).
+  @override
+  Set<Origin> get unlockedSystems => const {Origin.azure};
 
   @override
   ChangeSet describeChanges() => ChangeSet(

--- a/packages/account_actions/lib/src/group_dispatch.dart
+++ b/packages/account_actions/lib/src/group_dispatch.dart
@@ -11,11 +11,15 @@ import 'group_placement.dart';
 /// the split is on the WISA/Smartschool pair rather than all three systems
 /// (there is no Azure group action):
 /// - If the class is missing from WISA **or** Smartschool, the lifecycle-style
-///   actions ([DoNotImportFromWisa], [ClassExistsAsSmartschoolGroup],
-///   [AddToSmartschool], [CreateInSmartschool], [DoNotImportFromSmartschool])
-///   are considered — in that legacy order, so a WISA-only class raises both
-///   [DoNotImportFromWisa] and exactly one of [AddToSmartschool] /
-///   [CreateInSmartschool].
+///   actions ([ClassExistsAsSmartschoolGroup], [AddToSmartschool],
+///   [CreateInSmartschool], [DoNotImportFromWisa],
+///   [DoNotImportFromSmartschool]) are considered, so a WISA-only class raises
+///   [DoNotImportFromWisa] *and* exactly one of [AddToSmartschool] /
+///   [CreateInSmartschool]. Those two are not two to-dos: they share the
+///   [classImportAlternative] key, so the pending list renders them as one
+///   either/or choice and an apply runs only the picked one (#244). Legacy
+///   ordered [DoNotImportFromWisa] first; it now trails the create it is an
+///   alternative to, so the create leads the radio pair.
 /// - If it is present in both, only [ModifySmartschoolData] is considered.
 ///
 /// [ClassExistsAsSmartschoolGroup] (#225) sits where the two create actions
@@ -71,10 +75,14 @@ List<GroupAction> groupActionsFor(
     if (both)
       ModifySmartschoolData(group)
     else ...[
-      DoNotImportFromWisa(group),
       ClassExistsAsSmartschoolGroup(group),
+      // The create actions lead [DoNotImportFromWisa], which they are mutually
+      // exclusive with (#244): the order is the order the operator reads the
+      // radio pair in, and the fallback the grouping uses if a default is ever
+      // forgotten — so the provisioning half comes first, never the blacklist.
       if (placement != null) AddToSmartschool(group, placement),
       if (placement != null) CreateInSmartschool(group, placement),
+      DoNotImportFromWisa(group),
       DoNotImportFromSmartschool(group),
     ],
     // The Office 365 group of a class is orthogonal to its Smartschool state,

--- a/packages/account_actions/lib/src/staff_action.dart
+++ b/packages/account_actions/lib/src/staff_action.dart
@@ -51,9 +51,9 @@ sealed class StaffAction {
   ChangeSet describeChanges();
 
   /// The key shared by mutually-exclusive alternatives resolving the same
-  /// situation (#110). No staff action has alternatives today, so this is always
-  /// `null`; the getter exists so the pending-list grouping treats every family
-  /// uniformly. See [StudentAction.alternativeGroup].
+  /// situation (#110). `null` (the default) means the action stands on its own.
+  /// The staff family's one key is [staffImportAlternative] (#248). See
+  /// [StudentAction.alternativeGroup].
   String? get alternativeGroup => null;
 
   /// Whether this action is the default alternative within its
@@ -126,6 +126,42 @@ sealed class StaffAction {
 // Lifecycle actions — evaluated only when a system is missing (§6.3).
 // ---------------------------------------------------------------------------
 
+/// The [StaffAction.alternativeGroup] key shared by the mutually exclusive
+/// readings of a WISA staff member with no Smartschool account (#248): finish
+/// provisioning them ([AddStaffToAzure] when the Office 365 account is still
+/// missing, [AddStaffToSmartschool] once it exists) *or* stop importing them
+/// ([DontImportStaffFromWisa]).
+///
+/// They are opposite decisions, so they are one choice and never two to-dos.
+/// Both used to return `null`, so `_choicesFor` made each its own choice-of-one
+/// and `applyEntry` ran every selected choice: one click on a newly hired
+/// teacher created their Office 365 *and* Smartschool accounts (the #240 chain)
+/// and then wrote a [wapi.DontImportUserFromWisa] rule on the very code it had
+/// just provisioned. The rule set is persisted and re-applied on every WISA
+/// pull, so the next sync dropped the staff member the operator had just
+/// provisioned — and their fresh accounts went unmanaged.
+///
+/// The two create actions never fire together — [AddStaffToAzure] needs
+/// `azure == null` and [AddStaffToSmartschool] needs `azure != null` — so all
+/// three can share the single key and exactly one default is ever offered.
+///
+/// **The default is the create action**, the same polarity the group family's
+/// [classImportAlternative] chose and deliberately the opposite of
+/// [smartschoolDepartureAlternative], where the conservative "keep the account"
+/// option leads. Provisioning a new hire is the normal operation; a
+/// mis-defaulted bulk apply that silently blacklists a term's worth of new
+/// staff — dropping them from the next snapshot entirely — is far worse than
+/// one that creates their accounts.
+///
+/// The [AddStaffToAzure] → [AddStaffToSmartschool] chain of #240 is unaffected:
+/// the applier's follow-up walk keys on [StaffAction.unlocks] and never reads
+/// this, so the Azure create still pulls the Smartschool create in behind it.
+/// The key matters for the Smartschool create in its *own* right — a record
+/// that is already WISA + Azure (an account adopted by `employeeId`, #231, or a
+/// chain whose second write failed) raises it beside the opt-out as the same
+/// two contradictory to-dos.
+const String staffImportAlternative = 'staff-import';
+
 /// Create an Office 365 account for a staff member present in WISA but not
 /// Azure. Ported from `Action\StaffAccount\AddToAzure` (the `-Personeel` group
 /// placement is deferred — see the README).
@@ -142,6 +178,15 @@ class AddStaffToAzure extends StaffAction {
   /// the full provisioning intent.
   @override
   Set<Type> get unlocks => const {AddStaffToSmartschool};
+
+  /// Provisioning the staff member is the leading half of the
+  /// [staffImportAlternative] choice (#248), and its **default**: hiring is the
+  /// normal operation, so a bulk apply provisions rather than blacklists.
+  @override
+  String? get alternativeGroup => staffImportAlternative;
+
+  @override
+  bool get isDefaultAlternative => true;
 
   String get _displayName => '${_wisa.firstName} ${_wisa.lastName}'.trim();
 
@@ -258,6 +303,19 @@ class AddStaffToSmartschool extends StaffAction {
   @override
   bool evaluate() =>
       staff.wisa != null && staff.azure != null && staff.smartschool == null;
+
+  /// Once the Office 365 account exists this create stands in for
+  /// [AddStaffToAzure] inside the [staffImportAlternative] choice (#248), and is
+  /// the default in its place — the two are separated by the `azure == null`
+  /// test, so exactly one default is ever offered. It needs the key in its own
+  /// right: a record that is already WISA + Azure (adopted by `employeeId`
+  /// (#231), or a #240 chain whose second write failed) raises this create and
+  /// [DontImportStaffFromWisa] as the same pair of contradictory to-dos.
+  @override
+  String? get alternativeGroup => staffImportAlternative;
+
+  @override
+  bool get isDefaultAlternative => true;
 
   ss.SmartschoolAccount _build() {
     final wisa = _wisa;
@@ -467,6 +525,12 @@ class DontImportStaffFromWisa extends StaffAction {
 
   @override
   bool evaluate() => staff.wisa != null && staff.smartschool == null;
+
+  /// Blacklisting the staff member is one half of the [staffImportAlternative]
+  /// choice (#248) — never a to-do beside the create it contradicts. It is not
+  /// the default: an operator has to pick it.
+  @override
+  String? get alternativeGroup => staffImportAlternative;
 
   wapi.DontImportUserFromWisa _rule() =>
       wapi.DontImportUserFromWisa(_wisa.code.value);

--- a/packages/account_actions/lib/src/staff_action.dart
+++ b/packages/account_actions/lib/src/staff_action.dart
@@ -94,6 +94,12 @@ sealed class StaffAction {
   /// would on the next sync.
   Set<Type> get unlocks => const {};
 
+  /// The systems the [unlocks] chain would write to, beyond the one
+  /// [describeChanges] already names (#234) — the staff half of
+  /// [StudentAction.unlockedSystems], which documents why the UI cannot derive
+  /// this from a pending action.
+  Set<Origin> get unlockedSystems => const {};
+
   /// Performs the change on the target system. Impure. With
   /// [ApplyOptions.dryRun] set, performs **no** writes and returns the
   /// projected [ActionResult] (PAIN-3).
@@ -178,6 +184,11 @@ class AddStaffToAzure extends StaffAction {
   /// the full provisioning intent.
   @override
   Set<Type> get unlocks => const {AddStaffToSmartschool};
+
+  /// That follow-up writes Smartschool, so one confirmed apply of this action
+  /// reaches both systems and the confirmation dialog says both (#234).
+  @override
+  Set<Origin> get unlockedSystems => const {Origin.smartschool};
 
   /// Provisioning the staff member is the leading half of the
   /// [staffImportAlternative] choice (#248), and its **default**: hiring is the

--- a/packages/account_actions/lib/src/staff_dispatch.dart
+++ b/packages/account_actions/lib/src/staff_dispatch.dart
@@ -24,6 +24,15 @@ import 'staff_action_config.dart';
 /// never had a `department` repair (#233). Like the student `ModifyAzureSchool`
 /// it sits in the modify branch, so an adopted account is stamped on the pass
 /// *after* its Smartschool side is built and the record is complete.
+///
+/// A staff member with no Smartschool account raises [DontImportStaffFromWisa]
+/// *and* exactly one of [AddStaffToAzure] / [AddStaffToSmartschool]. Those are
+/// not two to-dos: they share the [staffImportAlternative] key, so the pending
+/// list renders them as one either/or choice and an apply runs only the picked
+/// one (#248). The creates lead the list on purpose — that is the order the
+/// operator reads the radio pair in, and the fallback the grouping uses if a
+/// default is ever forgotten, so the provisioning half comes first and never
+/// the blacklist.
 List<StaffAction> staffActionsFor(
   LinkedStaff staff,
   StaffActionConfig config,
@@ -39,6 +48,11 @@ List<StaffAction> staffActionsFor(
           SetStaffCopyCode(staff, config),
         ]
       : <StaffAction>[
+          // The creates lead [DontImportStaffFromWisa], which they are mutually
+          // exclusive with (#248): the order is the order the operator reads the
+          // radio pair in, and the fallback the grouping uses if a default is
+          // ever forgotten — so the provisioning half comes first, never the
+          // blacklist.
           AddStaffToAzure(staff, config),
           AddStaffToSmartschool(staff, config),
           RemoveStaffFromSmartschool(staff, config),

--- a/packages/account_actions/lib/src/student_action.dart
+++ b/packages/account_actions/lib/src/student_action.dart
@@ -95,6 +95,25 @@ sealed class StudentAction {
   /// would on the next sync.
   Set<Type> get unlocks => const {};
 
+  /// The systems the [unlocks] chain would write to, beyond the one
+  /// [describeChanges] already names (#234).
+  ///
+  /// A confirmed apply is not confined to the system the visible action targets:
+  /// [AddStudentToAzure] writes Office 365 and then, through its chain, writes
+  /// Smartschool as well. The apply-confirmation dialog has to be able to say so
+  /// *before* the write, and at that point the follow-up does not exist yet —
+  /// the dispatcher cannot produce it until the first write has relinked the
+  /// record — so it cannot be read off a pending action. Declaring it here is
+  /// what lets the UI name a system the pass will genuinely reach.
+  ///
+  /// Keep it in step with [unlocks]: it names the same follow-ups' target
+  /// systems. Each family's dispatch test pins the two against the follow-up's
+  /// own [ChangeSet.system], so they cannot drift apart unnoticed.
+  ///
+  /// Like [unlocks] it names what *may* follow, never what must — the
+  /// follow-up's own [evaluate] still decides.
+  Set<Origin> get unlockedSystems => const {};
+
   /// Performs the change on the target system. Impure. With
   /// [ApplyOptions.dryRun] set, performs **no** writes and returns the
   /// projected [ActionResult] (PAIN-3).
@@ -154,6 +173,11 @@ class AddStudentToAzure extends StudentAction {
   /// Acties panel never showed the full provisioning intent.
   @override
   Set<Type> get unlocks => const {AddStudentToSmartschool};
+
+  /// That follow-up writes Smartschool, so one confirmed apply of this action
+  /// reaches both systems and the confirmation dialog says both (#234).
+  @override
+  Set<Origin> get unlockedSystems => const {Origin.smartschool};
 
   @override
   ChangeSet describeChanges() {

--- a/packages/account_actions/test/alternatives_test.dart
+++ b/packages/account_actions/test/alternatives_test.dart
@@ -1,0 +1,83 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:test/test.dart';
+
+/// A stand-in for anything carrying the two alternative keys — the point of
+/// [collapseAlternatives] is that it knows nothing about actions or candidates,
+/// so the reconcile controller's live options and the materialized view's
+/// persisted candidates get the same partition (#251).
+class _Option {
+  const _Option(this.kind, {this.group, this.isDefault = false});
+  final String kind;
+  final String? group;
+  final bool isDefault;
+}
+
+List<Alternatives<_Option>> _collapse(List<_Option> options) =>
+    collapseAlternatives<_Option>(
+      options,
+      groupOf: (o) => o.group,
+      isDefault: (o) => o.isDefault,
+    );
+
+void main() {
+  group('collapseAlternatives (#110/#251)', () {
+    test('an item with no group is a choice of one', () {
+      final choices = _collapse(const [_Option('ModifyAzureName')]);
+      expect(choices, hasLength(1));
+      expect(choices.single.isChoice, isFalse);
+      expect(choices.single.selected.kind, 'ModifyAzureName');
+    });
+
+    test('items sharing a key collapse into one choice on its default', () {
+      final choices = _collapse(const [
+        _Option('UnregisterStudentFromSmartschool',
+            group: 'smartschool-departure', isDefault: true),
+        _Option('DeleteStudentFromSmartschool', group: 'smartschool-departure'),
+      ]);
+
+      expect(choices, hasLength(1), reason: 'one situation, one decision');
+      expect(choices.single.isChoice, isTrue);
+      expect(choices.single.options.map((o) => o.kind), hasLength(2));
+      expect(choices.single.selected.kind, 'UnregisterStudentFromSmartschool');
+    });
+
+    test('two different keys stay two choices', () {
+      final choices = _collapse(const [
+        _Option('AddToSmartschool', group: 'class-import', isDefault: true),
+        _Option('DoNotImportFromWisa', group: 'class-import'),
+        _Option('CreateAzureClassGroup', group: 'azure-class-group'),
+      ]);
+      expect(choices, hasLength(2));
+    });
+
+    test('a group with no declared default falls back to its first item', () {
+      // Every dispatch keeps the provisioning half first, so the fallback is
+      // never the "stop importing it" opt-out.
+      final choices = _collapse(const [
+        _Option('AddToSmartschool', group: 'class-import'),
+        _Option('DoNotImportFromWisa', group: 'class-import'),
+      ]);
+      expect(choices.single.selected.kind, 'AddToSmartschool');
+    });
+
+    test('lone items keep their place and groups follow in first-seen order',
+        () {
+      final choices = _collapse(const [
+        _Option('ModifySmartschoolData'),
+        _Option('B1', group: 'b'),
+        _Option('A1', group: 'a', isDefault: true),
+        _Option('B2', group: 'b', isDefault: true),
+        _Option('A2', group: 'a'),
+      ]);
+
+      expect(
+        choices.map((c) => c.selected.kind),
+        <String>['ModifySmartschoolData', 'B2', 'A1'],
+      );
+    });
+
+    test('no items at all is no decisions', () {
+      expect(_collapse(const []), isEmpty);
+    });
+  });
+}

--- a/packages/account_actions/test/azure_class_group_test.dart
+++ b/packages/account_actions/test/azure_class_group_test.dart
@@ -139,6 +139,31 @@ void main() {
       expect(create.unlocks, <Type>{SyncAzureClassGroupMembers});
     });
 
+    test('the create names the system its follow-up writes — its own (#234)',
+        () {
+      // The roster write lands in Office 365 too, so this chain reaches no
+      // system the create does not already name and the confirmation dialog has
+      // no second system to announce for it. Pinned against the follow-up's own
+      // ChangeSet so the two cannot drift apart.
+      final create = groupActionsFor(
+        linkedGroup(wisa: wisaGroup(), smartschool: ssGroup()),
+        azurePlanFor: (_) => azurePlan(),
+      ).single as CreateAzureClassGroup;
+      final followUp = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(),
+          smartschool: ssGroup(),
+          azure: azureClassGroup('3A'),
+        ),
+        azurePlanFor: (_) => azurePlan(membersToAdd: const ['az-1']),
+      ).single as SyncAzureClassGroupMembers;
+      expect(create.unlockedSystems, <Origin>{Origin.azure});
+      expect(
+          create.unlockedSystems, <Origin>{followUp.describeChanges().system});
+      expect(create.unlockedSystems, <Origin>{create.describeChanges().system},
+          reason: 'the chain stays inside Office 365');
+    });
+
     test('the roster sync ends the chain', () {
       final actions = groupActionsFor(
         linkedGroup(
@@ -149,6 +174,7 @@ void main() {
         azurePlanFor: (_) => azurePlan(membersToAdd: const ['az-1']),
       );
       expect(actions.single.unlocks, isEmpty);
+      expect(actions.single.unlockedSystems, isEmpty);
     });
 
     test('every other group action unlocks nothing', () {
@@ -174,6 +200,9 @@ void main() {
         )) {
           if (action is CreateAzureClassGroup) continue;
           expect(action.unlocks, isEmpty, reason: '${action.runtimeType}');
+          // …and so claims no second system on the confirmation dialog (#234).
+          expect(action.unlockedSystems, isEmpty,
+              reason: '${action.runtimeType}');
         }
       }
     });

--- a/packages/account_actions/test/azure_class_group_test.dart
+++ b/packages/account_actions/test/azure_class_group_test.dart
@@ -74,7 +74,7 @@ void main() {
       );
       expect(
         actions.map((a) => a.runtimeType),
-        [DoNotImportFromWisa, AddToSmartschool, CreateAzureClassGroup],
+        [AddToSmartschool, DoNotImportFromWisa, CreateAzureClassGroup],
       );
     });
 
@@ -119,7 +119,7 @@ void main() {
           linkedGroup(wisa: wisaGroup()),
           placementFor: (_) => groupPlacement(containsStudents: true),
         ).map((a) => a.runtimeType),
-        [DoNotImportFromWisa, AddToSmartschool],
+        [AddToSmartschool, DoNotImportFromWisa],
       );
     });
   });

--- a/packages/account_actions/test/group_dispatch_test.dart
+++ b/packages/account_actions/test/group_dispatch_test.dart
@@ -26,7 +26,7 @@ void main() {
       expect(actions.map((a) => a.runtimeType), [DoNotImportFromWisa]);
     });
 
-    test('WISA only with students → DoNotImportFromWisa + AddToSmartschool',
+    test('WISA only with students → AddToSmartschool + DoNotImportFromWisa',
         () {
       final actions = groupActionsFor(
         linkedGroup(wisa: wisaGroup()),
@@ -34,11 +34,12 @@ void main() {
       );
       expect(
         actions.map((a) => a.runtimeType),
-        [DoNotImportFromWisa, AddToSmartschool],
+        // The create leads the blacklist it is an alternative to (#244).
+        [AddToSmartschool, DoNotImportFromWisa],
       );
     });
 
-    test('WISA only, empty class → DoNotImportFromWisa + CreateInSmartschool',
+    test('WISA only, empty class → CreateInSmartschool + DoNotImportFromWisa',
         () {
       final actions = groupActionsFor(
         linkedGroup(wisa: wisaGroup()),
@@ -46,7 +47,7 @@ void main() {
       );
       expect(
         actions.map((a) => a.runtimeType),
-        [DoNotImportFromWisa, CreateInSmartschool],
+        [CreateInSmartschool, DoNotImportFromWisa],
       );
     });
 
@@ -79,7 +80,7 @@ void main() {
       );
       expect(
         actions.map((a) => a.runtimeType),
-        [DoNotImportFromWisa, ClassExistsAsSmartschoolGroup],
+        [ClassExistsAsSmartschoolGroup, DoNotImportFromWisa],
       );
     });
 
@@ -97,7 +98,7 @@ void main() {
       );
       expect(
         actions.map((a) => a.runtimeType),
-        [DoNotImportFromWisa, ClassExistsAsSmartschoolGroup],
+        [ClassExistsAsSmartschoolGroup, DoNotImportFromWisa],
       );
     });
 
@@ -110,7 +111,7 @@ void main() {
       );
       expect(
         actions.map((a) => a.runtimeType),
-        [DoNotImportFromWisa, ClassExistsAsSmartschoolGroup],
+        [ClassExistsAsSmartschoolGroup, DoNotImportFromWisa],
       );
     });
 
@@ -136,6 +137,101 @@ void main() {
       // Neither missing-branch action evaluates (each needs its own system),
       // and there is no Azure group action.
       expect(groupActionsFor(linkedGroup()), isEmpty);
+    });
+  });
+
+  group('the WISA-only class is one choice, not two to-dos (#244)', () {
+    test('create + do-not-import share one key, the create leading as default',
+        () {
+      final actions = groupActionsFor(
+        linkedGroup(wisa: wisaGroup()),
+        placementFor: (_) => groupPlacement(containsStudents: true),
+      );
+      final create = actions.whereType<AddToSmartschool>().single;
+      final ignore = actions.whereType<DoNotImportFromWisa>().single;
+
+      // Same key ⇒ the pending list collapses them into one either/or choice
+      // and an apply runs only the picked one. Both used to return null, so
+      // "apply all" created the class *and* blacklisted the name it created.
+      expect(create.alternativeGroup, classImportAlternative);
+      expect(ignore.alternativeGroup, create.alternativeGroup);
+
+      // Polarity: provisioning leads, blacklisting is a deliberate pick.
+      expect(create.isDefaultAlternative, isTrue);
+      expect(ignore.isDefaultAlternative, isFalse);
+      expect(actions.indexOf(create), lessThan(actions.indexOf(ignore)));
+    });
+
+    test('an empty class defaults to the informational wait-or-delete notice',
+        () {
+      final actions = groupActionsFor(
+        linkedGroup(wisa: wisaGroup()),
+        placementFor: (_) => groupPlacement(containsStudents: false),
+      );
+      final empty = actions.whereType<CreateInSmartschool>().single;
+      final ignore = actions.whereType<DoNotImportFromWisa>().single;
+
+      expect(empty.alternativeGroup, classImportAlternative);
+      expect(ignore.alternativeGroup, classImportAlternative);
+      // It stands in for the create, so it takes the default with it — and it
+      // cannot be applied, so a bulk apply writes nothing for an empty class.
+      expect(empty.isDefaultAlternative, isTrue);
+      expect(empty.canApply, isFalse);
+      expect(ignore.isDefaultAlternative, isFalse);
+    });
+
+    test('exactly one default is ever offered — the creates never co-occur',
+        () {
+      for (final hasStudents in const [true, false]) {
+        final actions = groupActionsFor(
+          linkedGroup(wisa: wisaGroup()),
+          placementFor: (_) => groupPlacement(containsStudents: hasStudents),
+        );
+        final alternatives = actions
+            .where((a) => a.alternativeGroup == classImportAlternative)
+            .toList();
+        expect(alternatives, hasLength(2));
+        expect(
+          alternatives.where((a) => a.isDefaultAlternative),
+          hasLength(1),
+          reason: 'containsStudents picks exactly one of the two creates',
+        );
+      }
+    });
+
+    test('a class present in both systems carries no alternatives', () {
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(description: 'Nieuw'),
+          smartschool: ssGroup(description: 'Oud'),
+        ),
+      );
+      expect(actions.single.alternativeGroup, isNull);
+    });
+
+    test('the Smartschool-only orphan notice stands on its own', () {
+      final actions = groupActionsFor(linkedGroup(smartschool: ssGroup()));
+      expect(actions.single.alternativeGroup, isNull);
+    });
+
+    test('the namesake notice (#225) is not part of the choice', () {
+      // It is a different reading of the class — "align the names by hand" —
+      // and merging it into the key would pool it with the create bucket for
+      // bulk apply. It keeps its own situation.
+      final actions = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(name: '2G'),
+          smartschoolNamesake: ssGroupNode(code: 'G2G', name: '2G'),
+        ),
+        placementFor: (_) => groupPlacement(containsStudents: true),
+      );
+      expect(
+        actions
+            .whereType<ClassExistsAsSmartschoolGroup>()
+            .single
+            .alternativeGroup,
+        isNull,
+      );
     });
   });
 
@@ -177,7 +273,7 @@ void main() {
       );
       expect(
         actions.map((a) => a.runtimeType),
-        [DoNotImportFromWisa, AddToSmartschool],
+        [AddToSmartschool, DoNotImportFromWisa],
       );
     });
   });

--- a/packages/account_actions/test/staff_dispatch_test.dart
+++ b/packages/account_actions/test/staff_dispatch_test.dart
@@ -255,6 +255,24 @@ void main() {
       expect(create.unlocks, <Type>{AddStaffToSmartschool});
     });
 
+    test('the WISA-only create names the system its follow-up writes (#234)',
+        () {
+      // The apply-confirmation dialog has to name Smartschool for this one
+      // action, and it cannot read it off the follow-up: the follow-up does not
+      // exist until the create has run and relinked. Pinned against the
+      // follow-up's own ChangeSet so the two cannot drift apart.
+      final create = staffActionsFor(linkedStaff(wisa: wisaStaff()), cfg)
+          .whereType<AddStaffToAzure>()
+          .single;
+      final followUp = staffActionsFor(
+        linkedStaff(wisa: wisaStaff(), azure: azureStaff()),
+        cfg,
+      ).whereType<AddStaffToSmartschool>().single;
+      expect(create.unlockedSystems, <Origin>{Origin.smartschool});
+      expect(
+          create.unlockedSystems, <Origin>{followUp.describeChanges().system});
+    });
+
     test('the Smartschool create ends the chain', () {
       // Nothing follows it: the record is complete afterwards, so the next pass
       // is the ordinary modify branch, not another link of this chain.
@@ -262,8 +280,9 @@ void main() {
         linkedStaff(wisa: wisaStaff(), azure: azureStaff()),
         cfg,
       );
-      expect(
-          actions.whereType<AddStaffToSmartschool>().single.unlocks, isEmpty);
+      final create = actions.whereType<AddStaffToSmartschool>().single;
+      expect(create.unlocks, isEmpty);
+      expect(create.unlockedSystems, isEmpty);
     });
 
     test('every other staff action unlocks nothing', () {
@@ -283,6 +302,9 @@ void main() {
         for (final action in staffActionsFor(staff, cfg)) {
           if (action is AddStaffToAzure) continue;
           expect(action.unlocks, isEmpty, reason: '${action.runtimeType}');
+          // …and so claims no second system on the confirmation dialog (#234).
+          expect(action.unlockedSystems, isEmpty,
+              reason: '${action.runtimeType}');
         }
       }
     });

--- a/packages/account_actions/test/staff_dispatch_test.dart
+++ b/packages/account_actions/test/staff_dispatch_test.dart
@@ -163,6 +163,86 @@ void main() {
     });
   });
 
+  group(
+      'a WISA staff member with no Smartschool account is one choice, '
+      'not two to-dos (#248)', () {
+    test('the Azure create + do-not-import share one key, the create leading',
+        () {
+      final actions = staffActionsFor(linkedStaff(wisa: wisaStaff()), cfg);
+      final create = actions.whereType<AddStaffToAzure>().single;
+      final ignore = actions.whereType<DontImportStaffFromWisa>().single;
+
+      // Same key ⇒ the pending list collapses them into one either/or choice
+      // and an apply runs only the picked one. Both used to return null, so one
+      // click provisioned the teacher *and* blacklisted their WISA code — and
+      // the persisted rule dropped them from the very next pull.
+      expect(create.alternativeGroup, staffImportAlternative);
+      expect(ignore.alternativeGroup, create.alternativeGroup);
+
+      // Polarity: provisioning leads, blacklisting is a deliberate pick.
+      expect(create.isDefaultAlternative, isTrue);
+      expect(ignore.isDefaultAlternative, isFalse);
+      expect(actions.indexOf(create), lessThan(actions.indexOf(ignore)));
+    });
+
+    test('the Smartschool create takes the key in its own right', () {
+      // WISA + Azure, no Smartschool — an account adopted by employeeId (#231),
+      // or a #240 chain whose second write failed. The dispatch offers this
+      // create beside the opt-out as the identical contradictory pair, so the
+      // key cannot ride on AddStaffToAzure alone.
+      final actions = staffActionsFor(
+        linkedStaff(wisa: wisaStaff(), azure: azureStaff()),
+        cfg,
+      );
+      final create = actions.whereType<AddStaffToSmartschool>().single;
+      final ignore = actions.whereType<DontImportStaffFromWisa>().single;
+
+      expect(create.alternativeGroup, staffImportAlternative);
+      expect(ignore.alternativeGroup, staffImportAlternative);
+      expect(create.isDefaultAlternative, isTrue,
+          reason: 'it stands in for AddStaffToAzure, so it takes the default');
+      expect(ignore.isDefaultAlternative, isFalse);
+      expect(actions.indexOf(create), lessThan(actions.indexOf(ignore)));
+    });
+
+    test('exactly one default is ever offered — the creates never co-occur',
+        () {
+      for (final staff in <LinkedStaff>[
+        linkedStaff(wisa: wisaStaff()),
+        linkedStaff(wisa: wisaStaff(), azure: azureStaff()),
+      ]) {
+        final alternatives = staffActionsFor(staff, cfg)
+            .where((a) => a.alternativeGroup == staffImportAlternative)
+            .toList();
+        expect(alternatives, hasLength(2));
+        expect(
+          alternatives.where((a) => a.isDefaultAlternative),
+          hasLength(1),
+          reason: 'the azure == null test picks exactly one of the two creates',
+        );
+      }
+    });
+
+    test('every other staff action stands on its own', () {
+      // A stray key would pool unrelated actions into one radio group and hide
+      // all but the selected one from the operator.
+      for (final staff in <LinkedStaff>[
+        linkedStaff(smartschool: ssStaff()),
+        linkedStaff(azure: azureStaff()),
+        linkedStaff(
+          wisa: wisaStaff(code: 'SMIT', wisaId: '42'),
+          smartschool: ssStaff(accountId: 'OLD', fax: '9999'),
+          azure: azureStaff(department: 'OTHER - Wiskunde'),
+        ),
+      ]) {
+        for (final action in staffActionsFor(staff, cfg)) {
+          expect(action.alternativeGroup, isNull,
+              reason: '${action.runtimeType}');
+        }
+      }
+    });
+  });
+
   group('unlocked follow-ups (#240)', () {
     test('the WISA-only create declares its Smartschool follow-up', () {
       // Provisioning a new staff member is a chain the dispatcher cannot

--- a/packages/account_actions/test/student_dispatch_test.dart
+++ b/packages/account_actions/test/student_dispatch_test.dart
@@ -76,6 +76,24 @@ void main() {
       expect(create.unlocks, <Type>{AddStudentToSmartschool});
     });
 
+    test('the WISA-only create names the system its follow-up writes (#234)',
+        () {
+      // The apply-confirmation dialog has to name Smartschool for this one
+      // action, and it cannot read it off the follow-up: the follow-up does not
+      // exist until the create has run and relinked. So the action declares it
+      // — and this pins the declaration against the follow-up's own ChangeSet,
+      // which is the thing that would otherwise silently drift.
+      final create = studentActionsFor(linked(wisa: wisaStudent()), cfg).single
+          as AddStudentToAzure;
+      final followUp = studentActionsFor(
+        linked(wisa: wisaStudent(), azure: azureUser()),
+        cfg,
+      ).single as AddStudentToSmartschool;
+      expect(create.unlockedSystems, <Origin>{Origin.smartschool});
+      expect(
+          create.unlockedSystems, <Origin>{followUp.describeChanges().system});
+    });
+
     test('the Smartschool create ends the chain (#230)', () {
       // Nothing follows it: the record is complete afterwards, so the next pass
       // is the ordinary modify branch, not another link of this chain.
@@ -84,6 +102,7 @@ void main() {
         cfg,
       );
       expect(actions.single.unlocks, isEmpty);
+      expect(actions.single.unlockedSystems, isEmpty);
     });
 
     test('every other student action unlocks nothing (#230)', () {
@@ -101,6 +120,9 @@ void main() {
         for (final action in studentActionsFor(account, cfg)) {
           if (action is AddStudentToAzure) continue;
           expect(action.unlocks, isEmpty, reason: '${action.runtimeType}');
+          // …and so claims no second system on the confirmation dialog (#234).
+          expect(action.unlockedSystems, isEmpty,
+              reason: '${action.runtimeType}');
         }
       }
     });

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -37,16 +37,29 @@ MaterializedView materialize(
     // Since #245 the student family has an informational member too
     // (`AzureClassGroupMembership`), so the flag is read off the action rather
     // than assumed — a diagnosis must not count as pending work or offer an
-    // apply the action would throw on.
-    (byAccount[a.target.id.value] ??= <CandidateAction>[]).add(
-        _candidate('student', a, a.describeChanges(), canApply: a.canApply));
+    // apply the action would throw on. The alternative-group keys ride along
+    // since #251 so the persisted view can tell one either/or from two to-dos.
+    (byAccount[a.target.id.value] ??= <CandidateAction>[]).add(_candidate(
+      'student',
+      a,
+      a.describeChanges(),
+      canApply: a.canApply,
+      alternativeGroup: a.alternativeGroup,
+      isDefaultAlternative: a.isDefaultAlternative,
+    ));
   }
   final byStaff = <String, List<CandidateAction>>{};
   for (final a in linked.staffActions) {
     // Read off the action like the other two families since #240: every staff
     // action is applyable today, but nothing here should assume it.
-    (byStaff[a.target.id.value] ??= <CandidateAction>[])
-        .add(_candidate('staff', a, a.describeChanges(), canApply: a.canApply));
+    (byStaff[a.target.id.value] ??= <CandidateAction>[]).add(_candidate(
+      'staff',
+      a,
+      a.describeChanges(),
+      canApply: a.canApply,
+      alternativeGroup: a.alternativeGroup,
+      isDefaultAlternative: a.isDefaultAlternative,
+    ));
   }
 
   // Account-scoped warnings, keyed by the Smartschool uid they name.
@@ -134,8 +147,14 @@ List<MaterializedGroup> _materializeGroups(
   final targets = <String, core.LinkedGroup>{};
   for (final a in groupActions) {
     final key = _groupKey(a.target);
-    (byGroup[key] ??= <CandidateAction>[])
-        .add(_candidate('group', a, a.describeChanges(), canApply: a.canApply));
+    (byGroup[key] ??= <CandidateAction>[]).add(_candidate(
+      'group',
+      a,
+      a.describeChanges(),
+      canApply: a.canApply,
+      alternativeGroup: a.alternativeGroup,
+      isDefaultAlternative: a.isDefaultAlternative,
+    ));
     targets.putIfAbsent(key, () => a.target);
   }
   return [
@@ -154,12 +173,14 @@ List<MaterializedGroup> _materializeGroups(
 
 /// The single "Klasgroepen" [Rollup] over every [MaterializedGroup], or `null`
 /// when no group has a pending action (nothing to drill into). [accountCount] is
-/// the number of group docs, [pendingCount] their applyable actions.
+/// the number of group docs, [pendingCount] the **decisions** they carry
+/// ([pendingDecisionCount], #251) — since #244 every new class of the school
+/// year is one create-or-ignore either/or, which counted as two.
 Rollup? _buildGroupsRollup(List<MaterializedGroup> groups) {
   if (groups.isEmpty) return null;
   var pending = 0;
   for (final g in groups) {
-    pending += g.candidates.where((c) => c.canApply).length;
+    pending += pendingDecisionCount(g.candidates);
   }
   return Rollup(
     level: RollupLevel.groups,
@@ -177,7 +198,8 @@ Rollup? _buildGroupsRollup(List<MaterializedGroup> groups) {
 /// Derives the school / grade-year / classroom [Rollup] tree from the
 /// materialized [accounts]. Exposed for direct testing: each node's
 /// [Rollup.accountCount] is the number of accounts beneath it and
-/// [Rollup.pendingCount] the total applyable candidate actions they carry.
+/// [Rollup.pendingCount] the total pending **decisions** they carry — one per
+/// either/or, not one per alternative ([pendingDecisionCount], #251).
 List<Rollup> buildRollups(List<MaterializedAccount> accounts) {
   // classroomKey -> aggregate; grade/school keys accumulate from these.
   final classrooms = <String, _Agg>{};
@@ -185,7 +207,7 @@ List<Rollup> buildRollups(List<MaterializedAccount> accounts) {
   final schools = <String, _Agg>{};
 
   for (final a in accounts) {
-    final pending = a.candidates.where((c) => c.canApply).length;
+    final pending = pendingDecisionCount(a.candidates);
     final schoolKey = _schoolKey(a.school);
     final gradeKey = _gradeKey(a.school, a.gradeYear);
     final classKey = _classroomKey(a.school, a.gradeYear, a.classroom);
@@ -336,6 +358,8 @@ CandidateAction _candidate(
   Object action,
   actions.ChangeSet changes, {
   required bool canApply,
+  required String? alternativeGroup,
+  required bool isDefaultAlternative,
 }) =>
     CandidateAction(
       family: family,
@@ -344,6 +368,8 @@ CandidateAction _candidate(
       summary: changes.summary,
       fields: changes.fields,
       canApply: canApply,
+      alternativeGroup: alternativeGroup,
+      isDefaultAlternative: isDefaultAlternative,
     );
 
 // The core linked records carry only linking keys; human names live on the

--- a/packages/account_state/lib/src/materialize/materialized_state.dart
+++ b/packages/account_state/lib/src/materialize/materialized_state.dart
@@ -14,7 +14,8 @@
 /// the Cosmos-backed store.
 library;
 
-import 'package:account_actions/account_actions.dart' show FieldChange;
+import 'package:account_actions/account_actions.dart'
+    show Alternatives, FieldChange, collapseAlternatives;
 import 'package:account_core/account_core.dart' as core;
 
 /// One dispatched action, flattened for storage and display.
@@ -32,6 +33,8 @@ class CandidateAction {
     required this.summary,
     this.fields = const [],
     this.canApply = true,
+    this.alternativeGroup,
+    this.isDefaultAlternative = false,
   });
 
   /// `student`, `staff`, or `group` — the dispatcher family.
@@ -54,6 +57,23 @@ class CandidateAction {
   /// operator but the apply pass skips them).
   final bool canApply;
 
+  /// The key shared by the mutually-exclusive alternatives that resolve the
+  /// **same situation** (#110), copied off the live action's
+  /// `alternativeGroup`; `null` when the action stands on its own.
+  ///
+  /// Persisted since #251, because a passive session has nothing else to tell an
+  /// either/or from two independent to-dos: without it the rollup badges counted
+  /// both halves of one choice, and the read-only tiles listed both as separate
+  /// bullets. Absent in documents written before #251, which read back as `null`
+  /// — the pre-#110 shape, and correct for every candidate that has no
+  /// alternative.
+  final String? alternativeGroup;
+
+  /// Whether this candidate is the pre-selected default of its
+  /// [alternativeGroup] — the resolution an apply pass runs unless the operator
+  /// switches. Ignored when [alternativeGroup] is `null`.
+  final bool isDefaultAlternative;
+
   Map<String, dynamic> toJson() => {
         'family': family,
         'kind': kind,
@@ -69,6 +89,8 @@ class CandidateAction {
               },
           ],
         'canApply': canApply,
+        if (alternativeGroup != null) 'alternativeGroup': alternativeGroup,
+        if (isDefaultAlternative) 'isDefaultAlternative': true,
       };
 
   factory CandidateAction.fromJson(Map<String, dynamic> json) =>
@@ -86,7 +108,44 @@ class CandidateAction {
             ),
         ],
         canApply: json['canApply'] as bool? ?? true,
+        alternativeGroup: json['alternativeGroup'] as String?,
+        isDefaultAlternative: json['isDefaultAlternative'] as bool? ?? false,
       );
+}
+
+/// The decision points a candidate list represents (#251) — the persisted-view
+/// counterpart of the reconcile controller's `PendingChoice`, built by the one
+/// shared [collapseAlternatives] both layers use.
+///
+/// Candidates sharing a non-null [CandidateAction.alternativeGroup] collapse
+/// into a single choice pre-selected on its declared default; every other
+/// candidate is a choice of one. Exposed so the read-only tiles can render an
+/// either/or as the one line it is instead of two independent bullets.
+List<Alternatives<CandidateAction>> candidateChoices(
+  Iterable<CandidateAction> candidates,
+) =>
+    collapseAlternatives<CandidateAction>(
+      candidates,
+      groupOf: (c) => c.alternativeGroup,
+      isDefault: (c) => c.isDefaultAlternative,
+    );
+
+/// How many pending **decisions** [candidates] leave for the operator — the
+/// number behind every "N pending here" badge (#251).
+///
+/// Counts one per [candidateChoices] entry whose selected option is applyable,
+/// which is exactly what an apply pass would write (the controller's
+/// `applyableCount` resolves the same way over the live actions). So a departed
+/// student's unregister/delete pair counts **once**, a new class's
+/// create/opt-out pair counts once, an empty class — whose default half is the
+/// informational notice — counts zero, and the informational actions of #245
+/// never count at all.
+int pendingDecisionCount(Iterable<CandidateAction> candidates) {
+  var pending = 0;
+  for (final choice in candidateChoices(candidates)) {
+    if (choice.selected.canApply) pending++;
+  }
+  return pending;
 }
 
 /// The kind of operator intent an [AccountDecision] records.
@@ -237,8 +296,10 @@ class MaterializedAccount {
   final List<AccountDecision> decisions;
 
   /// Whether an apply pass would write anything here (drives the "pending"
-  /// badge counts): at least one applyable candidate.
-  bool get hasPending => candidates.any((c) => c.canApply);
+  /// badge counts): at least one decision whose selected resolution is
+  /// applyable — [pendingDecisionCount] read as a flag, so the work-list filter
+  /// keeps exactly the accounts the badges count (#251).
+  bool get hasPending => pendingDecisionCount(candidates) > 0;
 
   MaterializedAccount withDecisions(List<AccountDecision> decisions) =>
       MaterializedAccount(
@@ -377,9 +438,11 @@ class MaterializedGroup {
   /// The partition every group document shares — [groupsPartition].
   String get school => groupsPartition;
 
-  /// Whether an apply pass would write anything here: at least one applyable
-  /// candidate (the informational notices do not count).
-  bool get hasPending => candidates.any((c) => c.canApply);
+  /// Whether an apply pass would write anything here: at least one decision
+  /// whose selected resolution is applyable (#251). The informational notices do
+  /// not count, and neither does the opt-out half of an either/or the operator
+  /// has not switched to.
+  bool get hasPending => pendingDecisionCount(candidates) > 0;
 
   MaterializedGroup withDecisions(List<AccountDecision> decisions) =>
       MaterializedGroup(

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -559,6 +559,149 @@ void main() {
     });
   });
 
+  group('pending counts are decisions, not actions (#251)', () {
+    /// A WISA-departed, Smartschool-only student: the dispatch raises the
+    /// mutually-exclusive unregister/delete pair (#110) on one account.
+    LinkedState departedLinked() => LinkedState.recompute(
+          wisa: wapi.WisaSnapshot(
+            fetchedAt: _d,
+            students: const [],
+            staff: const [],
+            classGroups: const [],
+            schools: const [],
+          ),
+          smartschool: ss.SmartschoolSnapshot(
+            fetchedAt: _d,
+            groups: const [],
+            accounts: [_ssAccount()],
+            memberships: const [],
+          ),
+          azure: az.AzureSnapshot(
+              fetchedAt: _d, users: const [], groups: const []),
+          resolver: _SeqResolver(),
+          studentConfig: _studentConfig,
+          staffConfig: _staffConfig,
+        );
+
+    CandidateAction candidate(
+      String kind, {
+      String? group,
+      bool isDefault = false,
+      bool canApply = true,
+    }) =>
+        CandidateAction(
+          family: 'group',
+          kind: kind,
+          system: core.Origin.smartschool,
+          summary: kind,
+          canApply: canApply,
+          alternativeGroup: group,
+          isDefaultAlternative: isDefault,
+        );
+
+    test('two alternatives of one choice count once', () {
+      // The heart of the bug: an operator resolves this situation once and
+      // exactly one of the two ever runs, so it is one pending item.
+      final candidates = [
+        candidate('UnregisterStudentFromSmartschool',
+            group: 'smartschool-departure', isDefault: true),
+        candidate('DeleteStudentFromSmartschool',
+            group: 'smartschool-departure'),
+      ];
+      expect(candidateChoices(candidates), hasLength(1));
+      expect(candidateChoices(candidates).single.isChoice, isTrue);
+      expect(pendingDecisionCount(candidates), 1);
+    });
+
+    test('a choice whose default is informational counts nothing', () {
+      // The empty-class reading of #244: the pre-selected half has no write, so
+      // a bulk apply writes nothing here — blacklisting stays a deliberate pick.
+      final candidates = [
+        candidate('CreateInSmartschool',
+            group: 'class-import', isDefault: true, canApply: false),
+        candidate('DoNotImportFromWisa', group: 'class-import'),
+      ];
+      expect(pendingDecisionCount(candidates), 0);
+    });
+
+    test('independent actions still count one each, informational ones zero',
+        () {
+      expect(
+        pendingDecisionCount([
+          candidate('ModifySmartschoolData'),
+          candidate('CreateAzureClassGroup'),
+          candidate('AzureClassGroupMembership', canApply: false),
+        ]),
+        2,
+        reason: 'no alternative keys ⇒ nothing collapses; #245 never counts',
+      );
+    });
+
+    test('a candidate written before #251 reads back as a lone action', () {
+      // Older documents carry no alternative keys at all, which is the pre-#110
+      // shape and correct for every candidate that has no alternative.
+      final restored = CandidateAction.fromJson(<String, dynamic>{
+        'family': 'student',
+        'kind': 'MoveToSmartschoolClassGroup',
+        'system': core.Origin.smartschool.toJson(),
+        'summary': 'Move to class',
+      });
+      expect(restored.alternativeGroup, isNull);
+      expect(restored.isDefaultAlternative, isFalse);
+      expect(pendingDecisionCount([restored]), 1);
+    });
+
+    test('the alternative keys survive a candidate JSON round-trip', () {
+      final original = candidate('UnregisterStudentFromSmartschool',
+          group: 'smartschool-departure', isDefault: true);
+      final restored = CandidateAction.fromJson(original.toJson());
+      expect(restored.alternativeGroup, 'smartschool-departure');
+      expect(restored.isDefaultAlternative, isTrue);
+    });
+
+    test('buildRollups counts the choice once at every level', () {
+      final account = _account(candidates: [
+        candidate('UnregisterStudentFromSmartschool',
+            group: 'smartschool-departure', isDefault: true),
+        candidate('DeleteStudentFromSmartschool',
+            group: 'smartschool-departure'),
+      ]);
+      for (final r in buildRollups([account])) {
+        expect(r.pendingCount, 1, reason: '${r.level} badge');
+      }
+    });
+
+    test(
+        'a departed student materializes as one pending item on every badge, '
+        'carrying both alternatives', () {
+      final view = materialize(departedLinked(), generation: 1);
+
+      final account = view.accounts.single;
+      expect(
+        account.candidates.map((c) => c.kind),
+        containsAll(<String>[
+          'UnregisterStudentFromSmartschool',
+          'DeleteStudentFromSmartschool',
+        ]),
+        reason: 'both readings are still offered — only the count collapses',
+      );
+      expect(
+        account.candidates.map((c) => c.alternativeGroup).toSet(),
+        <String>{smartschoolDepartureAlternative},
+        reason: 'the key the dispatch declares is persisted (#251)',
+      );
+      expect(
+        account.candidates.where((c) => c.isDefaultAlternative),
+        hasLength(1),
+      );
+      expect(account.hasPending, isTrue);
+
+      for (final r in view.rollups) {
+        expect(r.pendingCount, 1, reason: '${r.level} badge counted twice');
+      }
+    });
+  });
+
   group('gradeYearOf', () {
     test('takes the leading digits of the class group', () {
       expect(gradeYearOf('3C'), '3');


### PR DESCRIPTION
Batch chunk C — seven issues, one commit each, each individually green on the full local gates. Follows chunks A (#242) and B (#249).

Every issue here was **filed by a worker during this batch** rather than up front: the Acties view got a lot of attention in chunks A and B, and the workers kept finding things wrong with how it presents and applies work. Two of them are correctness bugs an operator could have been bitten by.

## What changed

**`81c71bf` — #244 a new class was two contradictory to-dos, not a choice**
`GroupAction.alternativeGroup` was hard-coded `null` for the whole family, so a WISA-only class raised "Voeg deze klas toe aan Smartschool" **and** "Negeer deze klas bij het importeren uit WISA" as two independent applyable items — and `_selectedActions` runs every selected choice, so one "Apply to all" created each class and then wrote a `DontImportClass` rule for the same name. All three actions now share a `classImportAlternative` key with the create as the default; dispatch reordered so the create leads the pair. `_ChoiceControl` gained the selected option's field diff, without which collapsing two rows into one would have hidden the name/description/parent the operator is deciding on.

**`9c2f89c` — #248 the same defect in the staff family**
One click provisioned a teacher *and* blacklisted them from future WISA imports. Same shape: a shared `staffImportAlternative`. This one diverged from the group fix deliberately — `AddStaffToSmartschool` also takes the key, because a record that is already WISA + Azure (an account adopted by `employeeId` in #231, or a #240 chain whose Smartschool write failed) raises the identical contradictory pair without ever passing through the WISA-only state. The two creates are separated by the `azure == null` test, so exactly one default is ever offered.

**`cb88b2d` — #234 the apply dialog always said "Smartschool and Azure AD"**
Now derived from the selection: `applyScope` resolves the same options the apply will run and reports one `Origin` per action. Chained follow-ups (#230/#240/#245) are named in a separate sentence — a confirmed Azure create really does go on to write Smartschool, so hiding it would repeat the bug in the other direction — but not *counted*, because the follow-up's own `evaluate` decides at apply time whether it runs. Actions declare this as `unlockedSystems`, pinned in each family's dispatch test against the follow-up's own `ChangeSet.system` so the two cannot drift. WISA opt-outs now read "legt N importregel(s) vast (er wordt niets naar WISA geschreven)", because that family writes no system at all.

**`c8aa5a3` — #243 a modal progress dialog during apply/dry-run**
Driven by a new `ReconcileController.applyStep`, published per action off the same `_selectedActions` list `applyScope` reports on. It is published through its own notification rather than riding `_setProgress`, which ignores any value not greater than the current one and would have dropped the first step of every pass. The dialog counts *planned* actions and surfaces chained writes separately rather than inflating a total the operator was already shown, and it is dismissed in a `finally` so a failed pass cannot strand them. Also made the Acties header bar determinate — the defect the issue named directly.

**`fc3f012` — #235 the Acties tree collapsed every time you came back from a class**
Expansion lived inside the `ExpansionTile`s, which are disposed while a class is open, so the state died with them. Lifted to `ReconcileController.expandedPath` — one node **per depth**, not a single key, because the Personeel tree is school → grade-year → class and a flat key would have collapsed the school out from under the year used to reach it. Also makes the tree a single-open accordion, cleared on re-sync, and pruned when #226's filter changes so a year hidden in between does not come back open.

**`cede5ac` — #236 the overview badges kept their pre-apply counts**
`_rollups` was only ever assigned by `_persist`, which only runs from `_relink()` — so after an apply the drilled-in list (live) and the overview (stored) disagreed until the next sync. Since #226 filters the tree on that same count, a stale count also kept applied-away classes on screen. A real apply now re-derives the rollups from the refreshed `_linked` through the same pure `materialize()`; dry-runs deliberately do not.

Deliberately **local-only, not written back**: `LinkedStore.writeMaterialized` replaces the whole ~9.6k-document view with no narrow per-account seam, and bumping this session's generation would gate out the very `onStoreChanged` that should overrule a local correction. So the session stays *behind* the store, never ahead — pinned by a test asserting the stored generation and rollup are untouched. The shared half (narrow write seam + `ChangeSignal` shard, so other operators stop being offered work already applied) is filed as **#254**.

**`711d706` — #251 a single either/or was counted as two pending items**
`Rollup.pendingCount` counted candidate *actions* while the live list counted *decisions*, and `CandidateAction` did not persist the alternative-group key, so the materialized view could not tell one either/or from two to-dos. Added a family-agnostic `collapseAlternatives` in `account_actions`, persisted the keys on `CandidateAction`, and pointed `buildRollups` and both `hasPending` getters at a new `pendingDecisionCount` — so count and visibility (#226's filter) stay in step, and the sync path and #236's post-apply refresh get the fix from one place.

## Test plan

Every commit was verified individually before landing; the numbers below are the final state of the branch.

- `dart format --set-exit-if-changed .` — clean, 300 files, 0 changed
- `dart analyze --fatal-infos --fatal-warnings` — clean
- `dart test` per package — account_core 82, wisa_api 127, smartschool_api 147, azure_api 110, account_linker 72, account_actions 204, account_state 426, account_store 8 — all pass; skips throughout are the opt-in live tests, deliberately not run
- `flutter test` (account_manager widget) — 359 pass
- `flutter test integration_test/app_launch_test.dart -d windows` — 78 pass, including new e2e cases for #234, #235, #236, #243, #244, #248 and #251
- Each issue's new test was confirmed **failing on unpatched code**.

No live WISA / Smartschool / Azure hosts were contacted.

### Existing tests that changed behaviour — all deliberate

Worth reviewing, since these are assertions that were *right before and are right now*, for different reasons:

- **#235** — three e2e tests (`#221`, `#245`, `#226`) re-opened the grade-year after every return to Overzicht, with comments spelling out the old behaviour ("Closing a classroom rebuilds — and so collapses — the drill-down tree"). Under a persistent accordion that second tap *closes* the year, so they now open it once.
- **#248** — the #240 e2e recorded the buggy staff behaviour verbatim as a three-row result list, with a pointer to #248. It is now the fixed two-row result.
- **#251** — `reconcile_controller_test.dart`'s "departed students sum across the unassigned bucket" asserted `pending: 6` for 3 leavers, with the comment "so the rollup pendingCount is 3 × 2". That comment *is* the bug; it is now `3`, with an added assertion that `applyableCount` agrees.
- **#244/#248** — assertions using exact `find.text` on class and staff summaries now carry the `(keuze)` suffix.

## Follow-ups filed during this chunk

Queued for the next chunk: **#250**, **#252**, **#253**, **#254**, **#255** — joining **#227** (the Klasgroepen inventory tab), **#246** and **#247** from earlier chunks.

Closes #234
Closes #235
Closes #236
Closes #243
Closes #244
Closes #248
Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)
