### PR TITLE
Batch: apply-scope correctness, live settings, and Dutch on the Acties screen (#246 #247 #250 #252 #253 #255)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2245,6 +2245,99 @@ void main() {
   });
 
   testWidgets(
+      'a classroom\'s bulk "Alles toepassen" writes only that classroom, '
+      'leaving the identical situation in another class pending (#252)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation. Three students share one
+    // situation — a stale Office 365 display name — but they are split across
+    // two classes: Sam and Sara in 3C, Tom in 3D.
+    //
+    // This is the layer that sees it. The bulk header is built over *one*
+    // class's entries and counts them, while the pass behind it re-resolved the
+    // situation key against the whole linked view — so the operator drilled
+    // into 3C, read "Alles toepassen (2)", and wrote three accounts including
+    // one in a class they never opened. Only a run that drills into a class,
+    // presses the class's own bulk button, and then comes back out to look at
+    // the other class puts both sides on screen in that order.
+    useTallWindow(tester);
+    final harness = crossClassSituationHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    expect(harness.controller.error, isNull);
+
+    final jaar3 = find.byKey(const ValueKey('rollup-grade-grades|3'));
+    final klas3C = find.byKey(const ValueKey('rollup-class-class|1|3|3C'));
+    final klas3D = find.byKey(const ValueKey('rollup-class-class|1|3|3D'));
+
+    // Two classes, both carrying the same student work: 3C badged 2, 3D 1.
+    await tester.ensureVisible(jaar3);
+    await tester.tap(jaar3);
+    await tester.pumpAndSettle();
+    expect(
+        find.descendant(of: klas3C, matching: find.text('2')), findsOneWidget);
+    expect(
+        find.descendant(of: klas3D, matching: find.text('1')), findsOneWidget);
+
+    // Drill into 3C. Its bulk header counts this class, and only this class.
+    await tester.ensureVisible(klas3C);
+    await tester.tap(klas3C);
+    await tester.pumpAndSettle();
+    expect(harness.controller.selectedClassroom?.classroom, '3C');
+    expect(find.text('Sam Sels'), findsWidgets);
+    expect(find.text('Sara Segers'), findsWidgets);
+    expect(find.text('Tom Tas'), findsNothing,
+        reason: 'the operator is looking at 3C — Tom is not on this page');
+
+    final key = harness.controller.classroomPendingEntries.first.situationKey;
+    final bulk = find.byKey(ValueKey('situation-apply-$key'));
+    await tester.ensureVisible(bulk);
+    expect(
+        find.descendant(of: bulk, matching: find.text('Alles toepassen (2)')),
+        findsOneWidget);
+
+    // The confirmation quotes the same two writes the label counts (#234) —
+    // the mismatch that surfaced this said "3 wijzigingen" here.
+    await tester.tap(bulk);
+    await tester.pumpAndSettle();
+    expect(find.textContaining('2 wijzigingen'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Apply result'), findsWidgets);
+    expect(harness.controller.applyResults, hasLength(2));
+    final patched = harness.graph.requests
+        .where((r) => r.method == 'PATCH')
+        .map((r) => r.url.path)
+        .toList();
+    expect(patched, hasLength(2),
+        reason: 'two accounts written, not every account group-wide');
+    expect(patched.any((p) => p.endsWith(kSam3C)), isTrue);
+    expect(patched.any((p) => p.endsWith(kSara3C)), isTrue);
+    expect(patched.any((p) => p.endsWith(kTom3D)), isFalse,
+        reason: "Tom's class was never opened, so it must not be written");
+
+    // Overzicht: 3C is done and drops out under the work filter, while 3D still
+    // stands there badged 1 — its identical situation is untouched, waiting for
+    // someone to open it.
+    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(jaar3);
+    if (klas3D.evaluate().isEmpty) {
+      await tester.tap(jaar3);
+      await tester.pumpAndSettle();
+    }
+    expect(klas3C, findsNothing, reason: 'the class the operator cleared');
+    expect(
+        find.descendant(of: klas3D, matching: find.text('1')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'a single-group class whose name another school shares raises no class '
       'change, and "00" never reaches a class name end-to-end (#221)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -5053,6 +5053,108 @@ void main() {
   });
 
   testWidgets(
+      "the Acties overview's freshness stamp names the werkdatum the shared "
+      'view was pulled with, and holds it across a settings save (#247)',
+      (WidgetTester tester) async {
+    // #239 put the werkdatum in the Log panel, which is a *session* diagnostic:
+    // it is gone when the app closes, and a passive operator reading the shared
+    // view never saw it at all. The date is a per-pass input the whole
+    // materialized view depends on, so it belongs beside "wie synchroniseerde,
+    // wanneer" — and it has to name the pull, not the setting, because #238
+    // made those two able to disagree. Driven over the *production* WISA pull
+    // and the real Instellingen form, so the date on screen is the one that
+    // really went on the wire.
+    useTallWindow(tester);
+    final stored = AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9, 1)),
+      ),
+    );
+    final live = LiveSettings(stored);
+    final wire = RecordingWisaSoap();
+    final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+    final settings = SettingsHarness(initial: stored, liveSettings: live);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(wire.werkdatums, <String>['01/09/2025']);
+
+    // The overview names the school year it describes, in the wire's own
+    // dd/MM/yyyy, on the same line as the generation and the operator.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining('Generatie 1 · ', skipOffstage: false),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('· werkdatum 01/09/2025', skipOffstage: false),
+      findsOneWidget,
+    );
+
+    // The operator moves the werkdatum in Instellingen and saves. That is the
+    // *next* pull's input; the view on Acties is still the one pulled as of
+    // 01/09/2025 and must keep saying so.
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    final pick = find.byKey(const ValueKey('settings-workdate-pick'));
+    await tester.ensureVisible(pick);
+    await tester.pumpAndSettle();
+    await tester.tap(pick);
+    await tester.pumpAndSettle();
+    await tester.tap(find.descendant(
+      of: find.byType(DatePickerDialog),
+      matching: find.text('15'),
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.descendant(
+      of: find.byType(DatePickerDialog),
+      matching: find.text('OK'),
+    ));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining('· werkdatum 01/09/2025', skipOffstage: false),
+      findsOneWidget,
+      reason: 'the stamp describes the pull, not the pending setting',
+    );
+    expect(
+      find.textContaining('15/09/2025', skipOffstage: false),
+      findsNothing,
+    );
+
+    // Only the Synchroniseer moves it — the same pass that moves the roster.
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(wire.werkdatums, <String>['01/09/2025', '15/09/2025']);
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining('· werkdatum 15/09/2025', skipOffstage: false),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
       'a Check for drift whose stored Azure delta token Graph refuses still '
       'finishes, on a full re-read that leaves a usable token behind, and '
       'reads as the clean pass it was (#213/#229)',

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -41,7 +41,7 @@ import 'package:account_state/account_state.dart'
 import 'package:azure_api/azure_api.dart'
     show AzureCredentials, StaticAuthProvider;
 import 'package:smartschool_api/smartschool_api.dart'
-    show SmartschoolConnector, SmartschoolMethod, SmartschoolSoapTransport;
+    show DiscardSmartschoolGroup, SmartschoolConnector;
 import 'package:wisa_api/wisa_api.dart' show WisaSchool, parseSchoolRow;
 import 'package:flutter/gestures.dart' show PointerDeviceKind, kSecondaryButton;
 import 'package:flutter/material.dart';
@@ -4643,7 +4643,7 @@ void main() {
 
     // …and the next pull really is pruned by them: the production connector,
     // over a scripted SOAP wire, handed nothing but what Settings persisted.
-    final wire = _GroupTreeSoap();
+    final wire = GroupTreeSoap();
     final snapshot = await SmartschoolConnector.fromParts(
       site: 'school',
       accessCode: 'ac',
@@ -4673,7 +4673,7 @@ void main() {
     // (a typo) is named in the panel instead of vanishing.
     useTallWindow(tester);
     final settings = SettingsHarness();
-    final wire = _GroupTreeSoap();
+    final wire = GroupTreeSoap();
     // The next session's reconcile stack, whose Smartschool pull is the
     // production connector over that wire; its rules are picked up from the
     // settings document below, as bootstrapReconcile picks them up on open.
@@ -4832,6 +4832,158 @@ void main() {
           .widget<OutlinedButton>(find.byKey(const ValueKey('reconcile-drift')))
           .onPressed,
       isNotNull,
+    );
+  });
+
+  testWidgets(
+      'marking a school beheerd in Instellingen surfaces its students without '
+      'a relaunch (#246)', (WidgetTester tester) async {
+    // The headline symptom of #246, driven the way the operator lives it: the
+    // Actions drill-down hides a school's students, they tick **beheerd** in
+    // Instellingen, save, and come back. Before #246 the applier's managed-school
+    // set was captured when `bootstrapReconcile` assembled the stack, so the
+    // student stayed in the leaver bucket until the app was relaunched — with
+    // nothing on screen to explain why.
+    useTallWindow(tester);
+    final stored = AppSettings(
+      wisa: const WisaConnection(server: 'wisa.example', port: '9000'),
+      wisaSchools: const <WisaSchoolProfile>[
+        WisaSchoolProfile(
+            schoolId: 1, code: 'S1', name: 'Sint-Jan', ours: true),
+        WisaSchoolProfile(schoolId: 2, code: 'S2', name: 'Sint-Pieter'),
+      ],
+    );
+    final live = LiveSettings(stored);
+    // One student, enrolled in school 2 and fully present in our Smartschool +
+    // Azure. The WISA schools carry no `MarkAsOurs` flag, so who is managed can
+    // only come from the settings document — the #178 wiring, now live.
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(schoolId: 2)],
+        schools: [wisaSchool(1), wisaSchool(2)],
+      ),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: [ssAccount()],
+        memberships: const [],
+      ),
+      azure: azSnap(users: [azUser()]),
+      liveSettings: live,
+    );
+    final settings = SettingsHarness(initial: stored, liveSettings: live);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // School 2 is not ours yet, so its student is re-bucketed as a leaver and
+    // their class is nowhere in the tree.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(find.text('Niet toegewezen'), findsOneWidget);
+    expect(find.text('Jaar 3'), findsNothing);
+
+    // Instellingen → Wisa → tick "beheerd" for Sint-Pieter → Opslaan.
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    final ours = find.byKey(const ValueKey('settings-wisa-school-2-ours'));
+    await tester.ensureVisible(ours);
+    await tester.pumpAndSettle();
+    await tester.tap(ours);
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    expect((await settings.store.load()).managedWisaSchoolIds, const {1, 2});
+
+    // Back on Reconcile, Check for drift is offered: ownership is applied when
+    // the view is relinked, not when WISA is pulled, so the #238 gate — which
+    // guards the WISA pull inputs — must not stand in the way here.
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('reconcile-drift-blocked')), findsNothing);
+    expect(find.byKey(const ValueKey('reconcile-relaunch-required')),
+        findsNothing);
+    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.pumpAndSettle();
+
+    // …and the student is out of the leaver bucket and browsable under their
+    // own class, with no relaunch anywhere in this test.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(find.text('Niet toegewezen'), findsNothing);
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    expect(find.text('3C'), findsWidgets);
+  });
+
+  testWidgets(
+      'a Smartschool import rule saved in Instellingen prunes the very next '
+      'Smartschool pull (#246)', (WidgetTester tester) async {
+    // #241's end-to-end proved the rules work; it had to hand-carry the saved
+    // document into the reconcile harness itself, because the running pull had
+    // closed over the bootstrap one. Nothing is handed over here — the two
+    // bootstraps share one LiveSettings, exactly as `main()` wires them.
+    useTallWindow(tester);
+    final wire = GroupTreeSoap();
+    final live = LiveSettings(const AppSettings());
+    final settings = SettingsHarness(liveSettings: live);
+    final harness =
+        ReconcileHarness(smartschoolTransport: wire, liveSettings: live);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // A first pass, on the rules as they stand: the whole tree comes in.
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(
+      harness.app.smartschool.snapshot?.groups.map((g) => g.id.value).toList(),
+      <String>['SCH', 'ORG', 'HID', 'KLA', 'C1A'],
+    );
+
+    // The operator authors the rule that drops "Organisatie" and saves.
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-smartschool');
+    await addSmartschoolRule(tester, 'discardGroup', 'Organisatie');
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    expect(
+      (await settings.store.load()).smartschoolRules.single,
+      isA<DiscardSmartschoolGroup>(),
+    );
+
+    // Back on Reconcile the operator presses **Check for drift** — the pass
+    // that re-reads Smartschool at all, since #99's smart sync leaves a system
+    // this session already holds alone. It is offered, because an import rule is
+    // not a WISA pull input and so never arms #238's gate…
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('reconcile-drift-blocked')), findsNothing);
+    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.pumpAndSettle();
+
+    // …and the pull it just ran is the pruned one. No hand-off, no relaunch.
+    expect(
+      harness.app.smartschool.snapshot?.groups.map((g) => g.id.value).toList(),
+      <String>['SCH', 'KLA', 'C1A'],
     );
   });
 
@@ -5847,62 +5999,4 @@ class _FakeSignalRSocket implements SignalRSocket {
   void serverSend(String frame) {
     if (!_incoming.isClosed) _incoming.add(frame);
   }
-}
-
-/// A scripted Smartschool SOAP wire for the import-rule end-to-end (#202):
-/// answers `getAllGroupsAndClasses` with a small base64 group tree and reports
-/// "no direct accounts" (code 19) for every group, recording the group codes the
-/// connector asked about so the test can see the pruned ones were never read.
-class _GroupTreeSoap implements SmartschoolSoapTransport {
-  /// The group codes `getAllAccountsExtended` was called for, in walk order.
-  final List<String> accountCodes = <String>[];
-
-  static const String _tree = '<groups>'
-      '<group><name>School</name><type>G</type><code>SCH</code>'
-      '<visible>1</visible><children>'
-      '<group><name>Organisatie</name><type>G</type><code>ORG</code>'
-      '<visible>1</visible><children>'
-      '<group><name>Verborgen</name><type>G</type><code>HID</code>'
-      '<visible>1</visible></group>'
-      '</children></group>'
-      '<group><name>Klassen</name><type>G</type><code>KLA</code>'
-      '<visible>1</visible><children>'
-      '<group><name>1A</name><type>K</type><code>C1A</code>'
-      '<visible>1</visible></group>'
-      '</children></group>'
-      '</children></group></groups>';
-
-  @override
-  Future<String> send({
-    required Uri endpoint,
-    required String soapAction,
-    required String envelope,
-  }) async {
-    // The SOAPAction is `<namespace>#<method>`.
-    final String method = soapAction.split('#').last;
-    if (method == SmartschoolMethod.getAllGroupsAndClasses) {
-      return _wrap(
-        method,
-        base64.encode(utf8.encode(_tree)),
-        'xsd:base64Binary',
-      );
-    }
-    if (method == SmartschoolMethod.getAllAccountsExtended) {
-      accountCodes.add(
-        RegExp(r'<code[^>]*>([^<]*)</code>').firstMatch(envelope)?.group(1) ??
-            '',
-      );
-      return _wrap(method, '19', 'xsd:int'); // Smartschool: no direct accounts.
-    }
-    return _wrap(method, '0', 'xsd:int');
-  }
-
-  String _wrap(String method, String value, String type) =>
-      '<?xml version="1.0" encoding="utf-8"?>'
-      '<soap:Envelope '
-      'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" '
-      'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
-      '<soap:Body><${method}Response>'
-      '<return xsi:type="$type">$value</return>'
-      '</${method}Response></soap:Body></soap:Envelope>';
 }

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1560,6 +1560,133 @@ void main() {
   });
 
   testWidgets(
+      'a class the #225 notice says to fix by hand survives "Alles toepassen" '
+      'untouched end-to-end (#250)', (WidgetTester tester) async {
+    // The real app, real fonts, real navigation, over the real Smartschool
+    // write path. Four WISA classes: `1A`/`1B` are genuinely new, while `2G`
+    // and `2H` already exist in Smartschool on groups that are not flagged as
+    // official classes — the #225 shape, where the app offers no create and
+    // tells the operator to make the group official by hand.
+    //
+    // Refusing the create left "Negeer deze klas bij het importeren uit WISA"
+    // as the *only* member of the create-or-ignore either/or of #244, and a
+    // choice of one is always the selected one. The bulk **Alles toepassen**
+    // therefore wrote a DontImportClass rule on the very classes the notice
+    // beside them had just said to align by hand: they dropped out of the next
+    // WISA snapshot while the Smartschool groups stayed behind, unmanaged.
+    //
+    // This is the layer that sees it. Which half of a choice is pre-selected,
+    // which bulk subset a class lands in, and what the button on that subset
+    // writes are three different halves of the screen, composed by the
+    // dispatch, the entry grouping and the drill-down — only a full run puts
+    // the notice and the button that acts on it on screen together.
+    useTallWindow(tester);
+    final harness = namesakeClassChoiceHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
+    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
+    await tester.pumpAndSettle();
+
+    // Every class is on the list, and each namesake one reads as the hand-fix
+    // notice — the resolution that is pre-selected for it.
+    for (final id in const ['2G', '2H']) {
+      expect(
+        find.descendant(
+          of: find.byKey(ValueKey('entry-group-$id')),
+          matching: find.textContaining(
+              'Deze klas bestaat in Smartschool maar is geen officiële klas'),
+        ),
+        findsOneWidget,
+      );
+    }
+    expect(find.text('Voeg deze klas toe aan Smartschool (keuze)'),
+        findsNWidgets(2),
+        reason: '1A and 1B are the ordinary new-class case');
+    expect(
+        find.text('Negeer deze klas bij het importeren uit WISA'), findsNothing,
+        reason: 'the opt-out is an alternative to pick, never a to-do that '
+            'also runs');
+
+    // The namesake classes form a bulk subset of their own. Pooling them with
+    // the new classes would have filed them under a header offering to create
+    // classes that already exist.
+    final namesakeKey = harness.controller.groupPendingEntries
+        .firstWhere((e) => e.targetId == '2G')
+        .situationKey;
+    final newKey = harness.controller.groupPendingEntries
+        .firstWhere((e) => e.targetId == '1A')
+        .situationKey;
+    expect(namesakeKey, isNot(newKey));
+
+    final namesakeBulk = find.byKey(ValueKey('situation-apply-$namesakeKey'));
+    await tester.ensureVisible(namesakeBulk);
+    expect(
+      find.textContaining('dan wordt ze gekoppeld. / Negeer deze klas bij '
+          'het importeren uit WISA'),
+      findsOneWidget,
+      reason: 'the header names one either/or led by the hand-fix notice',
+    );
+
+    // Run that whole subset. It is not a no-op — each class still needs its
+    // Office 365 group (#228), which is a decision of its own — but nothing it
+    // writes touches the class's import: no Smartschool class is created, and
+    // no DontImportClass rule is written.
+    final pulls = harness.wisaSyncs;
+    await tester.tap(namesakeBulk);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(
+      harness.controller.applyResults!.map((r) => r.changes.summary),
+      isNot(contains('Negeer deze klas bij het importeren uit WISA')),
+      reason: 'the rule would drop the classes the app just said to repair',
+    );
+    expect(harness.soap.soapActions.where((a) => a.endsWith('#saveClass')),
+        isEmpty,
+        reason: 'Smartschool already holds 2G and 2H');
+    // A DontImportClass rule re-pulls WISA, so an untouched pull count is the
+    // proof that none was written.
+    expect(harness.wisaSyncs, pulls);
+
+    // The two classes are still on the list, still asking for the hand repair.
+    for (final id in const ['2G', '2H']) {
+      expect(
+        find.descendant(
+          of: find.byKey(ValueKey('entry-group-$id')),
+          matching: find.textContaining(
+              'Deze klas bestaat in Smartschool maar is geen officiële klas'),
+        ),
+        findsOneWidget,
+      );
+    }
+
+    // And the fix did not simply silence the list: the other subset still
+    // creates the genuinely new classes, and blacklists neither.
+    final newBulk = find.byKey(ValueKey('situation-apply-$newKey'));
+    await tester.ensureVisible(newBulk);
+    await tester.tap(newBulk);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(harness.soap.soapActions.where((a) => a.endsWith('#saveClass')),
+        hasLength(2));
+    expect(
+      harness.controller.applyResults!.map((r) => r.changes.summary),
+      isNot(contains('Negeer deze klas bij het importeren uit WISA')),
+    );
+    expect(harness.wisaSyncs, pulls);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'the Acties badges count one pending item per either/or, so the '
       'Klasgroepen node agrees with the list it opens end-to-end (#251)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -153,6 +153,14 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(ReconcileScreen), findsOneWidget);
     expect(find.text('Not configured'), findsOneWidget);
+
+    // The Acties screen renders the same panel, in the operator's language
+    // (#253): everything the Acties view says is Dutch, including the states
+    // that stand in for it.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(find.byType(ActionsScreen), findsOneWidget);
+    expect(find.text('Niet geconfigureerd'), findsOneWidget);
   });
 
   testWidgets(
@@ -218,7 +226,7 @@ void main() {
     await tester.ensureVisible(find.byKey(const ValueKey('actions-dry-run')));
     await tester.tap(find.byKey(const ValueKey('actions-dry-run')));
     await tester.pumpAndSettle();
-    expect(find.text('Dry-run result'), findsOneWidget);
+    expect(find.text('Resultaat van de dry-run'), findsOneWidget);
     expect(harness.soap.soapActions, isEmpty);
 
     // Apply all: confirm the dialog, the Smartschool write happens for real.
@@ -227,7 +235,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     expect(harness.soap.soapActions, isNotEmpty);
 
     // Back on Reconcile, re-sync with unchanged WISA: the smart diff reports
@@ -410,7 +418,7 @@ void main() {
     gates[1].complete();
     await tester.pumpAndSettle();
     expect(progressDialog, findsNothing);
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     expect(harness.soap.soapActions, isNotEmpty);
     expect(tester.takeException(), isNull);
   });
@@ -446,7 +454,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(progressDialog, findsNothing);
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     expect(
       find.textContaining('Smartschool weigerde de schrijfactie'),
       findsWidgets,
@@ -458,7 +466,7 @@ void main() {
   });
 
   testWidgets(
-      'a completed sync logs a terminal "Sync complete … Ready." line and the '
+      'a completed sync logs a terminal "Sync voltooid … Klaar." line and the '
       'last-sync box renders a row per system end-to-end (#162/#188)',
       (WidgetTester tester) async {
     // The real app composition over the offline harness, driven the way the
@@ -485,7 +493,7 @@ void main() {
     // The terminal ready line is logged (newest-first in the log panel) so the
     // operator knows the pass finished, and it names the pending-action count.
     expect(
-      find.textContaining('Sync complete — 4 pending action(s). Ready.'),
+      find.textContaining('Sync voltooid — 4 openstaande actie(s). Klaar.'),
       findsOneWidget,
     );
     // The last-sync freshness now renders as a dedicated box headed "Last sync"
@@ -506,7 +514,8 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
     expect(
-      find.textContaining('Sync complete — no account changes needed. Ready.'),
+      find.textContaining(
+          'Sync voltooid — geen accountwijzigingen nodig. Klaar.'),
       findsOneWidget,
     );
   });
@@ -706,7 +715,7 @@ void main() {
     expect(
         find.byKey(const ValueKey('reconcile-last-sync-wisa')), findsOneWidget);
     expect(find.textContaining('by yvan@school.example'), findsWidgets);
-    // …and the terminal "Sync complete" line names them too (#169).
+    // …and the terminal "Sync voltooid" line names them too (#169).
     expect(
       find.textContaining('Operator: yvan@school.example'),
       findsOneWidget,
@@ -823,7 +832,7 @@ void main() {
       harness.log.entries.where((e) => e.isError).map((e) => e.message),
       isEmpty,
     );
-    expect(find.textContaining('Sync complete'), findsOneWidget);
+    expect(find.textContaining('Sync voltooid'), findsOneWidget);
 
     // Throttling was reported as progress, not silence (#196.5).
     expect(
@@ -981,7 +990,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     expect(harness.soap.soapActions, isNotEmpty);
     final summaries =
         harness.controller.applyResults!.map((r) => r.changes.summary);
@@ -1047,7 +1056,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     expect(harness.soap.soapActions, isNotEmpty);
     expect(harness.graph.requests, isEmpty, reason: 'Azure account is kept');
     final summaries =
@@ -1385,6 +1394,13 @@ void main() {
     expect(find.text('Kies één oplossing:'), findsOneWidget);
     expect(find.text('Negeer deze klas bij het importeren uit WISA'),
         findsOneWidget);
+    // The pre-selected notice writes nothing, and the detail under the radios
+    // says so in Dutch (#253) — it used to read "(manual — not applied
+    // automatically)" on an otherwise Dutch screen.
+    expect(
+      find.textContaining('(manueel — wordt niet automatisch toegepast)'),
+      findsOneWidget,
+    );
     expect(
       tester
           .widget<FilledButton>(find.byKey(const ValueKey('entry-apply-1A')))
@@ -1860,7 +1876,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
 
     // Graph was asked for exactly one group, and for the right kind of group.
     expect(harness.graph.createdGroups, hasLength(1));
@@ -2410,7 +2426,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
-    expect(find.text('Apply result'), findsWidgets);
+    expect(find.text('Resultaat van het toepassen'), findsWidgets);
     expect(harness.controller.classroomPendingEntries, isEmpty,
         reason: 'the live list drops the work immediately — it always did');
 
@@ -2495,6 +2511,10 @@ void main() {
     final key = harness.controller.classroomPendingEntries.first.situationKey;
     final bulk = find.byKey(ValueKey('situation-apply-$key'));
     await tester.ensureVisible(bulk);
+    // The header line the count sits on is Dutch, like the rest of the screen
+    // (#253) — the operator-facing language everywhere in this app.
+    expect(
+        find.textContaining('2 accounts in dezelfde situatie'), findsOneWidget);
     expect(
         find.descendant(of: bulk, matching: find.text('Alles toepassen (2)')),
         findsOneWidget);
@@ -2507,7 +2527,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
-    expect(find.text('Apply result'), findsWidgets);
+    expect(find.text('Resultaat van het toepassen'), findsWidgets);
     expect(harness.controller.applyResults, hasLength(2));
     final patched = harness.graph.requests
         .where((r) => r.method == 'PATCH')
@@ -3644,7 +3664,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     final queued = await harness.passwordQueue.load();
     expect(queued, hasLength(1),
         reason: 'the created account\'s password landed in the queue');
@@ -5268,7 +5288,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
 
     // One PATCH, touching `department` only, with our prefix at the head and
     // the subject the other school wrote still on it.
@@ -5378,7 +5398,7 @@ void main() {
     // And confirming really does write only there: one Graph PATCH, no SOAP.
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     expect(
       harness.graph.requests.where((r) => r.method == 'PATCH'),
       hasLength(1),
@@ -5477,7 +5497,7 @@ void main() {
 
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
 
     // Both accounts exist now, off that single click, and both writes are
     // reported — the second is a real write the operator must see, not a
@@ -5589,7 +5609,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
 
     // Both accounts exist now, off that single click, and both writes are
     // reported — the second is a real write the operator must see, not a silent

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2009,6 +2009,78 @@ void main() {
   });
 
   testWidgets(
+      'a passive session marks the same informational candidate "(manueel)" on '
+      'the account card end-to-end (#255)', (WidgetTester tester) async {
+    // The same #245 fixture, read the way most operators meet it: session 1
+    // syncs and materializes the shared view, session 2 is the real app over
+    // those stores and never syncs, so Acties renders stored documents as static
+    // cards (#214) instead of interactive tiles.
+    //
+    // This is the layer that sees the bug. The two renderings are different
+    // widgets fed by different pipelines — the interactive tile reads live
+    // `PendingChoice`s, the passive card reads `CandidateAction`s round-tripped
+    // through the store's JSON — and only a full-app run puts an operator in
+    // front of the passive one. There Sam's line used to read as ordinary due
+    // work beside a badge counting it 0, with no way to tell "the app will do
+    // this" from "you must do this by hand".
+    useTallWindow(tester);
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await azureClassMembershipHarness(
+      store: snapshots,
+      linkedStore: linkedStore,
+    ).controller.sync();
+
+    final resumed = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: resumed.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+
+    // Nothing applyable hangs off the students, so the work list hides their
+    // classes until the inventory toggle is flipped (#226) — exactly the state
+    // in which the unmarked line was most misleading.
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+
+    final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
+    await tester.ensureVisible(yearNode);
+    await tester.tap(yearNode);
+    await tester.pumpAndSettle();
+    final klas1B = find.byKey(const ValueKey('rollup-class-class|1|1|1B'));
+    await tester.ensureVisible(klas1B);
+    await tester.tap(klas1B);
+    await tester.pumpAndSettle();
+
+    // The card is the passive one — locked, no interactive entry tile — and
+    // Sam's one line now says the operator has to fix this by hand.
+    expect(resumed.controller.linked, isNull,
+        reason: 'link() is never called in a passive session');
+    expect(find.byKey(const ValueKey('actions-read-only')), findsOneWidget);
+    expect(find.text('Sam Sels'), findsOneWidget);
+    expect(
+      find.textContaining('Zit in de verkeerde Office 365-klasgroep: GBS-1A '
+          'in plaats van GBS-1B'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('(manueel)'), findsOneWidget,
+        reason: 'the class row performs the write, so this card diagnoses');
+    expect(resumed.wisaSyncs, 0);
+    expect(resumed.ssSyncs, 0);
+    expect(resumed.azSyncs, 0);
+  });
+
+  testWidgets(
       'the Acties drill-down opens on grade-years merged across the managed '
       'schools end-to-end, with no school level to guess at (#210)',
       (WidgetTester tester) async {

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -97,13 +97,20 @@ class ReconcileServices {
   });
 
   /// The settings document as it stood when the stack was assembled. A
-  /// point-in-time copy: what the WISA pull actually uses lives in
-  /// [liveSettings] (#238).
+  /// point-in-time copy, kept only for what genuinely froze with it — the
+  /// connection profiles the three connectors were constructed from. Everything
+  /// the running stack acts on is read from [liveSettings] instead (#238/#246).
   final AppSettings settings;
 
-  /// The shared settings holder the WISA syncer reads at pull time and the
-  /// Settings view publishes into, so a saved werkdatum reaches the next
-  /// Synchroniseer without relaunching the app (#238).
+  /// The shared settings holder every settings-derived value in this stack is
+  /// read from, and the Settings view publishes into on every load and save.
+  ///
+  /// #238 wired the WISA pull inputs (werkdatum, virtuele werkdatum, virtual
+  /// marks) through it; #246 the rest — the managed-school set, the school
+  /// prefix, the Azure domain, the Smartschool class tree and import rules, and
+  /// the curated school profiles. So a save reaches the next pass rather than
+  /// the next launch. What it cannot reach is the connectors' own endpoints and
+  /// credential refs; `ReconcileController.relaunchRequiredReason` says so.
   final LiveSettings liveSettings;
 
   final ApplicationState app;
@@ -152,10 +159,20 @@ class ReconcileConfigException implements Exception {
 /// `ApplicationState` → `StateApplier` → [ReconcileController].
 ///
 /// [liveSettings] is the process-wide settings holder the Settings view
-/// publishes into (#238). The WISA pull reads its werkdatum pair and virtual
-/// marks from it at pull time, so a save reaches the next Synchroniseer without
-/// a relaunch. Production wires the same instance into [bootstrapSettings];
-/// omitting it gives this stack a private holder that only bootstrap writes.
+/// publishes into (#238). Everything this stack derives from the settings
+/// document is read back from it **at use time** rather than captured here —
+/// the WISA pull's werkdatum pair and virtual marks (#238), and the
+/// managed-school set, school prefix, Azure domain, Smartschool class tree and
+/// import rules, and curated school profiles (#246) — so a save reaches the next
+/// pass instead of the next launch. Production wires the same instance into
+/// [bootstrapSettings]; omitting it gives this stack a private holder that only
+/// bootstrap writes.
+///
+/// The one residue is the connection profiles: the WISA server/port/database/
+/// login, the Smartschool site, and the two secret refs are resolved here, once,
+/// into live connections and Key Vault reads. Changing one needs a relaunch, and
+/// `ReconcileController.relaunchRequiredReason` puts that on screen rather than
+/// letting the session quietly keep talking to the previous endpoints.
 ///
 /// The optional parameters are test seams; production callers pass only
 /// [session], [aad] and [liveSettings]. The Cosmos containers are provisioned
@@ -323,14 +340,21 @@ Future<ReconcileServices> bootstrapReconcile({
 
   // Per-school values prefer the persisted settings and fall back to the
   // dart-define sign-in config, so a not-yet-filled settings row still runs.
-  final schoolPrefix = _firstNonEmpty(settings.schoolPrefix, aad.schoolPrefix);
-  final azureDomain = _firstNonEmpty(settings.azure.domain, aad.azureDomain);
+  // Both are read from the **live** document at every use (#246): the operator
+  // can change either in Instellingen, and before #246 the value captured here
+  // was the only one the session ever saw. The credentials below still carry the
+  // bootstrap-time prefix, but only as the connector's default — every pull
+  // passes the current one explicitly.
+  String schoolPrefixNow() =>
+      _firstNonEmpty(live.current.schoolPrefix, aad.schoolPrefix);
+  String azureDomainNow() =>
+      _firstNonEmpty(live.current.azure.domain, aad.azureDomain);
   final azConnector = az.AzureConnector(
     credentials: az.AzureCredentials(
       clientId: aad.clientId,
       tenantId: aad.tenantId,
-      azureDomain: azureDomain,
-      schoolPrefix: schoolPrefix,
+      azureDomain: azureDomainNow(),
+      schoolPrefix: schoolPrefixNow(),
     ),
     authProvider: GraphSessionAuthProvider(session, aad.graph),
     log: logBuffer,
@@ -365,8 +389,12 @@ Future<ReconcileServices> bootstrapReconcile({
   // (#178) and by the Azure back-fill below (#224) so both scope to the same
   // schools. Null when no school is flagged, so a not-yet-configured group
   // falls back to the snapshot's own `MarkAsOurs` flags.
-  final Set<int>? ourSchoolIds =
-      settings.wisaSchools.isEmpty ? null : settings.managedWisaSchoolIds;
+  //
+  // Read from the live document at every use (#246) — flipping a school's
+  // **beheerd** mark in Instellingen must reach the next relink, not the next
+  // launch. Both readers below call this, so the linker and the Azure back-fill
+  // can never end up scoping to different school sets.
+  Set<int>? ourSchoolIdsNow() => managedSchoolIdsOf(live.current);
 
   // Assigned immediately below; the Azure syncer closes over it so it can read
   // the WISA snapshot *this* pass just pulled (WISA always syncs first).
@@ -402,7 +430,14 @@ Future<ReconcileServices> bootstrapReconcile({
         syncedBy: syncedBy,
         payloadOf: (s) => s.toJson(),
         onError: (e) => logSnapshotIssue(core.Origin.smartschool, e),
-        inner: (_) => ssConnector.sync(rules: settings.smartschoolRules),
+        // The operator's import rules, read from the live document at pull time
+        // (#241 authored them, #246 unfroze them): authoring a
+        // `DiscardSmartschoolGroup` in Instellingen reaches the very next
+        // Smartschool pull rather than the next launch. Which pass that is stays
+        // the smart-sync contract — Synchroniseer leaves a system this session
+        // already holds alone, so it is **Check for drift** that adopts a rule
+        // change (filed as #259).
+        inner: (_) => ssConnector.sync(rules: live.current.smartschoolRules),
       ),
     ),
     azure: SystemState<az.AzureSnapshot>(
@@ -427,10 +462,16 @@ Future<ReconcileServices> bootstrapReconcile({
           expectedEmployeeIds: () => <String>{
             ...managedStudentEmployeeIds(
               app.wisa.snapshot,
-              ourSchoolIds: ourSchoolIds,
+              ourSchoolIds: ourSchoolIdsNow(),
             ),
             ...managedStaffEmployeeIds(app.wisa.snapshot),
           },
+          // The prefix scopes the whole Azure pull, and it is operator-editable
+          // (#246). Changing it makes this pass re-read in full rather than
+          // layering the new school's changes over the old school's users. As
+          // with the Smartschool rules, the pass that re-reads Azure at all is
+          // Check for drift (#259).
+          schoolPrefix: schoolPrefixNow,
         ),
       ),
     ),
@@ -444,22 +485,29 @@ Future<ReconcileServices> bootstrapReconcile({
     ),
     resolver: CosmosPersonIdResolver(client: client),
     wisaRules: wisaRules,
-    studentConfig: actions.StudentActionConfig(
-      schoolPrefix: schoolPrefix,
-      azureDomain: azureDomain,
-    ),
-    staffConfig: actions.StaffActionConfig(
-      schoolPrefix: schoolPrefix,
-      azureDomain: azureDomain,
-    ),
-    classTree: classTreeFrom(settings.smartschool),
     passwordQueue: passwordQueue,
-    // Wire the operator's managed-school choice into the linker (#178): the
-    // `ours`-flagged WISA schools from Settings drive `wisaPresence`, so the
-    // Actions view only surfaces schools we manage. Null when no school is
-    // flagged, so a not-yet-configured group falls back to the snapshot's
-    // `MarkAsOurs` flags rather than treating an empty managed set as "none".
-    ourSchoolIds: ourSchoolIds,
+    // Every settings-derived input the applier needs, sampled from the live
+    // document on each link and each apply (#246). Before this the four values
+    // were captured here once, so the school prefix, the Azure domain, the
+    // Smartschool class tree and the managed-school set — the last of which
+    // drives which schools the Actions view surfaces at all (#178) — were
+    // relaunch-only.
+    settings: () {
+      final prefix = schoolPrefixNow();
+      final domain = azureDomainNow();
+      return ApplierSettings(
+        studentConfig: actions.StudentActionConfig(
+          schoolPrefix: prefix,
+          azureDomain: domain,
+        ),
+        staffConfig: actions.StaffActionConfig(
+          schoolPrefix: prefix,
+          azureDomain: domain,
+        ),
+        classTree: classTreeFrom(live.current.smartschool),
+        ourSchoolIds: ourSchoolIdsNow(),
+      );
+    },
   );
 
   // The live SignalR subscriber (#124): on every (re)connect it re-reads the
@@ -519,6 +567,19 @@ Future<ReconcileServices> bootstrapReconcile({
     ),
   );
 }
+
+/// The WISA school ids the operator manages, as the linker and the Azure
+/// back-fill both want them: the `ours`-flagged ids of [settings], or `null`
+/// when the operator has curated no school at all.
+///
+/// The null is load-bearing and is why this is a named function rather than an
+/// inline read (#178/#246). An **empty set** means "ownership is configured and
+/// nothing is ours"; `null` means "not configured", which makes `link()` and
+/// [PlacementResolver] fall back to the snapshot's own `MarkAsOurs` flags. A
+/// group that has never filled the WISA-scholen grid in must get the second, not
+/// the first.
+Set<int>? managedSchoolIdsOf(AppSettings settings) =>
+    settings.wisaSchools.isEmpty ? null : settings.managedWisaSchoolIds;
 
 /// The Smartschool class-tree live-config, derived from the persisted
 /// connection profile: the year or grade group codes (whichever the school

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -133,7 +133,7 @@ class PendingActionOption {
 /// dialog (#234).
 ///
 /// Built by [ReconcileController.applyScope] from the **selected**, applyable
-/// option of each choice — exactly the actions `applyAll` / `applySituation` /
+/// option of each choice — exactly the actions `applyAll` / `applyEntries` /
 /// `applyEntry` would run — so the dialog names the systems the pass genuinely
 /// reaches instead of the hard-coded "Smartschool and Azure AD" it used to
 /// claim for every action.
@@ -1315,7 +1315,11 @@ class ReconcileController extends ChangeNotifier {
 
   /// What a confirmed apply of [entries] would actually write (#234) — the
   /// systems the apply-confirmation dialog names, derived from the very options
-  /// [applyAll] / [applySituation] / [applyEntry] would run.
+  /// [applyAll] / [applyEntries] / [applyEntry] would run.
+  ///
+  /// Pass the confirmation dialog the *same* list the pass will run over
+  /// (#252): the dialog and the write agreeing is the whole point of building
+  /// both from one resolution.
   ///
   /// Two halves, because they are not the same claim. [ApplyScope.systems] is
   /// what the selected actions write themselves, one entry per action.
@@ -1620,29 +1624,34 @@ class ReconcileController extends ChangeNotifier {
 
   /// Dry-runs one entry's chosen resolution (#110): the per-row preview.
   Future<void> dryRunEntry(PendingAccountEntry entry) =>
-      _run(_selectedActions([entry]), dry: true);
+      dryRunEntries(<PendingAccountEntry>[entry]);
 
   /// Applies one entry's chosen resolution (#110): the per-row apply.
   Future<void> applyEntry(PendingAccountEntry entry) =>
-      _run(_selectedActions([entry]), dry: false);
+      applyEntries(<PendingAccountEntry>[entry]);
 
-  /// Applies the chosen resolution to every entry in the same situation (#110):
-  /// "apply this resolution to all departed students". Each entry keeps its own
-  /// chosen alternative. [situationKey] matches [PendingAccountEntry.situationKey].
-  Future<void> applySituation(String situationKey) => _run(
-        _selectedActions(
-          pendingEntries.where((e) => e.situationKey == situationKey),
-        ),
-        dry: false,
-      );
+  /// Applies the chosen resolution of every entry in [entries] (#110) — the
+  /// bulk "apply this resolution to all of these" pass. Each entry keeps its
+  /// own chosen alternative, so a subset of departed students can be
+  /// unregistered while another is deleted.
+  ///
+  /// It takes the entries themselves rather than a `situationKey` to resolve
+  /// back through [pendingEntries], and that is the whole of #252. The bulk
+  /// header this runs for is rendered over a **scoped** list — the open
+  /// classroom's entries, or the group drill-down's, minus whatever the search
+  /// box filters out — while re-resolving a key against [pendingEntries] means
+  /// every entry in the entire linked view, across every class. A button
+  /// labelled "Alles toepassen (1)" therefore wrote every account group-wide
+  /// that happened to share the situation, none of which the operator had seen.
+  /// Passing the very list the header counted makes that mismatch structurally
+  /// impossible: label, confirmation scope ([applyScope]) and write are one
+  /// list.
+  Future<void> applyEntries(Iterable<PendingAccountEntry> entries) =>
+      _run(_selectedActions(entries), dry: false);
 
-  /// Dry-runs every entry in the same situation (#110).
-  Future<void> dryRunSituation(String situationKey) => _run(
-        _selectedActions(
-          pendingEntries.where((e) => e.situationKey == situationKey),
-        ),
-        dry: true,
-      );
+  /// Dry-runs [entries]' chosen resolutions — [applyEntries] with no writes.
+  Future<void> dryRunEntries(Iterable<PendingAccountEntry> entries) =>
+      _run(_selectedActions(entries), dry: true);
 
   /// Runs [selected] — the pre-resolved, applyable options — through the apply
   /// path (dry or real). Shared by the global, per-entry, and per-situation

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -359,19 +359,26 @@ class ReconcileController extends ChangeNotifier {
     required this.log,
     required this.store,
     this.syncedBy = '',
-    this.schoolProfiles = const <WisaSchoolProfile>[],
+    List<WisaSchoolProfile> schoolProfiles = const <WisaSchoolProfile>[],
     this.settingsStore,
     this.liveSettings,
     this.publisher,
     this.subscriber,
     this.persistTimeout = const Duration(minutes: 10),
     DateTime Function()? clock,
-  }) : _now = clock ?? DateTime.now {
+  })  : _bootstrapSchoolProfiles = schoolProfiles,
+        _now = clock ?? DateTime.now {
     final sub = subscriber;
     if (sub != null) _signalSub = sub.signals.listen(_onSignal);
     // The snapshot this session starts with — seeded from the cold store, or
     // pulled later — belongs to the settings as they stand right now (#238).
     _wisaPullFingerprint = _wisaFingerprint();
+    // The endpoints and credential refs the connectors in hand were built from
+    // (#246). Unlike everything else, a later change to these cannot be adopted
+    // — see [relaunchRequiredReason].
+    final live = liveSettings;
+    _bootstrapConnection =
+        live == null ? null : connectionFingerprint(live.current);
     // A save the operator makes in Instellingen must repaint this screen: it is
     // kept alive across tab switches, so nothing else would tell it the WISA
     // pull inputs moved.
@@ -395,6 +402,15 @@ class ReconcileController extends ChangeNotifier {
   /// The operator (UPN) whose session writes the materialized view.
   final String syncedBy;
 
+  /// The profiles bootstrap was assembled with — the fallback for a session
+  /// that models no live settings document at all.
+  final List<WisaSchoolProfile> _bootstrapSchoolProfiles;
+
+  /// The [connectionFingerprint] of the document the connectors were built
+  /// from, or null when no [liveSettings] is wired (which leaves
+  /// [relaunchRequiredReason] permanently silent).
+  late final String? _bootstrapConnection;
+
   /// The operator-curated WISA schools from the settings document
   /// (AppSettings.wisaSchools), each carrying the school's short code and long
   /// name. They are what [_schoolLabels] names a school with, so the Actions
@@ -402,7 +418,12 @@ class ReconcileController extends ChangeNotifier {
   /// session that has not pulled WISA yet (#204). Empty until an operator has
   /// filled the WISA-scholen grid in, which is when the label falls back to the
   /// snapshot and finally to `School <id>`.
-  final List<WisaSchoolProfile> schoolProfiles;
+  ///
+  /// Read from [liveSettings] when one is wired (#246), so renaming a school —
+  /// or adding one — in Instellingen re-labels the drill-down on the next
+  /// materialize instead of on the next launch.
+  List<WisaSchoolProfile> get schoolProfiles =>
+      liveSettings?.current.wisaSchools ?? _bootstrapSchoolProfiles;
 
   /// Where [schoolProfiles] is persisted, so a WISA pull can repair the stored
   /// profiles from the school list it just loaded (#207).
@@ -1055,6 +1076,34 @@ class ReconcileController extends ChangeNotifier {
   /// this session's roster was pulled (#238).
   bool get canCheckDrift =>
       !busy && !syncLockedByOther && driftBlockedReason == null;
+
+  /// Why this session must be relaunched before it can honour the settings as
+  /// they now stand, or `null` when it can honour all of them (#246).
+  ///
+  /// #246 made every *derived* settings value live — the managed-school set, the
+  /// school prefix, the Azure domain, the Smartschool class tree and import
+  /// rules all reach the next pass. The connection profiles cannot follow: a
+  /// WISA host/port/database/login is bound into an open SQL connection, a
+  /// Smartschool site into a SOAP endpoint, and either password ref into a Key
+  /// Vault secret bootstrap resolved once, asynchronously, before any of this
+  /// existed. Rebuilding the connectors under a running pass is not something
+  /// this layer can do safely.
+  ///
+  /// So the session keeps talking to the endpoints it was built with, and says
+  /// so. Nothing is refused — the operator may well have edited a profile they
+  /// are not using this session, and stranding them behind a hard block would be
+  /// worse than a plain statement of fact. That statement is the point: silently
+  /// syncing the *previous* WISA server while Instellingen shows a new one is
+  /// exactly the class of lie #238 set out to end.
+  String? get relaunchRequiredReason {
+    final live = liveSettings;
+    final at = _bootstrapConnection;
+    if (live == null || at == null) return null;
+    return connectionFingerprint(live.current) == at
+        ? null
+        : 'Verbindingsinstellingen gewijzigd — deze sessie blijft de vorige '
+            'gebruiken tot de app herstart wordt.';
+  }
 
   /// Records that the WISA snapshot now in hand was pulled with [fingerprint] —
   /// the live settings as they stood when the pull *started*, so a save landing
@@ -2017,7 +2066,15 @@ class ReconcileController extends ChangeNotifier {
           if (repaired[i] != stored.wisaSchools[i]) repaired[i].schoolId,
       ];
       if (healed.isEmpty) return;
-      await store.save(stored.copyWith(wisaSchools: repaired));
+      final saved = stored.copyWith(wisaSchools: repaired);
+      await store.save(saved);
+      // Publish what we just wrote (#246). [schoolProfiles] now reads the live
+      // document, and this pass has both repaired the stored profiles *and*
+      // possibly picked up another operator's save in the re-read above — so
+      // without this the holder would keep serving the pre-repair names for the
+      // rest of the session, and the Settings view would show one thing while
+      // the drill-down labelled another.
+      liveSettings?.publish(saved);
       log.addMessage(
         core.Origin.wisa,
         'Updated the name and code of ${healed.length} WISA school(s) in the '

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -2102,9 +2102,19 @@ class ReconcileController extends ChangeNotifier {
 
   /// Stamps [snapshot]'s fetch time against [system] for this pass, folded into
   /// the shared store's per-system freshness on persist (#108).
+  ///
+  /// A WISA pull also stamps the **werkdatum** it asked for (#247), taken off
+  /// the snapshot the connector built rather than re-resolved here: with
+  /// `isNow: true` the date is resolved inside the pull, so asking the live
+  /// settings a second time could answer for a different day (a pass running
+  /// across midnight) or for a document saved while the pull was in flight.
+  /// The one place that resolved it is the only place that can say what it was.
   void _recordPull(core.Origin system, core.Snapshot snapshot) {
-    _pulled[system] =
-        SystemSyncMeta(syncedBy: syncedBy, at: snapshot.fetchedAt);
+    _pulled[system] = SystemSyncMeta(
+      syncedBy: syncedBy,
+      at: snapshot.fetchedAt,
+      workDate: snapshot is wapi.WisaSnapshot ? snapshot.workDate : null,
+    );
   }
 
   /// Stamps the smart-sync "WISA unchanged" path: nothing was re-linked, so the

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -1427,8 +1427,9 @@ class ReconcileController extends ChangeNotifier {
     // operator degrades gracefully (nothing appended, no dangling "by ").
     final by = syncedBy.isEmpty ? '' : ' Operator: $syncedBy.';
     final message = _noChangesNeeded
-        ? 'Sync complete — no account changes needed. Ready.$by'
-        : 'Sync complete — ${pendingActions.length} pending action(s). Ready.$by';
+        ? 'Sync voltooid — geen accountwijzigingen nodig. Klaar.$by'
+        : 'Sync voltooid — ${pendingActions.length} openstaande actie(s). '
+            'Klaar.$by';
     log.addMessage(core.Origin.all, message);
   }
 
@@ -1494,7 +1495,7 @@ class ReconcileController extends ChangeNotifier {
       if (_phase == ReconcilePhase.idle) _phase = ReconcilePhase.ready;
       notifyListeners();
     } on Object catch (e) {
-      log.addError(core.Origin.all, 'Could not load the overview: $e');
+      log.addError(core.Origin.all, 'Kon het overzicht niet laden: $e');
     }
   }
 
@@ -1522,7 +1523,8 @@ class ReconcileController extends ChangeNotifier {
     try {
       await _refetchFromStore();
     } on Object catch (e) {
-      log.addError(core.Origin.all, 'Could not catch up after reconnect: $e');
+      log.addError(
+          core.Origin.all, 'Kon niet bijwerken na het herverbinden: $e');
     }
   }
 
@@ -1542,14 +1544,14 @@ class ReconcileController extends ChangeNotifier {
           classroom: open.classroom,
         );
       } on Object catch (e) {
-        log.addError(core.Origin.all, 'Could not refresh ${open.label}: $e');
+        log.addError(core.Origin.all, 'Kon ${open.label} niet vernieuwen: $e');
       }
     }
     if (_showingGroups) {
       try {
         _groupDocs = await store.readGroups();
       } on Object catch (e) {
-        log.addError(core.Origin.all, 'Could not refresh the class groups: $e');
+        log.addError(core.Origin.all, 'Kon de klasgroepen niet vernieuwen: $e');
       }
     }
     notifyListeners();
@@ -1568,7 +1570,7 @@ class ReconcileController extends ChangeNotifier {
         classroom: classroom.classroom,
       );
     } on Object catch (e) {
-      log.addError(core.Origin.all, 'Could not open ${classroom.label}: $e');
+      log.addError(core.Origin.all, 'Kon ${classroom.label} niet openen: $e');
       _classroomAccounts = const [];
     } finally {
       _loadingClassroom = false;
@@ -1596,7 +1598,7 @@ class ReconcileController extends ChangeNotifier {
     try {
       _groupDocs = await store.readGroups();
     } on Object catch (e) {
-      log.addError(core.Origin.all, 'Could not open the class groups: $e');
+      log.addError(core.Origin.all, 'Kon de klasgroepen niet openen: $e');
       _groupDocs = const [];
     } finally {
       _loadingGroups = false;
@@ -1881,7 +1883,9 @@ class ReconcileController extends ChangeNotifier {
       // A correction that fails must not turn a successful apply into a failed
       // pass; the counts then simply stay as stale as they were before.
       log.addError(
-          core.Origin.all, 'Could not refresh the overview counts: $e');
+          core.Origin.all,
+          'Kon de tellingen in het overzicht niet '
+          'vernieuwen: $e');
     }
   }
 

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -13,6 +13,9 @@ import 'package:account_state/account_state.dart'
         pendingDecisionCount;
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
+// The `Werkdatum` SOAP parameter's own formatter, so the overview names the
+// date exactly as it went on the wire and as the Log panel reports it (#247).
+import 'package:wisa_api/wisa_api.dart' as wapi show formatWerkdatum;
 
 import '../format/timestamps.dart';
 import '../reconcile/reconcile_bootstrap.dart';
@@ -1457,6 +1460,18 @@ class _DrillDownSection extends StatelessWidget {
     );
   }
 
+  /// The one-line freshness stamp above the tree: which generation of the
+  /// shared view this is, when it was materialized, by whom — and, since #247,
+  /// the werkdatum the WISA roster underneath it was pulled with.
+  ///
+  /// That last part is not a restatement of the timestamp. WISA answers *as
+  /// of* a date, so "gisteren 09:14 door jan" says when the pass ran, never
+  /// which school year it describes; a pass run on the wrong side of the
+  /// rollover reads on Acties exactly like a class that went missing (#239).
+  /// It comes off the shared per-system stamp rather than the operator's own
+  /// Instellingen, so it names the date this *stored view* was pulled with even
+  /// when the setting has since moved on (#238) — and a passive session that
+  /// never ran the pass reads the same line.
   String? _freshness() {
     final state = controller.syncState;
     if (state.generation == 0) return null;
@@ -1467,7 +1482,14 @@ class _DrillDownSection extends StatelessWidget {
     final who = state.updatedBy == null || state.updatedBy!.isEmpty
         ? ''
         : ' door ${state.updatedBy}';
-    return 'Generatie ${state.generation}$when$who';
+    // Rendered with the connector's own formatter, so it reads exactly as the
+    // `Werkdatum` SOAP parameter went out and as the Log panel's pull line
+    // names it. Absent on a view synced before #247 recorded it.
+    final workDate = state.systems[core.Origin.wisa]?.workDate;
+    final asOf = workDate == null
+        ? ''
+        : ' · werkdatum ${wapi.formatWerkdatum(workDate)}';
+    return 'Generatie ${state.generation}$when$who$asOf';
   }
 
   @override

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -1754,16 +1754,16 @@ class _AccountTile extends StatelessWidget {
               padding: const EdgeInsets.only(top: PlinkSpacing.s1),
               child: Text(w, style: text.bodySmall),
             ),
-          // One line per *decision* (#251): a departed student's unregister /
-          // delete pair is one either/or, so it reads as the single choice the
-          // interactive tile shows — never as two bullets that both look due.
+          // One line per *decision* (#251), worded exactly as the interactive
+          // tile words it: a departed student's unregister / delete pair is one
+          // either/or, so it reads as the single choice the interactive tile
+          // shows — never as two bullets that both look due — and an
+          // informational candidate is marked "(manueel)" (#255).
           for (final c in candidateChoices(account.candidates))
             Padding(
               padding: const EdgeInsets.only(top: PlinkSpacing.s1),
               child: Text(
-                c.isChoice
-                    ? '• ${c.selected.summary} (keuze)'
-                    : '• ${c.selected.summary}',
+                _readOnlyCandidateLine(c),
                 style: text.bodySmall?.copyWith(color: muted),
               ),
             ),
@@ -1790,10 +1790,15 @@ class _ReadOnlyLock extends StatelessWidget {
       );
 }
 
-/// One read-only candidate line of a passive-session group tile, worded exactly
-/// as the interactive [_PendingEntryTile]'s: an either/or reads as one "(keuze)"
-/// on its pre-selected half (#251), an informational notice keeps its
-/// "(manueel)" marker (#225), and an ordinary action is its bare summary.
+/// One read-only candidate line of a passive-session tile — [_AccountTile] and
+/// [_GroupTile] share it — worded exactly as the interactive
+/// [_PendingEntryTile]'s: an either/or reads as one "(keuze)" on its
+/// pre-selected half (#251), an informational notice keeps its "(manueel)"
+/// marker (#225), and an ordinary action is its bare summary.
+///
+/// The account card used to render a bare bullet for every candidate (#255), so
+/// a student's informational candidate — since #245 the student family has one —
+/// read like due work next to a badge that counted it zero.
 String _readOnlyCandidateLine(actions.Alternatives<CandidateAction> choice) {
   final summary = choice.selected.summary;
   if (choice.isChoice) return '• $summary (keuze)';

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -1862,6 +1862,15 @@ class _GroupTile extends StatelessWidget {
 /// resolution to all" affordance that honours each entry's own chosen
 /// alternative. Rendered as its own row in the lazy list, only when more than
 /// one account shares the situation.
+///
+/// Every affordance here acts on [entries] — the exact subset this header was
+/// built over and counts (#252). That list is already scoped by whatever list
+/// rendered it: the open classroom's pending entries, or the group drill-down's,
+/// narrowed further by the search box. The bulk pass used to re-resolve the
+/// situation key against the *whole* linked view instead, so a header reading
+/// "Alles toepassen (1)" inside one class wrote every account group-wide in the
+/// same situation. The label, the confirmation scope and the write are now one
+/// list, so they cannot drift apart again.
 class _SituationHeader extends StatelessWidget {
   const _SituationHeader({required this.controller, required this.entries});
 
@@ -1897,7 +1906,7 @@ class _SituationHeader extends StatelessWidget {
                       context,
                       controller: controller,
                       dry: true,
-                      run: () => controller.dryRunSituation(key),
+                      run: () => controller.dryRunEntries(entries),
                     ),
             child: const Text('Dry-run alles'),
           ),
@@ -1910,15 +1919,10 @@ class _SituationHeader extends StatelessWidget {
                       context,
                       controller: controller,
                       title: 'Toepassen op ${entries.length} accounts?',
-                      // Scoped exactly as [ReconcileController.applySituation]
-                      // scopes the pass — every entry in this situation, not
-                      // only the ones this classroom happens to render — so the
-                      // dialog names what will actually be written (#234).
-                      scope: controller.applyScope(
-                        controller.pendingEntries
-                            .where((e) => e.situationKey == key),
-                      ),
-                      apply: () => controller.applySituation(key),
+                      // The dialog is scoped to the very entries the pass below
+                      // runs over — the ones this header counted (#234/#252).
+                      scope: controller.applyScope(entries),
+                      apply: () => controller.applyEntries(entries),
                     ),
             child: Text('Alles toepassen ($applyable)'),
           ),

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -103,23 +103,23 @@ class _ActionsScreenState extends State<ActionsScreen> {
     if (widget.bootstrap == null) {
       return const _MessagePanel(
         eyebrow: 'Arcadia · acties',
-        title: 'Not configured',
-        message: 'Azure AD is not configured for this build, so the settings '
-            'store and connectors cannot be reached. Provide the AAD '
-            '--dart-define values and restart.',
+        title: 'Niet geconfigureerd',
+        message: 'Azure AD is niet geconfigureerd voor deze build, dus de '
+            'instellingenopslag en de connectoren zijn onbereikbaar. Geef de '
+            'AAD --dart-define-waarden mee en start opnieuw op.',
       );
     }
     final error = _bootstrapError;
     if (error != null) {
-      final retryNote = _attempts > 1 ? '\n\n(Attempt $_attempts failed.)' : '';
+      final retryNote = _attempts > 1 ? '\n\n(Poging $_attempts mislukt.)' : '';
       return _MessagePanel(
         eyebrow: 'Arcadia · acties',
-        title: 'Could not prepare the actions screen',
+        title: 'Kan het Acties-scherm niet openen',
         message: '$error$retryNote',
         action: FilledButton(
           key: const ValueKey('actions-bootstrap-retry'),
           onPressed: _bootstrap,
-          child: const Text('Try again'),
+          child: const Text('Probeer opnieuw'),
         ),
       );
     }
@@ -127,8 +127,8 @@ class _ActionsScreenState extends State<ActionsScreen> {
     if (_bootstrapping || services == null) {
       return const _MessagePanel(
         eyebrow: 'Arcadia · acties',
-        title: 'Preparing…',
-        message: 'Loading the settings and connection profiles.',
+        title: 'Voorbereiden…',
+        message: 'De instellingen en verbindingsprofielen worden geladen.',
         progress: true,
       );
     }
@@ -793,8 +793,8 @@ class _ActionsBodyState extends State<_ActionsBody>
       slivers
         ..add(_gap(PlinkSpacing.s5))
         ..addAll(_resultSectionSlivers(
-          title: 'Dry-run result',
-          subtitle: 'No changes were written. This is what an apply would do.',
+          title: 'Resultaat van de dry-run',
+          subtitle: 'Er is niets geschreven. Dit is wat toepassen zou doen.',
           results: dry,
         ));
     }
@@ -802,8 +802,8 @@ class _ActionsBodyState extends State<_ActionsBody>
       slivers
         ..add(_gap(PlinkSpacing.s5))
         ..addAll(_resultSectionSlivers(
-          title: 'Apply result',
-          subtitle: 'Written to the target systems.',
+          title: 'Resultaat van het toepassen',
+          subtitle: 'Weggeschreven naar de doelsystemen.',
           results: applied,
         ));
     }
@@ -1898,7 +1898,7 @@ class _SituationHeader extends StatelessWidget {
           Expanded(
             child: Text(
               '${entries.first.situationLabel} — ${entries.length} '
-              'accounts in the same situation',
+              'accounts in dezelfde situatie',
               style: text.titleSmall,
             ),
           ),
@@ -2119,9 +2119,9 @@ class _OptionDetail extends StatelessWidget {
           ? <Widget>[
               Text(
                 option.canApply
-                    ? 'Lifecycle action — no per-field diff.'
+                    ? 'Levenscyclusactie — geen wijzigingen per veld.'
                     : '${option.changes.summary} '
-                        '(manual — not applied automatically)',
+                        '(manueel — wordt niet automatisch toegepast)',
                 style: text.bodySmall,
               ),
             ]

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -193,6 +193,9 @@ class _Header extends StatelessWidget {
     // Why Check for drift is unavailable, when it is the WISA settings rather
     // than another operator's lease that blocks it (#238).
     final String? driftBlocked = controller.driftBlockedReason;
+    // The one class of saved setting this running session cannot adopt — the
+    // connection profiles the connectors were constructed from (#246).
+    final String? relaunch = controller.relaunchRequiredReason;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -234,6 +237,18 @@ class _Header extends StatelessWidget {
               Icon(Icons.info_outline, size: 16, color: colors.primary),
               const SizedBox(width: PlinkSpacing.s2),
               Flexible(child: Text(driftBlocked, style: text.bodySmall)),
+            ],
+          ),
+        ],
+        if (relaunch != null) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s3),
+          Row(
+            key: const ValueKey('reconcile-relaunch-required'),
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(Icons.warning_amber_outlined, size: 16, color: colors.error),
+              const SizedBox(width: PlinkSpacing.s2),
+              Flexible(child: Text(relaunch, style: text.bodySmall)),
             ],
           ),
         ],

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -140,13 +140,13 @@ void main() {
       // names the operator who ran the pass (#169).
       expect(
         h.log.entries.map((e) => e.message),
-        contains('Sync complete — 4 pending action(s). Ready. '
+        contains('Sync voltooid — 4 openstaande actie(s). Klaar. '
             'Operator: operator@school.example.'),
       );
       // It is the *last* line — the operator sees it closing the pass.
       expect(
           h.log.entries.last.message,
-          'Sync complete — 4 pending action(s). Ready. '
+          'Sync voltooid — 4 openstaande actie(s). Klaar. '
           'Operator: operator@school.example.');
     });
 
@@ -157,7 +157,7 @@ void main() {
       await h.controller.sync();
 
       expect(h.log.entries.last.message,
-          'Sync complete — 4 pending action(s). Ready.');
+          'Sync voltooid — 4 openstaande actie(s). Klaar.');
     });
 
     test('the "no changes needed" path also logs a ready line', () async {
@@ -172,12 +172,12 @@ void main() {
       expect(h.controller.noChangesNeeded, isTrue);
       expect(
         h.log.entries.map((e) => e.message),
-        contains('Sync complete — no account changes needed. Ready. '
+        contains('Sync voltooid — geen accountwijzigingen nodig. Klaar. '
             'Operator: operator@school.example.'),
       );
       expect(
           h.log.entries.last.message,
-          'Sync complete — no account changes needed. Ready. '
+          'Sync voltooid — geen accountwijzigingen nodig. Klaar. '
           'Operator: operator@school.example.');
     });
   });

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -2197,11 +2197,8 @@ class GatedApplier extends StateApplier {
     required super.connectors,
     required super.resolver,
     required super.wisaRules,
-    required super.studentConfig,
-    required super.staffConfig,
-    super.classTree,
+    required super.settings,
     super.passwordQueue,
-    super.ourSchoolIds,
   });
 
   /// Awaited before each action; `null` for the ordinary harness.
@@ -2238,6 +2235,81 @@ class GatedApplier extends StateApplier {
     await _park();
     return super.applyGroup(action, options: options);
   }
+}
+
+/// A scripted Smartschool SOAP wire for the import-rule end-to-end (#202/#241):
+/// answers `getAllGroupsAndClasses` with a small base64 group tree and reports
+/// "no direct accounts" (code 19) for every group, recording the group codes the
+/// connector asked about so a test can see the pruned ones were never read.
+///
+/// Wire it as [ReconcileHarness.smartschoolTransport] to drive the *production*
+/// Smartschool pull, which reads the operator's rules from the live settings
+/// document at pull time (#246).
+class GroupTreeSoap implements ss.SmartschoolSoapTransport {
+  /// The group codes `getAllAccountsExtended` was called for, in walk order.
+  final List<String> accountCodes = <String>[];
+
+  static const String _tree = '<groups>'
+      '<group><name>School</name><type>G</type><code>SCH</code>'
+      '<visible>1</visible><children>'
+      '<group><name>Organisatie</name><type>G</type><code>ORG</code>'
+      '<visible>1</visible><children>'
+      '<group><name>Verborgen</name><type>G</type><code>HID</code>'
+      '<visible>1</visible></group>'
+      '</children></group>'
+      '<group><name>Klassen</name><type>G</type><code>KLA</code>'
+      '<visible>1</visible><children>'
+      '<group><name>1A</name><type>K</type><code>C1A</code>'
+      '<visible>1</visible></group>'
+      '</children></group>'
+      '</children></group></groups>';
+
+  @override
+  Future<String> send({
+    required Uri endpoint,
+    required String soapAction,
+    required String envelope,
+  }) async {
+    // The SOAPAction is `<namespace>#<method>`.
+    final String method = soapAction.split('#').last;
+    if (method == ss.SmartschoolMethod.getAllGroupsAndClasses) {
+      return _wrap(
+        method,
+        base64.encode(utf8.encode(_tree)),
+        'xsd:base64Binary',
+      );
+    }
+    if (method == ss.SmartschoolMethod.getAllAccountsExtended) {
+      accountCodes.add(
+        RegExp(r'<code[^>]*>([^<]*)</code>').firstMatch(envelope)?.group(1) ??
+            '',
+      );
+      return _wrap(method, '19', 'xsd:int'); // Smartschool: no direct accounts.
+    }
+    return _wrap(method, '0', 'xsd:int');
+  }
+
+  String _wrap(String method, String value, String type) =>
+      '<?xml version="1.0" encoding="utf-8"?>'
+      '<soap:Envelope '
+      'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" '
+      'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+      '<soap:Body><${method}Response>'
+      '<return xsi:type="$type">$value</return>'
+      '</${method}Response></soap:Body></soap:Envelope>';
+}
+
+/// The Smartschool class tree the live document configures, or null when it
+/// configures none — in which case the harness's own [ReconcileHarness.classTree]
+/// fixture stands in (#246).
+///
+/// Built with the production [classTreeFrom], so a test that saves a tree in
+/// Instellingen gets the tree the real bootstrap would derive.
+SmartschoolClassTree? _liveClassTree(SmartschoolConnection smartschool) {
+  final tree = classTreeFrom(smartschool);
+  final unset =
+      tree.years.isEmpty && tree.grades.isEmpty && tree.path.trim().isEmpty;
+  return unset ? null : tree;
 }
 
 /// One assembled reconcile stack against fakes: scripted per-system syncers
@@ -2278,6 +2350,18 @@ class ReconcileHarness {
         linkedStore = linkedStore ?? InMemoryLinkedStore() {
     log = LogBuffer(clock: () => kFixtureDate);
     final wisaRules = WisaImportRules();
+
+    // The controller reads its school profiles from the live document now
+    // (#246), so a fixture that curates schools has to put them there — which
+    // is what `bootstrapReconcile` does when it publishes the document it just
+    // loaded. Seeded only when the caller's own document carries none, so a test
+    // driving Instellingen for real always wins.
+    if (schoolProfiles.isNotEmpty &&
+        this.liveSettings.current.wisaSchools.isEmpty) {
+      this.liveSettings.publish(
+            this.liveSettings.current.copyWith(wisaSchools: schoolProfiles),
+          );
+    }
 
     // The scripted per-system pulls (with call counters). When a [store] is
     // wired, each is wrapped so a successful pull persists — mirroring how
@@ -2343,7 +2427,13 @@ class ReconcileHarness {
       );
       ssSync = (_) async {
         ssSyncs++;
-        return connector.sync(rules: smartschoolRules);
+        // The live document's rules win when it carries any (#246), exactly as
+        // `bootstrapReconcile` reads `live.current.smartschoolRules` at pull
+        // time; the [smartschoolRules] fixture stands in otherwise.
+        final live = this.liveSettings.current.smartschoolRules;
+        return connector.sync(
+          rules: live.isEmpty ? smartschoolRules : live,
+        );
       };
     } else {
       ssSync = (_) async {
@@ -2379,9 +2469,16 @@ class ReconcileHarness {
         expectedEmployeeIds: () => <String>{
           ...managedStudentEmployeeIds(
             app.wisa.snapshot,
-            ourSchoolIds: ourSchoolIds,
+            ourSchoolIds:
+                managedSchoolIdsOf(this.liveSettings.current) ?? ourSchoolIds,
           ),
           ...managedStaffEmployeeIds(app.wisa.snapshot),
+        },
+        // The prefix the pull scopes by, read live (#246) — the fixture's 'GBS'
+        // until a test saves one in Instellingen.
+        schoolPrefix: () {
+          final prefix = this.liveSettings.current.schoolPrefix;
+          return prefix.isEmpty ? 'GBS' : prefix;
         },
       );
       azSync = (previous) async {
@@ -2468,23 +2565,39 @@ class ReconcileHarness {
       ),
       resolver: SeqResolver(),
       wisaRules: wisaRules,
-      // The Smartschool group tree a freshly created class hangs under. Left
-      // unconfigured by default (no parent resolves, as in a bare tenant); a
-      // fixture that applies `AddToSmartschool` for real names the root here.
-      classTree: classTree,
-      studentConfig: actions.StudentActionConfig(
-        schoolPrefix: 'GBS',
-        azureDomain: 'school.example',
-      ),
-      staffConfig: actions.StaffActionConfig(
-        schoolPrefix: 'GBS',
-        azureDomain: 'school.example',
-      ),
       passwordQueue: passwordQueue,
-      // The operator's managed-school set from Settings (#178). When unset, the
-      // linker falls back to the WISA snapshot's MarkAsOurs flags, as bootstrap
-      // does for a not-yet-configured group.
-      ourSchoolIds: ourSchoolIds,
+      // Every settings-derived input, read from the live document on each link
+      // and apply exactly as `bootstrapReconcile` wires it (#246) — so a test
+      // can publish a save (or drive Instellingen for real) and see the very
+      // next relink honour it. Each value falls back to this harness's own
+      // fixture when the live document leaves it unset, mirroring how bootstrap
+      // falls back to the dart-define sign-in config; the ~40 fixtures that
+      // publish no document therefore behave exactly as before.
+      settings: () {
+        final s = this.liveSettings.current;
+        final prefix = s.schoolPrefix.isEmpty ? 'GBS' : s.schoolPrefix;
+        final domain =
+            s.azure.domain.isEmpty ? 'school.example' : s.azure.domain;
+        return ApplierSettings(
+          studentConfig: actions.StudentActionConfig(
+            schoolPrefix: prefix,
+            azureDomain: domain,
+          ),
+          staffConfig: actions.StaffActionConfig(
+            schoolPrefix: prefix,
+            azureDomain: domain,
+          ),
+          // The Smartschool group tree a freshly created class hangs under.
+          // Left unconfigured by default (no parent resolves, as in a bare
+          // tenant); a fixture that applies `AddToSmartschool` for real names
+          // the root here, and a test that saves one in Instellingen wins.
+          classTree: _liveClassTree(s.smartschool) ?? classTree,
+          // The operator's managed-school set from Settings (#178). When unset,
+          // the linker falls back to the WISA snapshot's MarkAsOurs flags, as
+          // bootstrap does for a not-yet-configured group.
+          ourSchoolIds: managedSchoolIdsOf(s) ?? ourSchoolIds,
+        );
+      },
     );
 
     final signalHub = hub;

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1268,7 +1268,17 @@ ReconcileHarness azureClassGroupHarness({bool withStaleGroup = false}) =>
 /// The class rows in Klasgroepen therefore carry the two applyable roster syncs,
 /// and each student's own card carries the informational reading of the same
 /// fact.
-ReconcileHarness azureClassMembershipHarness() => ReconcileHarness(
+///
+/// Wiring [store] / [linkedStore] persists what it syncs, so a second session
+/// can [ReconcileHarness.resume] over the same shared view and read those cards
+/// passively (#255).
+ReconcileHarness azureClassMembershipHarness({
+  SnapshotStore? store,
+  InMemoryLinkedStore? linkedStore,
+}) =>
+    ReconcileHarness(
+      store: store,
+      linkedStore: linkedStore,
       wisa: wisaSnap(
         students: [
           wisaStudent(wisaId: '1', classGroup: '1A'),
@@ -1747,12 +1757,28 @@ List<CandidateAction> departureChoice() => const <CandidateAction>[
       ),
     ];
 
+/// The lone **informational** candidate a student's account doc carries when
+/// they sit in the wrong Office 365 class group (#245): the class-level roster
+/// sync performs the one write, so the per-account row only diagnoses
+/// (`canApply == false`) and the badge beside it counts zero. The shape a
+/// passive card has to mark "(manueel)" (#255).
+List<CandidateAction> wrongAzureClassGroupNotice() => const <CandidateAction>[
+      CandidateAction(
+        family: 'student',
+        kind: 'AzureClassGroupMembership',
+        system: core.Origin.azure,
+        summary: 'Zit in de verkeerde Office 365-klasgroep: GBS-1A in plaats '
+            'van GBS-1B. Werk het ledenbestand van beide klassen bij.',
+        canApply: false,
+      ),
+    ];
+
 /// One [MaterializedAccount] for a passive-session classroom, placed in
 /// [school]/[gradeYear]/[classroom]. [withAction] decides whether it carries an
 /// applyable candidate — i.e. whether [MaterializedAccount.hasPending] is true,
 /// the "has actions" predicate the toggle filters on. [candidates] overrides it
 /// outright for a doc that needs a specific candidate set (e.g. the either/or of
-/// [departureChoice]).
+/// [departureChoice] or the notice of [wrongAzureClassGroupNotice]).
 MaterializedAccount matAccount({
   required String id,
   required String label,

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1840,6 +1840,8 @@ MaterializedAccount matStaff({
 Future<InMemoryLinkedStore> seededLinkedStore(
   List<MaterializedAccount> accounts, {
   String syncedBy = 'operator@school.example',
+  Map<core.Origin, SystemSyncMeta> systemSyncs =
+      const <core.Origin, SystemSyncMeta>{},
 }) async {
   final store = InMemoryLinkedStore();
   await store.writeMaterialized(
@@ -1850,6 +1852,10 @@ Future<InMemoryLinkedStore> seededLinkedStore(
     ),
     syncedBy: syncedBy,
     at: kFixtureDate,
+    // The per-system stamps another operator's sync left behind (#108), the
+    // WISA one of which also names the werkdatum the roster is as of (#247).
+    // Empty by default: most fixtures only need the view itself.
+    systemSyncs: systemSyncs,
   );
   return store;
 }

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1519,6 +1519,84 @@ ReconcileHarness newClassChoiceHarness() => ReconcileHarness(
       classTree: const SmartschoolClassTree(path: 'SCHOOL'),
     );
 
+/// A harness for the namesake-class either/or (#250) — the shape the #225
+/// notice leaves behind, alongside a genuinely new class so both readings are on
+/// screen at once.
+///
+/// Our school 1 runs four classes, each holding a student. Smartschool already
+/// carries `2G` and `2H`, but on groups that are **not flagged official**, so the
+/// class link passes them over and each lands as a
+/// [core.LinkedGroup.smartschoolNamesake]: the operator is told to make the
+/// group official by hand (#225). `1A` and `1B` are genuinely absent downstream
+/// and are the ordinary create-or-ignore choice of #244.
+///
+/// The bug this reproduces: both create actions refuse a namesake class, so
+/// `classImportAlternative` was left holding only `DoNotImportFromWisa` — a
+/// choice of one, hence always selected. **Alles toepassen** then wrote a
+/// `DontImportClass` rule on `2G` and `2H`, dropping from the next WISA snapshot
+/// the very classes the notice beside them had just said to repair in
+/// Smartschool, while the Smartschool groups stayed behind unmanaged.
+///
+/// Two of each on purpose: two namesake classes put them in a "same situation"
+/// subset of their own with its own bulk header — which is where the pooling
+/// half of the issue shows, since they must not share the new classes' subset —
+/// and two new classes give that other subset a header too, proving the fix did
+/// not simply silence the list: their creates still run.
+ReconcileHarness namesakeClassChoiceHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(wisaId: '1', classGroup: '1A'),
+          wisaStudent(wisaId: '2', classGroup: '1B'),
+          wisaStudent(wisaId: '3', classGroup: '2G'),
+          wisaStudent(wisaId: '4', classGroup: '2H'),
+        ],
+        schools: [wisaSchool(1)],
+        classGroups: [
+          wisaClassGroup(
+            '1A',
+            description: 'Onze eerste klas',
+            schoolCode: '111',
+            schoolId: 1,
+          ),
+          wisaClassGroup(
+            '1B',
+            description: 'Onze tweede klas',
+            schoolCode: '111',
+            schoolId: 1,
+          ),
+          wisaClassGroup(
+            '2G',
+            description: '2e lj A Klassieke talen',
+            schoolCode: '111',
+            schoolId: 1,
+          ),
+          wisaClassGroup(
+            '2H',
+            description: '2e lj A Handel',
+            schoolCode: '111',
+            schoolId: 1,
+          ),
+        ],
+      ),
+      smartschool: ssSnap(
+        groups: [
+          ssGroup(
+            'Leerlingen',
+            code: 'SCHOOL',
+            official: false,
+            type: core.GroupType.group,
+          ),
+          ssGroup('2G', code: 'G2G', official: false),
+          ssGroup('2H', code: 'G2H', official: false),
+        ],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+      ourSchoolIds: const {1},
+      classTree: const SmartschoolClassTree(path: 'SCHOOL'),
+    );
+
 /// A harness for the "new staff member" choice (#248) — the staff twin of
 /// [newClassChoiceHarness]. Two freshly hired teachers exist in WISA only, so
 /// each raises `AddStaffToAzure` (which since #240 chains the Smartschool

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1032,6 +1032,100 @@ ReconcileHarness appliedClassWorkHarness({
       ourSchoolIds: const {1},
     );
 
+/// A harness for the classroom-scoped bulk apply (#252). One managed school,
+/// two third-year classes, and the **same** student situation in both: every
+/// student's Office 365 display name is stale, so each raises a lone
+/// `ModifyAzureName` and they all share one `situationKey`.
+///
+/// 3C holds two of them (Sam and Sara) — enough for the same-situation bulk
+/// header to render at all, since it only appears above a subset of more than
+/// one — while 3D holds a third (Tom) in the identical situation. So an
+/// "Alles toepassen (2)" pressed inside 3C must write exactly Sam and Sara and
+/// leave Tom pending: before the fix the header resolved its situation key back
+/// through the whole linked view and wrote all three, none of which the
+/// operator drilled into.
+///
+/// Both classes are otherwise in sync with WISA (matching `untis` codes), so
+/// the only work anywhere in the student family is those three names.
+ReconcileHarness crossClassSituationHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(
+              wisaId: '1', classGroup: '3C', firstName: 'Sam', name: 'Sels'),
+          wisaStudent(
+              wisaId: '2', classGroup: '3C', firstName: 'Sara', name: 'Segers'),
+          wisaStudent(
+              wisaId: '3', classGroup: '3D', firstName: 'Tom', name: 'Tas'),
+        ],
+        schools: [wisaSchool(1)],
+        classGroups: [
+          wisaClassGroup('3C', adminCode: 'a3', schoolCode: '111'),
+          wisaClassGroup('3D', adminCode: 'a4', schoolCode: '111'),
+        ],
+      ),
+      smartschool: ssSnap(
+        groups: [
+          ssGroup('3C', code: '3C_ss', untis: '3C'),
+          ssGroup('3D', code: '3D_ss', untis: '3D'),
+        ],
+        accounts: [
+          ssAccount(
+            uid: 'sam',
+            accountId: '1',
+            mail: 'sam.sels@student.school.example',
+            givenName: 'Sam',
+            surname: 'Sels',
+          ),
+          ssAccount(
+            uid: 'sara',
+            accountId: '2',
+            mail: 'sara.segers@student.school.example',
+            givenName: 'Sara',
+            surname: 'Segers',
+          ),
+          ssAccount(
+            uid: 'tom',
+            accountId: '3',
+            mail: 'tom.tas@student.school.example',
+            givenName: 'Tom',
+            surname: 'Tas',
+          ),
+        ],
+        memberships: [
+          member('sam', '3C_ss'),
+          member('sara', '3C_ss'),
+          member('tom', '3D_ss'),
+        ],
+      ),
+      // Every display name left blank, so all three raise `ModifyAzureName` —
+      // one situation spanning two classes.
+      azure: azSnap(users: [
+        azUser(
+          id: kSam3C,
+          upn: 'sam.sels@student.school.example',
+          employeeId: '1',
+        ),
+        azUser(
+          id: kSara3C,
+          upn: 'sara.segers@student.school.example',
+          employeeId: '2',
+        ),
+        azUser(
+          id: kTom3D,
+          upn: 'tom.tas@student.school.example',
+          employeeId: '3',
+        ),
+      ]),
+      ourSchoolIds: const {1},
+    );
+
+/// The Azure object ids of [crossClassSituationHarness]'s three students — what
+/// a test matches the recorded Graph writes against to prove which accounts a
+/// classroom-scoped bulk apply actually touched (#252).
+const String kSam3C = 'az-sam-3c';
+const String kSara3C = 'az-sara-3c';
+const String kTom3D = 'az-tom-3d';
+
 /// A harness for the managed-school class-group scope (#205). WISA hands the
 /// session class groups from two schools, and the sibling school's arrive
 /// *first* in the pull: `1A` and `9Z` of school 2 (which we do not manage),

--- a/account_manager/test/reconcile/reconcile_live_settings_test.dart
+++ b/account_manager/test/reconcile/reconcile_live_settings_test.dart
@@ -1,6 +1,8 @@
+import 'package:account_core/account_core.dart' as core;
 import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
 import 'package:account_state/account_state.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:smartschool_api/smartschool_api.dart' as ss;
 import 'package:wisa_api/wisa_api.dart' as wapi;
 
 import 'reconcile_fakes.dart';
@@ -309,4 +311,211 @@ void main() {
       expect((await syncer(null)).classGroups, isEmpty);
     });
   });
+
+  group('the rest of the reconcile stack reads settings live too (#246)', () {
+    /// The #178 fixture, but with ownership coming from the settings document
+    /// rather than a constructor argument: one student enrolled in school 2 and
+    /// fully present in our Smartschool + Azure, and no `MarkAsOurs` flag on the
+    /// WISA schools — so who is managed is decided solely by [live].
+    ReconcileHarness managedFrom(LiveSettings live) => ReconcileHarness(
+          wisa: wisaSnap(
+            students: [wisaStudent(schoolId: 2)],
+            schools: [wisaSchool(1), wisaSchool(2)],
+          ),
+          smartschool: ssSnap(
+            groups: const [],
+            accounts: [ssAccount()],
+            memberships: const [],
+          ),
+          azure: azSnap(users: [azUser()]),
+          liveSettings: live,
+        );
+
+    AppSettings withSchools(List<WisaSchoolProfile> schools) =>
+        _settings(schools: schools);
+
+    test("a school's beheerd mark reaches the very next relink", () async {
+      // The headline symptom: the operator marks a school managed in
+      // Instellingen, and the Actions view keeps hiding its students until the
+      // app is relaunched.
+      final live = LiveSettings(withSchools(const <WisaSchoolProfile>[
+        WisaSchoolProfile(
+            schoolId: 1, code: 'S1', name: 'School 1', ours: true),
+        WisaSchoolProfile(schoolId: 2, code: 'S2', name: 'School 2'),
+      ]));
+      final harness = managedFrom(live);
+
+      await harness.controller.sync();
+      expect(harness.applier.ourSchoolIds, const {1});
+      var linked = await harness.applier.link();
+      expect(linked.snapshot.accounts.single.wisaPresence,
+          core.WisaPresence.groupOnly,
+          reason: "school 2 is not ours, so its student is out of scope");
+
+      live.publish(withSchools(const <WisaSchoolProfile>[
+        WisaSchoolProfile(
+            schoolId: 1, code: 'S1', name: 'School 1', ours: true),
+        WisaSchoolProfile(
+            schoolId: 2, code: 'S2', name: 'School 2', ours: true),
+      ]));
+
+      expect(harness.applier.ourSchoolIds, const {1, 2});
+      linked = await harness.applier.link();
+      expect(
+          linked.snapshot.accounts.single.wisaPresence, core.WisaPresence.ours,
+          reason: 'no relaunch: the relink honoured the save');
+    });
+
+    test('a beheerd mark does not block Check for drift', () async {
+      // #238 refuses drift while the *WISA pull inputs* have moved, because
+      // drift never re-pulls WISA. Ownership is not one of them — it is applied
+      // at link time — so drift is exactly the pass that adopts it.
+      final live = LiveSettings(withSchools(const <WisaSchoolProfile>[
+        WisaSchoolProfile(schoolId: 2, code: 'S2', name: 'School 2'),
+      ]));
+      final harness = managedFrom(live);
+      await harness.controller.sync();
+
+      live.publish(withSchools(const <WisaSchoolProfile>[
+        WisaSchoolProfile(
+            schoolId: 2, code: 'S2', name: 'School 2', ours: true),
+      ]));
+
+      expect(harness.controller.driftBlockedReason, isNull);
+      await harness.controller.checkDrift();
+      expect(harness.controller.linked?.snapshot.accounts.single.wisaPresence,
+          core.WisaPresence.ours);
+    });
+
+    test('the Smartschool import rules are read at pull time', () async {
+      // #241 authored them; before #246 the pull closed over the bootstrap
+      // document, so a rule saved in Instellingen pruned nothing until the next
+      // launch. The pass that adopts it is **Check for drift** — the one that
+      // re-reads Smartschool at all (#99's smart sync leaves it alone once this
+      // session has it) — and a rule change never arms #238's WISA gate, so
+      // drift is offered.
+      final wire = GroupTreeSoap();
+      final live = LiveSettings(_settings());
+      final harness =
+          ReconcileHarness(smartschoolTransport: wire, liveSettings: live);
+
+      await harness.controller.sync();
+      expect(
+        harness.app.smartschool.snapshot?.groups.map((g) => g.id.value),
+        <String>['SCH', 'ORG', 'HID', 'KLA', 'C1A'],
+      );
+
+      live.publish(_settings().copyWith(
+        smartschoolRules: const <ss.SmartschoolImportRule>[
+          ss.DiscardSmartschoolGroup('Organisatie'),
+        ],
+      ));
+      expect(harness.controller.driftBlockedReason, isNull);
+      await harness.controller.checkDrift();
+
+      expect(
+        harness.app.smartschool.snapshot?.groups.map((g) => g.id.value),
+        <String>['SCH', 'KLA', 'C1A'],
+        reason: 'the saved rule pruned the very next pull, subtree and all',
+      );
+    });
+
+    test('the Azure pull scopes by the school prefix as it now stands',
+        () async {
+      final wire = RecordingGraph();
+      final live = LiveSettings(_settings());
+      final harness =
+          ReconcileHarness(azureTransport: wire, liveSettings: live);
+
+      await harness.controller.sync();
+      expect(_userFilters(wire).last, contains('GBS'));
+
+      live.publish(_settings().copyWith(schoolPrefix: 'SSM'));
+      await harness.controller.checkDrift();
+
+      expect(_userFilters(wire).last, contains('SSM'),
+          reason: 'a saved prefix re-scopes the pull without a relaunch');
+    });
+
+    // The companion guard — that a moved prefix drops the delta token so no
+    // old-prefix user survives the pass — is proved in `account_state`'s
+    // `application_state_test`, over a transport that actually primes one;
+    // `RecordingGraph` answers every collection read empty, so it never gets a
+    // deltaLink and every pass here is a full read anyway.
+
+    test('the school profiles the drill-down is labelled from are live',
+        () async {
+      final live = LiveSettings(_settings());
+      final harness = ReconcileHarness(liveSettings: live);
+      expect(harness.controller.schoolProfiles, isEmpty);
+
+      live.publish(withSchools(const <WisaSchoolProfile>[
+        WisaSchoolProfile(
+          schoolId: 25,
+          code: 'ISMAA',
+          name: 'Instituut Sancta Maria-A',
+          ours: true,
+        ),
+      ]));
+
+      expect(harness.controller.schoolProfiles.single.code, 'ISMAA');
+    });
+  });
+
+  group('a connection profile the session cannot adopt says so (#246)', () {
+    test('stays silent while only live-adoptable values move', () async {
+      final live = LiveSettings(_settings());
+      final harness = ReconcileHarness(liveSettings: live);
+      expect(harness.controller.relaunchRequiredReason, isNull);
+
+      live.publish(_settings(workDate: _pinned(DateTime(2026, 9, 1))).copyWith(
+        schoolPrefix: 'GBS',
+        wisaSchools: const <WisaSchoolProfile>[
+          WisaSchoolProfile(schoolId: 1, code: 'A', name: 'A', ours: true),
+        ],
+      ));
+
+      expect(harness.controller.relaunchRequiredReason, isNull,
+          reason: 'every one of these reaches the running stack now');
+    });
+
+    test('names the relaunch when a WISA endpoint moves under the session',
+        () async {
+      // The connectors were constructed from the bootstrap document — a live
+      // SQL connection and a resolved Key Vault secret — so this session keeps
+      // talking to the old server. Saying so is the whole point: syncing the
+      // *previous* WISA host while Instellingen shows a new one is the silent
+      // stale-input failure #238 set out to end.
+      final live = LiveSettings(_settings());
+      final harness = ReconcileHarness(liveSettings: live);
+
+      live.publish(AppSettings(
+        wisa: const WisaConnection(server: 'nieuw.example', port: '9000'),
+      ));
+
+      expect(
+        harness.controller.relaunchRequiredReason,
+        'Verbindingsinstellingen gewijzigd — deze sessie blijft de vorige '
+        'gebruiken tot de app herstart wordt.',
+      );
+      // Nothing is refused, though — the operator may have edited a profile
+      // they are not using, and stranding them would be worse than the notice.
+      expect(harness.controller.canCheckDrift, isTrue);
+    });
+
+    test('a harness with no settings holder never nags', () {
+      expect(ReconcileHarness().controller.relaunchRequiredReason, isNull);
+    });
+  });
 }
+
+/// The `$filter` of every prefix-scoped `/users` bulk read [wire] saw, in
+/// order — the targeted `employeeId in (…)` back-fill lookups (#224) hit the
+/// same path but carry no prefix, so they are left out.
+List<String> _userFilters(RecordingGraph wire) => <String>[
+      for (final r in wire.requests)
+        if (r.url.path.endsWith('/users'))
+          if (!(r.url.queryParameters[r'$filter'] ?? '')
+              .startsWith('employeeId in'))
+            r.url.queryParameters[r'$filter'] ?? '',
+    ];

--- a/account_manager/test/reconcile/reconcile_live_settings_test.dart
+++ b/account_manager/test/reconcile/reconcile_live_settings_test.dart
@@ -285,6 +285,140 @@ void main() {
     });
   });
 
+  group('the shared state carries the werkdatum it was pulled with (#247)', () {
+    DateTime? storedWerkdatum(ReconcileHarness h) =>
+        h.controller.syncState.systems[core.Origin.wisa]?.workDate;
+
+    test('a sync stamps the WISA meta with the date it asked WISA for',
+        () async {
+      final live =
+          LiveSettings(_settings(workDate: _pinned(DateTime(2025, 9, 1))));
+      final wire = RecordingWisaSoap();
+      final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+
+      await harness.controller.sync();
+
+      expect(wire.werkdatums, <String>['01/09/2025']);
+      expect(storedWerkdatum(harness), DateTime(2025, 9, 1));
+    });
+
+    test('the stamp names the pull, not whatever Instellingen now says',
+        () async {
+      // The case the issue exists for. #238 made the werkdatum live, so the
+      // setting and the installed roster routinely disagree: the operator moves
+      // the date to the new school year and, until they press Synchroniseer,
+      // the shared view is still last year's. The stamp must say *pulled*.
+      final live =
+          LiveSettings(_settings(workDate: _pinned(DateTime(2025, 9, 1))));
+      final harness = ReconcileHarness(
+        wisaTransport: RecordingWisaSoap(),
+        liveSettings: live,
+      );
+      await harness.controller.sync();
+
+      live.publish(_settings(workDate: _pinned(DateTime(2026, 9, 1))));
+
+      expect(storedWerkdatum(harness), DateTime(2025, 9, 1),
+          reason: 'a save is not a pull');
+    });
+
+    test('a "volg de huidige datum" pull stamps the date it resolved to',
+        () async {
+      // The default setting, and the one that produces the reported symptom:
+      // the stamp has to name the resolved date, not the fact that it follows
+      // the clock.
+      final harness = ReconcileHarness(
+        wisaTransport: RecordingWisaSoap(),
+        liveSettings: LiveSettings(_settings()),
+      );
+
+      await harness.controller.sync();
+
+      // The harness clock is fixed at kFixtureDate (2026-07-01), and the stamp
+      // is the instant the pull resolved — not a re-ask a moment later, which
+      // is the whole reason it rides out on the snapshot.
+      expect(storedWerkdatum(harness), kFixtureDate);
+      expect(wapi.formatWerkdatum(storedWerkdatum(harness)!), '01/07/2026');
+    });
+
+    test('a passive session reads the same werkdatum off the shared store',
+        () async {
+      // The whole point of putting it on the shared record rather than in this
+      // session's log: an operator who never ran the pass can still tell which
+      // school year the view in front of them describes.
+      final linkedStore = InMemoryLinkedStore();
+      final snapshots = InMemorySnapshotStore();
+      final live =
+          LiveSettings(_settings(workDate: _pinned(DateTime(2025, 9, 1))));
+      final syncer = ReconcileHarness(
+        wisaTransport: RecordingWisaSoap(),
+        liveSettings: live,
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      await syncer.controller.sync();
+
+      final passive = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      await passive.controller.loadOverview();
+
+      expect(storedWerkdatum(passive), DateTime(2025, 9, 1));
+    });
+
+    test('a drift pass that does not re-pull WISA keeps the roster stamp',
+        () async {
+      // Check-for-drift re-reads Smartschool and Azure only, so the roster —
+      // and the date it is as of — is still the one the last sync installed.
+      final live =
+          LiveSettings(_settings(workDate: _pinned(DateTime(2025, 9, 1))));
+      final harness = ReconcileHarness(
+        wisaTransport: RecordingWisaSoap(),
+        liveSettings: live,
+      );
+      await harness.controller.sync();
+      await harness.controller.checkDrift();
+
+      expect(harness.controller.syncState.generation, 2,
+          reason: 'the drift pass really did rewrite the view');
+      expect(storedWerkdatum(harness), DateTime(2025, 9, 1));
+    });
+
+    test('the "WISA unchanged" shortcut still records the new werkdatum',
+        () async {
+      // A werkdatum change that lands the identical roster skips the re-link,
+      // but the view is now known to describe a different date — and the light
+      // metadata write is what has to carry it.
+      final live =
+          LiveSettings(_settings(workDate: _pinned(DateTime(2025, 9, 1))));
+      final harness = ReconcileHarness(
+        wisaTransport: RecordingWisaSoap(),
+        liveSettings: live,
+      );
+      await harness.controller.sync();
+      final generation = harness.controller.syncState.generation;
+
+      live.publish(_settings(workDate: _pinned(DateTime(2026, 9, 1))));
+      await harness.controller.sync();
+
+      expect(harness.controller.syncState.generation, generation,
+          reason: 'an unchanged roster is not a new view');
+      expect(storedWerkdatum(harness), DateTime(2026, 9, 1));
+    });
+
+    test('a scripted pull that never named a werkdatum stamps none', () async {
+      // Every other harness builds its WISA snapshot by hand, and a snapshot
+      // restored from a pre-#247 document carries no date either. Neither may
+      // be given one it does not have.
+      final harness = ReconcileHarness();
+      await harness.controller.sync();
+
+      expect(harness.controller.syncState.systems[core.Origin.wisa], isNotNull);
+      expect(storedWerkdatum(harness), isNull);
+    });
+  });
+
   group('wisaSyncer', () {
     test('reads the rules live too, so a DontImportFromWisa apply lands (#72)',
         () async {

--- a/account_manager/test/reconcile/reconcile_pending_choice_test.dart
+++ b/account_manager/test/reconcile/reconcile_pending_choice_test.dart
@@ -333,6 +333,111 @@ void main() {
     });
   });
 
+  group('a class Smartschool already has is never blacklisted (#250)', () {
+    const String notice =
+        'Deze klas bestaat in Smartschool maar is geen officiële klas';
+    const String ignore = 'Negeer deze klas bij het importeren uit WISA';
+    const String create = 'Voeg deze klas toe aan Smartschool';
+
+    List<String> summariesOf(ReconcileHarness h) =>
+        h.controller.applyResults!.map((r) => r.changes.summary).toList();
+
+    PendingAccountEntry entryFor(ReconcileHarness h, String id) =>
+        h.controller.groupPendingEntries.firstWhere((e) => e.targetId == id);
+
+    PendingChoice importChoiceOf(PendingAccountEntry entry) =>
+        entry.choices.singleWhere(
+          (c) => c.alternatives.any((a) => a.kind == 'DoNotImportFromWisa'),
+        );
+
+    test('the notice and the blacklist collapse into one choice, notice first',
+        () async {
+      final h = namesakeClassChoiceHarness();
+      await h.controller.sync();
+      final choice = importChoiceOf(entryFor(h, '2G'));
+
+      expect(choice.situationId, actions.namesakeClassAlternative);
+      expect(choice.isChoice, isTrue,
+          reason: 'repair it by hand or stop offering it — never both, and '
+              'never a choice of one');
+      expect(
+        choice.alternatives.map((a) => a.kind),
+        ['ClassExistsAsSmartschoolGroup', 'DoNotImportFromWisa'],
+        reason: 'the notice leads the radio pair',
+      );
+      expect(choice.selected.kind, 'ClassExistsAsSmartschoolGroup');
+      expect(choice.selected.canApply, isFalse,
+          reason: 'the default writes nothing: the repair is a hand edit');
+    });
+
+    test('a namesake class is not pooled with the new classes for bulk apply',
+        () async {
+      final h = namesakeClassChoiceHarness();
+      await h.controller.sync();
+
+      expect(
+        importChoiceOf(entryFor(h, '1A')).situationId,
+        actions.classImportAlternative,
+      );
+      expect(
+        entryFor(h, '2G').situationKey,
+        isNot(entryFor(h, '1A').situationKey),
+        reason: '"create this class" and "this class is already there" are two '
+            'situations, so they get two bulk headers',
+      );
+      expect(entryFor(h, '2G').situationKey, entryFor(h, '2H').situationKey);
+    });
+
+    test('"apply to all" creates the new classes and blacklists no namesake',
+        () async {
+      // The report's headline: Apply to all wrote a DontImportClass rule on
+      // every class the #225 notice had just told the operator to repair by
+      // hand.
+      final h = namesakeClassChoiceHarness();
+      await h.controller.sync();
+      final pulls = h.wisaSyncs;
+
+      await h.controller.applyEntries(h.controller.groupPendingEntries);
+
+      final summaries = summariesOf(h);
+      expect(summaries, isNot(contains(ignore)),
+          reason: 'the rule would drop the classes the notice says to repair');
+      expect(summaries.where((s) => s == create), hasLength(2),
+          reason: 'the genuinely new classes are still created');
+      expect(
+        h.soap.soapActions.where((a) => a.endsWith('#saveClass')),
+        hasLength(2),
+        reason: '2G and 2H already exist downstream — never created again',
+      );
+      expect(h.wisaSyncs, pulls,
+          reason: 'no import rule was added, so WISA was never re-pulled');
+    });
+
+    test('the operator can still blacklist a namesake class deliberately',
+        () async {
+      final h = namesakeClassChoiceHarness();
+      await h.controller.sync();
+      final entry = entryFor(h, '2G');
+      expect(importChoiceOf(entry).selected.canApply, isFalse,
+          reason: 'the import decision writes nothing until the operator '
+              'picks the opt-out (the class\'s Office 365 group is a '
+              'separate, orthogonal decision)');
+
+      h.controller.chooseAlternative(
+        entry: entry,
+        group: actions.namesakeClassAlternative,
+        kind: 'DoNotImportFromWisa',
+      );
+      final chosen = entryFor(h, '2G');
+      expect(chosen.canApply, isTrue);
+
+      await h.controller.applyEntry(chosen);
+
+      expect(summariesOf(h), contains(ignore));
+      expect(summariesOf(h), isNot(contains(notice)));
+    });
+  });
+
   group('a new staff member is one choice, not two to-dos (#248)', () {
     const String createAzure = 'Maak een nieuw Office 365 account';
     const String createSs = 'Maak een nieuw Smartschool account';

--- a/account_manager/test/reconcile/reconcile_pending_choice_test.dart
+++ b/account_manager/test/reconcile/reconcile_pending_choice_test.dart
@@ -136,9 +136,14 @@ void main() {
         group: actions.smartschoolDepartureAlternative,
         kind: 'DeleteStudentFromSmartschool',
       );
+      // Re-read the subset after the choice (the list is rebuilt), exactly as
+      // the screen does: `chooseAlternative` notifies, the bulk header rebuilds,
+      // and it hands the pass the entries it is showing (#252).
+      final chosen = h.controller.pendingEntries
+          .where((e) => e.family == 'student')
+          .toList();
 
-      final key = entries.first.situationKey;
-      await h.controller.applySituation(key);
+      await h.controller.applyEntries(chosen);
 
       final summaries =
           h.controller.applyResults!.map((r) => r.changes.summary).toList();
@@ -285,14 +290,15 @@ void main() {
       expect(entries.map((e) => e.targetId), containsAll(<String>['1A', '1B']));
 
       final key = entries.firstWhere((e) => e.targetId == '1A').situationKey;
+      final subset = entries.where((e) => e.situationKey == key).toList();
       expect(
-        entries.where((e) => e.situationKey == key).map((e) => e.targetId),
+        subset.map((e) => e.targetId),
         containsAll(<String>['1A', '1B']),
         reason: 'both new classes are the same situation, bulk-applied at once',
       );
       final pulls = h.wisaSyncs;
 
-      await h.controller.applySituation(key);
+      await h.controller.applyEntries(subset);
 
       final summaries = summariesOf(h);
       expect(summaries.where((s) => s == create), hasLength(2));
@@ -409,14 +415,15 @@ void main() {
       expect(entries, hasLength(2));
 
       final key = entries.first.situationKey;
+      final subset = entries.where((e) => e.situationKey == key).toList();
       expect(
-        entries.where((e) => e.situationKey == key),
+        subset,
         hasLength(2),
         reason: 'both new hires are the same situation, bulk-applied at once',
       );
       final pulls = h.wisaSyncs;
 
-      await h.controller.applySituation(key);
+      await h.controller.applyEntries(subset);
 
       final summaries = summariesOf(h);
       expect(summaries.where((s) => s == createAzure), hasLength(2));

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -1404,6 +1404,93 @@ void main() {
         reason: 'a stamp from a past day is never rendered as bare time');
   });
 
+  testWidgets(
+      "the overview's freshness stamp names the werkdatum the roster was "
+      'pulled with (#247)', (WidgetTester tester) async {
+    // "Wie synchroniseerde, wanneer" says when the pass ran, never which school
+    // year it describes — and WISA answers *as of* a date, so a pull made on
+    // the wrong side of the rollover reads here exactly like a class that went
+    // missing (#239). The stamp comes off the shared per-system record, so this
+    // passive session reads the date without having run the pull.
+    final store = await seededLinkedStore(
+      <MaterializedAccount>[
+        matAccount(id: 's1', label: 'Jane Doe', withAction: true),
+      ],
+      systemSyncs: <Origin, SystemSyncMeta>{
+        Origin.wisa: SystemSyncMeta(
+          syncedBy: 'operator@school.example',
+          at: kFixtureDate,
+          workDate: DateTime(2025, 9, 1),
+        ),
+      },
+    );
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // In the wire's own dd/MM/yyyy, the way the Log panel's pull line and the
+    // `Werkdatum` SOAP parameter both spell it.
+    expect(find.textContaining('· werkdatum 01/09/2025'), findsOneWidget);
+  });
+
+  testWidgets(
+      'a shared view synced before the werkdatum was recorded renders the '
+      'stamp unchanged (#247)', (WidgetTester tester) async {
+    // The store in production already holds views written without it, and a
+    // Smartschool/Azure-only stamp never has one. Neither may invent a date,
+    // and neither may lose the "wie, wanneer" half over its absence.
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('werkdatum'), findsNothing);
+    expect(
+      find.textContaining('Generatie 1'),
+      findsOneWidget,
+      reason: 'the who/when half stands on its own',
+    );
+  });
+
+  testWidgets(
+      'the stamp names the werkdatum the stored view was pulled with, not the '
+      'one Instellingen now holds (#247)', (WidgetTester tester) async {
+    // The disagreement the issue is about. #238 made the werkdatum live, so
+    // between a save and the next Synchroniseer the setting says one school
+    // year and the installed roster is another. Driven over the *production*
+    // WISA pull, so the date on screen is the one that really went out.
+    final live = LiveSettings(AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9, 1)),
+      ),
+    ));
+    final wire = RecordingWisaSoap();
+    final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+    await harness.controller.sync();
+    expect(wire.werkdatums, <String>['01/09/2025']);
+
+    // The operator moves the werkdatum to the new school year and saves. Until
+    // they sync, the overview below is still the old year's.
+    live.publish(AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2026, 9, 1)),
+      ),
+    ));
+
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('· werkdatum 01/09/2025'), findsOneWidget);
+    expect(find.textContaining('01/09/2026'), findsNothing,
+        reason: 'a saved werkdatum describes the next pull, not this view');
+  });
+
   // --- The read-only drill-down state (#214) -------------------------------
 
   final readOnly = find.byKey(const ValueKey('actions-read-only'));

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -43,8 +43,34 @@ void main() {
     await tester.pumpWidget(_wrap(const ActionsScreen(bootstrap: null)));
     await tester.pumpAndSettle();
 
-    expect(find.text('Not configured'), findsOneWidget);
+    expect(find.text('Niet geconfigureerd'), findsOneWidget);
     expect(find.byKey(const ValueKey('actions-dry-run')), findsNothing);
+  });
+
+  testWidgets('a failed bootstrap offers a retry, in Dutch (#253)',
+      (WidgetTester tester) async {
+    // The stand-in panels are as operator-facing as the tree they replace, so
+    // they speak the same language as it. The retry itself is the point of the
+    // panel: a second attempt has to be one button away.
+    var attempts = 0;
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: () async {
+      attempts++;
+      if (attempts == 1) throw StateError('geen verbinding');
+      return ReconcileHarness().bootstrap();
+    })));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Kan het Acties-scherm niet openen'), findsOneWidget);
+    final retry = find.byKey(const ValueKey('actions-bootstrap-retry'));
+    expect(find.descendant(of: retry, matching: find.text('Probeer opnieuw')),
+        findsOneWidget);
+
+    await tester.tap(retry);
+    await tester.pumpAndSettle();
+
+    expect(attempts, 2);
+    expect(find.text('Kan het Acties-scherm niet openen'), findsNothing);
+    expect(find.text('Acties'), findsOneWidget);
   });
 
   testWidgets(
@@ -96,7 +122,7 @@ void main() {
     // Dry-run everything from the header — no drill needed, nothing written.
     await tester.tap(find.byKey(const ValueKey('actions-dry-run')));
     await tester.pumpAndSettle();
-    expect(find.text('Dry-run result'), findsOneWidget);
+    expect(find.text('Resultaat van de dry-run'), findsOneWidget);
     expect(harness.soap.soapActions, isEmpty);
 
     // Apply everything: confirm the dialog, the Smartschool write happens.
@@ -106,7 +132,7 @@ void main() {
     expect(find.text('Openstaande acties toepassen?'), findsOneWidget);
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     expect(harness.soap.soapActions, isNotEmpty);
   });
 
@@ -125,7 +151,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(harness.soap.soapActions, isEmpty);
-    expect(find.text('Apply result'), findsNothing);
+    expect(find.text('Resultaat van het toepassen'), findsNothing);
   });
 
   group('the apply-confirmation dialog says what the pass really writes (#234)',
@@ -307,6 +333,10 @@ void main() {
     final deleteAlt = ValueKey('alt-$id-DeleteStudentFromSmartschool');
     expect(find.byKey(unregisterAlt), findsOneWidget);
     expect(find.byKey(deleteAlt), findsOneWidget);
+    // An unregister carries no field diff, so the detail under the radios is
+    // the lifecycle note — in Dutch, like the rest of the screen (#253).
+    expect(find.text('Levenscyclusactie — geen wijzigingen per veld.'),
+        findsOneWidget);
 
     await tester.tap(find.byKey(deleteAlt));
     await tester.pumpAndSettle();
@@ -317,7 +347,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     expect(harness.soap.soapActions, isNotEmpty,
         reason: 'delete is a real Smartschool write');
     final summaries =
@@ -339,7 +369,7 @@ void main() {
     await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
 
     expect(
-        find.textContaining('accounts in the same situation'), findsOneWidget);
+        find.textContaining('accounts in dezelfde situatie'), findsOneWidget);
     final key = harness.controller.pendingEntries
         .firstWhere((e) => e.family == 'student')
         .situationKey;
@@ -365,7 +395,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     expect(harness.controller.applyResults, hasLength(2));
     final summaries =
         harness.controller.applyResults!.map((r) => r.changes.summary).toList();
@@ -415,7 +445,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
-    expect(find.text('Apply result'), findsOneWidget);
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     expect(harness.controller.applyResults, hasLength(2),
         reason: 'one write per account of the open class');
     final patched = harness.graph.requests
@@ -1633,7 +1663,7 @@ void main() {
       gates[1].complete();
       await tester.pumpAndSettle();
       expect(dialog, findsNothing);
-      expect(find.text('Apply result'), findsOneWidget);
+      expect(find.text('Resultaat van het toepassen'), findsOneWidget);
       expect(harness.controller.applyResults, hasLength(2));
       expect(harness.soap.soapActions, isNotEmpty);
     });
@@ -1664,7 +1694,7 @@ void main() {
       gate.complete();
       await tester.pumpAndSettle();
       expect(dialog, findsNothing);
-      expect(find.text('Dry-run result'), findsOneWidget);
+      expect(find.text('Resultaat van de dry-run'), findsOneWidget);
       expect(harness.soap.soapActions, isEmpty);
     });
 
@@ -1696,7 +1726,7 @@ void main() {
 
       expect(dialog, findsNothing,
           reason: 'a failed pass must not trap anyone');
-      expect(find.text('Apply result'), findsOneWidget);
+      expect(find.text('Resultaat van het toepassen'), findsOneWidget);
       expect(
         harness.controller.applyResults!.map((r) => r.outcome),
         everyElement(ActionOutcome.failed),
@@ -1754,7 +1784,7 @@ void main() {
       gate.complete();
       await tester.pumpAndSettle();
       expect(dialog, findsNothing);
-      expect(find.text('Apply result'), findsOneWidget);
+      expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     });
   });
 }

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -1256,6 +1256,69 @@ void main() {
   });
 
   testWidgets(
+      'a read-only account card marks an informational candidate "(manueel)" '
+      '(#255)', (WidgetTester tester) async {
+    // A passive session over a student who sits in the wrong Office 365 class
+    // group (#245): the write belongs to the class row, so this candidate only
+    // diagnoses and the card's badge counts it zero. The card used to render
+    // every candidate as a bare bullet, so this line read exactly like due work
+    // beside a (0) badge — while the group tile and the interactive tile have
+    // both marked it "(manueel)" all along.
+    _useTallWindow(tester);
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(
+        id: 's1',
+        label: 'Sam Sels',
+        classroom: '3C',
+        candidates: wrongAzureClassGroupNotice(),
+      ),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // Nothing here is applyable, so the work list hides the class until the
+    // inventory toggle is flipped (#226) — the state the unmarked line was most
+    // misleading in.
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+    expect(harness.controller.linked, isNull, reason: 'passive session');
+    expect(find.text('Sam Sels'), findsOneWidget);
+
+    expect(
+      find.text('• Zit in de verkeerde Office 365-klasgroep: GBS-1A in plaats '
+          'van GBS-1B. Werk het ledenbestand van beide klassen bij. (manueel)'),
+      findsOneWidget,
+      reason: 'the operator must be able to tell manual work from due work',
+    );
+
+    // …and it stays a "(manueel)" line, never a "(keuze)" one: it stands alone.
+    expect(find.textContaining('(keuze)'), findsNothing);
+  });
+
+  testWidgets(
+      'a read-only account card leaves an applyable candidate unmarked (#255)',
+      (WidgetTester tester) async {
+    // The other half of the same rule: marking must distinguish, so an ordinary
+    // applyable candidate keeps its bare summary.
+    _useTallWindow(tester);
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+    expect(find.text('• Wijzig de klas in Smartschool'), findsOneWidget);
+    expect(find.textContaining('(manueel)'), findsNothing);
+  });
+
+  testWidgets(
       "a generation bump refetches the passive Actions overview's freshness "
       '(#108)', (WidgetTester tester) async {
     final linkedStore = InMemoryLinkedStore();

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -346,6 +346,19 @@ void main() {
     final bulkApply = ValueKey('situation-apply-$key');
     expect(find.byKey(bulkApply), findsOneWidget);
 
+    // Switch the second row to delete, leaving the first on the default. The
+    // header hands the pass the entries it is *showing*, so the pick has to
+    // survive the rebuild that publishes it (#110/#252).
+    final second = harness.controller.classroomPendingEntries[1].targetId;
+    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$second')));
+    await tester.tap(find.byKey(ValueKey('entry-student-$second')));
+    await tester.pumpAndSettle();
+    final deleteAlt =
+        find.byKey(ValueKey('alt-$second-DeleteStudentFromSmartschool'));
+    await tester.ensureVisible(deleteAlt);
+    await tester.tap(deleteAlt);
+    await tester.pumpAndSettle();
+
     await tester.ensureVisible(find.byKey(bulkApply));
     await tester.tap(find.byKey(bulkApply));
     await tester.pumpAndSettle();
@@ -354,6 +367,71 @@ void main() {
 
     expect(find.text('Apply result'), findsOneWidget);
     expect(harness.controller.applyResults, hasLength(2));
+    final summaries =
+        harness.controller.applyResults!.map((r) => r.changes.summary).toList();
+    expect(summaries, contains('Schrijf de leerling uit in Smartschool'));
+    expect(summaries, contains('Verwijder dit account uit Smartschool'),
+        reason: "the bulk pass runs each row's own chosen alternative");
+  });
+
+  testWidgets(
+      "a class's bulk apply stops at that class: the identical situation in "
+      'another class is left untouched (#252)', (WidgetTester tester) async {
+    // Three students in one situation — a stale Office 365 name — split across
+    // two classes: Sam and Sara in 3C, Tom in 3D. The bulk header lives inside
+    // one class and counts one class, but the pass behind it used to resolve
+    // its situation key back through the whole linked view, so pressing
+    // "Alles toepassen (2)" in 3C wrote Tom too.
+    _useTallWindow(tester);
+    final harness = crossClassSituationHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+
+    final inClass = harness.controller.classroomPendingEntries;
+    expect(inClass, hasLength(2), reason: '3C holds Sam and Sara');
+    final key = inClass.first.situationKey;
+    expect(
+      harness.controller.pendingEntries.where((e) => e.situationKey == key),
+      hasLength(3),
+      reason: "Tom's 3D entry is the very same situation, group-wide",
+    );
+
+    // The button's own count is the class's, and so is what it writes.
+    final bulkApply = find.byKey(ValueKey('situation-apply-$key'));
+    await tester.ensureVisible(bulkApply);
+    expect(tester.widget<FilledButton>(bulkApply).child, isA<Text>());
+    expect(
+        find.descendant(
+            of: bulkApply, matching: find.text('Alles toepassen (2)')),
+        findsOneWidget);
+
+    await tester.tap(bulkApply);
+    await tester.pumpAndSettle();
+    // The confirmation quotes the same two writes, not three (#234).
+    expect(find.textContaining('2 wijzigingen'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Apply result'), findsOneWidget);
+    expect(harness.controller.applyResults, hasLength(2),
+        reason: 'one write per account of the open class');
+    final patched = harness.graph.requests
+        .where((r) => r.method == 'PATCH')
+        .map((r) => r.url.path)
+        .toList();
+    expect(patched, hasLength(2));
+    expect(patched.any((p) => p.endsWith(kSam3C)), isTrue);
+    expect(patched.any((p) => p.endsWith(kSara3C)), isTrue);
+    expect(patched.any((p) => p.endsWith(kTom3D)), isFalse,
+        reason: 'the operator never opened 3D — it must not be written');
+    // …and Tom's work is still pending, waiting for someone to open his class.
+    expect(
+      harness.controller.pendingEntries.where((e) => e.situationKey == key),
+      hasLength(1),
+    );
   });
 
   testWidgets(

--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -130,7 +130,17 @@ ride alongside **both** branches:
   **no** students; informational), and `DoNotImportFromSmartschool` (orphan
   Smartschool class; informational). A WISA-only class therefore raises
   `DoNotImportFromWisa` plus exactly one of `AddToSmartschool` /
-  `CreateInSmartschool`.
+  `CreateInSmartschool` — or, when Smartschool already carries the name on a
+  group the linker could not adopt (#225), the informational
+  `ClassExistsAsSmartschoolGroup` in place of both creates.
+
+  These are never independent to-dos: `DoNotImportFromWisa` shares an
+  `alternativeGroup` key with the reading it contradicts, so the pending list
+  renders one either/or and an apply runs only the picked half. The key is
+  `classImportAlternative` for a genuinely new class (#244) and
+  `namesakeClassAlternative` for one Smartschool already has (#250), which keeps
+  the two situations in separate bulk-apply subsets. The default is always the
+  provisioning/diagnosis half, never the blacklist.
 - **Present in both** → only `ModifySmartschoolData` (sync institute number,
   Untis code, and description).
 

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -72,7 +72,9 @@ sealed class GroupAction {
 
   /// The key shared by mutually-exclusive alternatives resolving the same
   /// situation (#110). `null` (the default) means the action stands on its own.
-  /// The group family's one key is [classImportAlternative] (#244). See
+  /// The group family has two: [classImportAlternative] for a class Smartschool
+  /// does not have (#244) and [namesakeClassAlternative] for one it already
+  /// carries under a group the linker could not adopt (#250). See
   /// [StudentAction.alternativeGroup].
   String? get alternativeGroup => null;
 
@@ -155,7 +157,10 @@ sealed class GroupAction {
 ///
 /// The two create actions never fire together (the [GroupPlacement] membership
 /// signal picks exactly one), so all three can share the single key and exactly
-/// one default is ever offered.
+/// one default is ever offered — except when Smartschool already carries the
+/// name, where both creates step aside and the pair moves to
+/// [namesakeClassAlternative] instead (#250). This key therefore always has a
+/// create in it, and the blacklist is never left alone in it.
 ///
 /// **The default is the create action, deliberately the opposite polarity from
 /// [smartschoolDepartureAlternative]**, where the conservative "keep the
@@ -175,6 +180,33 @@ sealed class GroupAction {
 /// leads the radio list and is also what the grouping falls back to if a
 /// default is ever forgotten.
 const String classImportAlternative = 'class-import';
+
+/// The [GroupAction.alternativeGroup] key shared by the mutually exclusive
+/// readings of a WISA class Smartschool **already carries**, on a group the
+/// linker could not adopt (#225): repair it in Smartschool by hand
+/// ([ClassExistsAsSmartschoolGroup]) *or* stop offering the class altogether
+/// ([DoNotImportFromWisa]).
+///
+/// **Why a second key and not a third member of [classImportAlternative].** The
+/// pending list keys a "same situation" bulk-apply subset on this very string
+/// (`PendingChoice.situationId`), so pooling the namesake classes with the
+/// genuinely new ones would file both under one header naming both readings and
+/// one **Apply to all**. They are different situations — "create this class" and
+/// "this class is already there, go fix its flag" — so they get different keys
+/// and each keeps its own bulk pass.
+///
+/// **The default is the notice**, the same polarity [CreateInSmartschool] has
+/// inside [classImportAlternative]: it is informational, so a bulk apply writes
+/// **nothing** for a namesake class and blacklisting one stays a deliberate
+/// pick. That is the whole of #250. Before it, the create actions refused a
+/// namesake class (they would ask Smartschool for a duplicate name) while
+/// [DoNotImportFromWisa] still declared [classImportAlternative], so the choice
+/// collapsed to a single member — and a lone option is always the selected one.
+/// "Apply to all" therefore wrote a [wapi.DontImportClass] rule on the very
+/// class the notice beside it had just told the operator to align by hand: the
+/// class dropped out of the next WISA snapshot while the Smartschool group
+/// stayed, which is exactly the failure mode #244 fixed for the create case.
+const String namesakeClassAlternative = 'class-namesake';
 
 /// Stop importing a class from WISA. Ported from `Action\Group\DoNotImportFromWisa`:
 /// the class exists in WISA but not Smartschool, and the operator judges it need
@@ -197,11 +229,24 @@ class DoNotImportFromWisa extends GroupAction {
   @override
   bool evaluate() => group.wisa != null && group.smartschool == null;
 
-  /// Blacklisting the class is one half of the [classImportAlternative] choice
-  /// (#244) — never a to-do beside the create it contradicts. It is not the
-  /// default: an operator has to pick it.
+  /// Blacklisting the class is never a to-do beside the reading it contradicts
+  /// — it is one half of a choice. *Which* choice depends on what Smartschool
+  /// already holds:
+  /// - **no namesake** (#244): the class is genuinely absent downstream, so the
+  ///   either/or is [classImportAlternative] — create it ([AddToSmartschool] /
+  ///   [CreateInSmartschool]'s wait-or-delete notice) or stop offering it;
+  /// - **a namesake** ([LinkedGroup.smartschoolNamesake], #250): the class is
+  ///   already there under a group the linker could not adopt, so the either/or
+  ///   is [namesakeClassAlternative] — repair it by hand
+  ///   ([ClassExistsAsSmartschoolGroup]) or stop offering it.
+  ///
+  /// The two keys are deliberately distinct: they are different situations, and
+  /// the pending list bulk-applies per situation key. Either way this half is
+  /// never the default — an operator has to pick it.
   @override
-  String? get alternativeGroup => classImportAlternative;
+  String? get alternativeGroup => group.smartschoolNamesake != null
+      ? namesakeClassAlternative
+      : classImportAlternative;
 
   wapi.DontImportClass _rule() => wapi.DontImportClass(_wisa.name);
 
@@ -443,6 +488,17 @@ class ClassExistsAsSmartschoolGroup extends GroupAction {
       group.wisa != null &&
       group.smartschool == null &&
       group.smartschoolNamesake != null;
+
+  /// The notice leads — and is the default of — the [namesakeClassAlternative]
+  /// choice (#250). [DoNotImportFromWisa] is its other half: the two are
+  /// opposite readings of one class, so they are one either/or and never two
+  /// to-dos. Being informational, the default makes a bulk apply write nothing
+  /// for a class the app has just told the operator to repair in Smartschool.
+  @override
+  String? get alternativeGroup => namesakeClassAlternative;
+
+  @override
+  bool get isDefaultAlternative => true;
 
   @override
   bool get canApply => false;

--- a/packages/account_actions/lib/src/group_dispatch.dart
+++ b/packages/account_actions/lib/src/group_dispatch.dart
@@ -30,6 +30,14 @@ import 'group_placement.dart';
 /// raised whether or not [placementFor] is wired, and a WISA-only class is
 /// never left with a create proposal as its only reading.
 ///
+/// Taking the create's place means taking its side of the either/or too (#250):
+/// the notice and [DoNotImportFromWisa] share [namesakeClassAlternative], a key
+/// of their own so the namesake classes are not bulk-applied together with the
+/// genuinely new ones. Without it the blacklist was the *lone* member of
+/// [classImportAlternative] on such a class, hence always selected, and "Apply
+/// to all" wrote a `DontImportClass` rule on the class the notice beside it had
+/// just said to fix by hand.
+///
 /// [placementFor] wires the membership-dependent creation actions (#65). When
 /// supplied it is called for each WISA-only class (`wisa != null &&
 /// smartschool == null`) to build its [GroupPlacement]: the membership signal
@@ -75,11 +83,12 @@ List<GroupAction> groupActionsFor(
     if (both)
       ModifySmartschoolData(group)
     else ...[
+      // Whichever reading of the class fires — the namesake notice (#250) or a
+      // create (#244) — it leads the [DoNotImportFromWisa] it is mutually
+      // exclusive with: the order is the order the operator reads the radio
+      // pair in, and the fallback the grouping uses if a default is ever
+      // forgotten, so the blacklist is never first.
       ClassExistsAsSmartschoolGroup(group),
-      // The create actions lead [DoNotImportFromWisa], which they are mutually
-      // exclusive with (#244): the order is the order the operator reads the
-      // radio pair in, and the fallback the grouping uses if a default is ever
-      // forgotten — so the provisioning half comes first, never the blacklist.
       if (placement != null) AddToSmartschool(group, placement),
       if (placement != null) CreateInSmartschool(group, placement),
       DoNotImportFromWisa(group),

--- a/packages/account_actions/test/group_dispatch_test.dart
+++ b/packages/account_actions/test/group_dispatch_test.dart
@@ -214,10 +214,12 @@ void main() {
       expect(actions.single.alternativeGroup, isNull);
     });
 
-    test('the namesake notice (#225) is not part of the choice', () {
-      // It is a different reading of the class — "align the names by hand" —
-      // and merging it into the key would pool it with the create bucket for
-      // bulk apply. It keeps its own situation.
+    test('the namesake notice (#225) leads a choice of its own (#250)', () {
+      // The notice takes the create's place for a class Smartschool already
+      // carries, so it takes the create's side of the either/or too — under its
+      // own key, because "this class is already there, go fix its flag" is a
+      // different situation from "create this class" and must not share a bulk
+      // apply with it.
       final actions = groupActionsFor(
         linkedGroup(
           wisa: wisaGroup(name: '2G'),
@@ -225,13 +227,53 @@ void main() {
         ),
         placementFor: (_) => groupPlacement(containsStudents: true),
       );
+      final notice = actions.whereType<ClassExistsAsSmartschoolGroup>().single;
+      final ignore = actions.whereType<DoNotImportFromWisa>().single;
+
+      expect(notice.alternativeGroup, namesakeClassAlternative);
+      expect(ignore.alternativeGroup, namesakeClassAlternative);
       expect(
-        actions
-            .whereType<ClassExistsAsSmartschoolGroup>()
-            .single
-            .alternativeGroup,
-        isNull,
+        notice.alternativeGroup,
+        isNot(classImportAlternative),
+        reason: 'a namesake class is not bulk-applied with the new classes',
       );
+
+      // Polarity: the informational notice leads and is the default, so a bulk
+      // apply writes *nothing* for a class the operator was told to repair by
+      // hand — blacklisting it stays a deliberate pick (#250).
+      expect(notice.isDefaultAlternative, isTrue);
+      expect(notice.canApply, isFalse);
+      expect(ignore.isDefaultAlternative, isFalse);
+      expect(actions.indexOf(notice), lessThan(actions.indexOf(ignore)));
+    });
+
+    test('the blacklist is never the lone member of a choice (#250)', () {
+      // The bug: the creates refuse a namesake class, so `class-import` was
+      // left holding only `DoNotImportFromWisa` — and a lone option is always
+      // the selected one, which made "Apply to all" blacklist the class.
+      for (final hasStudents in const [true, false]) {
+        final actions = groupActionsFor(
+          linkedGroup(
+            wisa: wisaGroup(name: '2G'),
+            smartschoolNamesake: ssGroupNode(code: 'G2G', name: '2G'),
+          ),
+          placementFor: (_) => groupPlacement(containsStudents: hasStudents),
+        );
+        final ignore = actions.whereType<DoNotImportFromWisa>().single;
+        final siblings = actions
+            .where((a) => a.alternativeGroup == ignore.alternativeGroup)
+            .toList();
+
+        expect(siblings, hasLength(2),
+            reason: 'the blacklist always has the reading it contradicts '
+                'beside it');
+        expect(siblings.where((a) => a.isDefaultAlternative), hasLength(1));
+        expect(
+          siblings.singleWhere((a) => a.isDefaultAlternative).canApply,
+          isFalse,
+          reason: 'nothing is written for a namesake class by default',
+        );
+      }
     });
   });
 

--- a/packages/account_state/lib/src/apply/state_applier.dart
+++ b/packages/account_state/lib/src/apply/state_applier.dart
@@ -44,6 +44,42 @@ class ApplyResult {
   bool get refreshed => linked != null;
 }
 
+/// Everything [StateApplier] derives from the operator's settings document,
+/// gathered into one value it re-reads at every use (#246).
+///
+/// These four used to be `final` fields on the applier, captured when
+/// `bootstrapReconcile` assembled the stack and never looked at again. That made
+/// the school prefix, the Azure domain, the Smartschool class tree and the
+/// managed-school set relaunch-only: an operator could flip a school's
+/// **beheerd** mark in Instellingen, save, sync, and get the old scoping back
+/// with nothing on screen to explain it. Bundling them means the applier takes
+/// **one** supplier rather than four, and that a pass which samples them
+/// ([StateApplier.link]) is guaranteed to see one consistent document.
+class ApplierSettings {
+  const ApplierSettings({
+    required this.studentConfig,
+    required this.staffConfig,
+    this.classTree = const SmartschoolClassTree(),
+    this.ourSchoolIds,
+  });
+
+  /// Student action config — the school prefix the linker scopes Azure by and
+  /// the UPN domains new accounts are minted under.
+  final StudentActionConfig studentConfig;
+
+  /// Staff action config; carries the same prefix and base domain.
+  final StaffActionConfig staffConfig;
+
+  /// The Smartschool grade/year vocabulary and group root a freshly created
+  /// class hangs under (`classTreeFrom(settings.smartschool)`).
+  final SmartschoolClassTree classTree;
+
+  /// The `ours`-flagged WISA school ids (#178), or null when no school is
+  /// flagged — which falls back to the snapshot's own `MarkAsOurs` flags rather
+  /// than treating an empty managed set as "none".
+  final Set<int>? ourSchoolIds;
+}
+
 /// Drives the action engine from the State layer and keeps the in-memory
 /// snapshots consistent afterwards (spec `docs/domain-model.md` §6.4; #72).
 ///
@@ -67,19 +103,50 @@ class ApplyResult {
 /// `uid1`, `uid2`, … — the legacy `AccountManager.CreateUID` counter). Read the
 /// current derived view (and the actions to apply) via [link], so both linking
 /// and applying use those uniqueness-aware configs.
+///
+/// **Settings are read live (#246).** Every settings-derived input arrives as
+/// one [ApplierSettings] supplier that is called *per link and per apply*, never
+/// captured in a field. Before #246 the four values were `final`, so an operator
+/// who flipped a school's **beheerd** mark, changed the school prefix or edited
+/// the Smartschool class tree kept getting the bootstrap-time answer until the
+/// app was relaunched.
 class StateApplier {
   StateApplier({
     required this.app,
     required this.connectors,
     required this.resolver,
     required this.wisaRules,
+    required ApplierSettings Function() settings,
+    this.passwordQueue,
+  }) : _settings = settings;
+
+  /// Convenience wiring for a stack whose settings genuinely cannot change
+  /// while it lives — a headless linking pass, a fixture, a unit test. Supplies
+  /// the same [ApplierSettings] on every read; production always uses the
+  /// unnamed constructor with a supplier over the live document.
+  StateApplier.fixed({
+    required ApplicationState app,
+    required Connectors connectors,
+    required core.PersonIdResolver resolver,
+    required WisaImportRules wisaRules,
     required StudentActionConfig studentConfig,
     required StaffActionConfig staffConfig,
-    this.classTree = const SmartschoolClassTree(),
-    this.passwordQueue,
-    this.ourSchoolIds,
-  })  : _studentConfig = _uniqueStudentConfig(studentConfig, _uidsFrom(app)),
-        _staffConfig = _uniqueStaffConfig(staffConfig, _uidsFrom(app));
+    SmartschoolClassTree classTree = const SmartschoolClassTree(),
+    Set<int>? ourSchoolIds,
+    PasswordQueueStore? passwordQueue,
+  }) : this(
+          app: app,
+          connectors: connectors,
+          resolver: resolver,
+          wisaRules: wisaRules,
+          passwordQueue: passwordQueue,
+          settings: () => ApplierSettings(
+            studentConfig: studentConfig,
+            staffConfig: staffConfig,
+            classTree: classTree,
+            ourSchoolIds: ourSchoolIds,
+          ),
+        );
 
   /// The snapshots this applier reads and patches.
   final ApplicationState app;
@@ -95,9 +162,6 @@ class StateApplier {
   /// [WisaImportRules]).
   final WisaImportRules wisaRules;
 
-  /// Smartschool class-tree live-config the placement resolver needs.
-  final SmartschoolClassTree classTree;
-
   /// The shared password-distribution queue (#105). When wired, every apply that
   /// **creates** an account drops the password it minted into this store, keyed
   /// by [core.PersonId], so one operator can generate while another prints and
@@ -108,21 +172,31 @@ class StateApplier {
   /// still written to the target system but not queued.
   final PasswordQueueStore? passwordQueue;
 
+  /// The settings-derived inputs, read afresh on every use (#246).
+  final ApplierSettings Function() _settings;
+
+  /// The settings-derived inputs as they stand **right now**. Call this once
+  /// per operation and use the result throughout it, so a save landing mid-pass
+  /// cannot split one link across two documents.
+  ApplierSettings get settings => _settings();
+
   /// The WISA school ids the operator actually manages (from the persisted
   /// `AppSettings.wisaSchools` ownership flags, #178). Threaded into `link()` so
   /// a student present only in a non-managed sibling school is classified
   /// [core.WisaPresence.groupOnly] and kept out of the managed-school Actions
   /// view. Null falls back to the snapshot's `MarkAsOurs` flags (see `link()`).
-  final Set<int>? ourSchoolIds;
+  Set<int>? get ourSchoolIds => settings.ourSchoolIds;
 
-  final StudentActionConfig _studentConfig;
-  final StaffActionConfig _staffConfig;
+  /// Smartschool class-tree live-config the placement resolver needs.
+  SmartschoolClassTree get classTree => settings.classTree;
 
   /// The uid-uniqueness-aware student config used for both linking and applying.
-  StudentActionConfig get studentConfig => _studentConfig;
+  StudentActionConfig get studentConfig =>
+      _uniqueStudentConfig(settings.studentConfig, _uidsFrom(app));
 
   /// The uid-uniqueness-aware staff config used for both linking and applying.
-  StaffActionConfig get staffConfig => _staffConfig;
+  StaffActionConfig get staffConfig =>
+      _uniqueStaffConfig(settings.staffConfig, _uidsFrom(app));
 
   /// The current derived linked view over [app]'s snapshots, built with the
   /// uniqueness-aware configs. Rebuild the UI's action lists from this after
@@ -132,14 +206,24 @@ class StateApplier {
   /// Asynchronous because [resolver] may be a [PreparablePersonIdResolver] (the
   /// DB-backed identity map), which is primed before the pure `link()` runs; a
   /// file/in-memory resolver skips that step and this resolves immediately.
-  Future<LinkedState> link() => LinkedState.fromApplicationAsync(
-        app,
-        resolver: resolver,
-        studentConfig: _studentConfig,
-        staffConfig: _staffConfig,
-        classTree: classTree,
-        ourSchoolIds: ourSchoolIds,
-      );
+  ///
+  /// The settings are sampled **once** here and threaded through the whole pass
+  /// (#246): the school prefix the linker scopes by, the managed-school set and
+  /// the class tree must all describe the same document, or `link()` would scope
+  /// Azure by one prefix while `naturalKeysFor` primed the resolver with
+  /// another.
+  Future<LinkedState> link() {
+    final now = settings;
+    final uids = _uidsFrom(app);
+    return LinkedState.fromApplicationAsync(
+      app,
+      resolver: resolver,
+      studentConfig: _uniqueStudentConfig(now.studentConfig, uids),
+      staffConfig: _uniqueStaffConfig(now.staffConfig, uids),
+      classTree: now.classTree,
+      ourSchoolIds: now.ourSchoolIds,
+    );
+  }
 
   /// Applies a [StudentAction] and refreshes the snapshot on a real write, then
   /// runs whatever that write unlocked on the same student (#230).

--- a/packages/account_state/lib/src/materialize/materialized_state.dart
+++ b/packages/account_state/lib/src/materialize/materialized_state.dart
@@ -582,7 +582,11 @@ class Rollup {
 /// not just this session's in-process [SystemState.lastSync]. Written into the
 /// [SyncState.systems] map by the operator whose sync pulled that system.
 class SystemSyncMeta {
-  const SystemSyncMeta({required this.syncedBy, required this.at});
+  const SystemSyncMeta({
+    required this.syncedBy,
+    required this.at,
+    this.workDate,
+  });
 
   /// The operator (AAD UPN) whose session pulled this system.
   final String syncedBy;
@@ -590,14 +594,31 @@ class SystemSyncMeta {
   /// When that pull's snapshot was fetched.
   final DateTime at;
 
+  /// The **werkdatum** a WISA pull asked for — the date the roster now
+  /// installed is *as of* (#247). Null for Smartschool and Azure, which have
+  /// no such input, and on a WISA stamp written before this was recorded.
+  ///
+  /// It rides here rather than on [SyncState] itself because it is a property
+  /// of the WISA *pull*, not of the materialize: a Check-for-drift re-links
+  /// without re-pulling WISA, so the roster — and the date it describes — stays
+  /// the one this entry already names, exactly as [at] and [syncedBy] do. That
+  /// also puts it in the shared store, so a passive session (#115) reading a
+  /// view somebody else synced can tell which school year it describes without
+  /// having run the pass itself.
+  final DateTime? workDate;
+
   Map<String, dynamic> toJson() => {
         'syncedBy': syncedBy,
         'at': at.toIso8601String(),
+        if (workDate != null) 'workDate': workDate!.toIso8601String(),
       };
 
   factory SystemSyncMeta.fromJson(Map<String, dynamic> json) => SystemSyncMeta(
         syncedBy: json['syncedBy'] as String,
         at: DateTime.parse(json['at'] as String),
+        workDate: json['workDate'] == null
+            ? null
+            : DateTime.parse(json['workDate'] as String),
       );
 }
 

--- a/packages/account_state/lib/src/settings/live_settings.dart
+++ b/packages/account_state/lib/src/settings/live_settings.dart
@@ -72,3 +72,32 @@ String wisaPullFingerprint(AppSettings settings) {
 
 String _workDateKey(WorkDateSetting setting) =>
     setting.isNow ? 'now' : (setting.date?.toIso8601String() ?? 'unset');
+
+/// A stable identity for the settings a running session **cannot** adopt: the
+/// endpoints and credential refs the three connectors were constructed from
+/// (#246).
+///
+/// #246 made every *derived* settings value live — the managed-school set, the
+/// school prefix, the Azure domain, the Smartschool class tree and import
+/// rules — by routing each reader through [LiveSettings] at use time. The
+/// connection profiles are the residue that cannot follow. A WISA host, port,
+/// database or login is baked into a live SQL connection; a Smartschool site
+/// into a SOAP endpoint; either password ref into a Key Vault secret the
+/// bootstrap already resolved (an async read that cannot happen inside a
+/// syncer). Re-reading them mid-session would mean tearing down and rebuilding
+/// the connectors under whatever pass is in flight.
+///
+/// So they stay frozen, and the reconcile screen says so instead: a document
+/// whose fingerprint has moved since bootstrap means the connectors in hand are
+/// talking to the *previous* endpoints, which is exactly the silent-stale-input
+/// failure #238 set out to end. Fingerprinting only the secret **ref** (never a
+/// value) keeps this free of anything sensitive — rotating the secret behind an
+/// unchanged ref is a Key Vault event this cannot and need not see.
+String connectionFingerprint(AppSettings settings) {
+  final wisa = settings.wisa;
+  final smartschool = settings.smartschool;
+  return 'wisa=${wisa.server.trim()}:${wisa.port.trim()}/'
+      '${wisa.database.trim()}@${wisa.username.trim()}'
+      '#${wisa.passwordRef.name};'
+      'smartschool=${smartschool.uri.trim()}#${smartschool.passphraseRef.name}';
+}

--- a/packages/account_state/lib/src/sync/application_state.dart
+++ b/packages/account_state/lib/src/sync/application_state.dart
@@ -79,15 +79,43 @@ class ApplicationState {
 /// one-liner `(_) => connector.sync(...)`, written at the wiring site because
 /// their per-sync parameters (WISA schools/workdate, the import-rule sets) come
 /// from live-config that a later slice folds in.
+///
+/// [schoolPrefix] is likewise read **at sync time** (#246): the prefix scopes
+/// both the bulk `$filter` and the group listing, and the operator can change it
+/// in Instellingen while the app runs, so the connector's own
+/// `AzureCredentials.schoolPrefix` — frozen when bootstrap built it — must not
+/// be the last word. Omit it and the pull is exactly as it shipped before #246.
+///
+/// **Changing the prefix forces a full read.** `/users/delta` returns the
+/// tenant's changes and the walk filters them client-side by prefix, so an
+/// incremental pass layers the new prefix's *changes* on top of the previous
+/// pass's *old-prefix* user list. The snapshot would then be a mix of two
+/// schools that no relink could untangle, and it would persist to the cold store
+/// and materialize for everyone. So when the prefix has moved since the last
+/// pull this syncer performed, the stored token and previous list are dropped
+/// and the pass re-reads in full — the same recovery #213 already makes when
+/// Graph refuses a token.
 Syncer<AzureSnapshot> azureSyncer(
   AzureConnector connector, {
   Iterable<String> Function()? expectedEmployeeIds,
-}) =>
-    (previous) => connector.sync(
-          deltaToken: previous?.deltaToken,
-          previous: previous,
-          expectedEmployeeIds: expectedEmployeeIds?.call() ?? const <String>[],
-        );
+  String Function()? schoolPrefix,
+}) {
+  // The prefix the snapshot in hand was read with. Seeded from the wiring-time
+  // value, which is the one the cold seed (if any) was pulled with: bootstrap
+  // wires this from the very document it just loaded.
+  var pulledWith = schoolPrefix?.call() ?? connector.credentials.schoolPrefix;
+  return (previous) {
+    final prefix = schoolPrefix?.call() ?? connector.credentials.schoolPrefix;
+    final moved = prefix != pulledWith;
+    pulledWith = prefix;
+    return connector.sync(
+      deltaToken: moved ? null : previous?.deltaToken,
+      previous: moved ? null : previous,
+      expectedEmployeeIds: expectedEmployeeIds?.call() ?? const <String>[],
+      schoolPrefix: prefix,
+    );
+  };
+}
 
 /// The WISA ids of the students in [snapshot] that belong to a school we
 /// manage — the ids [azureSyncer] hands the connector as the accounts this pass

--- a/packages/account_state/test/application_state_test.dart
+++ b/packages/account_state/test/application_state_test.dart
@@ -223,6 +223,111 @@ void main() {
         ["employeeId in ('W7')"],
       );
     });
+
+    test(
+        'the school prefix is read at sync time too, not at wiring time (#246)',
+        () async {
+      // The prefix scopes the whole pull, and the operator can change it in
+      // Instellingen mid-session. Before #246 the connector's credentials —
+      // frozen when bootstrap built them — were the only answer, so a saved
+      // prefix took a relaunch.
+      var prefix = 'GBS';
+      final state = SystemState<AzureSnapshot>(
+        system: core.Origin.azure,
+        syncer: azureSyncer(
+          AzureConnector(
+            credentials: AzureCredentials(
+              clientId: 'c',
+              tenantId: 't',
+              azureDomain: 'school.example',
+              schoolPrefix: 'FROZEN',
+            ),
+            authProvider: const StaticAuthProvider('T'),
+            transport: transport,
+          ),
+          schoolPrefix: () => prefix,
+        ),
+      );
+
+      await state.sync();
+      final first =
+          transport.requests.firstWhere((r) => r.url.path.endsWith('/users'));
+      expect(first.url.queryParameters[r'$filter'], contains('GBS'));
+      expect(first.url.queryParameters[r'$filter'], isNot(contains('FROZEN')));
+
+      prefix = 'SSM';
+      await state.sync();
+      final second =
+          transport.requests.lastWhere((r) => r.url.path.endsWith('/users'));
+      expect(second.url.queryParameters[r'$filter'], contains('SSM'));
+    });
+
+    test(
+        'a changed prefix re-reads in full instead of deltaing over the old '
+        'school (#246)', () async {
+      // `/users/delta` returns tenant changes filtered client-side by prefix, so
+      // an incremental pass would layer the *new* school's changes on the *old*
+      // school's user list — a snapshot mixing two schools that then persists to
+      // the cold store and materializes for the whole team. Dropping the token
+      // costs one full read and cannot lie.
+      var prefix = 'GBS';
+      final state = SystemState<AzureSnapshot>(
+        system: core.Origin.azure,
+        syncer: azureSyncer(
+          AzureConnector(
+            credentials: AzureCredentials(
+              clientId: 'c',
+              tenantId: 't',
+              azureDomain: 'school.example',
+              schoolPrefix: 'GBS',
+            ),
+            authProvider: const StaticAuthProvider('T'),
+            transport: transport,
+          ),
+          schoolPrefix: () => prefix,
+        ),
+      );
+
+      await state.sync();
+      // Unchanged prefix ⇒ the ordinary incremental pass, as before #246.
+      await state.sync();
+      expect(
+        transport.requests
+            .lastWhere((r) => r.url.path.contains('users/delta'))
+            .url
+            .queryParameters[r'$deltatoken'],
+        'PRIMED1',
+      );
+
+      final bulkReadsBefore =
+          transport.requests.where((r) => r.url.path.endsWith('/users')).length;
+      prefix = 'SSM';
+      final snapshot = await state.sync();
+
+      final bulkReadsAfter =
+          transport.requests.where((r) => r.url.path.endsWith('/users')).length;
+      expect(bulkReadsAfter, bulkReadsBefore + 1,
+          reason: 'the prefix moved ⇒ a full read, not a delta');
+      expect(
+        transport.requests
+            .lastWhere((r) => r.url.path.endsWith('/users'))
+            .url
+            .queryParameters[r'$filter'],
+        contains('SSM'),
+      );
+      expect(snapshot.deltaToken, 'PRIMED1',
+          reason: 'the full read primes a fresh token for the new prefix');
+
+      // …and the pass after that is incremental again: only the *change* forces
+      // the full read, not the new prefix forever.
+      final beforeSteady =
+          transport.requests.where((r) => r.url.path.endsWith('/users')).length;
+      await state.sync();
+      expect(
+        transport.requests.where((r) => r.url.path.endsWith('/users')).length,
+        beforeSteady,
+      );
+    });
   });
 
   group('managedStudentEmployeeIds (#224)', () {

--- a/packages/account_state/test/live_settings_test.dart
+++ b/packages/account_state/test/live_settings_test.dart
@@ -124,4 +124,73 @@ void main() {
       );
     });
   });
+
+  group('connectionFingerprint (#246)', () {
+    test('moves for every endpoint half a connector is built from', () {
+      final base = _settings();
+      final variants = <String, AppSettings>{
+        'server': base.copyWith(wisa: base.wisa.copyWith(server: 'other.host')),
+        'port': base.copyWith(wisa: base.wisa.copyWith(port: '9001')),
+        'database': base.copyWith(wisa: base.wisa.copyWith(database: 'other')),
+        'username': base.copyWith(wisa: base.wisa.copyWith(username: 'other')),
+        'passwordRef': base.copyWith(
+          wisa: base.wisa.copyWith(passwordRef: const SecretRef('wisa.pw2')),
+        ),
+        'uri': base.copyWith(
+          smartschool: base.smartschool.copyWith(uri: 'other.smartschool.be'),
+        ),
+        'passphraseRef': base.copyWith(
+          smartschool: base.smartschool
+              .copyWith(passphraseRef: const SecretRef('ss.pass2')),
+        ),
+      };
+      for (final entry in variants.entries) {
+        expect(
+          connectionFingerprint(entry.value),
+          isNot(connectionFingerprint(base)),
+          reason: 'changing ${entry.key} rebuilds a connector',
+        );
+      }
+    });
+
+    test('never carries a secret value — only the ref that names one', () {
+      // The whole point of the SecretRef seam: nothing sensitive is ever
+      // serialized, and a fingerprint is a string this app logs and renders
+      // around. Rotating the secret behind an unchanged ref is a Key Vault
+      // event, invisible (and irrelevant) here.
+      final print = connectionFingerprint(_settings());
+      expect(print, contains('wisa.password'));
+      expect(print, isNot(contains('geheim')));
+    });
+
+    test('ignores everything #246 made live, so a live change never nags', () {
+      // The values the running stack now adopts must not raise the
+      // relaunch notice: the prefix, the domain, the managed/virtual marks, the
+      // class tree, the rules and the werkdatum all reach the next pass.
+      final base = _settings();
+      final live = base.copyWith(
+        schoolPrefix: 'GBS',
+        azure: const AzureConnection(domain: 'school.example'),
+        smartschool: base.smartschool.copyWith(
+          studentGroup: 'SCHOOL',
+          useYears: true,
+          years: const ['1', '2', '3', '4', '5', '6', '7'],
+        ),
+        wisa: base.wisa.copyWith(
+          workDate: WorkDateSetting(isNow: false, date: DateTime(2026, 9)),
+        ),
+        wisaSchools: const [
+          WisaSchoolProfile(schoolId: 1, code: 'A', name: 'A', ours: true),
+        ],
+      );
+      expect(connectionFingerprint(live), connectionFingerprint(base));
+    });
+
+    test('is insensitive to surrounding whitespace an operator typed', () {
+      final base = _settings();
+      final padded =
+          base.copyWith(wisa: base.wisa.copyWith(server: '  wisa.local  '));
+      expect(connectionFingerprint(padded), connectionFingerprint(base));
+    });
+  });
 }

--- a/packages/account_state/test/materialize/linked_store_test.dart
+++ b/packages/account_state/test/materialize/linked_store_test.dart
@@ -188,6 +188,43 @@ void main() {
       expect(back.generation, 3);
       expect(back.systems[core.Origin.smartschool]?.syncedBy, 'mieke@school');
       expect(back.systems[core.Origin.smartschool]?.at, t0);
+      expect(back.systems[core.Origin.smartschool]?.workDate, isNull,
+          reason: 'only a WISA pull is made as of a werkdatum');
+    });
+
+    test("json carries a WISA stamp's werkdatum (#247)", () {
+      // The date the installed roster was pulled as of. It has to survive the
+      // store, or a passive session reading somebody else's sync would have no
+      // way to tell which school year the view describes.
+      final state = SyncState(
+        generation: 3,
+        updatedAt: t0,
+        updatedBy: 'jan@school',
+        systems: {
+          core.Origin.wisa: SystemSyncMeta(
+            syncedBy: 'jan@school',
+            at: t0,
+            workDate: DateTime(2026, 9, 1),
+          ),
+        },
+      );
+
+      final back = SyncState.fromJson(state.toJson());
+      expect(back.systems[core.Origin.wisa]?.workDate, DateTime(2026, 9, 1));
+    });
+
+    test('a stamp written before #247 reads back without a werkdatum', () {
+      // Forward-compatibility the other way round: the shared document in
+      // Cosmos predates the field, and must still parse.
+      final legacy = <String, dynamic>{
+        'generation': 2,
+        'systems': {
+          'wisa': {'syncedBy': 'jan@school', 'at': t0.toIso8601String()},
+        },
+      };
+      final back = SyncState.fromJson(legacy);
+      expect(back.systems[core.Origin.wisa]?.at, t0);
+      expect(back.systems[core.Origin.wisa]?.workDate, isNull);
     });
   });
 }

--- a/packages/account_state/test/password_queue_capture_test.dart
+++ b/packages/account_state/test/password_queue_capture_test.dart
@@ -236,7 +236,7 @@ class _Harness {
     );
     var n = 0;
     String nextPassword() => 'pw${++n}';
-    applier = StateApplier(
+    applier = StateApplier.fixed(
       app: app,
       connectors: Connectors(smartschool: _ssConn(), azure: _azConn()),
       resolver: _SeqResolver(),

--- a/packages/account_state/test/state_applier_test.dart
+++ b/packages/account_state/test/state_applier_test.dart
@@ -329,7 +329,7 @@ class _Harness {
 
     app =
         ApplicationState(wisa: wisaState, smartschool: ssState, azure: azState);
-    applier = StateApplier(
+    applier = StateApplier.fixed(
       app: app,
       connectors: Connectors(smartschool: _ssConn(soap), azure: _azConn(graph)),
       resolver: _SeqResolver(),
@@ -568,7 +568,7 @@ void main() {
     test('both minted passwords land on one password sheet (#105)', () async {
       final queue = InMemoryPasswordQueueStore();
       final harness = newIntake();
-      final applier = StateApplier(
+      final applier = StateApplier.fixed(
         app: harness.app,
         connectors: Connectors(
           smartschool: _ssConn(harness.soap),
@@ -722,7 +722,7 @@ void main() {
     test('both minted passwords land on one password sheet (#105)', () async {
       final queue = InMemoryPasswordQueueStore();
       final harness = newHire();
-      final applier = StateApplier(
+      final applier = StateApplier.fixed(
         app: harness.app,
         connectors: Connectors(
           smartschool: _ssConn(harness.soap),
@@ -985,6 +985,134 @@ void main() {
           everyElement(contains('ledenbestand')),
         );
       });
+    });
+  });
+
+  group('settings are read live, never captured (#246)', () {
+    /// An applier over one Azure-only orphan carrying `companyName: SSM`, with
+    /// the settings-derived inputs coming from a mutable [ApplierSettings] the
+    /// test rewrites between links — the shape `bootstrapReconcile` wires over
+    /// `LiveSettings`.
+    (StateApplier, void Function(ApplierSettings)) build() {
+      var current = ApplierSettings(
+        studentConfig: _studentConfig(),
+        staffConfig: _staffConfig(),
+      );
+      final applier = StateApplier(
+        app: ApplicationState(
+          wisa: SystemState<wapi.WisaSnapshot>(
+            system: core.Origin.wisa,
+            initial: _wSnap(),
+            syncer: (_) async => _wSnap(),
+          ),
+          smartschool: SystemState<ss.SmartschoolSnapshot>(
+            system: core.Origin.smartschool,
+            initial: _sSnap(),
+            syncer: (_) async => _sSnap(),
+          ),
+          azure: SystemState<az.AzureSnapshot>(
+            system: core.Origin.azure,
+            initial: _aSnap(users: [_azUser(id: 'az-orphan')]),
+            syncer: (_) async => _aSnap(),
+          ),
+        ),
+        connectors:
+            Connectors(smartschool: _ssConn(_RecordingSoap()), azure: null),
+        resolver: _SeqResolver(),
+        wisaRules: WisaImportRules(),
+        settings: () => current,
+      );
+      return (applier, (next) => current = next);
+    }
+
+    test('a school prefix saved after bootstrap scopes the very next link()',
+        () async {
+      // INV-22: an Azure-only user stamped with our `companyName` is a former
+      // student we keep so the engine can flag it. Whether this orphan is ours
+      // is therefore a pure function of the prefix — which used to be frozen
+      // into the applier when bootstrap built it.
+      final (applier, publish) = build();
+
+      final before = await applier.link();
+      expect(before.snapshot.accounts, hasLength(1),
+          reason: 'companyName SSM matches the prefix in force');
+
+      publish(ApplierSettings(
+        studentConfig: StudentActionConfig(
+          schoolPrefix: 'OTHER',
+          azureDomain: 'school.example',
+        ),
+        staffConfig: StaffActionConfig(
+          schoolPrefix: 'OTHER',
+          azureDomain: 'school.example',
+        ),
+      ));
+
+      final after = await applier.link();
+      expect(after.snapshot.accounts, isEmpty,
+          reason: 'the relink honoured the new prefix without a relaunch');
+    });
+
+    test('the class tree and managed-school set are re-read on every access',
+        () {
+      final (applier, publish) = build();
+      expect(applier.classTree.path, '');
+      expect(applier.ourSchoolIds, isNull);
+
+      publish(ApplierSettings(
+        studentConfig: _studentConfig(),
+        staffConfig: _staffConfig(),
+        classTree: const SmartschoolClassTree(path: 'SCHOOL'),
+        ourSchoolIds: const {1, 2},
+      ));
+
+      expect(applier.classTree.path, 'SCHOOL');
+      expect(applier.ourSchoolIds, const {1, 2});
+    });
+
+    test('the uid-uniqueness wrapping survives the change', () async {
+      // The wrapping used to happen once, in the constructor. Rebuilding the
+      // config per read must not lose it, or a created login could collide with
+      // an account an earlier apply spliced into the snapshot (#72).
+      final (applier, publish) = build();
+      expect(applier.studentConfig.smartschoolUid('Jan', 'Peeters'),
+          'jan.peeters');
+
+      publish(ApplierSettings(
+        studentConfig: StudentActionConfig(
+          schoolPrefix: 'OTHER',
+          azureDomain: 'other.example',
+        ),
+        staffConfig: StaffActionConfig(
+          schoolPrefix: 'OTHER',
+          azureDomain: 'other.example',
+        ),
+      ));
+
+      expect(applier.studentConfig.azureDomain, 'other.example');
+      expect(applier.studentConfig.studentDomain, 'student.other.example');
+      expect(applier.staffConfig.schoolPrefix, 'OTHER');
+      expect(
+          applier.studentConfig.smartschoolUid('Jan', 'Peeters'), 'jan.peeters',
+          reason: 'still uniqueness-aware against the current snapshot');
+    });
+
+    test('StateApplier.fixed keeps answering with the one config it was given',
+        () {
+      final applier = StateApplier.fixed(
+        app: _Harness().app,
+        connectors:
+            Connectors(smartschool: _ssConn(_RecordingSoap()), azure: null),
+        resolver: _SeqResolver(),
+        wisaRules: WisaImportRules(),
+        studentConfig: _studentConfig(),
+        staffConfig: _staffConfig(),
+        classTree: const SmartschoolClassTree(path: 'ROOT'),
+        ourSchoolIds: const {7},
+      );
+      expect(applier.studentConfig.schoolPrefix, 'SSM');
+      expect(applier.classTree.path, 'ROOT');
+      expect(applier.ourSchoolIds, const {7});
     });
   });
 }

--- a/packages/azure_api/lib/src/connector.dart
+++ b/packages/azure_api/lib/src/connector.dart
@@ -98,18 +98,29 @@ class AzureConnector {
   /// student who transferred in from a sibling group school — whose account
   /// carries neither our `companyName` nor our `department` — is seen instead of
   /// being proposed for a second, duplicate account.
+  ///
+  /// [schoolPrefix] overrides [AzureCredentials.schoolPrefix] for this one pull
+  /// (#246). The prefix is operator-editable in Instellingen while the app runs,
+  /// but the credentials are baked into the connector at bootstrap — so the
+  /// caller passes the prefix as it stands *now* and the credentials' copy is
+  /// only the default. Both managers already take it as a parameter, so nothing
+  /// below this line had to change.
   Future<AzureSnapshot> sync({
     String? deltaToken,
     AzureSnapshot? previous,
     Iterable<String> expectedEmployeeIds = const <String>[],
+    String? schoolPrefix,
   }) async {
-    final groupList = await groups.listGroups(credentials.schoolPrefix);
+    final prefix = schoolPrefix ?? credentials.schoolPrefix;
+    final groupList = await groups.listGroups(prefix);
 
-    if (deltaToken == null) return _fullRead(groupList, expectedEmployeeIds);
+    if (deltaToken == null) {
+      return _fullRead(groupList, expectedEmployeeIds, prefix);
+    }
 
     final UserDelta delta;
     try {
-      delta = await users.delta(deltaToken, credentials.schoolPrefix);
+      delta = await users.delta(deltaToken, prefix);
     } on GraphException catch (e) {
       if (!e.isRejectedDeltaToken) rethrow;
       _log?.addMessage(
@@ -118,7 +129,7 @@ class AzureConnector {
         '(${_tokenAge(previous)}) — $e. Discarding it and re-reading all '
         'accounts in full.',
       );
-      return _fullRead(groupList, expectedEmployeeIds);
+      return _fullRead(groupList, expectedEmployeeIds, prefix);
     }
 
     // No `@odata.deltaLink` on the final page means this walk produced no
@@ -154,10 +165,11 @@ class AzureConnector {
   Future<AzureSnapshot> _fullRead(
     List<AzureGroup> groupList,
     Iterable<String> expectedEmployeeIds,
+    String schoolPrefix,
   ) async {
     final token = await users.latestDeltaToken();
     final userList = await _adoptByEmployeeId(
-      await users.load(credentials.schoolPrefix),
+      await users.load(schoolPrefix),
       expectedEmployeeIds,
     );
     return AzureSnapshot(

--- a/packages/azure_api/test/connector_test.dart
+++ b/packages/azure_api/test/connector_test.dart
@@ -67,6 +67,37 @@ void main() {
       );
       expect(bulk.url.queryParameters[r'$filter'], isNotNull);
     });
+
+    test(
+        'a per-pull schoolPrefix overrides the credentials\' frozen one (#246)',
+        () async {
+      // The prefix is operator-editable in Instellingen while the app runs, but
+      // the credentials are baked in when bootstrap constructs the connector.
+      // The caller therefore passes the prefix as it stands now; the
+      // credentials' copy is only the default.
+      final transport = FakeGraphTransport(route);
+      await connectorWith(transport).sync(schoolPrefix: 'SSM');
+
+      final bulk =
+          transport.requests.firstWhere((r) => r.url.path.endsWith('/users'));
+      expect(bulk.url.queryParameters[r'$filter'], contains('SSM'));
+      expect(bulk.url.queryParameters[r'$filter'], isNot(contains('GBS')));
+
+      final groups =
+          transport.requests.firstWhere((r) => r.url.path.endsWith('/groups'));
+      expect(groups.url.queryParameters[r'$filter'], contains('SSM'),
+          reason: 'the group listing is scoped by the same prefix');
+    });
+
+    test('omitting it keeps the credentials\' prefix, as before #246',
+        () async {
+      final transport = FakeGraphTransport(route);
+      await connectorWith(transport).sync();
+
+      final bulk =
+          transport.requests.firstWhere((r) => r.url.path.endsWith('/users'));
+      expect(bulk.url.queryParameters[r'$filter'], contains('GBS'));
+    });
   });
 
   group('drift-check progress logging (#177)', () {

--- a/packages/wisa_api/lib/src/connector.dart
+++ b/packages/wisa_api/lib/src/connector.dart
@@ -163,6 +163,10 @@ class WisaConnector {
 
     return WisaSnapshot(
       fetchedAt: DateTime.now(),
+      // The roster is only meaningful together with the date it is *as of*, so
+      // the snapshot carries it out of here rather than leaving the caller to
+      // re-derive a date that may already have moved on (#247).
+      workDate: workDate,
       students: allStudents,
       staff: applyRulesToStaff(allStaff, rules),
       classGroups: applyRulesToClassGroups(allClassGroups, rules),

--- a/packages/wisa_api/lib/src/snapshot.dart
+++ b/packages/wisa_api/lib/src/snapshot.dart
@@ -18,6 +18,21 @@ class WisaSnapshot implements core.Snapshot {
   @override
   core.Origin get origin => core.Origin.wisa;
 
+  /// The **werkdatum** this roster was pulled as of — the `Werkdatum` SOAP
+  /// parameter the row queries went out with (#247).
+  ///
+  /// WISA answers *as of* a date, so the roster is only meaningful together
+  /// with it: a pull made on the wrong side of the school-year rollover simply
+  /// has none of the new intake in it. [fetchedAt] says when we asked, this
+  /// says which school year we asked about — and the two routinely disagree.
+  ///
+  /// Null on a snapshot no [WisaConnector.sync] stamped: a hand-built fixture,
+  /// or one restored from a `snapshots` document written before this existed.
+  /// A virtual school's rows come from the *virtuele* werkdatum instead; this
+  /// is the ordinary one, the same date [WisaConnector.sync] gives every
+  /// non-virtual school.
+  final DateTime? workDate;
+
   final UnmodifiableListView<WisaStudent> students;
   final UnmodifiableListView<WisaStaff> staff;
   final UnmodifiableListView<WisaClassGroup> classGroups;
@@ -29,6 +44,7 @@ class WisaSnapshot implements core.Snapshot {
     required List<WisaStaff> staff,
     required List<WisaClassGroup> classGroups,
     required List<WisaSchool> schools,
+    this.workDate,
   })  : students = UnmodifiableListView(List.of(students)),
         staff = UnmodifiableListView(List.of(staff)),
         classGroups = UnmodifiableListView(List.of(classGroups)),
@@ -40,6 +56,7 @@ class WisaSnapshot implements core.Snapshot {
   /// WISA (#107).
   Map<String, dynamic> toJson() => {
         'fetchedAt': fetchedAt.toIso8601String(),
+        if (workDate != null) 'workDate': workDate!.toIso8601String(),
         'students': [for (final s in students) s.toJson()],
         'staff': [for (final s in staff) s.toJson()],
         'classGroups': [for (final g in classGroups) g.toJson()],
@@ -48,6 +65,9 @@ class WisaSnapshot implements core.Snapshot {
 
   factory WisaSnapshot.fromJson(Map<String, dynamic> json) => WisaSnapshot(
         fetchedAt: DateTime.parse(json['fetchedAt'] as String),
+        workDate: json['workDate'] == null
+            ? null
+            : DateTime.parse(json['workDate'] as String),
         students: [
           for (final e in (json['students'] as List<dynamic>? ?? const []))
             WisaStudent.fromJson(e as Map<String, dynamic>),

--- a/packages/wisa_api/test/connector_test.dart
+++ b/packages/wisa_api/test/connector_test.dart
@@ -183,6 +183,41 @@ void main() {
       expect(werkdates, {'01/09/2024'});
     });
 
+    test('stamps the snapshot with the werkdatum it pulled as of (#247)',
+        () async {
+      // The roster and the date it is *as of* must travel together: the caller
+      // cannot re-derive the date afterwards, because "volg de huidige datum"
+      // resolves afresh on every ask.
+      final t = _FakeTransport(fixtures);
+      final c = buildConnector(t);
+      final schools = await c.loadSchools();
+      final snapshot = await c.sync(
+        schools: [schools.firstWhere((s) => s.id == 25)],
+        workDate: DateTime(2024, 9, 1),
+      );
+      expect(snapshot.workDate, DateTime(2024, 9, 1));
+    });
+
+    test(
+        'stamps the ordinary werkdatum even when a virtual school pulled its '
+        'own (#247)', () async {
+      // The virtuele werkdatum is a per-school override; the snapshot names the
+      // date the pass asked for, which is the one the overview reports.
+      final t = _FakeTransport(fixtures);
+      final c = buildConnector(t);
+      final schools = await c.loadSchools();
+      final snapshot = await c.sync(
+        schools: [
+          schools.firstWhere((s) => s.id == 25).copyWith(
+                isVirtual: true,
+              )
+        ],
+        workDate: DateTime(2024, 9, 1),
+        virtualWorkDate: DateTime(2025, 9, 1),
+      );
+      expect(snapshot.workDate, DateTime(2024, 9, 1));
+    });
+
     test('uses virtualWorkDate when school.isVirtual is true', () async {
       final t = _FakeTransport(fixtures);
       final c = buildConnector(t);

--- a/packages/wisa_api/test/snapshot_test.dart
+++ b/packages/wisa_api/test/snapshot_test.dart
@@ -50,6 +50,28 @@ void main() {
       expect(snap.schools, hasLength(1));
     });
 
+    test('workDate is null when nothing stamped one', () {
+      // A hand-built fixture, or a snapshot restored from a document written
+      // before the werkdatum was recorded (#247).
+      expect(snapshot.workDate, isNull);
+      expect(snapshot.toJson().containsKey('workDate'), isFalse);
+    });
+
+    test('toJson/fromJson round-trips the werkdatum (#247)', () {
+      // The date the roster is *as of*, which the shared state carries onto the
+      // Acties freshness stamp — so a cold-stored snapshot must not lose it.
+      final stamped = WisaSnapshot(
+        fetchedAt: DateTime.utc(2026, 8, 21, 9, 0),
+        workDate: DateTime(2026, 9, 1),
+        students: const [],
+        staff: const [],
+        classGroups: const [],
+        schools: const [],
+      );
+      expect(WisaSnapshot.fromJson(stamped.toJson()).workDate,
+          DateTime(2026, 9, 1));
+    });
+
     test('toJson/fromJson round-trips every list and field (#107)', () {
       final full = WisaSnapshot(
         fetchedAt: DateTime.utc(2026, 5, 20, 9, 30, 15),


### PR DESCRIPTION
Batch chunk D — six issues, one commit each, each individually green on the full local gates. Follows chunks A (#242), B (#249) and C (#256).

All six were filed by workers during this batch. Two are apply-path correctness bugs where the app wrote something the operator did not ask for — those went first.

## What changed

**`b01022c` — #252 a classroom's bulk apply reached across every class**
The worst bug in the queue. `_SituationHeader` is built over a *scoped* entry list — the open classroom's situations, further narrowed by the search box — and labelled itself `Alles toepassen (N)` from that list. But its button called `applySituation(key)`, which re-resolved the key against `pendingEntries`: **every** entry in the entire linked view. So a bulk apply inside 3C also wrote every identical situation in every other class. Since #234 quoted the real count, the button could read `(1)` while the dialog said "Dit schrijft 2 wijzigingen" — the symptom it was filed on.

`applySituation` / `dryRunSituation` are gone, replaced by `applyEntries(entries)` / `dryRunEntries(entries)`. The header passes the very list it counted, so label, confirmation scope and write are one resolution; the key-based re-lookup that could reach outside the class no longer exists anywhere. `applyEntry` became a thin wrapper on the same path, so per-entry and bulk apply behave identically.

**`a5a25cf` — #250 "Apply to all" blacklisted a class the #225 notice said to fix by hand**
`ClassExistsAsSmartschoolGroup` (#225) replaces both create actions when Smartschool already has a namesake — but #244 had given `classImportAlternative` to the creates *and* to `DoNotImportFromWisa`, leaving the blacklist as the **lone** member of the group. `collapseAlternatives` selects the only option, so an applyable `DontImportClass` rule was pre-selected on exactly the classes the app had just told the operator to repair manually. A new `namesakeClassAlternative` pairs the notice (leading, default, informational) with the blacklist, so a bulk apply writes nothing there and blacklisting stays a deliberate pick. It is a separate key rather than a third member of the existing one because `PendingChoice.situationId` *is* the alternative-group key — pooling would have filed namesake classes under a bulk header naming both readings.

**`7e6d33f` — #255 a passive card did not mark an informational candidate**
`_AccountTile` built its bullet inline and ignored `canApply`, so since #245 a passive reader saw `AzureClassGroupMembership` as ordinary due work next to a badge counting it zero. It now shares `_readOnlyCandidateLine` with `_GroupTile`, so one function decides `(keuze)` / `(manueel)` / bare summary for both read-only tiles. The e2e for this runs a genuine passive session — sync in session 1, resume over the stored view in session 2 — because the passive card reads `CandidateAction`s round-tripped through store JSON, a different pipeline from the interactive tile.

**`7c9bebb` — #253 the rest of the Acties screen was English**
Results sections, the same-situation bulk header, the option-detail fallbacks, the three full-panel states, and the controller's store-read/bootstrap error lines. Wording matches what the screen already said — `openstaande actie(s)`, `(manueel)`, `Dry-run`. About 40 test assertions moved, none left asserting English; no `ValueKey` changed; developer-facing log lines stayed English. Three previously-uncovered strings gained widget + e2e coverage.

**`401e034` — #246 the rest of the reconcile stack still froze settings at bootstrap**
#238 fixed this for the werkdatum; this finishes it. `StateApplier` takes an `ApplierSettings` supplier instead of four `final` fields, sampled per link and per apply — with `link()` sampling *once* and threading that one document through, so the linker's prefix cannot disagree with the one `naturalKeysFor` primed the resolver with. `azureSyncer` reads the school prefix per pull, and a **changed** prefix drops the delta token and re-reads in full: `/users/delta` filters client-side, so an incremental pass would have kept the old school's users under the new prefix and persisted that mixed snapshot to the cold store.

What genuinely cannot be re-read is stated rather than forced: the three connection profiles and the two secret refs are bound into open connections and a resolved Key Vault read, so a changed one raises a visible relaunch notice instead of silently syncing the old endpoints.

**`4a8d365` — #247 the werkdatum on the Acties freshness stamp**
`WisaSnapshot` now carries the work date its rows were pulled as of, which rides into `SystemSyncMeta` in the shared sync-state document and renders as ` · werkdatum dd/MM/yyyy`. Two calls worth noting: it lives on the per-system stamp rather than `SyncState`, so a drift pass that re-links without re-pulling WISA keeps it exactly as it keeps that entry's `at`/`syncedBy`; and it is the date resolved **at pull time**, not re-derived — with `isNow: true` a re-ask can answer for a different day, and the stamp must keep naming the pulled date after a later Instellingen save moves the setting. That disagreement is tested at controller, widget and e2e level. Being on the shared record, a passive session reads it without having synced.

## Test plan

Every commit was verified individually before landing; the numbers below are the final state of the branch.

- `dart format --set-exit-if-changed .` — clean, 300 files, 0 changed
- `dart analyze --fatal-infos --fatal-warnings` — clean
- `dart test` per package — account_core 82, wisa_api 131, smartschool_api 147, azure_api 112, account_linker 72, account_actions 205, account_state 438, account_store 8 — 1187 pass, 0 fail; skips are the opt-in live tests, deliberately not run
- `flutter test` (account_manager widget) — 385 pass
- `flutter test integration_test/app_launch_test.dart -d windows` — 84 pass, including new e2e cases for #246, #247, #250, #252, #253 and #255
- Each issue's new test was confirmed **failing on unpatched code**, several at two layers independently. For #252 the unpatched run fails the write assertion with `length 3` where 2 were expected — the third write is the other classroom.

No live WISA / Smartschool / Azure hosts were contacted.

## Worth reading before the next release

**#259**, filed while doing #246: #99's smart sync only re-pulls Smartschool/Azure when the session lacks their snapshot, so a saved import rule or school prefix is picked up by **Check for drift**, not by **Synchroniseer** — and Synchroniseer meanwhile reports "geen accountwijzigingen nodig" while the save sits unapplied. That is pre-existing sync design rather than a regression from this chunk, but it means a settings change can look applied when it is not.

## Follow-ups filed during this chunk

**#257**, **#258**, **#259** — joining **#227** (the Klasgroepen inventory tab) and **#254** for the next chunk.

Closes #246
Closes #247
Closes #250
Closes #252
Closes #253
Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
