### PR TITLE
Batch: the Klasgroepen inventory tab, shared apply results, and Dutch throughout (#227 #254 #257 #258 #259)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -126,7 +126,7 @@ void main() {
     expect(find.byType(AppShell), findsOneWidget);
     expect(find.byType(HomeScreen), findsOneWidget);
     expect(find.byType(NavigationRail), findsOneWidget);
-    expect(find.text('Home'), findsOneWidget);
+    expect(find.text('Start'), findsOneWidget);
 
     // Wrapped in the Plink design system: MaterialApp carries both the paper
     // and ink themes, and this app's per-product accent is layered on.
@@ -146,21 +146,42 @@ void main() {
     expect(display?.fontFamily, contains('Fraunces'));
     expect(find.text('Account Manager'), findsOneWidget);
 
-    // The shell carries both the Reconcile and the new Actions destinations;
-    // with no AAD config the reconcile screen renders its "not configured"
-    // panel instead of bootstrapping.
-    expect(find.text('Actions'), findsOneWidget);
-    await tester.tap(find.text('Reconcile'));
+    // Every destination on the rail names itself in the operator's language
+    // (#257). The rail is read together with the heading it leads to, and it
+    // used to read Home / Reconcile / Actions over pages titled in Dutch.
+    for (final String label in <String>[
+      'Start',
+      'Synchronisatie',
+      'Acties',
+      'Klasgroepen',
+      'Wachtwoorden',
+      'Instellingen',
+    ]) {
+      expect(find.text(label), findsOneWidget,
+          reason: '"$label" is the rail label for its destination');
+    }
+
+    // With no AAD config each screen renders its "not configured" panel
+    // instead of bootstrapping — in Dutch on every one of them (#253/#257),
+    // since a panel standing in for a view is as operator-facing as the view.
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     expect(find.byType(ReconcileScreen), findsOneWidget);
-    expect(find.text('Not configured'), findsOneWidget);
+    expect(find.text('Niet geconfigureerd'), findsOneWidget);
 
-    // The Acties screen renders the same panel, in the operator's language
-    // (#253): everything the Acties view says is Dutch, including the states
-    // that stand in for it.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.byType(ActionsScreen), findsOneWidget);
+    expect(find.text('Niet geconfigureerd'), findsOneWidget);
+
+    await tester.tap(find.text('Wachtwoorden'));
+    await tester.pumpAndSettle();
+    expect(find.byType(PasswordsScreen), findsOneWidget);
+    expect(find.text('Niet geconfigureerd'), findsOneWidget);
+
+    await tester.tap(find.text('Instellingen'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
     expect(find.text('Niet geconfigureerd'), findsOneWidget);
   });
 
@@ -183,7 +204,7 @@ void main() {
     expect(find.byType(AppShell), findsOneWidget);
 
     // Open the reconcile screen; the stack bootstraps lazily.
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('reconcile-sync')), findsOneWidget);
 
@@ -212,7 +233,7 @@ void main() {
 
     // Switch to the Actions tab: the actions are browsed by the year → class
     // drill-down. Drill into 3C to build that class's action tile.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.byType(ActionsScreen), findsOneWidget);
     expect(find.text('Overzicht'), findsOneWidget);
@@ -243,7 +264,7 @@ void main() {
     // "no changes needed" and leaves Smartschool / Azure unread.
     harness.wisaResult =
         wisaSnap(fetchedAt: kFixtureDate.add(const Duration(hours: 1)));
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.ensureVisible(find.byKey(const ValueKey('reconcile-sync')));
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
@@ -272,7 +293,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
 
     // Idle: no progress bar at all.
@@ -334,11 +355,11 @@ void main() {
   /// Syncs on Reconcile and lands on the Actions tab, the way the operator gets
   /// to the apply affordances.
   Future<void> syncThenOpenActions(WidgetTester tester) async {
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
   }
 
@@ -351,7 +372,7 @@ void main() {
 
   /// Syncs on Reconcile and lands on the Klasgroepen tab.
   Future<void> syncThenOpenKlasgroepen(WidgetTester tester) async {
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -498,7 +519,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
 
     // Before syncing there is no last-sync box yet.
@@ -516,14 +537,14 @@ void main() {
     // The last-sync freshness now renders as a dedicated box headed "Last sync"
     // with one row per system (#188).
     expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
-    expect(find.text('Last sync'), findsOneWidget);
+    expect(find.text('Laatste synchronisatie'), findsOneWidget);
     expect(
         find.byKey(const ValueKey('reconcile-last-sync-wisa')), findsOneWidget);
     expect(find.byKey(const ValueKey('reconcile-last-sync-smartschool')),
         findsOneWidget);
     expect(find.byKey(const ValueKey('reconcile-last-sync-azure')),
         findsOneWidget);
-    expect(find.textContaining('by operator@school.example'), findsWidgets);
+    expect(find.textContaining('door operator@school.example'), findsWidgets);
 
     // A second, unchanged re-sync logs the no-change ready line too.
     harness.wisaResult =
@@ -554,7 +575,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -572,10 +593,10 @@ void main() {
     // After the first full sync all three systems appear on their own rows:
     // WISA as a sync, Smartschool and Azure as drift checks.
     expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
-    expect(rowText('wisa'), contains('sync'));
-    expect(rowText('wisa'), isNot(contains('drift check')));
-    expect(rowText('smartschool'), contains('drift check'));
-    expect(rowText('azure'), contains('drift check'));
+    expect(rowText('wisa'), contains('synchronisatie'));
+    expect(rowText('wisa'), isNot(contains('driftcontrole')));
+    expect(rowText('smartschool'), contains('driftcontrole'));
+    expect(rowText('azure'), contains('driftcontrole'));
 
     // Check for drift re-pulls Smartschool and Azure at a later time; WISA is
     // not re-pulled, so its sync stamp stays put while the drift pair advances.
@@ -588,8 +609,8 @@ void main() {
 
     // The rows still carry the right kinds, and the underlying state proves the
     // drift pair advanced while WISA held its earlier sync time.
-    expect(rowText('wisa'), contains('sync'));
-    expect(rowText('smartschool'), contains('drift check'));
+    expect(rowText('wisa'), contains('synchronisatie'));
+    expect(rowText('smartschool'), contains('driftcontrole'));
     final systems = harness.controller.syncState.systems;
     expect(systems[Origin.wisa]?.at, kFixtureDate);
     expect(systems[Origin.smartschool]?.at, driftAt);
@@ -624,7 +645,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -676,7 +697,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
 
     // Derived independently of the production formatter: the store was stamped
@@ -722,7 +743,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(AppShell), findsOneWidget);
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -731,7 +752,7 @@ void main() {
     expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
     expect(
         find.byKey(const ValueKey('reconcile-last-sync-wisa')), findsOneWidget);
-    expect(find.textContaining('by yvan@school.example'), findsWidgets);
+    expect(find.textContaining('door yvan@school.example'), findsWidgets);
     // …and the terminal "Sync voltooid" line names them too (#169).
     expect(
       find.textContaining('Operator: yvan@school.example'),
@@ -760,7 +781,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
 
     // Start the sync; while the persist hangs the pass is busy and Synchronise
@@ -825,7 +846,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -891,7 +912,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
 
     // The persist is a few hundred real round trips; let each pass finish.
@@ -969,7 +990,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -977,7 +998,7 @@ void main() {
     // The departed account is browsed on the Actions tab, under the
     // "Niet toegewezen" → "Zonder klas" bucket (#210 dropped the always-empty
     // grade level between them).
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Niet toegewezen'));
     await tester.pumpAndSettle();
@@ -1032,7 +1053,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -1053,7 +1074,7 @@ void main() {
     // its node is kept out of the drill-down (#178). The departed student is
     // re-bucketed to "Niet toegewezen" so its Smartschool cleanup stays
     // actionable — never surfacing a non-managed school node.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.text('School 2'), findsNothing,
         reason: 'a school we do not manage never appears in Actions (#178)');
@@ -1099,12 +1120,12 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.text('Overzicht'), findsOneWidget);
     // The non-managed school is not a node in the drill-down…
@@ -1131,12 +1152,12 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.text('Niet toegewezen'), findsNothing,
         reason: 'managing school 2 takes its student out of the leaver bucket');
@@ -1173,12 +1194,12 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.text('School 25'), findsNothing,
         reason: 'the numeric id is the last resort, not the rendering (#204)');
@@ -1230,12 +1251,12 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     // The label lives in the shared documents now that #210 took the school
     // level out of the tree — it must be neither inverted nor the bare id, and
@@ -1266,7 +1287,7 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -1311,7 +1332,7 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -1334,7 +1355,7 @@ void main() {
     // Over on Acties: the virtual school's student is still imported and still
     // sits in the class their own WISA record names — dropping the class-group
     // records moved nobody.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     // The merged first year spans both managed schools (#210), so the virtual
     // school's 1V sits beside our own 1A under it.
@@ -1373,7 +1394,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -1452,7 +1473,7 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -1522,7 +1543,7 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -1842,7 +1863,7 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -2012,7 +2033,7 @@ void main() {
 
     // And the same list is not maintained in two places: the Klasgroepen node
     // has left the Acties drill-down.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('rollup-groups')), findsNothing);
     expect(tester.takeException(), isNull);
@@ -2040,7 +2061,7 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -2061,7 +2082,7 @@ void main() {
       findsWidgets,
     );
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
 
     // Nothing applyable hangs off either class's *students*, so the work list
@@ -2155,7 +2176,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
 
     // Nothing applyable hangs off the students, so the work list hides their
@@ -2210,12 +2231,12 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.text('Jaar 1'), findsOneWidget);
     expect(find.text('Jaar 3'), findsOneWidget);
@@ -2348,7 +2369,7 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -2366,7 +2387,7 @@ void main() {
     expect(pendingByClass['1|1C'], 0);
     expect(pendingByClass['2|1C'], 0);
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
 
     // One switch, on the Acties tab itself, already on.
@@ -2432,11 +2453,11 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
 
     final jaar1 = find.byKey(const ValueKey('rollup-grade-grades|1'));
@@ -2592,7 +2613,7 @@ void main() {
       reconcileBootstrap: operatorB.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
 
     final jaar3 = find.byKey(const ValueKey('rollup-grade-grades|3'));
@@ -2775,7 +2796,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -2801,7 +2822,7 @@ void main() {
     // Browse it the way the operator does: the merged first year holds both
     // schools' `1C`, each still keyed to its own school partition. The year is
     // opened once — since #235 Overzicht comes back to it still open.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
 
     final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
@@ -2853,13 +2874,13 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
     // On the Actions tab the family tab bar carries both families.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(
         find.byKey(const ValueKey('actions-tab-leerlingen')), findsOneWidget);
@@ -2917,7 +2938,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Open the Passwords view: the two family tabs render.
-    await tester.tap(find.text('Passwords'));
+    await tester.tap(find.text('Wachtwoorden'));
     await tester.pumpAndSettle();
     expect(find.byType(PasswordsScreen), findsOneWidget);
     expect(
@@ -2984,7 +3005,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Passwords'));
+    await tester.tap(find.text('Wachtwoorden'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('passwords-tab-personeel')));
     await tester.pumpAndSettle();
@@ -3055,7 +3076,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Passwords'));
+    await tester.tap(find.text('Wachtwoorden'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('passwords-tab-personeel')));
     await tester.pumpAndSettle();
@@ -3109,7 +3130,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Passwords'));
+    await tester.tap(find.text('Wachtwoorden'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('password-class-3C')));
     await tester.pumpAndSettle();
@@ -3189,13 +3210,13 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
     // Browse the student on the Actions tab, drilling into her class (3C).
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
@@ -3236,13 +3257,13 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
     // Browse them on the Actions tab: drill into their "Zonder klas" bucket.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Niet toegewezen'));
     await tester.pumpAndSettle();
@@ -3290,7 +3311,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
 
     final panel = find.byKey(const ValueKey('reconcile-log-panel'));
@@ -3326,7 +3347,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('reconcile-sync')), findsOneWidget);
 
@@ -3366,7 +3387,7 @@ void main() {
 
     // The overview lives on the Actions tab now — rendered straight from the
     // store, no Synchronise tapped.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.text('Overzicht'), findsOneWidget);
     // The stored view projects to the same school-less tree a syncing session
@@ -3419,7 +3440,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
 
     // The per-category overview renders straight from the stored rollups — no
@@ -3464,7 +3485,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
 
     // The account overview is there, straight from the store — no Synchronise
@@ -3514,7 +3535,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(resumed.controller.linked, isNull);
 
@@ -3533,7 +3554,7 @@ void main() {
     expect(klasgroepenReadOnly, findsOneWidget);
     expect(find.text('Alleen-lezen overzicht'), findsOneWidget);
     expect(pendingTiles, findsNothing);
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
 
     // The classroom tree: the same announcement, and the cards themselves carry
@@ -3597,17 +3618,17 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
 
     // The shared per-system last-sync box renders (#162/#188) straight from the
     // store (who last synced each system — not this passive session), proving it
     // survives a restart.
     expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
-    expect(find.text('Last sync'), findsOneWidget);
+    expect(find.text('Laatste synchronisatie'), findsOneWidget);
     expect(
         find.byKey(const ValueKey('reconcile-last-sync-wisa')), findsOneWidget);
-    expect(find.textContaining('by operator@school.example'), findsWidgets);
+    expect(find.textContaining('door operator@school.example'), findsWidgets);
 
     // The lock is surfaced by name and Synchronise/Check-for-drift are disabled
     // so two operators cannot sync at once.
@@ -3646,7 +3667,7 @@ void main() {
       reconcileBootstrap: resumed.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
 
     // Nothing locked yet — Synchronise is live.
@@ -3733,7 +3754,7 @@ void main() {
       reconcileBootstrap: resumed.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
 
     // The overview rendered at generation 1 and the subscriber connected.
@@ -3788,7 +3809,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -3836,14 +3857,14 @@ void main() {
     await tester.pumpAndSettle();
 
     // Reconcile → sync → the create is pending. The queue starts empty.
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
     expect(await harness.passwordQueue.load(), isEmpty);
 
     // Browse the create on the Actions tab, in the student's class.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
@@ -3868,7 +3889,7 @@ void main() {
     // Switch to the Passwords view: the freshly captured account sheet is
     // surfaced as a printable student sheet (the reworked view no longer shows
     // a per-entry distribute card — the queue feeds the print/CSV exports).
-    await tester.tap(find.text('Passwords'));
+    await tester.tap(find.text('Wachtwoorden'));
     await tester.pumpAndSettle();
     expect(find.byType(PasswordsScreen), findsOneWidget);
     final exportBtn = find.byKey(const ValueKey('passwords-export-students'));
@@ -3914,7 +3935,7 @@ void main() {
     expect(find.byType(AppShell), findsOneWidget);
 
     // Open Settings; the stored document is read into the real, laid-out form.
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     expect(find.byType(SettingsScreen), findsOneWidget);
     // The app-wide prefix shows on the default Algemeen tab.
@@ -3974,7 +3995,7 @@ void main() {
 
     // Open Settings; the seeded school renders in the real, laid-out form with
     // its managed switch off.
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     expect(find.byType(SettingsScreen), findsOneWidget);
     // The known-school list lives under the Wisa tab now (#140); open it and
@@ -4024,7 +4045,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     expect(find.byType(SettingsScreen), findsOneWidget);
     await openSettingsTab(tester, 'settings-tab-wisa');
@@ -4091,7 +4112,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Open Settings → Wisa tab; the fetch action is available for a valid config.
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     expect(find.byType(SettingsScreen), findsOneWidget);
     await openSettingsTab(tester, 'settings-tab-wisa');
@@ -4154,7 +4175,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     expect(find.byType(SettingsScreen), findsOneWidget);
     await openSettingsTab(tester, 'settings-tab-wisa');
@@ -4234,7 +4255,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     await openSettingsTab(tester, 'settings-tab-wisa');
 
@@ -4325,7 +4346,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Before any sync: the bug, in the real grid.
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     await openSettingsTab(tester, 'settings-tab-wisa');
     final tile = find.byKey(const ValueKey('settings-wisa-school-25-ours'));
@@ -4345,13 +4366,13 @@ void main() {
     );
 
     // One ordinary sync on the Reconcile view.
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
     // Back to Settings and re-read the document — no Opslaan was ever pressed.
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     await tester.ensureVisible(find.byKey(const ValueKey('settings-reload')));
     await tester.tap(find.byKey(const ValueKey('settings-reload')));
@@ -4392,7 +4413,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Open Settings; the werkdatum controls sit on the default Algemeen tab.
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     expect(find.byType(SettingsScreen), findsOneWidget);
 
@@ -4440,7 +4461,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     expect(find.byType(SettingsScreen), findsOneWidget);
 
@@ -4466,7 +4487,7 @@ void main() {
     expect(broker.silentCalls, ['graph']);
     expect(broker.interactiveCalls, isEmpty);
     expect(find.byType(AppShell), findsOneWidget);
-    expect(find.text('Home'), findsOneWidget);
+    expect(find.text('Start'), findsOneWidget);
   });
 
   testWidgets('interactive fallback then retry reaches the shell',
@@ -4488,10 +4509,10 @@ void main() {
     await tester.pumpAndSettle();
 
     // First attempt failed → the failure panel renders in the real app.
-    expect(find.text('Could not sign in'), findsOneWidget);
+    expect(find.text('Kon je niet aanmelden'), findsOneWidget);
     expect(find.byType(AppShell), findsNothing);
 
-    await tester.tap(find.text('Try again'));
+    await tester.tap(find.text('Probeer opnieuw'));
     await tester.pumpAndSettle();
 
     expect(find.byType(AppShell), findsOneWidget);
@@ -4549,7 +4570,7 @@ void main() {
     // Open the Actions tab (passive overview from the store). The global filter
     // is on by default since #226 and sits above the family tab bar; this test
     // is about the name search, so start from the full inventory.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
     expect(toggle, findsOneWidget);
@@ -4657,7 +4678,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
 
     // A real pass fills the panel; then a known tail so the drag has stable
@@ -4741,7 +4762,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
 
     // A real pass fills the panel, then a known short tail so the row the
@@ -4808,7 +4829,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     expect(find.byType(SettingsScreen), findsOneWidget);
     await openSettingsTab(tester, 'settings-tab-smartschool');
@@ -4881,7 +4902,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     await openSettingsTab(tester, 'settings-tab-smartschool');
 
@@ -4899,7 +4920,7 @@ void main() {
     expect(saved.smartschoolRules, hasLength(3));
     harness.smartschoolRules = saved.smartschoolRules;
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -4958,7 +4979,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // A first Synchroniseer pulls WISA with the stored werkdatum.
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -4966,7 +4987,7 @@ void main() {
 
     // Now the operator moves the werkdatum, the way they do: Instellingen →
     // Algemeen → Kies datum → Opslaan.
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     expect(find.byType(SettingsScreen), findsOneWidget);
     final pick = find.byKey(const ValueKey('settings-workdate-pick'));
@@ -4996,7 +5017,7 @@ void main() {
     // and says why. A drift pass never re-reads WISA, so running one now would
     // relink against the roster the change never reached and publish that to
     // every other operator.
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     expect(
       find.byKey(const ValueKey('reconcile-drift-blocked')),
@@ -5074,20 +5095,20 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
     // School 2 is not ours yet, so its student is re-bucketed as a leaver and
     // their class is nowhere in the tree.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.text('Niet toegewezen'), findsOneWidget);
     expect(find.text('Jaar 3'), findsNothing);
 
     // Instellingen → Wisa → tick "beheerd" for Sint-Pieter → Opslaan.
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     await openSettingsTab(tester, 'settings-tab-wisa');
     final ours = find.byKey(const ValueKey('settings-wisa-school-2-ours'));
@@ -5103,7 +5124,7 @@ void main() {
     // Back on Reconcile, Check for drift is offered: ownership is applied when
     // the view is relinked, not when WISA is pulled, so the #238 gate — which
     // guards the WISA pull inputs — must not stand in the way here.
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('reconcile-drift-blocked')), findsNothing);
     expect(find.byKey(const ValueKey('reconcile-relaunch-required')),
@@ -5113,7 +5134,7 @@ void main() {
 
     // …and the student is out of the leaver bucket and browsable under their
     // own class, with no relaunch anywhere in this test.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.text('Niet toegewezen'), findsNothing);
     await tester.tap(find.text('Jaar 3'));
@@ -5151,7 +5172,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // A first pass, on the rules as they stand: the whole tree comes in.
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -5161,7 +5182,7 @@ void main() {
     );
 
     // The operator authors the rule that drops "Organisatie" and saves.
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     await openSettingsTab(tester, 'settings-tab-smartschool');
     await addSmartschoolRule(tester, 'discardGroup', 'Organisatie');
@@ -5176,7 +5197,7 @@ void main() {
     // Back on Reconcile the screen names the save that is still waiting — the
     // silence #259 closed. Nothing is refused: an import rule is not a WISA
     // pull input, so #238's drift gate stays open too.
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('reconcile-drift-blocked')), findsNothing);
     expect(
@@ -5260,7 +5281,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -5312,7 +5333,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -5320,7 +5341,7 @@ void main() {
 
     // The overview names the school year it describes, in the wire's own
     // dd/MM/yyyy, on the same line as the generation and the operator.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(
       find.textContaining('Generatie 1 · ', skipOffstage: false),
@@ -5334,7 +5355,7 @@ void main() {
     // The operator moves the werkdatum in Instellingen and saves. That is the
     // *next* pull's input; the view on Acties is still the one pulled as of
     // 01/09/2025 and must keep saying so.
-    await tester.tap(find.text('Settings'));
+    await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     final pick = find.byKey(const ValueKey('settings-workdate-pick'));
     await tester.ensureVisible(pick);
@@ -5355,7 +5376,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('settings-save')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(
       find.textContaining('· werkdatum 01/09/2025', skipOffstage: false),
@@ -5368,13 +5389,13 @@ void main() {
     );
 
     // Only the Synchroniseer moves it — the same pass that moves the roster.
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
     expect(wire.werkdatums, <String>['01/09/2025', '15/09/2025']);
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(
       find.textContaining('· werkdatum 15/09/2025', skipOffstage: false),
@@ -5413,7 +5434,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     // Yesterday's session: WISA + Smartschool pull, the seeded Azure snapshot
     // is reused untouched (its token is not spent yet).
@@ -5532,7 +5553,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -5562,7 +5583,7 @@ void main() {
 
     // And that is what the operator sees: browse Acties → Leerlingen the way
     // they did when they reported this.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
@@ -5622,7 +5643,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -5652,7 +5673,7 @@ void main() {
 
     // And that is what the operator sees: browse Acties → Personeel the way
     // they did when they reported this.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
@@ -5721,7 +5742,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -5739,7 +5760,7 @@ void main() {
         'OTHER - Wiskunde');
 
     // Acties → Personeel: the operator is offered the repair.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
@@ -5832,13 +5853,13 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
     expect(harness.controller.error, isNull);
 
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
@@ -5931,7 +5952,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -5939,7 +5960,7 @@ void main() {
 
     // Browse Acties → Leerlingen the way the operator did when they reported
     // this: the student is under their own year and class.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
@@ -6043,7 +6064,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
@@ -6051,7 +6072,7 @@ void main() {
 
     // Browse Acties → Personeel: the staff member is under the synthetic staff
     // school, with the first link of the chain offered and only that one.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
@@ -6152,14 +6173,14 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reconcile'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
     expect(harness.controller.error, isNull);
 
     // Browse Acties → Personeel, where the operator met this.
-    await tester.tap(find.text('Actions'));
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -5123,11 +5123,19 @@ void main() {
 
   testWidgets(
       'a Smartschool import rule saved in Instellingen prunes the very next '
-      'Smartschool pull (#246)', (WidgetTester tester) async {
+      'Synchroniseer, and the screen says so meanwhile (#246/#259)',
+      (WidgetTester tester) async {
     // #241's end-to-end proved the rules work; it had to hand-carry the saved
     // document into the reconcile harness itself, because the running pull had
     // closed over the bootstrap one. Nothing is handed over here — the two
     // bootstraps share one LiveSettings, exactly as `main()` wires them.
+    //
+    // And the pass driven here is the one the operator actually reaches for.
+    // Until #259 this journey ended in the reported bug: #99's smart sync left
+    // Smartschool alone because the session already held it, so Synchroniseer
+    // pulled WISA, found it unchanged and reported "geen accountwijzigingen
+    // nodig" — over the rule the operator had just saved. Only Check for drift
+    // adopted it, and nothing on screen said so.
     useTallWindow(tester);
     final wire = GroupTreeSoap();
     final live = LiveSettings(const AppSettings());
@@ -5165,20 +5173,45 @@ void main() {
       isA<DiscardSmartschoolGroup>(),
     );
 
-    // Back on Reconcile the operator presses **Check for drift** — the pass
-    // that re-reads Smartschool at all, since #99's smart sync leaves a system
-    // this session already holds alone. It is offered, because an import rule is
-    // not a WISA pull input and so never arms #238's gate…
+    // Back on Reconcile the screen names the save that is still waiting — the
+    // silence #259 closed. Nothing is refused: an import rule is not a WISA
+    // pull input, so #238's drift gate stays open too.
     await tester.tap(find.text('Reconcile'));
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('reconcile-drift-blocked')), findsNothing);
-    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    expect(
+      find.byKey(const ValueKey('reconcile-settings-pending')),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('Instellingen voor Smartschool gewijzigd'),
+      findsOneWidget,
+    );
+
+    // The operator presses **Synchroniseer**, the pass they reach for.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    // …and the pull it just ran is the pruned one. No hand-off, no relaunch.
+    // The pull it just ran is the pruned one. No drift check, no hand-off, no
+    // relaunch.
     expect(
       harness.app.smartschool.snapshot?.groups.map((g) => g.id.value).toList(),
       <String>['SCH', 'KLA', 'C1A'],
+    );
+    // …the notice is gone, because the pass applied it…
+    expect(
+      find.byKey(const ValueKey('reconcile-settings-pending')),
+      findsNothing,
+    );
+    // …and the Log panel never claimed there was nothing to do, which is the
+    // half of this bug the operator actually saw.
+    expect(find.textContaining('geen accountwijzigingen nodig'), findsNothing);
+    expect(
+      find.textContaining(
+        'Smartschool-instellingen gewijzigd — Smartschool wordt opnieuw '
+        'opgehaald.',
+      ),
+      findsOneWidget,
     );
   });
 

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -269,9 +269,52 @@ void main() {
     await tester.ensureVisible(find.byKey(const ValueKey('reconcile-sync')));
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
-    expect(find.textContaining('no account changes needed'), findsWidgets);
+    // The on-screen banner is #265's to translate; the Log *line* beside it is
+    // Dutch since #258.
+    expect(find.textContaining('no account changes needed'), findsOneWidget);
     expect(harness.ssSyncs, 1);
     expect(harness.azSyncs, 1);
+
+    // The Log panel is one running account of everything this session did —
+    // three pulls, a link, a dry-run, an apply, a second pass — and it reads in
+    // one language from top to bottom (#258). Before this it switched halfway:
+    // English pull/link/apply lines under the Dutch terminal line #253 wrote.
+    expect(find.byKey(const ValueKey('reconcile-log-panel')), findsOneWidget);
+    for (final String line in <String>[
+      'WISA ophalen…',
+      'Smartschool ophalen…',
+      'Azure AD ophalen…',
+      'WISA is ongewijzigd sinds de vorige synchronisatie — '
+          'geen accountwijzigingen nodig.',
+      'Gekoppeld: ',
+      'Dry-run gestart voor ',
+      'Dry-run klaar: ',
+      'Toepassen gestart voor ',
+      'Toepassen klaar: ',
+      'Sync voltooid — ',
+    ]) {
+      expect(find.textContaining(line), findsWidgets, reason: line);
+    }
+    // …and not one entry the pass wrote is still the English it used to be.
+    final List<String> logged =
+        harness.log.entries.map((e) => e.message).toList();
+    for (final String english in <String>[
+      'Syncing ',
+      'WISA sync done',
+      'WISA is unchanged',
+      'Checking ',
+      'Linked: ',
+      'Apply started',
+      'Apply finished',
+      'Dry-run started',
+      'Dry-run finished',
+    ]) {
+      expect(
+        logged.where((String m) => m.startsWith(english)),
+        isEmpty,
+        reason: english,
+      );
+    }
   });
 
   testWidgets(
@@ -812,7 +855,12 @@ void main() {
       isNotNull,
     );
     // The operator sees the timeout in the log panel, not silence.
-    expect(find.textContaining('timed out'), findsOneWidget);
+    expect(
+      find.textContaining(
+        'Het opslaan van het gedeelde overzicht duurde langer dan',
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets(
@@ -822,7 +870,7 @@ void main() {
     // The real app, driven the way the operator drives it, over the *production*
     // Cosmos write path — a real HttpCosmosClient and CosmosLinkedStore — with
     // the account answering the middle of the write burst with 429s. Before the
-    // fix this ended the pass with "Could not persist the linked view:
+    // fix this ended the pass with "Kon het gedeelde overzicht niet opslaan:
     // CosmosException(429 …)" and left the shared containers holding this sync's
     // accounts next to the previous sync's groups and rollups.
     useTallWindow(tester);
@@ -865,7 +913,10 @@ void main() {
     // The pass finished normally: nothing failed, and the operator's log panel
     // carries the terminal ready line rather than a Cosmos error.
     expect(harness.controller.busy, isFalse);
-    expect(find.textContaining('Could not persist'), findsNothing);
+    expect(
+      find.textContaining('Kon het gedeelde overzicht niet opslaan'),
+      findsNothing,
+    );
     expect(
       harness.log.entries.where((e) => e.isError).map((e) => e.message),
       isEmpty,
@@ -5294,8 +5345,8 @@ void main() {
     expect(find.byKey(const ValueKey('reconcile-log-panel')), findsOneWidget);
     expect(
       find.textContaining(
-        'Pulling WISA with werkdatum 01/09/2025; virtuele werkdatum '
-        '01/10/2025 for V.',
+        'WISA ophalen met werkdatum 01/09/2025; virtuele werkdatum '
+        '01/10/2025 voor V.',
       ),
       findsOneWidget,
     );

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2554,6 +2554,106 @@ void main() {
   });
 
   testWidgets(
+      "another operator's apply reaches a running session live, with no "
+      're-sync end-to-end (#254)', (WidgetTester tester) async {
+    // The shared half of #236, at the layer it is actually felt. #236 fixed the
+    // badges of the session that ran the apply and deliberately wrote nothing
+    // back, so every *other* operator's Acties panel kept offering work that had
+    // already been applied until somebody ran a full Synchroniseer.
+    //
+    // Only a two-session run can see that: one session applies, and the bug is
+    // what the *other* one is still showing. So operator A is an offline
+    // session over the shared stores, and operator B is the real app — real
+    // fonts, real navigation, real rollup tree — reading the same shared view
+    // over the same realtime fan-out, and never syncing or linking at all.
+    useTallWindow(tester);
+    final hub = InMemorySignalHub();
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+
+    // Operator A materializes the shared view: Sam's stale Office 365 name is
+    // the one piece of student work anywhere, and it sits in 3C.
+    final operatorA = appliedClassWorkHarness(
+      store: snapshots,
+      linkedStore: linkedStore,
+      hub: hub,
+      syncedBy: 'jan@school.example',
+    );
+    await operatorA.controller.sync();
+
+    final operatorB = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+      hub: hub,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: operatorB.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+
+    final jaar3 = find.byKey(const ValueKey('rollup-grade-grades|3'));
+    final klas3C = find.byKey(const ValueKey('rollup-class-class|1|3|3C'));
+
+    // B is offered the work, badged 1 — read from the shared documents, with no
+    // pull and no link() of its own.
+    await tester.ensureVisible(jaar3);
+    await tester.tap(jaar3);
+    await tester.pumpAndSettle();
+    expect(
+        find.descendant(of: klas3C, matching: find.text('1')), findsOneWidget);
+
+    // A applies it. B is nudged over the realtime fan-out and refetches the one
+    // shard that moved.
+    await operatorA.controller.applyEntry(
+      operatorA.controller.pendingEntries
+          .singleWhere((e) => e.family == 'student'),
+    );
+    await tester.pumpAndSettle();
+
+    // Under the work-list filter the finished class is gone, and with 3D already
+    // clean the whole year goes with it — the panel has stopped offering work
+    // that is already done.
+    expect(klas3C, findsNothing,
+        reason: 'B used to keep advertising it until someone re-synced');
+    expect(jaar3, findsNothing);
+    expect(operatorB.wisaSyncs, 0, reason: 'the nudge never triggers a pull');
+    expect(operatorB.controller.linked, isNull,
+        reason: 'link() is never called in a passive session');
+
+    // Off the filter the class is back on the inventory, ticked off rather than
+    // badged — B's drill-down agrees with the store it just re-read.
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(jaar3);
+    if (klas3C.evaluate().isEmpty) {
+      await tester.tap(jaar3);
+      await tester.pumpAndSettle();
+    }
+    expect(find.descendant(of: klas3C, matching: find.text('1')), findsNothing);
+    expect(find.descendant(of: klas3C, matching: find.byIcon(Icons.check)),
+        findsOneWidget);
+
+    // …and drilling in shows the card with nothing left to do on it.
+    await tester.ensureVisible(klas3C);
+    await tester.tap(klas3C);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('actions-read-only')), findsOneWidget);
+    expect(find.text('Sam Sels'), findsOneWidget);
+    expect(
+      operatorB.controller.classroomAccounts!.expand((a) => a.candidates),
+      isEmpty,
+      reason: 'the stored document itself dropped the applied candidate',
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'a classroom\'s bulk "Alles toepassen" writes only that classroom, '
       'leaving the identical situation in another class pending (#252)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -10,6 +10,7 @@ import 'package:account_manager/main.dart' as app;
 import 'package:account_manager/src/app.dart';
 import 'package:account_manager/src/auth/auth.dart';
 import 'package:account_manager/src/screens/actions_screen.dart';
+import 'package:account_manager/src/screens/class_groups_screen.dart';
 import 'package:account_manager/src/screens/home_screen.dart';
 import 'package:account_manager/src/screens/passwords_screen.dart';
 import 'package:account_manager/src/screens/reconcile_screen.dart';
@@ -339,6 +340,22 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
+  }
+
+  /// Opens the Klasgroepen tab from the navigation rail (#227). The class
+  /// inventory is a destination of its own now, not a node inside Acties.
+  Future<void> openKlasgroepen(WidgetTester tester) async {
+    await tester.tap(find.text('Klasgroepen'));
+    await tester.pumpAndSettle();
+  }
+
+  /// Syncs on Reconcile and lands on the Klasgroepen tab.
+  Future<void> syncThenOpenKlasgroepen(WidgetTester tester) async {
+    await tester.tap(find.text('Reconcile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    await openKlasgroepen(tester);
   }
 
   /// The text of one line of the modal progress dialog.
@@ -1254,14 +1271,10 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
+    await openKlasgroepen(tester);
 
-    // Our own populated class is the only proposal on the list…
-    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
+    // Our own populated class is the only class in the inventory…
+    expect(find.byType(ClassGroupsScreen), findsOneWidget);
     expect(find.text('1A'), findsOneWidget);
     // …reading as the create side of the either/or choice of #244.
     expect(find.text('Voeg deze klas toe aan Smartschool (keuze)'),
@@ -1271,10 +1284,12 @@ void main() {
         reason: 'creating another school\'s class is never ours to propose');
 
     // The surviving proposal describes *our* 1A, not the sibling class that
-    // shares its name.
+    // shares its name — on the row itself and in the create's diff.
+    expect(find.text('Onze eerste klas'), findsOneWidget,
+        reason: 'the inventory row names our class');
     await tester.tap(find.byKey(const ValueKey('entry-group-1A')));
     await tester.pumpAndSettle();
-    expect(find.textContaining('Onze eerste klas'), findsOneWidget);
+    expect(find.textContaining('Onze eerste klas'), findsNWidgets(2));
     expect(find.textContaining('Klas van een andere school'), findsNothing);
   });
 
@@ -1301,26 +1316,25 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
+    await openKlasgroepen(tester);
 
-    // Only our own class is on the list; neither virtual class is anywhere.
-    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
+    // Only our own class is in the inventory; neither virtual class is anywhere
+    // — not as an entry tile, and not as a plain row either.
+    expect(find.byType(ClassGroupsScreen), findsOneWidget);
     expect(find.byKey(const ValueKey('entry-group-1A')), findsOneWidget);
     expect(find.byKey(const ValueKey('entry-group-1V')), findsNothing,
         reason: 'creating a virtual school\'s class is never worth proposing');
+    expect(find.byKey(const ValueKey('class-row-1V')), findsNothing);
     expect(find.byKey(const ValueKey('entry-group-9V')), findsNothing,
         reason: 'the empty-class notice for a virtual class is pure clutter');
+    expect(find.byKey(const ValueKey('class-row-9V')), findsNothing);
     expect(find.textContaining('Virtuele klas'), findsNothing);
     expect(find.textContaining('Lege virtuele klas'), findsNothing);
 
-    // Back out of Klasgroepen: the virtual school's student is still imported
-    // and still sits in the class their own WISA record names — dropping the
-    // class-group records moved nobody.
-    await tester.tap(find.byKey(const ValueKey('actions-groups-back')));
+    // Over on Acties: the virtual school's student is still imported and still
+    // sits in the class their own WISA record names — dropping the class-group
+    // records moved nobody.
+    await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
     // The merged first year spans both managed schools (#210), so the virtual
     // school's 1V sits beside our own 1A under it.
@@ -1364,14 +1378,10 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
+    await openKlasgroepen(tester);
 
-    // Our 1A is the only class on the list, and it reads as the empty one.
-    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
+    // Our 1A is the only class in the inventory, and it reads as the empty one.
+    expect(find.byType(ClassGroupsScreen), findsOneWidget);
     expect(find.byKey(const ValueKey('entry-group-1A')), findsOneWidget);
     expect(find.textContaining('bevat nog geen leerlingen'), findsOneWidget);
     expect(
@@ -1447,15 +1457,11 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
+    await openKlasgroepen(tester);
 
     // `2G` is on the list, and it says the class is already there — not that it
     // needs creating.
-    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
+    expect(find.byType(ClassGroupsScreen), findsOneWidget);
     expect(find.byKey(const ValueKey('entry-group-2G')), findsOneWidget);
     expect(
       find.textContaining(
@@ -1521,11 +1527,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
+    await openKlasgroepen(tester);
 
     // Both new classes are on the list, each reading as *one* choice…
     expect(find.byKey(const ValueKey('entry-group-1A')), findsOneWidget);
@@ -1604,10 +1606,7 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await syncThenOpenActions(tester);
-    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
 
     // Every class is on the list, and each namesake one reads as the hand-fix
     // notice — the resolution that is pre-selected for it.
@@ -1703,8 +1702,8 @@ void main() {
   });
 
   testWidgets(
-      'the Acties badges count one pending item per either/or, so the '
-      'Klasgroepen node agrees with the list it opens end-to-end (#251)',
+      'the badges count one pending item per either/or, so the Klasgroepen '
+      'rollup agrees with the list the tab renders end-to-end (#251)',
       (WidgetTester tester) async {
     // The real app, real fonts, real navigation. Two brand-new WISA classes,
     // each carrying the create-or-ignore either/or of #244 plus an Office 365
@@ -1731,13 +1730,11 @@ void main() {
     await syncThenOpenActions(tester);
     expect(harness.controller.error, isNull);
 
-    final klasgroepen = find.byKey(const ValueKey('rollup-groups'));
-    await tester.ensureVisible(klasgroepen);
-    expect(find.descendant(of: klasgroepen, matching: find.text('4')),
-        findsOneWidget,
+    // The stored Klasgroepen aggregate — what every badge on the classes is
+    // derived from — counts four decisions, never the six actions behind them.
+    expect(harness.controller.groupRollup!.pendingCount, 4,
         reason: 'two classes × (one either/or + one Office 365 group)');
-    expect(find.descendant(of: klasgroepen, matching: find.text('6')),
-        findsNothing,
+    expect(harness.controller.groupRollup!.pendingCount, isNot(6),
         reason: 'the badge used to count both halves of both choices');
 
     // Each student's own class carries one action and is badged once, so the
@@ -1751,16 +1748,25 @@ void main() {
     expect(
         find.descendant(of: klas1A, matching: find.text('1')), findsOneWidget);
 
-    // The number on the node is exactly what a confirmed apply of that list
-    // would write — the claim the badge and the dialog used to disagree on.
-    await tester.ensureVisible(klasgroepen);
-    await tester.tap(klasgroepen);
-    await tester.pumpAndSettle();
+    // The number on the aggregate is exactly what a confirmed apply of the
+    // Klasgroepen list would write — the claim the badge and the dialog used to
+    // disagree on. Each class row carries its own share of it, badged once.
+    await openKlasgroepen(tester);
     final groups = harness.controller.groupPendingEntries;
     expect(groups, hasLength(2));
     expect(harness.controller.applyScope(groups).systems, hasLength(4));
     expect(find.text('Voeg deze klas toe aan Smartschool (keuze)'),
         findsNWidgets(2));
+    for (final klas in const ['1A', '1B']) {
+      expect(
+        find.descendant(
+          of: find.byKey(ValueKey('entry-group-$klas')),
+          matching: find.text('2'),
+        ),
+        findsOneWidget,
+        reason: 'one either/or plus one Office 365 group on each class',
+      );
+    }
     expect(tester.takeException(), isNull);
   });
 
@@ -1841,14 +1847,10 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Actions'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
+    await openKlasgroepen(tester);
 
     // One proposal, named after the parent class `2F` — not `2F ECO`.
-    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
+    expect(find.byType(ClassGroupsScreen), findsOneWidget);
     expect(
       find.text('Maak de Office 365-groep GBS-2F voor klas 2F'),
       findsOneWidget,
@@ -1857,6 +1859,11 @@ void main() {
         reason: 'sub-groups get no group of their own');
     expect(find.byKey(const ValueKey('entry-group-1A')), findsNothing,
         reason: 'GBS-1A exists and holds its student — nothing to propose');
+    // …and the class is on the inventory all the same, ticked off (#227): the
+    // sibling rows say whose group they share rather than each looking like a
+    // class with a missing group of its own.
+    expect(find.byKey(const ValueKey('class-row-1A')), findsOneWidget);
+    expect(find.text('deelgroep van 2F'), findsNWidgets(2));
 
     // The group of a class that no longer exists is reported, never deleted.
     expect(
@@ -1918,6 +1925,100 @@ void main() {
   });
 
   testWidgets(
+      'the Klasgroepen tab is a full class inventory with a presence column '
+      'per system, and highlights the classes that need work end-to-end '
+      '(#227)', (WidgetTester tester) async {
+    // The real app, real fonts, real navigation, real rail. Our school runs
+    // `1A` — correct in all three systems — and the sub-grouped `2F`
+    // (`2F ECO` + `2F MAW`), which has no Office 365 group; `GBS-9Z` is the
+    // group of a class that is gone.
+    //
+    // This is the layer that sees what the issue is about. The inventory is
+    // composed from the *stored* documents (which only the materializer fills)
+    // while the interactive halves come from the live dispatch, and the tab has
+    // to be reachable from the shell at all — three different halves of the app
+    // that only a full run puts on screen together. The motivating bug (#225's
+    // `2G`) was invisible precisely because every row in the old list was a
+    // change; a row that is right has to be on screen for a wrong one to stand
+    // out.
+    useTallWindow(tester);
+    final harness = azureClassGroupHarness(withStaleGroup: true);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+    expect(harness.controller.error, isNull);
+    expect(find.byType(ClassGroupsScreen), findsOneWidget);
+
+    // Every class is a row — `1A` included, which raises nothing at all and so
+    // had no stored document whatsoever before this issue.
+    final healthy = find.byKey(const ValueKey('class-row-1A'));
+    expect(healthy, findsOneWidget);
+    expect(find.byKey(const ValueKey('class-row-2F MAW')), findsOneWidget);
+    final needsWork = find.byKey(const ValueKey('entry-group-2F ECO'));
+    expect(needsWork, findsOneWidget);
+    expect(find.byKey(const ValueKey('entry-group-GBS-9Z')), findsOneWidget);
+    expect(find.textContaining('4 klas(sen), waarvan 2 aandacht vragen'),
+        findsOneWidget);
+
+    // Three presence columns, and a class that is right everywhere reads as
+    // three ticks plus the name of its Office 365 group.
+    for (final system in const ['WISA', 'Smartschool', 'Office 365']) {
+      expect(find.descendant(of: healthy, matching: find.text(system)),
+          findsOneWidget);
+    }
+    expect(
+      find.descendant(
+          of: healthy, matching: find.byIcon(Icons.check_circle_outline)),
+      findsNWidgets(3),
+    );
+    expect(find.descendant(of: healthy, matching: find.text('GBS-1A')),
+        findsOneWidget);
+    // The Office 365 column is per *class*: both sub-groups of `2F` name the one
+    // group they share instead of each looking like a class missing its own.
+    expect(find.text('deelgroep van 2F'), findsNWidgets(2));
+
+    // The rows that need work are highlighted; the one that does not is not.
+    final BuildContext context = tester.element(find.byType(ClassGroupsScreen));
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    Color borderOf(String klas) {
+      final Container box =
+          tester.widget<Container>(find.byKey(ValueKey('class-row-$klas')));
+      return ((box.decoration! as BoxDecoration).border! as Border).top.color;
+    }
+
+    expect(borderOf('2F ECO'), colors.primary);
+    expect(
+      borderOf('1A'),
+      isNot(colors.primary),
+      reason: 'a class that is in order must not read as one that needs work',
+    );
+
+    // The filter mirrors the Acties switch but starts **off** — the full
+    // picture is this tab's job (#226/#227).
+    final filter = find.byKey(const ValueKey('class-groups-only-attention'));
+    expect(tester.widget<Switch>(filter).value, isFalse);
+    await tester.ensureVisible(filter);
+    await tester.tap(filter);
+    await tester.pumpAndSettle();
+    expect(healthy, findsNothing);
+    expect(needsWork, findsOneWidget);
+    await tester.tap(filter);
+    await tester.pumpAndSettle();
+    expect(healthy, findsOneWidget);
+
+    // And the same list is not maintained in two places: the Klasgroepen node
+    // has left the Acties drill-down.
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('rollup-groups')), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       "a student's Office 365 class group is reported on their own account "
       'end-to-end, pointing at the one class-level write (#245)',
       (WidgetTester tester) async {
@@ -1945,15 +2046,10 @@ void main() {
     await tester.pumpAndSettle();
     expect(harness.controller.error, isNull);
 
-    await tester.tap(find.text('Actions'));
-    await tester.pumpAndSettle();
-
     // The class rows still carry the single applyable write, on both classes.
-    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
-    // (Both classes raise the same kind of action, so the list also renders a
-    // "same situation" header carrying the first one's summary — hence
+    await openKlasgroepen(tester);
+    // (Both classes raise the same kind of action, so the tab also renders a
+    // "same situation" bulk header carrying the first one's summary — hence
     // findsWidgets rather than findsOneWidget.)
     expect(
       find.textContaining('Werk het ledenbestand van GBS-1A bij '
@@ -1964,7 +2060,8 @@ void main() {
       find.textContaining('Werk het ledenbestand van GBS-1B bij (1 toevoegen'),
       findsWidgets,
     );
-    await tester.tap(find.byKey(const ValueKey('actions-groups-back')));
+
+    await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
 
     // Nothing applyable hangs off either class's *students*, so the work list
@@ -2401,7 +2498,6 @@ void main() {
 
     final jaar3 = find.byKey(const ValueKey('rollup-grade-grades|3'));
     final klas3C = find.byKey(const ValueKey('rollup-class-class|1|3|3C'));
-    final klasgroepen = find.byKey(const ValueKey('rollup-groups'));
 
     // Sam's stale Office 365 name is the only student work: 3C carries it,
     // badged 1, and the class groups carry four writes of their own.
@@ -2410,8 +2506,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
         find.descendant(of: klas3C, matching: find.text('1')), findsOneWidget);
-    expect(find.descendant(of: klasgroepen, matching: find.text('4')),
-        findsOneWidget);
+    expect(harness.controller.groupRollup!.pendingCount, 4);
 
     // Drill into 3C and apply that one entry, confirmation dialog and all.
     await tester.ensureVisible(klas3C);
@@ -2439,8 +2534,7 @@ void main() {
     expect(jaar3, findsNothing);
     // …while the work nobody touched is untouched: a re-derivation of what
     // changed, not a blanket reset.
-    expect(find.descendant(of: klasgroepen, matching: find.text('4')),
-        findsOneWidget);
+    expect(harness.controller.groupRollup!.pendingCount, 4);
 
     // Off the filter, the class is back in the inventory — now ticked off
     // rather than badged, with no sync between.
@@ -3273,16 +3367,16 @@ void main() {
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
 
-    // The class-group node is part of the shared overview on the Actions tab,
-    // straight from the store — no Synchronise tapped.
+    // The account overview is there, straight from the store — no Synchronise
+    // tapped.
     expect(find.text('Overzicht'), findsOneWidget);
-    expect(find.text('Klasgroepen'), findsWidgets);
 
-    // Drilling into it lists the orphan Smartschool classes with their notice.
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
+    // And so is the class inventory, on its own tab, listing the orphan
+    // Smartschool classes with their notice (#227).
+    await openKlasgroepen(tester);
 
-    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
+    expect(find.byType(ClassGroupsScreen), findsOneWidget);
+    expect(find.byKey(const ValueKey('class-row-2B')), findsOneWidget);
     expect(
         find.textContaining('Deze klas bestaat in Smartschool'), findsWidgets);
     // …all without a single connector pull or link().
@@ -3331,14 +3425,15 @@ void main() {
     expect(readOnly, findsNothing,
         reason: 'the browsable overview is not the read-only surface');
 
-    // The Klasgroepen tree: static tiles, and now they say so.
-    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
-    expect(readOnly, findsOneWidget);
+    // The Klasgroepen tab: static rows, and they say so — the same
+    // announcement, keyed per view since #227 put the two on different tabs.
+    await openKlasgroepen(tester);
+    final klasgroepenReadOnly =
+        find.byKey(const ValueKey('class-groups-read-only'));
+    expect(klasgroepenReadOnly, findsOneWidget);
     expect(find.text('Alleen-lezen overzicht'), findsOneWidget);
     expect(pendingTiles, findsNothing);
-    await tester.tap(find.byKey(const ValueKey('actions-groups-back')));
+    await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
 
     // The classroom tree: the same announcement, and the cards themselves carry

--- a/account_manager/lib/src/auth/sign_in_gate.dart
+++ b/account_manager/lib/src/auth/sign_in_gate.dart
@@ -64,7 +64,8 @@ class _SignInGateState extends State<SignInGate> {
       if (mounted) {
         setState(() {
           _phase = _Phase.failed;
-          _error = e.isUserCancelled ? 'Sign-in was cancelled.' : e.message;
+          _error =
+              e.isUserCancelled ? 'Het aanmelden is geannuleerd.' : e.message;
         });
       }
     } catch (e) {
@@ -92,7 +93,7 @@ class _SignInGateState extends State<SignInGate> {
         return _SignInScaffold(
           key: const ValueKey('sign-in-failed'),
           child: _SignInFailedPanel(
-              message: _error ?? 'Sign-in failed.', onRetry: _signIn),
+              message: _error ?? 'Het aanmelden is mislukt.', onRetry: _signIn),
         );
     }
   }
@@ -139,11 +140,12 @@ class _SigningInPanel extends StatelessWidget {
       children: <Widget>[
         Eyebrow('Arcadia · office 365', onInk: ink),
         const SizedBox(height: PlinkSpacing.s4),
-        Text('Signing in…', style: text.headlineSmall),
+        Text('Aanmelden…', style: text.headlineSmall),
         const SizedBox(height: PlinkSpacing.s4),
         Text(
-          'Connecting to Azure AD with your school account. A browser window '
-          'may open for sign-in — complete it there and return here.',
+          'Verbinden met Azure AD via je schoolaccount. Mogelijk opent er een '
+          'browservenster om je aan te melden — rond het daar af en kom hier '
+          'terug.',
           style: text.bodyMedium,
         ),
         const SizedBox(height: PlinkSpacing.s5),
@@ -167,9 +169,9 @@ class _SignInFailedPanel extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Eyebrow('Arcadia · sign-in failed', onInk: ink),
+        Eyebrow('Arcadia · aanmelden mislukt', onInk: ink),
         const SizedBox(height: PlinkSpacing.s4),
-        Text('Could not sign in', style: text.headlineSmall),
+        Text('Kon je niet aanmelden', style: text.headlineSmall),
         const SizedBox(height: PlinkSpacing.s4),
         Text(message, style: text.bodyMedium),
         const SizedBox(height: PlinkSpacing.s5),
@@ -177,7 +179,7 @@ class _SignInFailedPanel extends StatelessWidget {
           alignment: Alignment.centerLeft,
           child: FilledButton(
             onPressed: onRetry,
-            child: const Text('Try again'),
+            child: const Text('Probeer opnieuw'),
           ),
         ),
       ],

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -433,10 +433,10 @@ Future<ReconcileServices> bootstrapReconcile({
         // The operator's import rules, read from the live document at pull time
         // (#241 authored them, #246 unfroze them): authoring a
         // `DiscardSmartschoolGroup` in Instellingen reaches the very next
-        // Smartschool pull rather than the next launch. Which pass that is stays
-        // the smart-sync contract — Synchroniseer leaves a system this session
-        // already holds alone, so it is **Check for drift** that adopts a rule
-        // change (filed as #259).
+        // Smartschool pull rather than the next launch. Since #259 that is
+        // whichever pass the operator runs next: a moved
+        // `smartschoolPullFingerprint` makes the smart sync re-pull this system
+        // instead of leaving the snapshot it already holds alone.
         inner: (_) => ssConnector.sync(rules: live.current.smartschoolRules),
       ),
     ),
@@ -468,9 +468,9 @@ Future<ReconcileServices> bootstrapReconcile({
           },
           // The prefix scopes the whole Azure pull, and it is operator-editable
           // (#246). Changing it makes this pass re-read in full rather than
-          // layering the new school's changes over the old school's users. As
-          // with the Smartschool rules, the pass that re-reads Azure at all is
-          // Check for drift (#259).
+          // layering the new school's changes over the old school's users — and
+          // since #259 it is also what makes the next Synchroniseer re-pull
+          // Azure at all, rather than leaving the snapshot in hand alone.
           schoolPrefix: schoolPrefixNow,
         ),
       ),

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -286,7 +286,7 @@ Future<ReconcileServices> bootstrapReconcile({
 
   final syncedBy = session.account ?? '';
   void logSnapshotIssue(core.Origin system, Object error) =>
-      logBuffer.addError(system, 'Snapshot store: $error');
+      logBuffer.addError(system, 'Snapshotopslag: $error');
 
   final secrets = secretProvider ??
       KeyVaultSecretProvider(
@@ -692,10 +692,10 @@ String wisaPullMessage({
     for (final s in schools)
       if (s.isVirtual) _schoolLabel(s),
   ];
-  final head = 'Pulling WISA with werkdatum ${wapi.formatWerkdatum(workDate)}';
+  final head = 'WISA ophalen met werkdatum ${wapi.formatWerkdatum(workDate)}';
   if (virtual.isEmpty) return '$head.';
   return '$head; virtuele werkdatum '
-      '${wapi.formatWerkdatum(virtualWorkDate)} for ${virtual.join(', ')}.';
+      '${wapi.formatWerkdatum(virtualWorkDate)} voor ${virtual.join(', ')}.';
 }
 
 /// How a school is named in the pull line: the short code the rest of the WISA

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -350,8 +350,10 @@ class CategorySummary {
 /// the fresh pull against it. When WISA is unchanged and a linked view already
 /// exists, it reports "no account changes needed" and stops — no re-link, no
 /// action churn. Smartschool / Azure are pulled only when still missing this
-/// session; re-reading them is the explicit [checkDrift] action (someone
-/// edited via another tool), not the default.
+/// session **or when their own settings inputs have moved** ([
+/// systemsAwaitingSettings], #259); re-reading them for drift somebody else
+/// introduced through another tool is the explicit [checkDrift] action, not the
+/// default.
 class ReconcileController extends ChangeNotifier {
   ReconcileController({
     required this.app,
@@ -373,6 +375,12 @@ class ReconcileController extends ChangeNotifier {
     // The snapshot this session starts with — seeded from the cold store, or
     // pulled later — belongs to the settings as they stand right now (#238).
     _wisaPullFingerprint = _wisaFingerprint();
+    // The same claim for the other two systems (#259). A cold seed was pulled
+    // by some other session whose settings this one cannot know, so — exactly
+    // as for WISA — it is credited to the document in hand, and only a save
+    // made *from here on* asks for a re-pull.
+    _smartschoolPullFingerprint = _settingsFingerprint(core.Origin.smartschool);
+    _azurePullFingerprint = _settingsFingerprint(core.Origin.azure);
     // The endpoints and credential refs the connectors in hand were built from
     // (#246). Unlike everything else, a later change to these cannot be adopted
     // — see [relaunchRequiredReason].
@@ -483,6 +491,13 @@ class ReconcileController extends ChangeNotifier {
   /// holds was pulled with (#238). Re-stamped on every WISA pull; compared
   /// against the live document to arm [driftBlockedReason].
   late String _wisaPullFingerprint;
+
+  /// The [smartschoolPullFingerprint] / [azurePullFingerprint] of the settings
+  /// the snapshot this session holds for that system was pulled with (#259).
+  /// Re-stamped on every pull of that system; compared against the live
+  /// document to arm [systemsAwaitingSettings].
+  late String _smartschoolPullFingerprint;
+  late String _azurePullFingerprint;
 
   ReconcilePhase _phase = ReconcilePhase.idle;
   double _progress = 0.0;
@@ -1073,8 +1088,67 @@ class ReconcileController extends ChangeNotifier {
   /// Whether **Check for drift** can be started right now: no pass running, no
   /// other operator holding the lease, and the WISA settings unchanged since
   /// this session's roster was pulled (#238).
+  ///
+  /// Deliberately *not* gated on [systemsAwaitingSettings]: a drift pass
+  /// unconditionally re-reads Smartschool and Azure, so it is one of the two
+  /// passes that adopt a saved rule or prefix rather than a pass that would
+  /// reconcile around it.
   bool get canCheckDrift =>
       !busy && !syncLockedByOther && driftBlockedReason == null;
+
+  /// The pull-input fingerprint of [system] as the live document stands right
+  /// now, or the empty sentinel when no [liveSettings] holder is wired — which
+  /// makes every comparison equal and leaves [systemsAwaitingSettings] empty
+  /// for the harnesses that model no settings at all.
+  String _settingsFingerprint(core.Origin system) {
+    final live = liveSettings;
+    if (live == null) return '';
+    return switch (system) {
+      core.Origin.smartschool => smartschoolPullFingerprint(live.current),
+      core.Origin.azure => azurePullFingerprint(live.current),
+      _ => '',
+    };
+  }
+
+  /// The systems whose *own* pull inputs have been changed in Instellingen
+  /// since the snapshot this session holds for them was pulled (#259).
+  ///
+  /// #99's smart sync re-pulls Smartschool and Azure only when this session
+  /// does not hold them yet, which is right when the question is "did somebody
+  /// edit those systems behind our back" (that is [checkDrift]'s job) and wrong
+  /// when the operator has just changed what the pull itself asks for. A saved
+  /// `DiscardSmartschoolGroup` or a new school prefix then reached the running
+  /// stack (#246) but no pass applied it, while [sync] reported "geen
+  /// accountwijzigingen nodig" over the very save it had skipped.
+  ///
+  /// So this is the targeted equivalent of the `snapshot == null` condition:
+  /// non-empty means the next [sync] re-pulls those systems, and
+  /// [pendingSettingsReason] says so on screen until it has.
+  Set<core.Origin> get systemsAwaitingSettings => <core.Origin>{
+        if (_settingsFingerprint(core.Origin.smartschool) !=
+            _smartschoolPullFingerprint)
+          core.Origin.smartschool,
+        if (_settingsFingerprint(core.Origin.azure) != _azurePullFingerprint)
+          core.Origin.azure,
+      };
+
+  /// Which saved settings are waiting for a Synchroniseer to be applied, or
+  /// `null` when none are (#259).
+  ///
+  /// Nothing is refused — the next [sync] adopts them by itself, and so does a
+  /// [checkDrift]. This only ends the silence between the save and that pass,
+  /// the way [driftBlockedReason] and [relaunchRequiredReason] name their own
+  /// situations.
+  String? get pendingSettingsReason {
+    final systems = systemsAwaitingSettings;
+    if (systems.isEmpty) return null;
+    final names = <String>[
+      if (systems.contains(core.Origin.smartschool)) 'Smartschool',
+      if (systems.contains(core.Origin.azure)) 'Azure AD',
+    ];
+    return 'Instellingen voor ${names.join(' en ')} gewijzigd — '
+        'synchroniseer om ze toe te passen.';
+  }
 
   /// Why this session must be relaunched before it can honour the settings as
   /// they now stand, or `null` when it can honour all of them (#246).
@@ -1109,6 +1183,17 @@ class ReconcileController extends ChangeNotifier {
   /// mid-pull stays pending rather than being credited to a pull that never saw
   /// it (#238).
   void _stampWisaPull(String fingerprint) => _wisaPullFingerprint = fingerprint;
+
+  /// The same record for Smartschool / Azure (#259): [fingerprint] is read
+  /// *before* the pull goes out, so a save landing mid-pull stays pending
+  /// rather than being credited to a pull that never saw it.
+  void _stampPull(core.Origin system, String fingerprint) {
+    if (system == core.Origin.smartschool) {
+      _smartschoolPullFingerprint = fingerprint;
+    } else if (system == core.Origin.azure) {
+      _azurePullFingerprint = fingerprint;
+    }
+  }
 
   /// Whether the store holds a materialized overview (rollups) to drill into —
   /// true after any session has synced, even without a pull this session.
@@ -1412,6 +1497,13 @@ class ReconcileController extends ChangeNotifier {
       // same document, so this names exactly the settings WISA was asked with
       // (#238).
       final pulledWith = _wisaFingerprint();
+      // Which held system's own pull inputs moved since it was pulled (#259),
+      // sampled before anything goes out for the same reason [pulledWith] is:
+      // a save landing mid-pass belongs to the next one. Read here rather than
+      // after the WISA pull so the school-profile back-fill below — which
+      // publishes a repaired document of its own (#207) — can never be mistaken
+      // for the operator changing something.
+      final stale = systemsAwaitingSettings;
       log.addMessage(core.Origin.wisa, 'Syncing WISA…');
       final fresh = await app.sync(core.Origin.wisa) as wapi.WisaSnapshot;
       _stampWisaPull(pulledWith);
@@ -1428,8 +1520,13 @@ class ReconcileController extends ChangeNotifier {
       // schools have no names.
       await _backfillSchoolProfiles(fresh.schools);
 
+      // "Nothing to do" is only honest while every input is the one the view in
+      // hand was built from. A saved import rule or school prefix (#259) is a
+      // change this pass has to apply, so it falls through to the re-pull below
+      // instead of reporting "geen accountwijzigingen nodig" over it.
       if (previous != null &&
           _linked != null &&
+          stale.isEmpty &&
           wisaSnapshotUnchanged(previous, fresh)) {
         _noChangesNeeded = true;
         log.addMessage(
@@ -1444,17 +1541,41 @@ class ReconcileController extends ChangeNotifier {
       }
 
       // First pass of the session: the linked view needs all three systems.
-      if (app.smartschool.snapshot == null) {
+      // And since #259, so does a pass whose own settings inputs moved — the
+      // targeted equivalent of that condition, keyed on the per-system
+      // fingerprint rather than on "do we hold anything at all".
+      final ssStale = stale.contains(core.Origin.smartschool);
+      if (app.smartschool.snapshot == null || ssStale) {
         await _renewLock();
+        if (ssStale) {
+          log.addMessage(
+            core.Origin.smartschool,
+            'Smartschool-instellingen gewijzigd — Smartschool wordt opnieuw '
+            'opgehaald.',
+          );
+        }
         log.addMessage(core.Origin.smartschool, 'Syncing Smartschool…');
+        final ssPulledWith = _settingsFingerprint(core.Origin.smartschool);
         _recordPull(
             core.Origin.smartschool, await app.sync(core.Origin.smartschool));
+        _stampPull(core.Origin.smartschool, ssPulledWith);
       }
       _setProgress(0.45);
-      if (app.azure.snapshot == null) {
+      final azStale = stale.contains(core.Origin.azure);
+      if (app.azure.snapshot == null || azStale) {
         await _renewLock();
+        if (azStale) {
+          // Worth naming: a moved prefix also drops the delta token (#246), so
+          // this one is a full tenant read rather than an incremental pass.
+          log.addMessage(
+            core.Origin.azure,
+            'Azure-instellingen gewijzigd — Azure AD wordt opnieuw opgehaald.',
+          );
+        }
         log.addMessage(core.Origin.azure, 'Syncing Azure AD…');
+        final azPulledWith = _settingsFingerprint(core.Origin.azure);
         _recordPull(core.Origin.azure, await app.sync(core.Origin.azure));
+        _stampPull(core.Origin.azure, azPulledWith);
       }
       _setProgress(0.65);
 
@@ -1505,12 +1626,20 @@ class ReconcileController extends ChangeNotifier {
         core.Origin.smartschool,
         'Checking Smartschool for drift…',
       );
+      // A drift pass re-reads both systems unconditionally, so it adopts a
+      // saved import rule or school prefix as surely as a sync does — and must
+      // stamp that, or the next Synchroniseer would re-pull for a change this
+      // pass already applied (#259).
+      final ssPulledWith = _settingsFingerprint(core.Origin.smartschool);
       _recordPull(
           core.Origin.smartschool, await app.sync(core.Origin.smartschool));
+      _stampPull(core.Origin.smartschool, ssPulledWith);
       _setProgress(0.35);
       await _renewLock();
       log.addMessage(core.Origin.azure, 'Checking Azure AD for drift…');
+      final azPulledWith = _settingsFingerprint(core.Origin.azure);
       _recordPull(core.Origin.azure, await app.sync(core.Origin.azure));
+      _stampPull(core.Origin.azure, azPulledWith);
       _setProgress(0.6);
 
       if (app.wisa.snapshot == null) {

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -1554,9 +1554,13 @@ class ReconcileController extends ChangeNotifier {
   /// realtime transport (#116) drives this from a SignalR change notification;
   /// until then it is exercised directly. A stale-or-equal [generation] is a
   /// no-op, so a duplicate notification does no work.
-  Future<void> onStoreChanged(int generation) async {
+  ///
+  /// [shard], when the signal named one (#254), says which part of the view
+  /// moved, so a drill-down the change provably cannot have touched is left
+  /// alone instead of re-read. A missing shard means "assume the whole view".
+  Future<void> onStoreChanged(int generation, {ShardRef? shard}) async {
     if (busy || generation <= _syncState.generation) return;
-    await _refetchFromStore();
+    await _refetchFromStore(shard: shard);
   }
 
   /// Catches this session up from the shared store after the realtime client
@@ -1580,13 +1584,26 @@ class ReconcileController extends ChangeNotifier {
   /// Re-reads the shared overview (sync state, rollups, lease) and any open
   /// drill-down from the store — the refetch [onStoreChanged] and
   /// [resyncFromStore] share (no pull, no `link()`).
-  Future<void> _refetchFromStore() async {
+  ///
+  /// The overview itself is always re-read: the rollups are the counts the nudge
+  /// was about, and they are small. The *drill-downs* are what [shard] narrows
+  /// (#254) — a one-classroom apply elsewhere in the school has nothing to say
+  /// about the class this session has open, or about the Klasgroepen inventory,
+  /// so those reads are skipped rather than paid for. A null shard (a sync's
+  /// whole-view rewrite, or a reconnect that cannot know what it missed) re-reads
+  /// everything, exactly as before.
+  Future<void> _refetchFromStore({ShardRef? shard}) async {
     _syncState = await store.readSyncState();
     _rollups = await store.readRollups();
     _decisions = await store.readDecisions();
     await _refreshLock();
     final open = _selectedClassroom;
-    if (open != null) {
+    if (open != null &&
+        (shard == null ||
+            shard.touchesClassroom(
+              school: open.school,
+              classroom: open.classroom,
+            ))) {
       try {
         _classroomAccounts = await store.readClassroom(
           school: open.school,
@@ -1596,7 +1613,8 @@ class ReconcileController extends ChangeNotifier {
         log.addError(core.Origin.all, 'Kon ${open.label} niet vernieuwen: $e');
       }
     }
-    if (_groupDocs != null) {
+    if (_groupDocs != null &&
+        (shard == null || shard.touchesPartition(groupsPartition))) {
       try {
         _groupDocs = await store.readGroups();
       } on Object catch (e) {
@@ -1661,14 +1679,14 @@ class ReconcileController extends ChangeNotifier {
 
   /// Dry-runs the chosen resolution of **every** pending entry (PAIN-3): the
   /// full apply path, zero writes. Results land in [dryRunResults].
-  Future<void> dryRun() => _run(_selectedActions(pendingEntries), dry: true);
+  Future<void> dryRun() => _run(pendingEntries, dry: true);
 
   /// Applies the chosen resolution of every pending entry for real, refreshing
   /// the linked view from the State layer's incremental patches as it goes.
   /// Only the **selected** alternative of each choice runs — a departed student
   /// is unregistered *or* deleted, never both (#110). Results land in
   /// [applyResults].
-  Future<void> applyAll() => _run(_selectedActions(pendingEntries), dry: false);
+  Future<void> applyAll() => _run(pendingEntries, dry: false);
 
   /// Dry-runs one entry's chosen resolution (#110): the per-row preview.
   Future<void> dryRunEntry(PendingAccountEntry entry) =>
@@ -1695,22 +1713,33 @@ class ReconcileController extends ChangeNotifier {
   /// impossible: label, confirmation scope ([applyScope]) and write are one
   /// list.
   Future<void> applyEntries(Iterable<PendingAccountEntry> entries) =>
-      _run(_selectedActions(entries), dry: false);
+      _run(entries, dry: false);
 
   /// Dry-runs [entries]' chosen resolutions — [applyEntries] with no writes.
   Future<void> dryRunEntries(Iterable<PendingAccountEntry> entries) =>
-      _run(_selectedActions(entries), dry: true);
+      _run(entries, dry: true);
 
-  /// Runs [selected] — the pre-resolved, applyable options — through the apply
-  /// path (dry or real). Shared by the global, per-entry, and per-situation
-  /// affordances so all three behave identically (#110). Each option is bound to
-  /// its own target; on a real write the applier patches the snapshot and
-  /// returns a fresh linked view we adopt as the pass proceeds.
+  /// Runs the selected, applyable option of every choice in [entries] through
+  /// the apply path (dry or real). Shared by the global, per-entry, and
+  /// per-situation affordances so all three behave identically (#110). Each
+  /// option is bound to its own target; on a real write the applier patches the
+  /// snapshot and returns a fresh linked view we adopt as the pass proceeds.
+  ///
+  /// It takes the *entries* rather than the resolved options because a real pass
+  /// owes the shared store a patch afterwards (#254), and the entries are what
+  /// name the targets it touched — an option carries only a display label.
   Future<void> _run(
-    List<PendingActionOption> selected, {
+    Iterable<PendingAccountEntry> entries, {
     required bool dry,
   }) async {
     if (busy || _linked == null) return;
+    final selected = _selectedActions(entries);
+    // The targets this pass writes to, captured before it starts: the entries
+    // are derived from the pre-apply linked view, which the pass replaces.
+    final touched = <PendingAccountEntry>[
+      for (final e in entries)
+        if (e.choices.any((c) => c.selected.canApply)) e,
+    ];
     _begin(ReconcilePhase.applying);
 
     final options =
@@ -1759,7 +1788,7 @@ class ReconcileController extends ChangeNotifier {
       } else {
         _applyResults = results;
         _dryRunResults = null;
-        _refreshRollups();
+        await _shareApplied(_refreshRollups(), touched);
       }
       _applyStep = null;
       _finish(ReconcilePhase.ready);
@@ -1771,8 +1800,9 @@ class ReconcileController extends ChangeNotifier {
       } else {
         _applyResults = results;
         // A pass that broke halfway still wrote whatever it got through, so the
-        // overview owes the operator those counts too (#236).
-        _refreshRollups();
+        // overview owes the operator those counts too (#236) — and so do the
+        // other operators (#254).
+        await _shareApplied(_refreshRollups(), touched);
       }
       // Nothing is in flight any more, however the pass ended (#243).
       _applyStep = null;
@@ -1904,27 +1934,30 @@ class ReconcileController extends ChangeNotifier {
   /// aggregates from a [LinkedState], so the correction is the same computation
   /// the sync path runs, minus the store write.
   ///
-  /// Deliberately **local-only**. Nothing is written back and the generation is
-  /// not bumped, for three reasons: the stored view is ~9.6k documents and
-  /// rewriting it per apply is not affordable ([LinkedStore.writeMaterialized]
-  /// is the sync path's tool, not an apply's); this session's generation must
-  /// stay behind the store's so a later [onStoreChanged] still wins over this
-  /// correction rather than being gated out as stale; and there is no narrow
-  /// per-account write seam to do it properly. So other operators keep the
-  /// pre-apply counts until someone syncs — the shared half of the bug, filed
-  /// separately (#254) because it needs that seam plus a [ChangeSignal] shard.
+  /// This is the **local** half. It writes nothing and does not bump the
+  /// generation: a session must never be ahead of the store on its own say-so,
+  /// or the [onStoreChanged] that should overrule it would be gated out as
+  /// stale. The shared half is [_shareApplied] (#254), which hands the same
+  /// derivation to [LinkedStore.writeApplied] and then adopts what the store
+  /// makes of it — so if the two ever disagree, the shared view wins.
+  ///
+  /// Returns the view it derived, so the shared half re-uses this one
+  /// computation rather than materializing the whole thing twice; `null` when
+  /// there is nothing to derive from or the derivation failed.
   ///
   /// Never called from the dry-run path: a projection writes nothing, so it must
   /// leave every count exactly as it found it.
-  void _refreshRollups() {
+  MaterializedView? _refreshRollups() {
     final linked = _linked;
-    if (linked == null) return;
+    if (linked == null) return null;
     try {
-      _rollups = materialize(
+      final view = materialize(
         linked,
         generation: _syncState.generation,
         schoolLabels: _schoolLabels(),
-      ).rollups;
+      );
+      _rollups = view.rollups;
+      return view;
     } on Object catch (e) {
       // A correction that fails must not turn a successful apply into a failed
       // pass; the counts then simply stay as stale as they were before.
@@ -1932,7 +1965,165 @@ class ReconcileController extends ChangeNotifier {
           core.Origin.all,
           'Kon de tellingen in het overzicht niet '
           'vernieuwen: $e');
+      return null;
     }
+  }
+
+  /// Writes the documents a **real** apply changed back to the shared store, so
+  /// every *other* operator stops being offered work this session already
+  /// applied (#254) — the half #236 deliberately left open.
+  ///
+  /// [view] is the refreshed derivation [_refreshRollups] just made; [touched]
+  /// the entries the pass actually wrote to. Together they give the patch its
+  /// exact scope: for each touched target, the document it has now — or its id
+  /// alone when the refreshed link no longer produces one (the account's last
+  /// system record was just deleted). Nothing else in the ~9.6k-document view is
+  /// read, written or even looked at.
+  ///
+  /// Three things follow the write, in this order and for a reason:
+  ///
+  /// - the session adopts the generation it just wrote, so it is *current*
+  ///   rather than ahead — a later sync bumps past it and [onStoreChanged] still
+  ///   fires;
+  /// - the rollups are re-read **from the store**, not kept from the local
+  ///   derivation, so another operator's concurrent correction outranks this
+  ///   session's picture of the same nodes rather than the other way round;
+  /// - a [ChangeSignal.viewChanged] naming the changed shard goes out, so
+  ///   passive sessions refetch that much and not the whole view.
+  ///
+  /// A write that is deferred (someone is mid-sync) or that fails leaves all
+  /// three undone: the local correction from #236 still stands for this session,
+  /// the shared view catches up on the next sync, and the operator is told which
+  /// it was. A failure here must never turn a successful apply into a failed
+  /// pass — the writes to Smartschool and Office 365 really happened.
+  Future<void> _shareApplied(
+    MaterializedView? view,
+    List<PendingAccountEntry> touched,
+  ) async {
+    if (view == null || touched.isEmpty) return;
+    final accounts = <String, MaterializedAccount>{
+      for (final a in view.accounts) a.id.value: a,
+    };
+    final groups = <String, MaterializedGroup>{
+      for (final g in view.groups) g.id.value: g,
+    };
+    final freshAccounts = <MaterializedAccount>[];
+    final freshGroups = <MaterializedGroup>[];
+    final removedAccountIds = <String>[];
+    final removedGroupIds = <String>[];
+    for (final entry in touched) {
+      if (entry.family == 'group') {
+        // A group entry is keyed by the display name the operator sees; the
+        // stored document is keyed by the materializer's namespaced form.
+        final id = materializedGroupId(entry.targetId);
+        final doc = groups[id];
+        if (doc == null) {
+          removedGroupIds.add(id);
+        } else {
+          freshGroups.add(doc);
+        }
+      } else {
+        final doc = accounts[entry.targetId];
+        if (doc == null) {
+          removedAccountIds.add(entry.targetId);
+        } else {
+          freshAccounts.add(doc);
+        }
+      }
+    }
+    // Re-attach the operator decisions the store holds for these targets, the
+    // way [_persist] does for the whole view: the derivation above carries none,
+    // and writing it raw would silently strip an accepted duplicate or a chosen
+    // alternative off exactly the documents this pass touched. Only the
+    // re-attachment is taken — `dropped` is meaningless over a subset, since
+    // every decision belonging to an untouched account would be in it.
+    final merged = mergeDecisions(
+      accounts: freshAccounts,
+      groups: freshGroups,
+      existing: _decisions,
+    );
+    final patch = AppliedPatch(
+      accounts: merged.accounts,
+      groups: merged.groups,
+      removedAccountIds: removedAccountIds,
+      removedGroupIds: removedGroupIds,
+    );
+    if (patch.isEmpty) return;
+
+    try {
+      final at = _now();
+      final written = await store
+          .writeApplied(patch, appliedBy: syncedBy, at: at)
+          .timeout(persistTimeout);
+      final generation = written.generation;
+      if (generation == null) {
+        final holder = written.deferredTo;
+        if (holder != null) {
+          log.addMessage(
+            core.Origin.all,
+            'Het gedeelde overzicht is niet bijgewerkt: ${holder.owner} '
+            'synchroniseert. De toegepaste wijzigingen komen erin zodra die '
+            'synchronisatie klaar is.',
+          );
+        }
+        return;
+      }
+      _syncState = SyncState(
+        generation: generation,
+        updatedAt: at,
+        updatedBy: syncedBy,
+        systems: _syncState.systems,
+      );
+      _rollups = await store.readRollups();
+      await _publish(ChangeSignal.viewChanged(
+        generation: generation,
+        shard: _appliedShard(patch),
+      ));
+    } on TimeoutException {
+      log.addError(
+        core.Origin.all,
+        'Het bijwerken van het gedeelde overzicht duurde langer dan '
+        '${persistTimeout.inSeconds}s — de wijzigingen zijn wel toegepast, maar '
+        'andere gebruikers zien ze pas na de volgende synchronisatie.',
+      );
+    } on Object catch (e) {
+      log.addError(
+        core.Origin.all,
+        'Kon het gedeelde overzicht niet bijwerken: $e',
+      );
+    }
+  }
+
+  /// The narrowest [ShardRef] that provably covers everything [patch] changed,
+  /// or `null` for "assume the whole view" (#254).
+  ///
+  /// Only ever narrows on what this session can vouch for, widening a level at a
+  /// time: one classroom, else one school, else the whole view. A removal's
+  /// document is gone, so where it sat is no longer knowable here, and a patch
+  /// touching accounts *and* class groups spans two partitions — in both the
+  /// honest answer is the whole view. A shard that under-claims would have
+  /// receivers skip a re-read they needed, which is far worse than one that
+  /// costs them a read they did not.
+  ShardRef? _appliedShard(AppliedPatch patch) {
+    if (patch.removedAccountIds.isNotEmpty ||
+        patch.removedGroupIds.isNotEmpty) {
+      return null;
+    }
+    final touchedGroups = patch.groups.isNotEmpty;
+    if (patch.accounts.isEmpty) {
+      return touchedGroups ? const ShardRef(school: groupsPartition) : null;
+    }
+    if (touchedGroups) return null;
+    final schools = <String>{for (final a in patch.accounts) a.school};
+    if (schools.length != 1) return null;
+    final classrooms = <String>{for (final a in patch.accounts) a.classroom};
+    if (classrooms.length != 1) return ShardRef(school: schools.single);
+    return ShardRef(
+      school: schools.single,
+      classroom: classrooms.single,
+      accountId:
+          patch.accounts.length == 1 ? patch.accounts.single.id.value : null,
+    );
   }
 
   /// Materializes the fresh linked view and writes it to the shared store
@@ -2215,7 +2406,9 @@ class ReconcileController extends ChangeNotifier {
     switch (signal.kind) {
       case ChangeSignalKind.viewChanged:
         final generation = signal.generation;
-        if (generation != null) await onStoreChanged(generation);
+        if (generation != null) {
+          await onStoreChanged(generation, shard: signal.shard);
+        }
       case ChangeSignalKind.syncStarted:
       case ChangeSignalKind.syncEnded:
         // While this session runs its own pass it owns the lease; ignore the

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -499,7 +499,6 @@ class ReconcileController extends ChangeNotifier {
   List<String> _expandedPath = const <String>[];
   List<MaterializedAccount>? _classroomAccounts;
   bool _loadingClassroom = false;
-  bool _showingGroups = false;
   List<MaterializedGroup>? _groupDocs;
   bool _loadingGroups = false;
   SyncLease? _lock;
@@ -1329,7 +1328,9 @@ class ReconcileController extends ChangeNotifier {
   }
 
   /// The class-groups category summary (#163): the single "Klasgroepen" rollup
-  /// node, or [CategorySummary.empty] when no group carries an action to surface.
+  /// node, or [CategorySummary.empty] when the view holds no class at all. Its
+  /// total is the whole class inventory since #227 (it used to be the number of
+  /// classes with work), which is what the Klasgroepen tab lists.
   CategorySummary get groupSummary {
     final r = groupRollup;
     return r == null
@@ -1337,8 +1338,9 @@ class ReconcileController extends ChangeNotifier {
         : CategorySummary(total: r.accountCount, pending: r.pendingCount);
   }
 
-  /// The single "Klasgroepen" rollup node (#119), or `null` when no group has a
-  /// pending action to drill into.
+  /// The single "Klasgroepen" rollup node (#119), or `null` when the shared view
+  /// holds no class at all. Since #227 it aggregates the whole class inventory
+  /// ([Rollup.accountCount] is every class), not only the ones with work.
   Rollup? get groupRollup {
     for (final r in _rollups) {
       if (r.level == RollupLevel.groups) return r;
@@ -1346,14 +1348,12 @@ class ReconcileController extends ChangeNotifier {
     return null;
   }
 
-  /// Whether the group ("Klasgroepen") drill-down is currently open.
-  bool get showingGroups => _showingGroups;
-
-  /// The per-group docs of the open group drill-down, lazily loaded from the
-  /// store; `null` until the "Klasgroepen" node is opened (#119).
+  /// The class inventory as stored documents — every linked class since #227,
+  /// not only those with work. `null` until [loadGroups] has read them, and
+  /// again after a sync rewrote the view (the Klasgroepen tab re-reads).
   List<MaterializedGroup>? get groupDocs => _groupDocs;
 
-  /// Whether a group drill-down read is in flight.
+  /// Whether a class-inventory read is in flight.
   bool get loadingGroups => _loadingGroups;
 
   /// How many pending actions an apply pass would actually write — the
@@ -1596,7 +1596,7 @@ class ReconcileController extends ChangeNotifier {
         log.addError(core.Origin.all, 'Kon ${open.label} niet vernieuwen: $e');
       }
     }
-    if (_showingGroups) {
+    if (_groupDocs != null) {
       try {
         _groupDocs = await store.readGroups();
       } on Object catch (e) {
@@ -1634,14 +1634,18 @@ class ReconcileController extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Opens the "Klasgroepen" drill-down (#119), lazily reading the per-group
-  /// docs from the store (no pull, no `link()`) — the group-family counterpart
-  /// of [openClassroom].
-  Future<void> openGroups() async {
-    _showingGroups = true;
-    _selectedClassroom = null;
-    _classroomAccounts = null;
-    _groupDocs = null;
+  /// Reads the **class inventory** — every stored class document — from the
+  /// store (no pull, no `link()`). One partition read; there are a few hundred
+  /// classes at most.
+  ///
+  /// The group-family counterpart of [openClassroom], except that it is not a
+  /// drill-down any more: since #227 Klasgroepen is a top-level tab that lists
+  /// every class rather than a node listing the ones with work, so the read is
+  /// "load the inventory" and there is nothing to close. A second call while a
+  /// read is in flight is a no-op; a sync drops [groupDocs] so the tab re-reads
+  /// the generation it just wrote.
+  Future<void> loadGroups() async {
+    if (_loadingGroups) return;
     _loadingGroups = true;
     notifyListeners();
     try {
@@ -1653,13 +1657,6 @@ class ReconcileController extends ChangeNotifier {
       _loadingGroups = false;
       notifyListeners();
     }
-  }
-
-  /// Closes the group drill-down, back to the overview.
-  void closeGroups() {
-    _showingGroups = false;
-    _groupDocs = null;
-    notifyListeners();
   }
 
   /// Dry-runs the chosen resolution of **every** pending entry (PAIN-3): the
@@ -2011,7 +2008,8 @@ class ReconcileController extends ChangeNotifier {
       _selectedClassroom = null;
       _expandedPath = const <String>[];
       _classroomAccounts = null;
-      _showingGroups = false;
+      // The class inventory goes with it: the Klasgroepen tab re-reads the
+      // generation this pass just wrote (#227).
       _groupDocs = null;
     } on TimeoutException {
       log.addError(

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -348,7 +348,7 @@ class CategorySummary {
 /// The smart-sync behaviour is the product-direction piece: [sync] retains the
 /// previous WISA snapshot (via [ApplicationState]'s [SystemState]) and diffs
 /// the fresh pull against it. When WISA is unchanged and a linked view already
-/// exists, it reports "no account changes needed" and stops — no re-link, no
+/// exists, it reports "geen accountwijzigingen nodig" and stops — no re-link, no
 /// action churn. Smartschool / Azure are pulled only when still missing this
 /// session **or when their own settings inputs have moved** ([
 /// systemsAwaitingSettings], #259); re-reading them for drift somebody else
@@ -1504,15 +1504,16 @@ class ReconcileController extends ChangeNotifier {
       // publishes a repaired document of its own (#207) — can never be mistaken
       // for the operator changing something.
       final stale = systemsAwaitingSettings;
-      log.addMessage(core.Origin.wisa, 'Syncing WISA…');
+      log.addMessage(core.Origin.wisa, 'WISA ophalen…');
       final fresh = await app.sync(core.Origin.wisa) as wapi.WisaSnapshot;
       _stampWisaPull(pulledWith);
       _recordPull(core.Origin.wisa, fresh);
       _setProgress(0.25);
       log.addMessage(
         core.Origin.wisa,
-        'WISA sync done: ${fresh.students.length} students, '
-        '${fresh.staff.length} staff, ${fresh.classGroups.length} classes.',
+        'WISA opgehaald: ${fresh.students.length} leerling(en), '
+        '${fresh.staff.length} personeelsleden, '
+        '${fresh.classGroups.length} klassen.',
       );
       // Repair the operator's stored school profiles from this pull (#207).
       // Runs before the unchanged-since-last-sync shortcut below, so a session
@@ -1531,8 +1532,8 @@ class ReconcileController extends ChangeNotifier {
         _noChangesNeeded = true;
         log.addMessage(
           core.Origin.wisa,
-          'WISA is unchanged since the previous sync — '
-          'no account changes needed.',
+          'WISA is ongewijzigd sinds de vorige synchronisatie — '
+          'geen accountwijzigingen nodig.',
         );
         await _persistSystemMeta();
         _logSyncComplete();
@@ -1554,7 +1555,7 @@ class ReconcileController extends ChangeNotifier {
             'opgehaald.',
           );
         }
-        log.addMessage(core.Origin.smartschool, 'Syncing Smartschool…');
+        log.addMessage(core.Origin.smartschool, 'Smartschool ophalen…');
         final ssPulledWith = _settingsFingerprint(core.Origin.smartschool);
         _recordPull(
             core.Origin.smartschool, await app.sync(core.Origin.smartschool));
@@ -1572,7 +1573,7 @@ class ReconcileController extends ChangeNotifier {
             'Azure-instellingen gewijzigd — Azure AD wordt opnieuw opgehaald.',
           );
         }
-        log.addMessage(core.Origin.azure, 'Syncing Azure AD…');
+        log.addMessage(core.Origin.azure, 'Azure AD ophalen…');
         final azPulledWith = _settingsFingerprint(core.Origin.azure);
         _recordPull(core.Origin.azure, await app.sync(core.Origin.azure));
         _stampPull(core.Origin.azure, azPulledWith);
@@ -1624,7 +1625,7 @@ class ReconcileController extends ChangeNotifier {
     try {
       log.addMessage(
         core.Origin.smartschool,
-        'Checking Smartschool for drift…',
+        'Smartschool controleren op drift…',
       );
       // A drift pass re-reads both systems unconditionally, so it adopts a
       // saved import rule or school prefix as surely as a sync does — and must
@@ -1636,7 +1637,7 @@ class ReconcileController extends ChangeNotifier {
       _stampPull(core.Origin.smartschool, ssPulledWith);
       _setProgress(0.35);
       await _renewLock();
-      log.addMessage(core.Origin.azure, 'Checking Azure AD for drift…');
+      log.addMessage(core.Origin.azure, 'Azure AD controleren op drift…');
       final azPulledWith = _settingsFingerprint(core.Origin.azure);
       _recordPull(core.Origin.azure, await app.sync(core.Origin.azure));
       _stampPull(core.Origin.azure, azPulledWith);
@@ -1645,7 +1646,7 @@ class ReconcileController extends ChangeNotifier {
       if (app.wisa.snapshot == null) {
         await _renewLock();
         final pulledWith = _wisaFingerprint();
-        log.addMessage(core.Origin.wisa, 'Syncing WISA…');
+        log.addMessage(core.Origin.wisa, 'WISA ophalen…');
         _recordPull(core.Origin.wisa, await app.sync(core.Origin.wisa));
         _stampWisaPull(pulledWith);
       }
@@ -1874,11 +1875,14 @@ class ReconcileController extends ChangeNotifier {
     final options =
         dry ? actions.ApplyOptions.dry : const actions.ApplyOptions();
     final results = <ActionOutcomeEntry>[];
-    final label = dry ? 'Dry-run' : 'Apply';
+    // "Dry-run" is the term the Acties buttons already use ("Dry-run alles"),
+    // so it stays; its counterpart is the "Alles toepassen" of those same
+    // buttons rather than a second word for the same thing.
+    final label = dry ? 'Dry-run' : 'Toepassen';
     log.addMessage(
       core.Origin.all,
-      '$label started for ${selected.length} of ${pendingActions.length} '
-      'pending action(s).',
+      '$label gestart voor ${selected.length} van ${pendingActions.length} '
+      'openstaande actie(s).',
     );
 
     try {
@@ -1909,8 +1913,8 @@ class ReconcileController extends ChangeNotifier {
           results.where((r) => r.outcome == actions.ActionOutcome.failed);
       log.addMessage(
         core.Origin.all,
-        '$label finished: ${results.length - failed.length} ok, '
-        '${failed.length} failed.',
+        '$label klaar: ${results.length - failed.length} gelukt, '
+        '${failed.length} mislukt.',
       );
       if (dry) {
         _dryRunResults = results;
@@ -2018,9 +2022,10 @@ class ReconcileController extends ChangeNotifier {
     final s = _linked!.snapshot;
     log.addMessage(
       core.Origin.all,
-      'Linked: ${s.accounts.length} students, ${s.staff.length} staff, '
-      '${s.groups.length} groups; ${pendingActions.length} pending '
-      'action(s), ${s.warnings.length} warning(s).',
+      'Gekoppeld: ${s.accounts.length} leerling(en), '
+      '${s.staff.length} personeelsleden, ${s.groups.length} klasgroepen; '
+      '${pendingActions.length} openstaande actie(s), '
+      '${s.warnings.length} waarschuwing(en).',
     );
     _logSkippedNamesakes(s.warnings);
     _setProgress(0.9);
@@ -2334,12 +2339,15 @@ class ReconcileController extends ChangeNotifier {
     } on TimeoutException {
       log.addError(
         core.Origin.all,
-        'Persisting the linked view timed out after '
-        '${persistTimeout.inSeconds}s — the linked view is usable this session '
-        'but was not saved to the shared store.',
+        'Het opslaan van het gedeelde overzicht duurde langer dan '
+        '${persistTimeout.inSeconds}s — deze sessie kan ermee verder, maar '
+        'andere gebruikers zien het pas na de volgende synchronisatie.',
       );
     } on Object catch (e) {
-      log.addError(core.Origin.all, 'Could not persist the linked view: $e');
+      log.addError(
+        core.Origin.all,
+        'Kon het gedeelde overzicht niet opslaan: $e',
+      );
     }
   }
 
@@ -2395,13 +2403,13 @@ class ReconcileController extends ChangeNotifier {
       liveSettings?.publish(saved);
       log.addMessage(
         core.Origin.wisa,
-        'Updated the name and code of ${healed.length} WISA school(s) in the '
-        'settings (id ${healed.join(', ')}).',
+        'Naam en code van ${healed.length} WISA-school(en) bijgewerkt in de '
+        'instellingen (id ${healed.join(', ')}).',
       );
     } on Object catch (e) {
       log.addError(
         core.Origin.wisa,
-        'Could not update the WISA school names in the settings: $e',
+        'Kon de WISA-schoolnamen niet bijwerken in de instellingen: $e',
       );
     }
   }
@@ -2449,7 +2457,10 @@ class ReconcileController extends ChangeNotifier {
         systems: {..._syncState.systems, ..._pulled},
       );
     } on Object catch (e) {
-      log.addError(core.Origin.all, 'Could not record sync metadata: $e');
+      log.addError(
+        core.Origin.all,
+        'Kon de synchronisatiegegevens niet opslaan: $e',
+      );
     }
   }
 
@@ -2476,7 +2487,10 @@ class ReconcileController extends ChangeNotifier {
       notifyListeners();
       return false;
     } on Object catch (e) {
-      log.addError(core.Origin.all, 'Could not take the sync lock: $e');
+      log.addError(
+        core.Origin.all,
+        'Kon de sync-vergrendeling niet nemen: $e',
+      );
       return true;
     }
   }
@@ -2496,7 +2510,10 @@ class ReconcileController extends ChangeNotifier {
         );
       }
     } on Object catch (e) {
-      log.addError(core.Origin.all, 'Could not renew the sync lock: $e');
+      log.addError(
+        core.Origin.all,
+        'Kon de sync-vergrendeling niet verlengen: $e',
+      );
     }
   }
 
@@ -2508,7 +2525,10 @@ class ReconcileController extends ChangeNotifier {
       // Only after the lease is actually gone — nudge others to re-enable.
       await _publish(ChangeSignal.syncEnded(owner: syncedBy));
     } on Object catch (e) {
-      log.addError(core.Origin.all, 'Could not release the sync lock: $e');
+      log.addError(
+        core.Origin.all,
+        'Kon de sync-vergrendeling niet vrijgeven: $e',
+      );
     }
   }
 
@@ -2558,7 +2578,10 @@ class ReconcileController extends ChangeNotifier {
     try {
       await p.publish(signal);
     } on Object catch (e) {
-      log.addError(core.Origin.all, 'Could not publish a change signal: $e');
+      log.addError(
+        core.Origin.all,
+        'Kon geen wijzigingssignaal versturen: $e',
+      );
     }
   }
 

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -1,0 +1,864 @@
+/// The tile vocabulary the action-bearing screens share — Acties (#154) and,
+/// since #227, Klasgroepen.
+///
+/// Everything here was born inside `actions_screen.dart` and stayed private to
+/// it while there was one such screen. The class inventory is the second: it
+/// lists every class, and a class that needs work has to be inspected,
+/// dry-run and applied *there* rather than sending the operator back to a
+/// second list of the same classes. So the pieces both screens render — the
+/// pending badge, the read-only announcement and lock, the interactive entry
+/// tile with its radios and per-entry apply, the same-situation bulk header,
+/// and the confirm/progress machinery every write goes through — live here,
+/// public, instead of being duplicated or reached for across a private boundary.
+///
+/// The screens keep what is theirs: the drill-down tree and account cards stay
+/// in Acties, the inventory rows in Klasgroepen.
+library;
+
+import 'dart:async';
+
+import 'package:account_actions/account_actions.dart' as actions;
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart' show CandidateAction;
+import 'package:flutter/material.dart';
+import 'package:plink_design_system/plink_design_system.dart';
+// The `Werkdatum` SOAP parameter's own formatter, so the freshness line names
+// the date exactly as it went on the wire and as the Log panel reports it
+// (#247).
+import 'package:wisa_api/wisa_api.dart' as wapi show formatWerkdatum;
+
+import '../format/timestamps.dart';
+import '../reconcile/reconcile_controller.dart';
+
+// ---------------------------------------------------------------------------
+// Rows.
+// ---------------------------------------------------------------------------
+
+/// One row of a per-classroom (or per-group) pending list: a same-situation
+/// bulk header or a single account entry. Flattening the situation → entries
+/// tree into a linear list lets a lazy [SliverList] build only the on-screen
+/// rows (#111/#154).
+sealed class PendingRow {
+  const PendingRow();
+}
+
+class SituationHeaderRow extends PendingRow {
+  const SituationHeaderRow(this.entries);
+
+  final List<PendingAccountEntry> entries;
+}
+
+class EntryRow extends PendingRow {
+  const EntryRow(this.entry);
+
+  final PendingAccountEntry entry;
+}
+
+/// Flattens same-situation [situations] into the linear [PendingRow] list a
+/// lazy sliver builds from: a bulk header only where more than one account
+/// shares the situation, then that subset's entries.
+List<PendingRow> pendingRows(List<List<PendingAccountEntry>> situations) {
+  final rows = <PendingRow>[];
+  for (final subset in situations) {
+    if (subset.length > 1) rows.add(SituationHeaderRow(subset));
+    for (final entry in subset) {
+      rows.add(EntryRow(entry));
+    }
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Wording.
+// ---------------------------------------------------------------------------
+
+/// The one-line freshness stamp above a view of the shared state: which
+/// generation it is, when it was materialized, by whom — and, since #247, the
+/// werkdatum the WISA roster underneath it was pulled with. `null` before the
+/// first sync of all.
+///
+/// That last part is not a restatement of the timestamp. WISA answers *as of* a
+/// date, so "gisteren 09:14 door jan" says when the pass ran, never which school
+/// year it describes; a pass run on the wrong side of the rollover reads on
+/// screen exactly like a class that went missing (#239). It comes off the shared
+/// per-system stamp rather than the operator's own Instellingen, so it names the
+/// date this *stored view* was pulled with even when the setting has since moved
+/// on (#238) — and a passive session that never ran the pass reads the same
+/// line.
+String? sharedViewFreshness(ReconcileController controller) {
+  final state = controller.syncState;
+  if (state.generation == 0) return null;
+  final at = state.updatedAt;
+  // Same dated stamp as the Reconcile last-sync box (#192): time-only made a
+  // generation from last week look like one from this morning.
+  final when = at == null ? '' : ' · ${formatFreshnessStamp(at)}';
+  final who = state.updatedBy == null || state.updatedBy!.isEmpty
+      ? ''
+      : ' door ${state.updatedBy}';
+  // Rendered with the connector's own formatter, so it reads exactly as the
+  // `Werkdatum` SOAP parameter went out and as the Log panel's pull line names
+  // it. Absent on a view synced before #247 recorded it.
+  final workDate = state.systems[core.Origin.wisa]?.workDate;
+  final asOf =
+      workDate == null ? '' : ' · werkdatum ${wapi.formatWerkdatum(workDate)}';
+  return 'Generatie ${state.generation}$when$who$asOf';
+}
+
+/// The Dutch name the operator knows a system by — the same names the action
+/// summaries and the rest of the screen use (#234). Azure AD is "Office 365"
+/// throughout this app, so the dialog says that and not the tenant's technical
+/// name.
+String systemLabel(core.Origin system) => switch (system) {
+      core.Origin.azure => 'Office 365',
+      core.Origin.smartschool => 'Smartschool',
+      core.Origin.wisa => 'WISA',
+      core.Origin.all => 'alle systemen',
+      core.Origin.other => 'een ander systeem',
+    };
+
+/// Joins system names the way Dutch reads them: "a", "a en b", "a, b en c".
+String _joinSystems(Iterable<core.Origin> systems) {
+  final names = <String>[
+    // Pinned order (WISA → Smartschool → Office 365) so the same selection
+    // always reads the same way, whatever order the actions were dispatched in.
+    for (final s in systems.toSet().toList()..sort((a, b) => a.index - b.index))
+      systemLabel(s),
+  ];
+  if (names.length <= 1) return names.join();
+  return '${names.take(names.length - 1).join(', ')} en ${names.last}';
+}
+
+String _changeCount(int n) => n == 1 ? '1 wijziging' : '$n wijzigingen';
+
+String _ruleCount(int n) => n == 1 ? '1 importregel' : '$n importregels';
+
+String _followUpCount(int n) => n == 1 ? '1 vervolgactie' : '$n vervolgacties';
+
+/// The body of the apply-confirmation dialog: what this particular pass will
+/// write, and where (#234).
+///
+/// It used to be one hard-coded sentence claiming "Smartschool and Azure AD"
+/// for every action, so a single Graph `PATCH` on one display name announced a
+/// write to a system it never touched. Everything needed to say it correctly is
+/// on the actions themselves; [ApplyScope] carries it here.
+///
+/// Three things it is careful about:
+/// - **WISA is never written.** The `DontImportFromWisa` family's `ChangeSet`
+///   carries `Origin.wisa`, but what it produces is a local import rule — the
+///   connector is read-only. So those are counted as import rules and the
+///   sentence says outright that nothing is written to WISA.
+/// - **Chained follow-ups are named, not counted.** A new student's Office 365
+///   create writes Smartschool too (#230/#240). Whether the follow-up runs is
+///   decided by its own `evaluate` after the first write, so it gets its own
+///   "kan ook" sentence rather than being folded into the count.
+/// - **A chain that stays inside a system it already named adds nothing** — a
+///   class group's create and its roster write are both Office 365 (#245), so
+///   there is no second system to announce.
+String applyConfirmationMessage(ApplyScope scope) {
+  final writes = scope.systems.where((s) => s != core.Origin.wisa).toList();
+  final rules = scope.systems.length - writes.length;
+  final clauses = <String>[
+    if (writes.isNotEmpty)
+      'schrijft ${_changeCount(writes.length)} naar ${_joinSystems(writes)}',
+    if (rules > 0)
+      'legt ${_ruleCount(rules)} vast (er wordt niets naar WISA geschreven)',
+  ];
+  final what =
+      clauses.isEmpty ? 'Dit schrijft niets.' : 'Dit ${clauses.join(' en ')}.';
+  final follow = scope.chained.isEmpty
+      ? ''
+      : ' Een vervolgactie kan ook naar ${_joinSystems(scope.chained)} '
+          'schrijven.';
+  return '$what$follow Doe eerst een dry-run om de exacte wijzigingen te '
+      'bekijken.';
+}
+
+/// One read-only candidate line of a passive-session tile — the account card and
+/// the class row share it — worded exactly as the interactive
+/// [PendingEntryTile]'s: an either/or reads as one "(keuze)" on its
+/// pre-selected half (#251), an informational notice keeps its "(manueel)"
+/// marker (#225), and an ordinary action is its bare summary.
+///
+/// The account card used to render a bare bullet for every candidate (#255), so
+/// a student's informational candidate — since #245 the student family has one —
+/// read like due work next to a badge that counted it zero.
+String readOnlyCandidateLine(actions.Alternatives<CandidateAction> choice) {
+  final summary = choice.selected.summary;
+  if (choice.isChoice) return '• $summary (keuze)';
+  return choice.selected.canApply ? '• $summary' : '• $summary (manueel)';
+}
+
+// ---------------------------------------------------------------------------
+// Confirm + progress.
+// ---------------------------------------------------------------------------
+
+/// Shows the apply-confirmation dialog and, on confirm, runs [apply] behind the
+/// modal progress dialog (#110/#243). Shared by the global, per-situation, and
+/// per-entry apply affordances so a write is always one deliberate confirmation
+/// followed by one visible pass.
+///
+/// [scope] is what that particular confirmation covers (#234) — the systems the
+/// pass will really reach, not a fixed pair.
+Future<void> confirmAndApply(
+  BuildContext context, {
+  required ReconcileController controller,
+  required String title,
+  required ApplyScope scope,
+  required Future<void> Function() apply,
+}) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(title),
+      content: Text(applyConfirmationMessage(scope)),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Annuleer'),
+        ),
+        FilledButton(
+          key: const ValueKey('actions-apply-confirm'),
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Toepassen'),
+        ),
+      ],
+    ),
+  );
+  if (!(confirmed ?? false)) return;
+  if (!context.mounted) return;
+  await runWithProgress(
+    context,
+    controller: controller,
+    dry: false,
+    run: apply,
+  );
+}
+
+/// Runs one dry-run/apply pass behind a **modal** progress dialog (#243).
+///
+/// An "Apply to all" over the September "zonder klas" bucket is sequential, one
+/// connector round-trip per action, and runs for minutes. Its only feedback used
+/// to be greyed-out buttons and an indeterminate bar in a page header the
+/// operator had usually scrolled past — so the app looked hung, and nothing
+/// stopped them scrolling, switching family tab, or navigating away mid-write.
+///
+/// Every affordance goes through here — global, per-situation, per-entry, and
+/// dry-run as well as apply — so the pass behaves the same wherever it is
+/// started. A dry-run over hundreds of accounts is exactly as slow and was
+/// exactly as silent.
+///
+/// The dialog's lifetime is bound to [run]'s future rather than to any observed
+/// controller state: it is dismissed in a `finally`, so a pass that fails — or
+/// one that returns immediately because another is already running — can never
+/// strand the operator behind a modal barrier.
+Future<void> runWithProgress(
+  BuildContext context, {
+  required ReconcileController controller,
+  required bool dry,
+  required Future<void> Function() run,
+}) async {
+  final NavigatorState navigator = Navigator.of(context, rootNavigator: true);
+  unawaited(showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) =>
+        _ApplyProgressDialog(controller: controller, dry: dry),
+  ));
+  try {
+    await run();
+  } finally {
+    if (navigator.mounted) navigator.pop();
+  }
+}
+
+/// The modal dialog a pass runs behind (#243): how far along it is, and the
+/// account and action in flight right now.
+///
+/// Rebuilt from [ReconcileController.applyStep], which the pass publishes before
+/// each action off the very list the confirmation dialog was built from, so the
+/// count here and the change count the operator just agreed to are the same
+/// resolution of the work.
+class _ApplyProgressDialog extends StatelessWidget {
+  const _ApplyProgressDialog({required this.controller, required this.dry});
+
+  final ReconcileController controller;
+
+  /// Whether this pass writes nothing, which is the one thing the operator most
+  /// wants confirmed while staring at a progress dialog for two minutes.
+  final bool dry;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    // Non-dismissible: the pass is a sequence of live writes, so there is
+    // nothing useful to do behind it and plenty of harm in navigating away.
+    return PopScope(
+      canPop: false,
+      child: AlertDialog(
+        key: const ValueKey('actions-progress-dialog'),
+        title: Text(dry ? 'Dry-run bezig…' : 'Acties toepassen…'),
+        content: SizedBox(
+          // A [LinearProgressIndicator] demands all the width it is offered, so
+          // without a bound the dialog stretches across a desktop window. Fixed
+          // at a readable measure, clamped so a narrow window cannot overflow.
+          width: (MediaQuery.sizeOf(context).width - 112).clamp(240.0, 400.0),
+          child: ListenableBuilder(
+            listenable: controller,
+            builder: (context, _) {
+              final ApplyStep? step = controller.applyStep;
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  // Always determinate — an indeterminate sweep is what #176
+                  // replaced on Reconcile, and is what this dialog exists to
+                  // stop showing.
+                  LinearProgressIndicator(
+                    key: const ValueKey('actions-progress-bar'),
+                    value: step == null ? 0.0 : (step.index - 1) / step.total,
+                  ),
+                  const SizedBox(height: PlinkSpacing.s4),
+                  Text(
+                    key: const ValueKey('actions-progress-count'),
+                    step == null
+                        ? 'Bezig…'
+                        : 'Actie ${step.index} van ${step.total}',
+                    style: text.titleSmall,
+                  ),
+                  if (step != null) ...<Widget>[
+                    const SizedBox(height: PlinkSpacing.s1),
+                    Text(
+                      key: const ValueKey('actions-progress-step'),
+                      '${step.target} — ${step.summary}',
+                      style: text.bodyMedium,
+                    ),
+                  ],
+                  if (step != null && step.followUps > 0) ...<Widget>[
+                    const SizedBox(height: PlinkSpacing.s2),
+                    Text(
+                      key: const ValueKey('actions-progress-followups'),
+                      // Named, never folded into the count: a follow-up is not
+                      // in the pending list, so it cannot be part of the total
+                      // the operator was shown (#230/#240/#245).
+                      '+ ${_followUpCount(step.followUps)} gestart door een '
+                      'eerdere actie.',
+                      style: text.bodySmall,
+                    ),
+                  ],
+                  const SizedBox(height: PlinkSpacing.s3),
+                  Text(
+                    dry
+                        ? 'Er wordt niets geschreven.'
+                        : 'Sluit het venster niet tot de reeks klaar is.',
+                    style: text.bodySmall,
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small shared widgets.
+// ---------------------------------------------------------------------------
+
+/// The "N pending here" badge, or a muted tick when there is nothing to do.
+class PendingBadge extends StatelessWidget {
+  const PendingBadge({super.key, required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    if (count == 0) {
+      return Icon(Icons.check,
+          size: 16, color: Theme.of(context).disabledColor);
+    }
+    return PlinkBadge('$count');
+  }
+}
+
+/// The muted lock a read-only card carries where an interactive tile carries
+/// its expand affordance (#214) — the per-row half of the read-only state,
+/// explained once by [ReadOnlyNotice] at the top of the list.
+class ReadOnlyLock extends StatelessWidget {
+  const ReadOnlyLock({super.key});
+
+  @override
+  Widget build(BuildContext context) => Tooltip(
+        message: 'Alleen-lezen — synchroniseer om acties toe te passen',
+        child: Icon(
+          Icons.lock_outline,
+          size: 16,
+          color: Theme.of(context).disabledColor,
+        ),
+      );
+}
+
+class EmptyLine extends StatelessWidget {
+  const EmptyLine(this.message, {super.key});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) =>
+      Text(message, style: Theme.of(context).textTheme.bodyMedium);
+}
+
+/// The read-only announcement above a list whose session has no linked view
+/// (#214).
+///
+/// `ReconcileController.linked` is what the interactive [PendingEntryTile] path
+/// is built from: the choices, the per-entry dry-run and apply. Without it the
+/// list can only render the stored account / group documents as static cards —
+/// correct, but silently so, which reads as an interactive list that stopped
+/// responding. This says which of the two the operator is looking at, why, and
+/// offers the sync that turns one into the other.
+///
+/// Two ways to get here, and the operator is told which: a **passive** session
+/// that only read the shared overview (`loadOverview()`, never synced), or one
+/// whose sync/drift pass **failed** before it could link. A failed pass never
+/// discards an existing linked view — `_fail` records the error and returns to
+/// `ready`, leaving `linked` untouched — so the failure wording only ever
+/// appears when this session had nothing linked to begin with.
+///
+/// [keyValue] names the notice per screen, so a shell that has built both tabs
+/// still has one identifiable notice per view.
+class ReadOnlyNotice extends StatelessWidget {
+  const ReadOnlyNotice({
+    super.key,
+    required this.controller,
+    this.keyValue = 'actions-read-only',
+  });
+
+  final ReconcileController controller;
+  final String keyValue;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final bool failed = controller.error != null;
+    final bool lockedByOther = controller.syncLockedByOther;
+
+    return Container(
+      key: ValueKey(keyValue),
+      padding: const EdgeInsets.all(PlinkSpacing.s4),
+      decoration: BoxDecoration(
+        border: Border.all(color: colors.primary),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Icon(Icons.visibility_outlined, size: 18, color: colors.primary),
+              const SizedBox(width: PlinkSpacing.s3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text('Alleen-lezen overzicht', style: text.titleSmall),
+                    const SizedBox(height: PlinkSpacing.s1),
+                    Text(
+                      failed
+                          ? 'De laatste sync is mislukt, dus deze sessie heeft '
+                              'geen actuele acties om toe te passen. Hieronder '
+                              'staat het gedeelde overzicht van de vorige sync.'
+                          : 'Deze sessie heeft nog niet gesynchroniseerd, dus '
+                              'deze acties kunnen niet worden toegepast. '
+                              'Hieronder staat het gedeelde overzicht van de '
+                              'laatste sync.',
+                      style: text.bodyMedium,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: PlinkSpacing.s3),
+          FilledButton.icon(
+            key: const ValueKey('actions-read-only-sync'),
+            onPressed:
+                controller.busy || lockedByOther ? null : controller.sync,
+            icon: const Icon(Icons.sync, size: 18),
+            label: const Text('Synchroniseer'),
+          ),
+          // A dead Synchronise needs its reason on screen too — the same
+          // named-holder line the Reconcile screen shows (#108).
+          if (lockedByOther) ...<Widget>[
+            const SizedBox(height: PlinkSpacing.s2),
+            Text(
+              '${controller.syncLockOwner} is aan het synchroniseren…',
+              style: text.bodySmall,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Full-panel message (loading / not-configured / error), mirroring the other
+/// screens' panels so the views read as one app.
+class MessagePanel extends StatelessWidget {
+  const MessagePanel({
+    super.key,
+    required this.eyebrow,
+    required this.title,
+    required this.message,
+    this.action,
+    this.progress = false,
+  });
+
+  final String eyebrow;
+  final String title;
+  final String message;
+  final Widget? action;
+  final bool progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final bool ink = Theme.of(context).brightness == Brightness.dark;
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: Padding(
+          padding: const EdgeInsets.all(PlinkSpacing.s6),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Eyebrow(eyebrow, onInk: ink),
+              const SizedBox(height: PlinkSpacing.s4),
+              Text(title, style: text.headlineSmall),
+              const SizedBox(height: PlinkSpacing.s4),
+              Text(message, style: text.bodyMedium),
+              if (progress) ...<Widget>[
+                const SizedBox(height: PlinkSpacing.s5),
+                const LinearProgressIndicator(),
+              ],
+              if (action != null) ...<Widget>[
+                const SizedBox(height: PlinkSpacing.s5),
+                action!,
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Interactive tiles.
+// ---------------------------------------------------------------------------
+
+/// The bulk header of one "same situation" subset (#110): the "apply this
+/// resolution to all" affordance that honours each entry's own chosen
+/// alternative. Rendered as its own row in the lazy list, only when more than
+/// one account shares the situation.
+///
+/// Every affordance here acts on [entries] — the exact subset this header was
+/// built over and counts (#252). That list is already scoped by whatever list
+/// rendered it: the open classroom's pending entries, or the class inventory's,
+/// narrowed further by the search box. The bulk pass used to re-resolve the
+/// situation key against the *whole* linked view instead, so a header reading
+/// "Alles toepassen (1)" inside one class wrote every account group-wide in the
+/// same situation. The label, the confirmation scope and the write are now one
+/// list, so they cannot drift apart again.
+class SituationHeader extends StatelessWidget {
+  const SituationHeader({
+    super.key,
+    required this.controller,
+    required this.entries,
+    this.noun = 'accounts',
+  });
+
+  final ReconcileController controller;
+  final List<PendingAccountEntry> entries;
+
+  /// What this subset is a subset *of*, in Dutch — "accounts" in a classroom,
+  /// "klassen" in the class inventory (#227).
+  final String noun;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final key = entries.first.situationKey;
+    final applyable = entries.where((e) => e.canApply).length;
+
+    return Padding(
+      padding: const EdgeInsets.only(
+        top: PlinkSpacing.s2,
+        bottom: PlinkSpacing.s2,
+      ),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Text(
+              '${entries.first.situationLabel} — ${entries.length} '
+              '$noun in dezelfde situatie',
+              style: text.titleSmall,
+            ),
+          ),
+          const SizedBox(width: PlinkSpacing.s2),
+          OutlinedButton(
+            key: ValueKey('situation-dry-run-$key'),
+            onPressed: controller.busy || applyable == 0
+                ? null
+                : () => runWithProgress(
+                      context,
+                      controller: controller,
+                      dry: true,
+                      run: () => controller.dryRunEntries(entries),
+                    ),
+            child: const Text('Dry-run alles'),
+          ),
+          const SizedBox(width: PlinkSpacing.s2),
+          FilledButton(
+            key: ValueKey('situation-apply-$key'),
+            onPressed: controller.busy || applyable == 0
+                ? null
+                : () => confirmAndApply(
+                      context,
+                      controller: controller,
+                      title: 'Toepassen op ${entries.length} $noun?',
+                      // The dialog is scoped to the very entries the pass below
+                      // runs over — the ones this header counted (#234/#252).
+                      scope: controller.applyScope(entries),
+                      apply: () => controller.applyEntries(entries),
+                    ),
+            child: Text('Alles toepassen ($applyable)'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The collapsed line one [PendingChoice] reads as: an either/or is marked
+/// "(keuze)" on its pre-selected half, an informational action "(manueel)", and
+/// an ordinary one is its bare summary.
+String pendingChoiceLine(PendingChoice c) {
+  final summary = c.selected.changes.summary;
+  if (c.isChoice) return '$summary (keuze)';
+  return c.selected.canApply ? summary : '$summary (manueel)';
+}
+
+/// One account's pending resolution (#110): a single expandable row showing the
+/// selected summary, the mutually-exclusive choice (as radios) when there is
+/// one, the per-field diff, and per-entry dry-run / apply.
+class PendingEntryTile extends StatelessWidget {
+  const PendingEntryTile({
+    super.key,
+    required this.controller,
+    required this.entry,
+  });
+
+  final ReconcileController controller;
+  final PendingAccountEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final Color hairline = Theme.of(context).dividerColor;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
+      decoration: BoxDecoration(
+        border: Border.all(color: hairline),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: ExpansionTile(
+        key: ValueKey('entry-${entry.family}-${entry.targetId}'),
+        shape: const Border(),
+        collapsedShape: const Border(),
+        leading: PlinkBadge(entry.family),
+        title: Text(entry.target, style: text.bodyLarge),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            for (final c in entry.choices)
+              Text(pendingChoiceLine(c), style: text.bodySmall),
+          ],
+        ),
+        childrenPadding: const EdgeInsets.fromLTRB(
+          PlinkSpacing.s5,
+          0,
+          PlinkSpacing.s5,
+          PlinkSpacing.s4,
+        ),
+        expandedCrossAxisAlignment: CrossAxisAlignment.start,
+        children: entryDetail(context, controller: controller, entry: entry),
+      ),
+    );
+  }
+}
+
+/// The expanded body of one pending entry: the radios (or the lone option's
+/// diff) plus the per-entry dry-run / apply pair.
+///
+/// Split out of [PendingEntryTile] so the class inventory can put the very same
+/// controls under a row that carries its own presence columns (#227), rather
+/// than nesting one expandable tile inside another.
+List<Widget> entryDetail(
+  BuildContext context, {
+  required ReconcileController controller,
+  required PendingAccountEntry entry,
+}) =>
+    <Widget>[
+      for (final choice in entry.choices)
+        if (choice.isChoice)
+          ChoiceControl(controller: controller, entry: entry, choice: choice)
+        else
+          OptionDetail(option: choice.selected),
+      const SizedBox(height: PlinkSpacing.s3),
+      Row(
+        children: <Widget>[
+          OutlinedButton(
+            key: ValueKey('entry-dry-run-${entry.targetId}'),
+            onPressed: controller.busy || !entry.canApply
+                ? null
+                : () => runWithProgress(
+                      context,
+                      controller: controller,
+                      dry: true,
+                      run: () => controller.dryRunEntry(entry),
+                    ),
+            child: const Text('Dry-run'),
+          ),
+          const SizedBox(width: PlinkSpacing.s2),
+          FilledButton(
+            key: ValueKey('entry-apply-${entry.targetId}'),
+            onPressed: controller.busy || !entry.canApply
+                ? null
+                : () => confirmAndApply(
+                      context,
+                      controller: controller,
+                      title: 'Toepassen voor ${entry.target}?',
+                      scope:
+                          controller.applyScope(<PendingAccountEntry>[entry]),
+                      apply: () => controller.applyEntry(entry),
+                    ),
+            child: const Text('Toepassen'),
+          ),
+        ],
+      ),
+    ];
+
+/// The radio group for a mutually-exclusive choice (#110): the operator picks
+/// exactly one resolution; the selected one is what an apply runs.
+class ChoiceControl extends StatelessWidget {
+  const ChoiceControl({
+    super.key,
+    required this.controller,
+    required this.entry,
+    required this.choice,
+  });
+
+  final ReconcileController controller;
+  final PendingAccountEntry entry;
+  final PendingChoice choice;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          'Kies één oplossing:',
+          style: text.bodySmall?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        for (final option in choice.alternatives)
+          InkWell(
+            key: ValueKey('alt-${entry.targetId}-${option.kind}'),
+            onTap: controller.busy
+                ? null
+                : () => controller.chooseAlternative(
+                      entry: entry,
+                      group: option.group!,
+                      kind: option.kind,
+                    ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: PlinkSpacing.s1),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Icon(
+                    option.kind == choice.selected.kind
+                        ? Icons.radio_button_checked
+                        : Icons.radio_button_unchecked,
+                    size: 18,
+                    color: option.kind == choice.selected.kind
+                        ? colors.primary
+                        : Theme.of(context).disabledColor,
+                  ),
+                  const SizedBox(width: PlinkSpacing.s2),
+                  Expanded(
+                    child: Text(option.changes.summary, style: text.bodySmall),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        // What the picked resolution will actually write. Collapsing two
+        // actions into one choice (#244) must not cost the operator the diff
+        // they used to read off the second row — a class create names the class,
+        // its description and its Smartschool parent, and that is exactly what
+        // decides whether the create or the opt-out is right.
+        const SizedBox(height: PlinkSpacing.s2),
+        OptionDetail(option: choice.selected),
+      ],
+    );
+  }
+}
+
+/// The per-field diff (or a lifecycle note) for a single option — the one that
+/// stands alone, or the one selected inside a [ChoiceControl].
+class OptionDetail extends StatelessWidget {
+  const OptionDetail({super.key, required this.option});
+
+  final PendingActionOption option;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final fields = option.changes.fields;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: fields.isEmpty
+          ? <Widget>[
+              Text(
+                option.canApply
+                    ? 'Levenscyclusactie — geen wijzigingen per veld.'
+                    : '${option.changes.summary} '
+                        '(manueel — wordt niet automatisch toegepast)',
+                style: text.bodySmall,
+              ),
+            ]
+          : <Widget>[
+              for (final f in fields)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
+                  child: Text(
+                    '${f.field}: ${f.before ?? '∅'} → ${f.after ?? '∅'}',
+                    style: text.bodySmall,
+                  ),
+                ),
+            ],
+    );
+  }
+}

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -1,26 +1,24 @@
 import 'dart:async';
 
 import 'package:account_actions/account_actions.dart' as actions;
-import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart'
     show
-        CandidateAction,
         MaterializedAccount,
-        MaterializedGroup,
         Rollup,
         RollupLevel,
         candidateChoices,
         pendingDecisionCount;
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
-// The `Werkdatum` SOAP parameter's own formatter, so the overview names the
-// date exactly as it went on the wire and as the Log panel reports it (#247).
-import 'package:wisa_api/wisa_api.dart' as wapi show formatWerkdatum;
 
-import '../format/timestamps.dart';
 import '../reconcile/reconcile_bootstrap.dart';
 import '../reconcile/reconcile_controller.dart';
 import '../search/name_query.dart';
+import 'action_tiles.dart';
+
+// The wording helpers moved to the shared tile library when Klasgroepen became
+// a screen of its own (#227); re-exported so they stay importable from here.
+export 'action_tiles.dart' show applyConfirmationMessage, systemLabel;
 
 /// The Actions view (#154): the pending-actions browser, split off the
 /// Reconcile screen so a September changeover's hundreds/thousands of tiles no
@@ -48,6 +46,11 @@ import '../search/name_query.dart';
 /// grade-year it was opened from, and opening another year closes the one that
 /// was open. The path is held on the [ReconcileController], because while a
 /// class is open the tree is not built at all.
+///
+/// Class groups are **not** here. The "Klasgroepen" node used to hang under the
+/// Leerlingen tree and open the classes that raised something; since #227 that
+/// is a top-level tab listing every class, which is a superset of what this node
+/// showed — so it left rather than being maintained in two places.
 ///
 /// A session with no linked view — passive, or one whose pass failed before it
 /// linked — can only show the stored documents, so both drill-downs say so out
@@ -104,7 +107,7 @@ class _ActionsScreenState extends State<ActionsScreen> {
   @override
   Widget build(BuildContext context) {
     if (widget.bootstrap == null) {
-      return const _MessagePanel(
+      return const MessagePanel(
         eyebrow: 'Arcadia · acties',
         title: 'Niet geconfigureerd',
         message: 'Azure AD is niet geconfigureerd voor deze build, dus de '
@@ -115,7 +118,7 @@ class _ActionsScreenState extends State<ActionsScreen> {
     final error = _bootstrapError;
     if (error != null) {
       final retryNote = _attempts > 1 ? '\n\n(Poging $_attempts mislukt.)' : '';
-      return _MessagePanel(
+      return MessagePanel(
         eyebrow: 'Arcadia · acties',
         title: 'Kan het Acties-scherm niet openen',
         message: '$error$retryNote',
@@ -128,7 +131,7 @@ class _ActionsScreenState extends State<ActionsScreen> {
     }
     final services = _services;
     if (_bootstrapping || services == null) {
-      return const _MessagePanel(
+      return const MessagePanel(
         eyebrow: 'Arcadia · acties',
         title: 'Voorbereiden…',
         message: 'De instellingen en verbindingsprofielen worden geladen.',
@@ -137,26 +140,6 @@ class _ActionsScreenState extends State<ActionsScreen> {
     }
     return _ActionsBody(controller: services.controller);
   }
-}
-
-/// One row of a per-classroom (or per-group) pending list: a same-situation
-/// bulk header or a single account entry. Flattening the situation → entries
-/// tree into a linear list lets a lazy [SliverList] build only the on-screen
-/// rows (#111/#154).
-sealed class _PendingRow {
-  const _PendingRow();
-}
-
-class _SituationHeaderRow extends _PendingRow {
-  const _SituationHeaderRow(this.entries);
-
-  final List<PendingAccountEntry> entries;
-}
-
-class _EntryRow extends _PendingRow {
-  const _EntryRow(this.entry);
-
-  final PendingAccountEntry entry;
 }
 
 /// The two family tabs (#179): staff and student actions are reviewed as
@@ -172,15 +155,11 @@ enum _ActionFamilyTab { leerlingen, personeel }
 class _FilteredTree {
   const _FilteredTree({
     required this.roots,
-    this.groups,
     required this.hidden,
   });
 
   /// The top-level accordion nodes still worth rendering.
   final List<Rollup> roots;
-
-  /// The "Klasgroepen" node, or `null` when this tab carries none.
-  final Rollup? groups;
 
   /// How many nodes disappeared from what the tree would otherwise show —
   /// counted as the operator would browse it, so a hidden year counts once
@@ -442,7 +421,6 @@ class _ActionsBodyState extends State<_ActionsBody>
       _shownIndex = index;
       _search.clear();
       if (controller.selectedClassroom != null) controller.closeClassroom();
-      if (controller.showingGroups) controller.closeGroups();
     }
     if (mounted) setState(() {});
   }
@@ -486,21 +464,15 @@ class _ActionsBodyState extends State<_ActionsBody>
   bool _keepGrade(Rollup grade) =>
       !_onlyWithActions || controller.childrenOf(grade.key).any(_keepNode);
 
-  /// Whether the "Klasgroepen" node survives the global filter (#226).
-  ///
-  /// Deliberately **not** `pendingCount > 0`, unlike every other node. A class
-  /// group's candidates are not all applyable: since #225 a class can carry an
-  /// informational-only notice (`ClassExistsAsSmartschoolGroup` and friends),
-  /// which is manual work the operator still has to do — it just has no
-  /// automated write, so it adds nothing to the pending count. Filtering this
-  /// node on the pending count would hide exactly the notices #225 exists to
-  /// surface. A group document is only ever written for a class that needs
-  /// attention, so the node stays as long as it holds one.
-  bool _keepGroups(Rollup groups) => groups.accountCount > 0;
-
   /// The Leerlingen drill-down after the global filter (#226): the merged
-  /// grade-years that still hold a visible classroom, plus the class-groups
-  /// node, and how many nodes went missing so the tree can say so.
+  /// grade-years that still hold a visible classroom, and how many nodes went
+  /// missing so the tree can say so.
+  ///
+  /// The "Klasgroepen" node used to hang below these roots and open a list of
+  /// the classes with work. It is a top-level tab of its own since #227 — a full
+  /// class inventory, not just the ones that raised something — so it is not
+  /// rendered here any more: the same list must not be maintained in two places,
+  /// and the tab is the superset.
   _FilteredTree _studentTree() {
     final roots = <Rollup>[];
     var hidden = 0;
@@ -515,12 +487,7 @@ class _ActionsBodyState extends State<_ActionsBody>
       roots.add(root);
       hidden += classrooms.length - kept;
     }
-    final groups = controller.groupRollup;
-    return _FilteredTree(
-      roots: roots,
-      groups: groups != null && _keepGroups(groups) ? groups : null,
-      hidden: hidden,
-    );
+    return _FilteredTree(roots: roots, hidden: hidden);
   }
 
   /// The Personeel drill-down after the global filter (#226): the staff school
@@ -572,20 +539,17 @@ class _ActionsBodyState extends State<_ActionsBody>
     final staffTab = _tabs.index == _ActionFamilyTab.personeel.index;
     if (controller.selectedClassroom != null) {
       slivers.addAll(_classroomSlivers(context));
-    } else if (controller.showingGroups) {
-      slivers.addAll(_groupSlivers(context));
     } else if (controller.hasOverview) {
       // Partition the drill-down by family: the Personeel tab shows only the
       // synthetic staff school node (school → grade → classroom, unchanged); the
-      // Leerlingen tab opens straight on the merged grade-years plus the
-      // class-groups node (class groups are student-oriented).
+      // Leerlingen tab opens straight on the merged grade-years. Class groups
+      // are a tab of their own since #227.
       final tree = staffTab ? _staffTree() : _studentTree();
       slivers.add(_section(staffTab
           ? _DrillDownSection(
               controller: controller,
               accordion: _accordion,
               roots: tree.roots,
-              groups: null,
               hidden: tree.hidden,
               filtering: _onlyWithActions,
               emptyLabel: 'Geen openstaande personeelsacties.',
@@ -604,7 +568,6 @@ class _ActionsBodyState extends State<_ActionsBody>
               controller: controller,
               accordion: _accordion,
               roots: tree.roots,
-              groups: tree.groups,
               hidden: tree.hidden,
               filtering: _onlyWithActions,
               emptyLabel: 'Nog geen gematerialiseerd overzicht.',
@@ -664,26 +627,26 @@ class _ActionsBodyState extends State<_ActionsBody>
       final situations = controller.classroomPendingSituations;
       if (situations.isEmpty) {
         return slivers
-          ..add(_section(const _EmptyLine('Geen openstaande acties in deze '
+          ..add(_section(const EmptyLine('Geen openstaande acties in deze '
               'klas.')));
       }
-      final rows = _pendingRows(_filterSituations(situations));
+      final rows = pendingRows(_filterSituations(situations));
       slivers
         ..addAll(searchSlivers)
         ..add(rows.isEmpty
-            ? _section(const _EmptyLine(_noMatchLabel))
+            ? _section(const EmptyLine(_noMatchLabel))
             : _rowsSliver(rows));
     } else {
       final accounts = controller.classroomAccounts;
       if (accounts == null || accounts.isEmpty) {
         return slivers
-          ..add(_section(const _EmptyLine('Geen accounts in deze klas.')));
+          ..add(_section(const EmptyLine('Geen accounts in deze klas.')));
       }
       final filtered = _filterAccounts(accounts);
       slivers
         ..addAll(searchSlivers)
         ..add(filtered.isEmpty
-            ? _section(const _EmptyLine(_noMatchLabel))
+            ? _section(const EmptyLine(_noMatchLabel))
             : SliverPadding(
                 padding: _hPad,
                 sliver: SliverList.builder(
@@ -709,84 +672,28 @@ class _ActionsBodyState extends State<_ActionsBody>
   List<Widget> _readOnlySlivers() {
     if (controller.linked != null) return const <Widget>[];
     return <Widget>[
-      _section(_ReadOnlyNotice(controller: controller)),
+      _section(ReadOnlyNotice(controller: controller)),
       _gap(PlinkSpacing.s3),
     ];
-  }
-
-  /// The drilled-into "Klasgroepen" node (#119): the live interactive group
-  /// entries (active) or the read-only materialized group docs (passive),
-  /// through a lazy [SliverList] (#154). The read-only half carries the same
-  /// announcement as the classroom drill-down (#214).
-  List<Widget> _groupSlivers(BuildContext context) {
-    final slivers = <Widget>[
-      _section(_DetailHeader(
-        backKey: const ValueKey('actions-groups-back'),
-        title: controller.groupRollup?.label ?? 'Klasgroepen',
-        onBack: controller.closeGroups,
-      )),
-      _gap(PlinkSpacing.s3),
-    ];
-    if (controller.loadingGroups) {
-      return slivers..add(_section(const LinearProgressIndicator()));
-    }
-    slivers.addAll(_readOnlySlivers());
-    if (controller.linked != null) {
-      final rows = _pendingRows(controller.groupPendingSituations);
-      if (rows.isEmpty) {
-        return slivers
-          ..add(_section(const _EmptyLine('Geen klasgroepen met openstaande '
-              'acties.')));
-      }
-      slivers.add(_rowsSliver(rows));
-    } else {
-      final groups = controller.groupDocs;
-      if (groups == null || groups.isEmpty) {
-        return slivers
-          ..add(_section(const _EmptyLine('Geen klasgroepen met openstaande '
-              'acties.')));
-      }
-      slivers.add(SliverPadding(
-        padding: _hPad,
-        sliver: SliverList.builder(
-          itemCount: groups.length,
-          itemBuilder: (context, index) => _GroupTile(group: groups[index]),
-        ),
-      ));
-    }
-    return slivers;
   }
 
   /// A lazy sliver over pending [rows] (situation headers + entry tiles) — the
   /// carried-over virtualized list from the old flat pending section (#111).
-  Widget _rowsSliver(List<_PendingRow> rows) => SliverPadding(
+  Widget _rowsSliver(List<PendingRow> rows) => SliverPadding(
         padding: _hPad,
         sliver: SliverList.builder(
           itemCount: rows.length,
           itemBuilder: (context, index) {
             final row = rows[index];
             return switch (row) {
-              _SituationHeaderRow(:final entries) =>
-                _SituationHeader(controller: controller, entries: entries),
-              _EntryRow(:final entry) =>
-                _PendingEntryTile(controller: controller, entry: entry),
+              SituationHeaderRow(:final entries) =>
+                SituationHeader(controller: controller, entries: entries),
+              EntryRow(:final entry) =>
+                PendingEntryTile(controller: controller, entry: entry),
             };
           },
         ),
       );
-
-  static List<_PendingRow> _pendingRows(
-    List<List<PendingAccountEntry>> situations,
-  ) {
-    final rows = <_PendingRow>[];
-    for (final subset in situations) {
-      if (subset.length > 1) rows.add(_SituationHeaderRow(subset));
-      for (final entry in subset) {
-        rows.add(_EntryRow(entry));
-      }
-    }
-    return rows;
-  }
 
   List<Widget> _resultsSlivers() {
     final dry = controller.dryRunResults;
@@ -879,7 +786,7 @@ class _ActionsHeader extends StatelessWidget {
               key: const ValueKey('actions-dry-run'),
               onPressed: controller.busy || controller.applyableCount == 0
                   ? null
-                  : () => _runWithProgress(
+                  : () => runWithProgress(
                         context,
                         controller: controller,
                         dry: true,
@@ -892,7 +799,7 @@ class _ActionsHeader extends StatelessWidget {
               key: const ValueKey('actions-apply'),
               onPressed: controller.busy || controller.applyableCount == 0
                   ? null
-                  : () => _confirmAndApply(
+                  : () => confirmAndApply(
                         context,
                         controller: controller,
                         title: 'Openstaande acties toepassen?',
@@ -1023,344 +930,6 @@ class _EmptyState extends StatelessWidget {
   }
 }
 
-/// The read-only announcement above a drill-down whose session has no linked
-/// view (#214).
-///
-/// `ReconcileController.linked` is what the interactive
-/// [_PendingEntryTile] path is built from: the choices, the per-entry dry-run
-/// and apply. Without it the drill-down can only render the stored account /
-/// group documents as static cards — correct, but silently so, which reads as
-/// an interactive list that stopped responding. This says which of the two the
-/// operator is looking at, why, and offers the sync that turns one into the
-/// other.
-///
-/// Two ways to get here, and the operator is told which: a **passive** session
-/// that only read the shared overview (`loadOverview()`, never synced), or one
-/// whose sync/drift pass **failed** before it could link. A failed pass never
-/// discards an existing linked view — `_fail` records the error and returns to
-/// `ready`, leaving `linked` untouched — so the failure wording only ever
-/// appears when this session had nothing linked to begin with.
-class _ReadOnlyNotice extends StatelessWidget {
-  const _ReadOnlyNotice({required this.controller});
-
-  final ReconcileController controller;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final ColorScheme colors = Theme.of(context).colorScheme;
-    final bool failed = controller.error != null;
-    final bool lockedByOther = controller.syncLockedByOther;
-
-    return Container(
-      key: const ValueKey('actions-read-only'),
-      padding: const EdgeInsets.all(PlinkSpacing.s4),
-      decoration: BoxDecoration(
-        border: Border.all(color: colors.primary),
-        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Icon(Icons.visibility_outlined, size: 18, color: colors.primary),
-              const SizedBox(width: PlinkSpacing.s3),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Text('Alleen-lezen overzicht', style: text.titleSmall),
-                    const SizedBox(height: PlinkSpacing.s1),
-                    Text(
-                      failed
-                          ? 'De laatste sync is mislukt, dus deze sessie heeft '
-                              'geen actuele acties om toe te passen. Hieronder '
-                              'staat het gedeelde overzicht van de vorige sync.'
-                          : 'Deze sessie heeft nog niet gesynchroniseerd, dus '
-                              'deze acties kunnen niet worden toegepast. '
-                              'Hieronder staat het gedeelde overzicht van de '
-                              'laatste sync.',
-                      style: text.bodyMedium,
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: PlinkSpacing.s3),
-          FilledButton.icon(
-            key: const ValueKey('actions-read-only-sync'),
-            onPressed:
-                controller.busy || lockedByOther ? null : controller.sync,
-            icon: const Icon(Icons.sync, size: 18),
-            label: const Text('Synchroniseer'),
-          ),
-          // A dead Synchronise needs its reason on screen too — the same
-          // named-holder line the Reconcile screen shows (#108).
-          if (lockedByOther) ...<Widget>[
-            const SizedBox(height: PlinkSpacing.s2),
-            Text(
-              '${controller.syncLockOwner} is aan het synchroniseren…',
-              style: text.bodySmall,
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _EmptyLine extends StatelessWidget {
-  const _EmptyLine(this.message);
-
-  final String message;
-
-  @override
-  Widget build(BuildContext context) =>
-      Text(message, style: Theme.of(context).textTheme.bodyMedium);
-}
-
-/// The Dutch name the operator knows a system by — the same names the action
-/// summaries and the rest of the screen use (#234). Azure AD is "Office 365"
-/// throughout this app, so the dialog says that and not the tenant's technical
-/// name.
-String systemLabel(core.Origin system) => switch (system) {
-      core.Origin.azure => 'Office 365',
-      core.Origin.smartschool => 'Smartschool',
-      core.Origin.wisa => 'WISA',
-      core.Origin.all => 'alle systemen',
-      core.Origin.other => 'een ander systeem',
-    };
-
-/// Joins system names the way Dutch reads them: "a", "a en b", "a, b en c".
-String _joinSystems(Iterable<core.Origin> systems) {
-  final names = <String>[
-    // Pinned order (WISA → Smartschool → Office 365) so the same selection
-    // always reads the same way, whatever order the actions were dispatched in.
-    for (final s in systems.toSet().toList()..sort((a, b) => a.index - b.index))
-      systemLabel(s),
-  ];
-  if (names.length <= 1) return names.join();
-  return '${names.take(names.length - 1).join(', ')} en ${names.last}';
-}
-
-String _changeCount(int n) => n == 1 ? '1 wijziging' : '$n wijzigingen';
-
-String _ruleCount(int n) => n == 1 ? '1 importregel' : '$n importregels';
-
-/// The body of the apply-confirmation dialog: what this particular pass will
-/// write, and where (#234).
-///
-/// It used to be one hard-coded sentence claiming "Smartschool and Azure AD"
-/// for every action, so a single Graph `PATCH` on one display name announced a
-/// write to a system it never touched. Everything needed to say it correctly is
-/// on the actions themselves; [ApplyScope] carries it here.
-///
-/// Three things it is careful about:
-/// - **WISA is never written.** The `DontImportFromWisa` family's `ChangeSet`
-///   carries `Origin.wisa`, but what it produces is a local import rule — the
-///   connector is read-only. So those are counted as import rules and the
-///   sentence says outright that nothing is written to WISA.
-/// - **Chained follow-ups are named, not counted.** A new student's Office 365
-///   create writes Smartschool too (#230/#240). Whether the follow-up runs is
-///   decided by its own `evaluate` after the first write, so it gets its own
-///   "kan ook" sentence rather than being folded into the count.
-/// - **A chain that stays inside a system it already named adds nothing** — a
-///   class group's create and its roster write are both Office 365 (#245), so
-///   there is no second system to announce.
-String applyConfirmationMessage(ApplyScope scope) {
-  final writes = scope.systems.where((s) => s != core.Origin.wisa).toList();
-  final rules = scope.systems.length - writes.length;
-  final clauses = <String>[
-    if (writes.isNotEmpty)
-      'schrijft ${_changeCount(writes.length)} naar ${_joinSystems(writes)}',
-    if (rules > 0)
-      'legt ${_ruleCount(rules)} vast (er wordt niets naar WISA geschreven)',
-  ];
-  final what =
-      clauses.isEmpty ? 'Dit schrijft niets.' : 'Dit ${clauses.join(' en ')}.';
-  final follow = scope.chained.isEmpty
-      ? ''
-      : ' Een vervolgactie kan ook naar ${_joinSystems(scope.chained)} '
-          'schrijven.';
-  return '$what$follow Doe eerst een dry-run om de exacte wijzigingen te '
-      'bekijken.';
-}
-
-/// Shows the apply-confirmation dialog and, on confirm, runs [apply] behind the
-/// modal progress dialog (#110/#243). Shared by the global, per-situation, and
-/// per-entry apply affordances so a write is always one deliberate confirmation
-/// followed by one visible pass.
-///
-/// [scope] is what that particular confirmation covers (#234) — the systems the
-/// pass will really reach, not a fixed pair.
-Future<void> _confirmAndApply(
-  BuildContext context, {
-  required ReconcileController controller,
-  required String title,
-  required ApplyScope scope,
-  required Future<void> Function() apply,
-}) async {
-  final confirmed = await showDialog<bool>(
-    context: context,
-    builder: (context) => AlertDialog(
-      title: Text(title),
-      content: Text(applyConfirmationMessage(scope)),
-      actions: <Widget>[
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(false),
-          child: const Text('Annuleer'),
-        ),
-        FilledButton(
-          key: const ValueKey('actions-apply-confirm'),
-          onPressed: () => Navigator.of(context).pop(true),
-          child: const Text('Toepassen'),
-        ),
-      ],
-    ),
-  );
-  if (!(confirmed ?? false)) return;
-  if (!context.mounted) return;
-  await _runWithProgress(
-    context,
-    controller: controller,
-    dry: false,
-    run: apply,
-  );
-}
-
-/// Runs one dry-run/apply pass behind a **modal** progress dialog (#243).
-///
-/// An "Apply to all" over the September "zonder klas" bucket is sequential, one
-/// connector round-trip per action, and runs for minutes. Its only feedback used
-/// to be greyed-out buttons and an indeterminate bar in a page header the
-/// operator had usually scrolled past — so the app looked hung, and nothing
-/// stopped them scrolling, switching family tab, or navigating away mid-write.
-///
-/// Every affordance goes through here — global, per-situation, per-entry, and
-/// dry-run as well as apply — so the pass behaves the same wherever it is
-/// started. A dry-run over hundreds of accounts is exactly as slow and was
-/// exactly as silent.
-///
-/// The dialog's lifetime is bound to [run]'s future rather than to any observed
-/// controller state: it is dismissed in a `finally`, so a pass that fails — or
-/// one that returns immediately because another is already running — can never
-/// strand the operator behind a modal barrier.
-Future<void> _runWithProgress(
-  BuildContext context, {
-  required ReconcileController controller,
-  required bool dry,
-  required Future<void> Function() run,
-}) async {
-  final NavigatorState navigator = Navigator.of(context, rootNavigator: true);
-  unawaited(showDialog<void>(
-    context: context,
-    barrierDismissible: false,
-    builder: (context) =>
-        _ApplyProgressDialog(controller: controller, dry: dry),
-  ));
-  try {
-    await run();
-  } finally {
-    if (navigator.mounted) navigator.pop();
-  }
-}
-
-/// The modal dialog a pass runs behind (#243): how far along it is, and the
-/// account and action in flight right now.
-///
-/// Rebuilt from [ReconcileController.applyStep], which the pass publishes before
-/// each action off the very list the confirmation dialog was built from, so the
-/// count here and the change count the operator just agreed to are the same
-/// resolution of the work.
-class _ApplyProgressDialog extends StatelessWidget {
-  const _ApplyProgressDialog({required this.controller, required this.dry});
-
-  final ReconcileController controller;
-
-  /// Whether this pass writes nothing, which is the one thing the operator most
-  /// wants confirmed while staring at a progress dialog for two minutes.
-  final bool dry;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    // Non-dismissible: the pass is a sequence of live writes, so there is
-    // nothing useful to do behind it and plenty of harm in navigating away.
-    return PopScope(
-      canPop: false,
-      child: AlertDialog(
-        key: const ValueKey('actions-progress-dialog'),
-        title: Text(dry ? 'Dry-run bezig…' : 'Acties toepassen…'),
-        content: SizedBox(
-          // A [LinearProgressIndicator] demands all the width it is offered, so
-          // without a bound the dialog stretches across a desktop window. Fixed
-          // at a readable measure, clamped so a narrow window cannot overflow.
-          width: (MediaQuery.sizeOf(context).width - 112).clamp(240.0, 400.0),
-          child: ListenableBuilder(
-            listenable: controller,
-            builder: (context, _) {
-              final ApplyStep? step = controller.applyStep;
-              return Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  // Always determinate — an indeterminate sweep is what #176
-                  // replaced on Reconcile, and is what this dialog exists to
-                  // stop showing.
-                  LinearProgressIndicator(
-                    key: const ValueKey('actions-progress-bar'),
-                    value: step == null ? 0.0 : (step.index - 1) / step.total,
-                  ),
-                  const SizedBox(height: PlinkSpacing.s4),
-                  Text(
-                    key: const ValueKey('actions-progress-count'),
-                    step == null
-                        ? 'Bezig…'
-                        : 'Actie ${step.index} van ${step.total}',
-                    style: text.titleSmall,
-                  ),
-                  if (step != null) ...<Widget>[
-                    const SizedBox(height: PlinkSpacing.s1),
-                    Text(
-                      key: const ValueKey('actions-progress-step'),
-                      '${step.target} — ${step.summary}',
-                      style: text.bodyMedium,
-                    ),
-                  ],
-                  if (step != null && step.followUps > 0) ...<Widget>[
-                    const SizedBox(height: PlinkSpacing.s2),
-                    Text(
-                      key: const ValueKey('actions-progress-followups'),
-                      // Named, never folded into the count: a follow-up is not
-                      // in the pending list, so it cannot be part of the total
-                      // the operator was shown (#230/#240/#245).
-                      '+ ${_followUpCount(step.followUps)} gestart door een '
-                      'eerdere actie.',
-                      style: text.bodySmall,
-                    ),
-                  ],
-                  const SizedBox(height: PlinkSpacing.s3),
-                  Text(
-                    dry
-                        ? 'Er wordt niets geschreven.'
-                        : 'Sluit het venster niet tot de reeks klaar is.',
-                    style: text.bodySmall,
-                  ),
-                ],
-              );
-            },
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-String _followUpCount(int n) => n == 1 ? '1 vervolgactie' : '$n vervolgacties';
-
 /// The stable widget key of one rollup node, by level — so a test (and the
 /// element tree) names a node the same way wherever it is rendered.
 String _rollupNodeKey(Rollup r) => switch (r.level) {
@@ -1372,8 +941,13 @@ String _rollupNodeKey(Rollup r) => switch (r.level) {
 
 /// The materialized overview (#115/#119): the drill-down driven by the stored
 /// rollups, so it renders from the shared state even in a passive session that
-/// never pulled or re-linked. Tapping a classroom (or the Klasgroepen node)
-/// lazily loads just that node's actions (#154).
+/// never pulled or re-linked. Tapping a classroom lazily loads just that node's
+/// actions (#154).
+///
+/// The "Klasgroepen" node used to sit below the student roots and open the
+/// classes with work. It became a top-level tab of its own in #227 — the full
+/// class inventory rather than a list of changes — so it is gone from here: the
+/// same list must not be maintained in two places.
 ///
 /// The tree is two levels deep on the Leerlingen tab (#210): merged grade-year →
 /// classroom, with no school node — the WISA school split is administrative, so
@@ -1385,7 +959,6 @@ class _DrillDownSection extends StatelessWidget {
     required this.controller,
     required this.accordion,
     required this.roots,
-    required this.groups,
     required this.emptyLabel,
     required this.childrenOf,
     required this.hidden,
@@ -1406,10 +979,6 @@ class _DrillDownSection extends StatelessWidget {
   /// Builds the expanded children of one root — classroom tiles under a merged
   /// grade-year, the nested grade nodes under the staff school.
   final List<Widget> Function(Rollup root) childrenOf;
-
-  /// The "Klasgroepen" rollup node to append below [roots], or `null` when
-  /// this tab carries no group family (the Personeel tab).
-  final Rollup? groups;
 
   /// The message shown when this tab has nothing to browse.
   final String emptyLabel;
@@ -1454,50 +1023,19 @@ class _DrillDownSection extends StatelessWidget {
         shape: const Border(),
         collapsedShape: const Border(),
         title: Text(root.label, style: text.bodyLarge),
-        trailing: _PendingBadge(count: root.pendingCount),
+        trailing: PendingBadge(count: root.pendingCount),
         children: childrenOf(root),
       ),
     );
-  }
-
-  /// The one-line freshness stamp above the tree: which generation of the
-  /// shared view this is, when it was materialized, by whom — and, since #247,
-  /// the werkdatum the WISA roster underneath it was pulled with.
-  ///
-  /// That last part is not a restatement of the timestamp. WISA answers *as
-  /// of* a date, so "gisteren 09:14 door jan" says when the pass ran, never
-  /// which school year it describes; a pass run on the wrong side of the
-  /// rollover reads on Acties exactly like a class that went missing (#239).
-  /// It comes off the shared per-system stamp rather than the operator's own
-  /// Instellingen, so it names the date this *stored view* was pulled with even
-  /// when the setting has since moved on (#238) — and a passive session that
-  /// never ran the pass reads the same line.
-  String? _freshness() {
-    final state = controller.syncState;
-    if (state.generation == 0) return null;
-    final at = state.updatedAt;
-    // Same dated stamp as the Reconcile last-sync box (#192): time-only made
-    // a generation from last week look like one from this morning.
-    final when = at == null ? '' : ' · ${formatFreshnessStamp(at)}';
-    final who = state.updatedBy == null || state.updatedBy!.isEmpty
-        ? ''
-        : ' door ${state.updatedBy}';
-    // Rendered with the connector's own formatter, so it reads exactly as the
-    // `Werkdatum` SOAP parameter went out and as the Log panel's pull line
-    // names it. Absent on a view synced before #247 recorded it.
-    final workDate = state.systems[core.Origin.wisa]?.workDate;
-    final asOf = workDate == null
-        ? ''
-        : ' · werkdatum ${wapi.formatWerkdatum(workDate)}';
-    return 'Generatie ${state.generation}$when$who$asOf';
   }
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     final Color hairline = Theme.of(context).dividerColor;
-    final freshness = _freshness();
-    final groupsNode = groups;
+    // The shared stamp both views carry (#247), so Acties and Klasgroepen name
+    // the same generation the same way.
+    final freshness = sharedViewFreshness(controller);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -1508,7 +1046,7 @@ class _DrillDownSection extends StatelessWidget {
           Text(freshness, style: text.bodySmall),
         ],
         const SizedBox(height: PlinkSpacing.s3),
-        if (roots.isEmpty && groupsNode == null)
+        if (roots.isEmpty)
           filtering && hidden > 0
               ? Text(
                   _allHiddenNote,
@@ -1518,32 +1056,6 @@ class _DrillDownSection extends StatelessWidget {
               : Text(emptyLabel, style: text.bodyMedium)
         else ...<Widget>[
           for (final root in roots) _rootTile(context, root, hairline),
-          if (groupsNode != null)
-            Container(
-              margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
-              decoration: BoxDecoration(
-                border: Border.all(color: hairline),
-                borderRadius:
-                    const BorderRadius.all(Radius.circular(PlinkRadius.base)),
-              ),
-              child: ListTile(
-                key: const ValueKey('rollup-groups'),
-                title: Text(groupsNode.label, style: text.bodyLarge),
-                subtitle: Text(
-                  // A node the filter kept while its badge shows a tick needs
-                  // its reason on the tile (#225/#226): every class in it
-                  // carries a notice to follow up by hand, none an automated
-                  // write.
-                  groupsNode.pendingCount == 0
-                      ? '${groupsNode.accountCount} klasgroep(en) — enkel '
-                          'meldingen om manueel op te volgen'
-                      : '${groupsNode.accountCount} klasgroep(en)',
-                  style: text.bodySmall,
-                ),
-                trailing: _PendingBadge(count: groupsNode.pendingCount),
-                onTap: controller.openGroups,
-              ),
-            ),
           if (filtering && hidden > 0) ...<Widget>[
             const SizedBox(height: PlinkSpacing.s1),
             Text(
@@ -1597,7 +1109,7 @@ class _GradeNode extends StatelessWidget {
       collapsedShape: const Border(),
       tilePadding: const EdgeInsets.only(left: PlinkSpacing.s5, right: 16),
       title: Text('Jaar ${grade.label}', style: text.bodyMedium),
-      trailing: _PendingBadge(count: grade.pendingCount),
+      trailing: PendingBadge(count: grade.pendingCount),
       children: <Widget>[
         for (final classroom in controller.childrenOf(grade.key))
           if (!onlyWithActions || classroom.pendingCount > 0)
@@ -1635,24 +1147,9 @@ class _ClassroomTile extends StatelessWidget {
       title: Text(classroom.label, style: text.bodyMedium),
       subtitle:
           Text('${classroom.accountCount} account(s)', style: text.bodySmall),
-      trailing: _PendingBadge(count: classroom.pendingCount),
+      trailing: PendingBadge(count: classroom.pendingCount),
       onTap: () => controller.openClassroom(classroom),
     );
-  }
-}
-
-class _PendingBadge extends StatelessWidget {
-  const _PendingBadge({required this.count});
-
-  final int count;
-
-  @override
-  Widget build(BuildContext context) {
-    if (count == 0) {
-      return Icon(Icons.check,
-          size: 16, color: Theme.of(context).disabledColor);
-    }
-    return PlinkBadge('$count');
   }
 }
 
@@ -1730,7 +1227,7 @@ class _ClassroomSearchBar extends StatelessWidget {
 /// Styled as the inert card it is (#214): a muted lock beside the pending
 /// badge, and the candidate lines in the disabled colour, so a card that offers
 /// no choice, dry-run or apply does not sit next to the interactive
-/// [_PendingEntryTile] looking identical to it. [_ReadOnlyNotice] above the
+/// [PendingEntryTile] looking identical to it. [ReadOnlyNotice] above the
 /// list carries the explanation.
 class _AccountTile extends StatelessWidget {
   const _AccountTile({required this.account});
@@ -1761,9 +1258,9 @@ class _AccountTile extends StatelessWidget {
           Row(
             children: <Widget>[
               Expanded(child: Text(account.label, style: text.bodyLarge)),
-              const _ReadOnlyLock(),
+              const ReadOnlyLock(),
               const SizedBox(width: PlinkSpacing.s2),
-              _PendingBadge(count: pendingDecisionCount(account.candidates)),
+              PendingBadge(count: pendingDecisionCount(account.candidates)),
             ],
           ),
           const SizedBox(height: PlinkSpacing.s2),
@@ -1785,378 +1282,12 @@ class _AccountTile extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.only(top: PlinkSpacing.s1),
               child: Text(
-                _readOnlyCandidateLine(c),
+                readOnlyCandidateLine(c),
                 style: text.bodySmall?.copyWith(color: muted),
               ),
             ),
         ],
       ),
-    );
-  }
-}
-
-/// The muted lock a read-only card carries where an interactive tile carries
-/// its expand affordance (#214) — the per-row half of the read-only state,
-/// explained once by [_ReadOnlyNotice] at the top of the list.
-class _ReadOnlyLock extends StatelessWidget {
-  const _ReadOnlyLock();
-
-  @override
-  Widget build(BuildContext context) => Tooltip(
-        message: 'Alleen-lezen — synchroniseer om acties toe te passen',
-        child: Icon(
-          Icons.lock_outline,
-          size: 16,
-          color: Theme.of(context).disabledColor,
-        ),
-      );
-}
-
-/// One read-only candidate line of a passive-session tile — [_AccountTile] and
-/// [_GroupTile] share it — worded exactly as the interactive
-/// [_PendingEntryTile]'s: an either/or reads as one "(keuze)" on its
-/// pre-selected half (#251), an informational notice keeps its "(manueel)"
-/// marker (#225), and an ordinary action is its bare summary.
-///
-/// The account card used to render a bare bullet for every candidate (#255), so
-/// a student's informational candidate — since #245 the student family has one —
-/// read like due work next to a badge that counted it zero.
-String _readOnlyCandidateLine(actions.Alternatives<CandidateAction> choice) {
-  final summary = choice.selected.summary;
-  if (choice.isChoice) return '• $summary (keuze)';
-  return choice.selected.canApply ? '• $summary' : '• $summary (manueel)';
-}
-
-/// One class group's read-only summary in a passive-session group drill-down,
-/// styled inert exactly as [_AccountTile] is (#214).
-class _GroupTile extends StatelessWidget {
-  const _GroupTile({required this.group});
-
-  final MaterializedGroup group;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final Color hairline = Theme.of(context).dividerColor;
-    final Color muted = Theme.of(context).disabledColor;
-    final systems = <String>[
-      if (group.inWisa) 'WISA',
-      if (group.inSmartschool) 'Smartschool',
-      if (group.inAzure) 'Azure',
-    ];
-
-    return Container(
-      margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
-      padding: const EdgeInsets.all(PlinkSpacing.s4),
-      decoration: BoxDecoration(
-        border: Border.all(color: hairline),
-        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Row(
-            children: <Widget>[
-              Expanded(child: Text(group.label, style: text.bodyLarge)),
-              const _ReadOnlyLock(),
-              const SizedBox(width: PlinkSpacing.s2),
-              _PendingBadge(count: pendingDecisionCount(group.candidates)),
-            ],
-          ),
-          const SizedBox(height: PlinkSpacing.s2),
-          Wrap(
-            spacing: PlinkSpacing.s2,
-            children: <Widget>[for (final s in systems) PlinkBadge(s)],
-          ),
-          // One line per *decision* (#251), marked exactly as the interactive
-          // tile marks it: since #244 a new class is one "create it or stop
-          // importing it" either/or, which used to read as two separate to-dos.
-          for (final c in candidateChoices(group.candidates))
-            Padding(
-              padding: const EdgeInsets.only(top: PlinkSpacing.s1),
-              child: Text(
-                _readOnlyCandidateLine(c),
-                style: text.bodySmall?.copyWith(color: muted),
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-}
-
-/// The bulk header of one "same situation" subset (#110): the "apply this
-/// resolution to all" affordance that honours each entry's own chosen
-/// alternative. Rendered as its own row in the lazy list, only when more than
-/// one account shares the situation.
-///
-/// Every affordance here acts on [entries] — the exact subset this header was
-/// built over and counts (#252). That list is already scoped by whatever list
-/// rendered it: the open classroom's pending entries, or the group drill-down's,
-/// narrowed further by the search box. The bulk pass used to re-resolve the
-/// situation key against the *whole* linked view instead, so a header reading
-/// "Alles toepassen (1)" inside one class wrote every account group-wide in the
-/// same situation. The label, the confirmation scope and the write are now one
-/// list, so they cannot drift apart again.
-class _SituationHeader extends StatelessWidget {
-  const _SituationHeader({required this.controller, required this.entries});
-
-  final ReconcileController controller;
-  final List<PendingAccountEntry> entries;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final key = entries.first.situationKey;
-    final applyable = entries.where((e) => e.canApply).length;
-
-    return Padding(
-      padding: const EdgeInsets.only(
-        top: PlinkSpacing.s2,
-        bottom: PlinkSpacing.s2,
-      ),
-      child: Row(
-        children: <Widget>[
-          Expanded(
-            child: Text(
-              '${entries.first.situationLabel} — ${entries.length} '
-              'accounts in dezelfde situatie',
-              style: text.titleSmall,
-            ),
-          ),
-          const SizedBox(width: PlinkSpacing.s2),
-          OutlinedButton(
-            key: ValueKey('situation-dry-run-$key'),
-            onPressed: controller.busy || applyable == 0
-                ? null
-                : () => _runWithProgress(
-                      context,
-                      controller: controller,
-                      dry: true,
-                      run: () => controller.dryRunEntries(entries),
-                    ),
-            child: const Text('Dry-run alles'),
-          ),
-          const SizedBox(width: PlinkSpacing.s2),
-          FilledButton(
-            key: ValueKey('situation-apply-$key'),
-            onPressed: controller.busy || applyable == 0
-                ? null
-                : () => _confirmAndApply(
-                      context,
-                      controller: controller,
-                      title: 'Toepassen op ${entries.length} accounts?',
-                      // The dialog is scoped to the very entries the pass below
-                      // runs over — the ones this header counted (#234/#252).
-                      scope: controller.applyScope(entries),
-                      apply: () => controller.applyEntries(entries),
-                    ),
-            child: Text('Alles toepassen ($applyable)'),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// One account's pending resolution (#110): a single expandable row showing the
-/// selected summary, the mutually-exclusive choice (as radios) when there is
-/// one, the per-field diff, and per-entry dry-run / apply.
-class _PendingEntryTile extends StatelessWidget {
-  const _PendingEntryTile({required this.controller, required this.entry});
-
-  final ReconcileController controller;
-  final PendingAccountEntry entry;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final Color hairline = Theme.of(context).dividerColor;
-
-    String lineFor(PendingChoice c) {
-      final summary = c.selected.changes.summary;
-      if (c.isChoice) return '$summary (keuze)';
-      return c.selected.canApply ? summary : '$summary (manueel)';
-    }
-
-    return Container(
-      margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
-      decoration: BoxDecoration(
-        border: Border.all(color: hairline),
-        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
-      ),
-      child: ExpansionTile(
-        key: ValueKey('entry-${entry.family}-${entry.targetId}'),
-        shape: const Border(),
-        collapsedShape: const Border(),
-        leading: PlinkBadge(entry.family),
-        title: Text(entry.target, style: text.bodyLarge),
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            for (final c in entry.choices)
-              Text(lineFor(c), style: text.bodySmall),
-          ],
-        ),
-        childrenPadding: const EdgeInsets.fromLTRB(
-          PlinkSpacing.s5,
-          0,
-          PlinkSpacing.s5,
-          PlinkSpacing.s4,
-        ),
-        expandedCrossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          for (final choice in entry.choices)
-            if (choice.isChoice)
-              _ChoiceControl(
-                controller: controller,
-                entry: entry,
-                choice: choice,
-              )
-            else
-              _OptionDetail(option: choice.selected),
-          const SizedBox(height: PlinkSpacing.s3),
-          Row(
-            children: <Widget>[
-              OutlinedButton(
-                key: ValueKey('entry-dry-run-${entry.targetId}'),
-                onPressed: controller.busy || !entry.canApply
-                    ? null
-                    : () => _runWithProgress(
-                          context,
-                          controller: controller,
-                          dry: true,
-                          run: () => controller.dryRunEntry(entry),
-                        ),
-                child: const Text('Dry-run'),
-              ),
-              const SizedBox(width: PlinkSpacing.s2),
-              FilledButton(
-                key: ValueKey('entry-apply-${entry.targetId}'),
-                onPressed: controller.busy || !entry.canApply
-                    ? null
-                    : () => _confirmAndApply(
-                          context,
-                          controller: controller,
-                          title: 'Toepassen voor ${entry.target}?',
-                          scope: controller.applyScope(<PendingAccountEntry>[
-                            entry,
-                          ]),
-                          apply: () => controller.applyEntry(entry),
-                        ),
-                child: const Text('Toepassen'),
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// The radio group for a mutually-exclusive choice (#110): the operator picks
-/// exactly one resolution; the selected one is what an apply runs.
-class _ChoiceControl extends StatelessWidget {
-  const _ChoiceControl({
-    required this.controller,
-    required this.entry,
-    required this.choice,
-  });
-
-  final ReconcileController controller;
-  final PendingAccountEntry entry;
-  final PendingChoice choice;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final ColorScheme colors = Theme.of(context).colorScheme;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Text(
-          'Kies één oplossing:',
-          style: text.bodySmall?.copyWith(fontWeight: FontWeight.w600),
-        ),
-        for (final option in choice.alternatives)
-          InkWell(
-            key: ValueKey('alt-${entry.targetId}-${option.kind}'),
-            onTap: controller.busy
-                ? null
-                : () => controller.chooseAlternative(
-                      entry: entry,
-                      group: option.group!,
-                      kind: option.kind,
-                    ),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: PlinkSpacing.s1),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Icon(
-                    option.kind == choice.selected.kind
-                        ? Icons.radio_button_checked
-                        : Icons.radio_button_unchecked,
-                    size: 18,
-                    color: option.kind == choice.selected.kind
-                        ? colors.primary
-                        : Theme.of(context).disabledColor,
-                  ),
-                  const SizedBox(width: PlinkSpacing.s2),
-                  Expanded(
-                    child: Text(option.changes.summary, style: text.bodySmall),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        // What the picked resolution will actually write. Collapsing two
-        // actions into one choice (#244) must not cost the operator the diff
-        // they used to read off the second row — a class create names the class,
-        // its description and its Smartschool parent, and that is exactly what
-        // decides whether the create or the opt-out is right.
-        const SizedBox(height: PlinkSpacing.s2),
-        _OptionDetail(option: choice.selected),
-      ],
-    );
-  }
-}
-
-/// The per-field diff (or a lifecycle note) for a single option — the one that
-/// stands alone, or the one selected inside a [_ChoiceControl].
-class _OptionDetail extends StatelessWidget {
-  const _OptionDetail({required this.option});
-
-  final PendingActionOption option;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final fields = option.changes.fields;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: fields.isEmpty
-          ? <Widget>[
-              Text(
-                option.canApply
-                    ? 'Levenscyclusactie — geen wijzigingen per veld.'
-                    : '${option.changes.summary} '
-                        '(manueel — wordt niet automatisch toegepast)',
-                style: text.bodySmall,
-              ),
-            ]
-          : <Widget>[
-              for (final f in fields)
-                Padding(
-                  padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
-                  child: Text(
-                    '${f.field}: ${f.before ?? '∅'} → ${f.after ?? '∅'}',
-                    style: text.bodySmall,
-                  ),
-                ),
-            ],
     );
   }
 }
@@ -2219,58 +1350,6 @@ class _ResultRow extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-/// Full-panel message (loading / not-configured / error), mirroring the other
-/// screens' panels so the views read as one app.
-class _MessagePanel extends StatelessWidget {
-  const _MessagePanel({
-    required this.eyebrow,
-    required this.title,
-    required this.message,
-    this.action,
-    this.progress = false,
-  });
-
-  final String eyebrow;
-  final String title;
-  final String message;
-  final Widget? action;
-  final bool progress;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final bool ink = Theme.of(context).brightness == Brightness.dark;
-
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 480),
-        child: Padding(
-          padding: const EdgeInsets.all(PlinkSpacing.s6),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Eyebrow(eyebrow, onInk: ink),
-              const SizedBox(height: PlinkSpacing.s4),
-              Text(title, style: text.headlineSmall),
-              const SizedBox(height: PlinkSpacing.s4),
-              Text(message, style: text.bodyMedium),
-              if (progress) ...<Widget>[
-                const SizedBox(height: PlinkSpacing.s5),
-                const LinearProgressIndicator(),
-              ],
-              if (action != null) ...<Widget>[
-                const SizedBox(height: PlinkSpacing.s5),
-                action!,
-              ],
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -923,8 +923,8 @@ class _EmptyState extends StatelessWidget {
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     return Text(
-      'Nog geen gematerialiseerd overzicht. Synchroniseer op het Reconcile-'
-      'scherm om openstaande acties per klas te zien.',
+      'Nog geen gematerialiseerd overzicht. Synchroniseer op het tabblad '
+      'Synchronisatie om openstaande acties per klas te zien.',
       style: text.bodyMedium,
     );
   }

--- a/account_manager/lib/src/screens/class_groups_screen.dart
+++ b/account_manager/lib/src/screens/class_groups_screen.dart
@@ -299,8 +299,8 @@ class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
     if (rows.isEmpty) {
       return slivers
         ..add(_section(const EmptyLine(
-          'Nog geen klasinventaris. Synchroniseer op het Reconcile-scherm om '
-          'alle klassen te zien.',
+          'Nog geen klasinventaris. Synchroniseer op het tabblad '
+          'Synchronisatie om alle klassen te zien.',
         )))
         ..add(_gap(PlinkSpacing.s6));
     }

--- a/account_manager/lib/src/screens/class_groups_screen.dart
+++ b/account_manager/lib/src/screens/class_groups_screen.dart
@@ -1,0 +1,813 @@
+import 'dart:async';
+
+import 'package:account_actions/account_actions.dart' show ActionOutcome;
+import 'package:account_state/account_state.dart'
+    show MaterializedGroup, candidateChoices, pendingDecisionCount;
+import 'package:flutter/material.dart';
+import 'package:plink_design_system/plink_design_system.dart';
+
+import '../reconcile/reconcile_bootstrap.dart';
+import '../reconcile/reconcile_controller.dart';
+import 'action_tiles.dart';
+
+/// The **Klasgroepen** tab (#227): the full class inventory.
+///
+/// Every class the last sync linked is a row here — not only the ones that
+/// raised something — with a presence column per system (WISA · Smartschool ·
+/// Office 365) and the rows that need work highlighted. That inversion is the
+/// whole point. The Acties drill-down listed changes, so a *wrong* proposal
+/// looked exactly like every right one: `2G` was offered for creation although
+/// Smartschool already had it (#225), and nothing on screen could have shown
+/// otherwise. Three ticks on a row means the class is correct everywhere, and
+/// anything else stands out.
+///
+/// Three things the layout is deliberate about:
+///
+/// - **The Office 365 column is per *class*, not per row.** Sub-groups get no
+///   group of their own (#228), so `2F ECO` / `2F MAW` / `2F MOW` / `2F STEMW`
+///   are all served by the one group `<PREFIX>-2F`. Each such row names that
+///   group and says whose sub-group it is, instead of four rows each looking
+///   like they own one.
+/// - **The filter defaults *off*.** Acties has the same switch on by default
+///   (#226) because it answers "what needs doing?"; this tab answers "is the
+///   inventory right?", which only the full list can.
+/// - **Informational notices are not buried.** A class Smartschool already
+///   holds, or an Office 365 group left behind by a class that is gone, is real
+///   manual work with no automated write, so it contributes nothing to a pending
+///   count (#225/#250). The filter and the highlight therefore key on
+///   [MaterializedGroup.needsAttention], never on the pending count.
+///
+/// A class that needs work is inspected — and, where it is applyable, dry-run
+/// and applied — right here, through the same tiles Acties uses
+/// (`action_tiles.dart`), so the operator never has to hop to a second list of
+/// the same classes. That is also why the Klasgroepen node left the Acties
+/// drill-down: this tab is its superset, and the same list must not be
+/// maintained in two places.
+///
+/// Shares the one memoized [ReconcileServices] (and so the one
+/// [ReconcileController]) with Reconcile, Acties and Wachtwoorden, so a sync run
+/// on Reconcile populates the inventory shown here.
+class ClassGroupsScreen extends StatefulWidget {
+  const ClassGroupsScreen({super.key, required this.bootstrap});
+
+  /// Assembles (or returns the already-assembled) reconcile stack, or `null`
+  /// when Azure AD is not configured for this build.
+  final Future<ReconcileServices> Function()? bootstrap;
+
+  @override
+  State<ClassGroupsScreen> createState() => _ClassGroupsScreenState();
+}
+
+class _ClassGroupsScreenState extends State<ClassGroupsScreen> {
+  ReconcileServices? _services;
+  Object? _bootstrapError;
+  bool _bootstrapping = false;
+  int _attempts = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _bootstrap();
+  }
+
+  Future<void> _bootstrap() async {
+    final make = widget.bootstrap;
+    if (make == null) return;
+    setState(() {
+      _attempts++;
+      _bootstrapping = true;
+      _bootstrapError = null;
+    });
+    try {
+      final services = await make();
+      if (mounted) setState(() => _services = services);
+      // Passive-session read (#115): the shared overview and the class
+      // inventory straight from the store, with no pull and no re-link.
+      // Idempotent with the other screens' own reads (all share one controller).
+      unawaited(services.controller.loadOverview());
+    } on Object catch (e) {
+      if (mounted) setState(() => _bootstrapError = e);
+    } finally {
+      if (mounted) setState(() => _bootstrapping = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.bootstrap == null) {
+      return const MessagePanel(
+        eyebrow: 'Arcadia · klasgroepen',
+        title: 'Niet geconfigureerd',
+        message: 'Azure AD is niet geconfigureerd voor deze build, dus de '
+            'instellingenopslag en de connectoren zijn onbereikbaar. Geef de '
+            'AAD --dart-define-waarden mee en start opnieuw op.',
+      );
+    }
+    final error = _bootstrapError;
+    if (error != null) {
+      final retryNote = _attempts > 1 ? '\n\n(Poging $_attempts mislukt.)' : '';
+      return MessagePanel(
+        eyebrow: 'Arcadia · klasgroepen',
+        title: 'Kan het Klasgroepen-scherm niet openen',
+        message: '$error$retryNote',
+        action: FilledButton(
+          key: const ValueKey('class-groups-bootstrap-retry'),
+          onPressed: _bootstrap,
+          child: const Text('Probeer opnieuw'),
+        ),
+      );
+    }
+    final services = _services;
+    if (_bootstrapping || services == null) {
+      return const MessagePanel(
+        eyebrow: 'Arcadia · klasgroepen',
+        title: 'Voorbereiden…',
+        message: 'De instellingen en verbindingsprofielen worden geladen.',
+        progress: true,
+      );
+    }
+    return _ClassGroupsBody(controller: services.controller);
+  }
+}
+
+/// One row of the inventory: the stored class document, plus the live pending
+/// entry for it when this session has one to act on.
+class _ClassRowModel {
+  const _ClassRowModel({required this.group, this.entry});
+
+  final MaterializedGroup group;
+
+  /// The interactive entry for this class in an **active** session; `null` in a
+  /// passive one, and for a class with nothing pending.
+  final PendingAccountEntry? entry;
+
+  /// Whether this class asks anything of the operator.
+  ///
+  /// An active session answers from the live dispatch, which drops an entry the
+  /// moment it is applied; a passive one from the stored candidates, which is
+  /// all it has. Either way the pending *count* is not the question — an
+  /// informational notice is work too (#225/#250).
+  bool attentionIn({required bool active}) =>
+      active ? entry != null : group.needsAttention;
+}
+
+class _ClassGroupsBody extends StatefulWidget {
+  const _ClassGroupsBody({required this.controller});
+
+  final ReconcileController controller;
+
+  @override
+  State<_ClassGroupsBody> createState() => _ClassGroupsBodyState();
+}
+
+class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
+  /// The inventory filter (#227), the mirror of the Acties switch (#226) —
+  /// **off** by default, because this tab's job is the full picture. On, it
+  /// keeps only the classes that ask something of the operator.
+  bool _onlyAttention = false;
+
+  ReconcileController get controller => widget.controller;
+
+  @override
+  void initState() {
+    super.initState();
+    controller.addListener(_ensureLoaded);
+    _ensureLoaded();
+  }
+
+  @override
+  void dispose() {
+    controller.removeListener(_ensureLoaded);
+    super.dispose();
+  }
+
+  /// Whether a read is already queued, so a burst of notifications schedules
+  /// one.
+  bool _scheduled = false;
+
+  /// Reads the inventory whenever this session does not have it: on first build,
+  /// and again after a sync — which drops the cached documents precisely so the
+  /// tab re-reads the generation it just wrote.
+  ///
+  /// Always **deferred to a microtask**, never run inline. This is reached from
+  /// `initState` and from a controller notification, and the read's own first act
+  /// is to publish its loading state — so calling it inline would notify the
+  /// other screens' listeners mid-build ("setState() called during build") and
+  /// re-enter `notifyListeners` while it is walking its listeners.
+  void _ensureLoaded() {
+    if (!mounted || _scheduled) return;
+    if (controller.groupDocs != null || controller.loadingGroups) return;
+    _scheduled = true;
+    scheduleMicrotask(() {
+      _scheduled = false;
+      if (!mounted) return;
+      if (controller.groupDocs == null && !controller.loadingGroups) {
+        unawaited(controller.loadGroups());
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (context, _) {
+        return Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 960),
+            child: CustomScrollView(slivers: _slivers(context)),
+          ),
+        );
+      },
+    );
+  }
+
+  static const EdgeInsets _hPad =
+      EdgeInsets.symmetric(horizontal: PlinkSpacing.s6);
+
+  static Widget _section(Widget child) => SliverPadding(
+        padding: _hPad,
+        sliver: SliverToBoxAdapter(child: child),
+      );
+
+  static SliverToBoxAdapter _gap(double height) =>
+      SliverToBoxAdapter(child: SizedBox(height: height));
+
+  /// The class inventory, name-sorted, with each class's live entry attached.
+  List<_ClassRowModel> _rows() {
+    final docs = controller.groupDocs ?? const <MaterializedGroup>[];
+    // The group family's entries are keyed by the class name, which is exactly
+    // the document label (both come from the linker's cross-system match key).
+    final byTarget = <String, PendingAccountEntry>{
+      for (final e in controller.groupPendingEntries) e.targetId: e,
+    };
+    final rows = <_ClassRowModel>[
+      for (final doc in docs)
+        _ClassRowModel(group: doc, entry: byTarget[doc.label]),
+    ];
+    rows.sort((a, b) => compareClassNames(a.group.label, b.group.label));
+    return rows;
+  }
+
+  List<Widget> _slivers(BuildContext context) {
+    final bool active = controller.linked != null;
+    final rows = _rows();
+    final int attention =
+        rows.where((r) => r.attentionIn(active: active)).length;
+    final visible = _onlyAttention
+        ? <_ClassRowModel>[
+            for (final r in rows)
+              if (r.attentionIn(active: active)) r,
+          ]
+        : rows;
+
+    final slivers = <Widget>[
+      _gap(PlinkSpacing.s6),
+      _section(_ClassGroupsHeader(
+        controller: controller,
+        total: rows.length,
+        attention: attention,
+      )),
+      _gap(PlinkSpacing.s4),
+      _section(_AttentionFilterBar(
+        onlyAttention: _onlyAttention,
+        onChanged: (v) => setState(() => _onlyAttention = v),
+      )),
+      _gap(PlinkSpacing.s4),
+    ];
+
+    // Without a linked view there is nothing to choose, dry-run or apply, and
+    // the static rows are otherwise indistinguishable from interactive ones
+    // whose taps stopped working (#214).
+    if (!active) {
+      slivers
+        ..add(_section(ReadOnlyNotice(
+          controller: controller,
+          keyValue: 'class-groups-read-only',
+        )))
+        ..add(_gap(PlinkSpacing.s4));
+    }
+
+    if (controller.loadingGroups && controller.groupDocs == null) {
+      return slivers
+        ..add(_section(const LinearProgressIndicator(
+          key: ValueKey('class-groups-loading'),
+        )))
+        ..add(_gap(PlinkSpacing.s6));
+    }
+
+    if (rows.isEmpty) {
+      return slivers
+        ..add(_section(const EmptyLine(
+          'Nog geen klasinventaris. Synchroniseer op het Reconcile-scherm om '
+          'alle klassen te zien.',
+        )))
+        ..add(_gap(PlinkSpacing.s6));
+    }
+
+    slivers.addAll(_bulkSlivers(active));
+
+    if (visible.isEmpty) {
+      slivers.add(_section(const EmptyLine(
+        'Elke klas staat in orde — er is niets dat aandacht vraagt.',
+      )));
+    } else {
+      slivers.add(SliverPadding(
+        padding: _hPad,
+        sliver: SliverList.builder(
+          itemCount: visible.length,
+          itemBuilder: (context, index) => _ClassRow(
+            controller: controller,
+            row: visible[index],
+            active: active,
+          ),
+        ),
+      ));
+    }
+    slivers
+      ..addAll(_resultsSlivers())
+      ..add(_gap(PlinkSpacing.s6));
+    return slivers;
+  }
+
+  /// The "same situation" bulk affordances (#110/#252), collected above the
+  /// inventory instead of interleaved in it.
+  ///
+  /// The inventory is sorted by class name — that is what makes it scannable —
+  /// so a subset of classes that share one situation is no longer a contiguous
+  /// run of rows to put a header on. They are still worth one click ("create
+  /// every new class of the year"), so they sit here, each acting on exactly the
+  /// classes it names.
+  List<Widget> _bulkSlivers(bool active) {
+    if (!active) return const <Widget>[];
+    final subsets = <List<PendingAccountEntry>>[
+      for (final subset in controller.groupPendingSituations)
+        if (subset.length > 1) subset,
+    ];
+    if (subsets.isEmpty) return const <Widget>[];
+    return <Widget>[
+      _section(const _SectionTitle('Klassen in dezelfde situatie')),
+      SliverPadding(
+        padding: _hPad,
+        sliver: SliverList.builder(
+          itemCount: subsets.length,
+          itemBuilder: (context, index) => SituationHeader(
+            controller: controller,
+            entries: subsets[index],
+            noun: 'klassen',
+          ),
+        ),
+      ),
+      _gap(PlinkSpacing.s4),
+    ];
+  }
+
+  /// The dry-run / apply outcome rows of a pass started from this tab, worded
+  /// exactly as Acties words them.
+  List<Widget> _resultsSlivers() {
+    final dry = controller.dryRunResults;
+    final applied = controller.applyResults;
+    final slivers = <Widget>[];
+    if (dry != null) {
+      slivers
+        ..add(_gap(PlinkSpacing.s5))
+        ..addAll(_resultSection(
+          title: 'Resultaat van de dry-run',
+          subtitle: 'Er is niets geschreven. Dit is wat toepassen zou doen.',
+          results: dry,
+        ));
+    }
+    if (applied != null) {
+      slivers
+        ..add(_gap(PlinkSpacing.s5))
+        ..addAll(_resultSection(
+          title: 'Resultaat van het toepassen',
+          subtitle: 'Weggeschreven naar de doelsystemen.',
+          results: applied,
+        ));
+    }
+    return slivers;
+  }
+
+  List<Widget> _resultSection({
+    required String title,
+    required String subtitle,
+    required List<ActionOutcomeEntry> results,
+  }) =>
+      <Widget>[
+        _section(_ResultsHeader(title: title, subtitle: subtitle)),
+        SliverPadding(
+          padding: _hPad,
+          sliver: SliverList.builder(
+            itemCount: results.length,
+            itemBuilder: (context, index) => _ResultRow(result: results[index]),
+          ),
+        ),
+      ];
+}
+
+/// Orders class names the way an operator reads a class list: by year first and
+/// numerically (`2A` before `10A`), then alphabetically, so `2F` sorts beside
+/// its sub-groups rather than between `20A` and `21B`.
+int compareClassNames(String a, String b) {
+  final ya = _leadingYear(a);
+  final yb = _leadingYear(b);
+  if (ya != yb) {
+    // A non-numeric class (`OKAN`) sorts after every numbered year.
+    if (ya == null) return 1;
+    if (yb == null) return -1;
+    return ya - yb;
+  }
+  return a.toLowerCase().compareTo(b.toLowerCase());
+}
+
+int? _leadingYear(String name) {
+  final match = RegExp(r'^\s*(\d+)').firstMatch(name);
+  return match == null ? null : int.tryParse(match.group(1)!);
+}
+
+/// The tab title plus the one-line state of the inventory.
+class _ClassGroupsHeader extends StatelessWidget {
+  const _ClassGroupsHeader({
+    required this.controller,
+    required this.total,
+    required this.attention,
+  });
+
+  final ReconcileController controller;
+  final int total;
+  final int attention;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final bool ink = Theme.of(context).brightness == Brightness.dark;
+    final String? freshness = sharedViewFreshness(controller);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Eyebrow('Arcadia · klasgroepen', onInk: ink),
+        const SizedBox(height: PlinkSpacing.s4),
+        Text('Klasgroepen', style: text.headlineMedium),
+        const SizedBox(height: PlinkSpacing.s2),
+        Text(
+          switch ((total, attention)) {
+            (0, _) => 'Nog geen klassen in het gedeelde overzicht.',
+            (_, 0) => '$total klas(sen) — alles staat in orde in WISA, '
+                'Smartschool en Office 365.',
+            _ => '$total klas(sen), waarvan $attention aandacht vragen. '
+                'Drie vinkjes betekent dat de klas overal juist staat.',
+          },
+          style: text.bodyMedium,
+        ),
+        if (freshness != null) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s1),
+          Text(freshness, style: text.bodySmall),
+        ],
+      ],
+    );
+  }
+}
+
+/// The inventory filter (#227) — the mirror of the Acties switch (#226), but off
+/// by default: the full list is what makes a wrong proposal visible beside the
+/// classes that are already right.
+class _AttentionFilterBar extends StatelessWidget {
+  const _AttentionFilterBar({
+    required this.onlyAttention,
+    required this.onChanged,
+  });
+
+  final bool onlyAttention;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    return Row(
+      children: <Widget>[
+        Switch(
+          key: const ValueKey('class-groups-only-attention'),
+          value: onlyAttention,
+          onChanged: onChanged,
+        ),
+        const SizedBox(width: PlinkSpacing.s2),
+        Expanded(
+          child: Text(
+            'Toon enkel klassen die aandacht vragen',
+            style: text.bodyMedium,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  const _SectionTitle(this.title);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) =>
+      Text(title, style: Theme.of(context).textTheme.titleMedium);
+}
+
+/// One class of the inventory.
+///
+/// A class with live work is an [ExpansionTile] keyed exactly as the Acties
+/// entry tiles are (`entry-group-<klas>`), so opening it offers the same
+/// radios, the same per-field diff and the same dry-run / apply pair. A class
+/// with nothing to do — the majority, and the reason this tab exists — is a
+/// plain card: name, description, three presence cells.
+class _ClassRow extends StatelessWidget {
+  const _ClassRow({
+    required this.controller,
+    required this.row,
+    required this.active,
+  });
+
+  final ReconcileController controller;
+  final _ClassRowModel row;
+
+  /// Whether this session has a linked view, i.e. whether the rows can act.
+  final bool active;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final Color hairline = Theme.of(context).dividerColor;
+    final MaterializedGroup group = row.group;
+    final PendingAccountEntry? entry = row.entry;
+    final bool attention = row.attentionIn(active: active);
+
+    final BoxDecoration decoration = BoxDecoration(
+      // The highlight #227 asks for: a class that needs work is picked out of
+      // the inventory by its border and a tint, not by being the only row.
+      color: attention ? colors.primary.withValues(alpha: 0.06) : null,
+      border: Border.all(color: attention ? colors.primary : hairline),
+      borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+    );
+
+    final Widget title = Row(
+      children: <Widget>[
+        Expanded(child: Text(group.label, style: text.bodyLarge)),
+        if (!active && attention) ...<Widget>[
+          const ReadOnlyLock(),
+          const SizedBox(width: PlinkSpacing.s2),
+        ],
+        PendingBadge(
+          count: entry == null
+              ? pendingDecisionCount(group.candidates)
+              : entry.choices.where((c) => c.selected.canApply).length,
+        ),
+      ],
+    );
+
+    final Widget body = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        if (group.description.isNotEmpty)
+          Text(group.description, style: text.bodySmall),
+        const SizedBox(height: PlinkSpacing.s2),
+        _PresenceRow(group: group),
+        for (final line in _lines(entry, group)) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s1),
+          Text(
+            line,
+            style: entry == null
+                ? text.bodySmall
+                    ?.copyWith(color: Theme.of(context).disabledColor)
+                : text.bodySmall,
+          ),
+        ],
+      ],
+    );
+
+    // Every row is addressable by its class name, whether or not it has work —
+    // the inventory is the thing being verified, so a test (and the element
+    // tree) names a class the same way in both shapes.
+    final Key rowKey = ValueKey('class-row-${group.label}');
+
+    if (entry == null) {
+      return Container(
+        key: rowKey,
+        margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
+        padding: const EdgeInsets.all(PlinkSpacing.s4),
+        decoration: decoration,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            title,
+            const SizedBox(height: PlinkSpacing.s2),
+            body,
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      key: rowKey,
+      margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
+      decoration: decoration,
+      child: ExpansionTile(
+        key: ValueKey('entry-group-${entry.targetId}'),
+        shape: const Border(),
+        collapsedShape: const Border(),
+        title: title,
+        subtitle: body,
+        childrenPadding: const EdgeInsets.fromLTRB(
+          PlinkSpacing.s5,
+          0,
+          PlinkSpacing.s5,
+          PlinkSpacing.s4,
+        ),
+        expandedCrossAxisAlignment: CrossAxisAlignment.start,
+        children: entryDetail(context, controller: controller, entry: entry),
+      ),
+    );
+  }
+
+  /// The collapsed summary lines: the live choices in an active session, the
+  /// stored candidates in a passive one — each worded exactly as Acties words
+  /// it, so an either/or reads as the one decision it is (#251).
+  List<String> _lines(PendingAccountEntry? entry, MaterializedGroup group) {
+    if (entry != null) {
+      return <String>[for (final c in entry.choices) pendingChoiceLine(c)];
+    }
+    return <String>[
+      for (final c in candidateChoices(group.candidates))
+        readOnlyCandidateLine(c),
+    ];
+  }
+}
+
+/// The three presence cells of one class: WISA · Smartschool · Office 365.
+class _PresenceRow extends StatelessWidget {
+  const _PresenceRow({required this.group});
+
+  final MaterializedGroup group;
+
+  @override
+  Widget build(BuildContext context) {
+    final MaterializedGroup g = group;
+    // The Office 365 group is named after the **parent** class (#228), so a
+    // sub-group's row names the group it shares rather than pretending to own
+    // one. Without this, `2F ECO` and its three siblings each read as a class
+    // with a missing group of its own.
+    // Only a record that really is a WISA class can be somebody's sub-group; an
+    // Azure-only leftover carries the bare name recovered from its display name
+    // (`GBS-9Z` → `9Z`), which is the class it *was*, not a parent it belongs to.
+    final String? bare = g.className;
+    final bool isSubGroup =
+        bare != null && g.inWisa && bare.trim() != g.label.trim();
+    final String azureDetail = g.azureGroupName ??
+        (isSubGroup ? 'nog geen groep voor $bare' : 'nog geen groep');
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Expanded(child: _PresenceCell(system: 'WISA', present: g.inWisa)),
+        Expanded(
+          child: _PresenceCell(system: 'Smartschool', present: g.inSmartschool),
+        ),
+        Expanded(
+          child: _PresenceCell(
+            system: 'Office 365',
+            present: g.inAzure,
+            detail: azureDetail,
+            note: isSubGroup ? 'deelgroep van $bare' : null,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PresenceCell extends StatelessWidget {
+  const _PresenceCell({
+    required this.system,
+    required this.present,
+    this.detail,
+    this.note,
+  });
+
+  final String system;
+  final bool present;
+
+  /// The name of the thing that is (or is not) there — the Office 365 group.
+  final String? detail;
+
+  /// A second line that explains the row's relationship to [detail].
+  final String? note;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final Color muted = Theme.of(context).disabledColor;
+
+    return Padding(
+      padding: const EdgeInsets.only(right: PlinkSpacing.s2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(
+            present ? Icons.check_circle_outline : Icons.remove_circle_outline,
+            size: 16,
+            color: present ? colors.primary : muted,
+          ),
+          const SizedBox(width: PlinkSpacing.s1),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Text(
+                  system,
+                  style: text.bodySmall,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (detail != null)
+                  Text(
+                    detail!,
+                    style: text.bodySmall?.copyWith(color: muted),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                if (note != null)
+                  Text(
+                    note!,
+                    style: text.bodySmall?.copyWith(color: muted),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The header of a dry-run/apply result set, above the lazy list of rows.
+class _ResultsHeader extends StatelessWidget {
+  const _ResultsHeader({required this.title, required this.subtitle});
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(title, style: text.titleMedium),
+        const SizedBox(height: PlinkSpacing.s1),
+        Text(subtitle, style: text.bodySmall),
+        const SizedBox(height: PlinkSpacing.s3),
+      ],
+    );
+  }
+}
+
+/// One outcome row of a dry-run/apply pass started from this tab.
+class _ResultRow extends StatelessWidget {
+  const _ResultRow({required this.result});
+
+  final ActionOutcomeEntry result;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final bool failed = result.outcome == ActionOutcome.failed;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(
+            failed ? Icons.close : Icons.check,
+            size: 16,
+            color: failed ? colors.error : colors.primary,
+          ),
+          const SizedBox(width: PlinkSpacing.s2),
+          Expanded(
+            child: Text(
+              failed
+                  ? '${result.target} — ${result.changes.summary}: '
+                      '${result.error}'
+                  : '${result.target} — ${result.changes.summary}',
+              style: text.bodySmall,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/account_manager/lib/src/screens/passwords_screen.dart
+++ b/account_manager/lib/src/screens/passwords_screen.dart
@@ -97,15 +97,15 @@ class _PasswordsScreenState extends State<PasswordsScreen> {
     if (widget.bootstrap == null) {
       return const _MessagePanel(
         eyebrow: 'Arcadia · wachtwoorden',
-        title: 'Not configured',
-        message: 'Azure AD is not configured for this build, so the connectors '
-            'and the shared password queue cannot be reached. Provide the AAD '
-            '--dart-define values and restart.',
+        title: 'Niet geconfigureerd',
+        message: 'Azure AD is niet geconfigureerd voor deze build, dus de '
+            'connectoren en de gedeelde wachtwoordwachtrij zijn onbereikbaar. '
+            'Geef de AAD --dart-define-waarden mee en start opnieuw op.',
       );
     }
     final error = _error;
     if (error != null && _controller == null) {
-      final retryNote = _attempts > 1 ? '\n\n(Attempt $_attempts failed.)' : '';
+      final retryNote = _attempts > 1 ? '\n\n(Poging $_attempts mislukt.)' : '';
       return _MessagePanel(
         eyebrow: 'Arcadia · wachtwoorden',
         title: 'Kon het wachtwoordscherm niet laden',
@@ -258,7 +258,7 @@ class _LeerlingenTab extends StatelessWidget {
                   padding: const EdgeInsets.all(PlinkSpacing.s6),
                   child: Text(
                     'Geen "Leerlingen"-groep gevonden. Synchroniseer eerst op '
-                    'het Reconcile-scherm zodat de klasboom geladen is.',
+                    'het tabblad Synchronisatie zodat de klasboom geladen is.',
                     key: const ValueKey('passwords-no-leerlingen'),
                     style: text.bodyMedium,
                   ),
@@ -528,8 +528,8 @@ class _PersoneelTab extends StatelessWidget {
       return Padding(
         padding: const EdgeInsets.all(PlinkSpacing.s6),
         child: Text(
-          'Geen personeel gevonden. Synchroniseer eerst op het Reconcile-scherm '
-          'zodat de "Personeel"-groep geladen is.',
+          'Geen personeel gevonden. Synchroniseer eerst op het tabblad '
+          'Synchronisatie zodat de "Personeel"-groep geladen is.',
           key: const ValueKey('passwords-no-personeel'),
           style: text.bodyMedium,
         ),

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -67,35 +67,35 @@ class _ReconcileScreenState extends State<ReconcileScreen> {
   Widget build(BuildContext context) {
     if (widget.bootstrap == null) {
       return const _MessagePanel(
-        eyebrow: 'Arcadia · reconcile',
-        title: 'Not configured',
-        message: 'Azure AD is not configured for this build, so the settings '
-            'store and connectors cannot be reached. Provide the AAD '
-            '--dart-define values and restart.',
+        eyebrow: 'Arcadia · synchronisatie',
+        title: 'Niet geconfigureerd',
+        message: 'Azure AD is niet geconfigureerd voor deze build, dus de '
+            'instellingenopslag en de connectoren zijn onbereikbaar. Geef de '
+            'AAD --dart-define-waarden mee en start opnieuw op.',
       );
     }
     final error = _bootstrapError;
     if (error != null) {
       // A fast failure makes a retry look like a dead button — say the
       // attempt happened.
-      final retryNote = _attempts > 1 ? '\n\n(Attempt $_attempts failed.)' : '';
+      final retryNote = _attempts > 1 ? '\n\n(Poging $_attempts mislukt.)' : '';
       return _MessagePanel(
-        eyebrow: 'Arcadia · reconcile',
-        title: 'Could not prepare the reconcile screen',
+        eyebrow: 'Arcadia · synchronisatie',
+        title: 'Kan het Synchronisatie-scherm niet openen',
         message: '$error$retryNote',
         action: FilledButton(
           key: const ValueKey('reconcile-bootstrap-retry'),
           onPressed: _bootstrap,
-          child: const Text('Try again'),
+          child: const Text('Probeer opnieuw'),
         ),
       );
     }
     final services = _services;
     if (_bootstrapping || services == null) {
       return const _MessagePanel(
-        eyebrow: 'Arcadia · reconcile',
-        title: 'Preparing…',
-        message: 'Loading the settings and connection profiles.',
+        eyebrow: 'Arcadia · synchronisatie',
+        title: 'Voorbereiden…',
+        message: 'De instellingen en verbindingsprofielen worden geladen.',
         progress: true,
       );
     }
@@ -204,9 +204,10 @@ class _Header extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Eyebrow('Arcadia · reconcile', onInk: ink),
+        Eyebrow('Arcadia · synchronisatie', onInk: ink),
         const SizedBox(height: PlinkSpacing.s4),
-        Text('Reconcile', style: text.headlineMedium),
+        // The page names itself the way the rail names it (#257).
+        Text('Synchronisatie', style: text.headlineMedium),
         const SizedBox(height: PlinkSpacing.s4),
         Wrap(
           spacing: PlinkSpacing.s3,
@@ -305,11 +306,12 @@ class _Header extends StatelessWidget {
   }
 }
 
-/// The shared per-system "Last sync" box (#188): a bordered card headed
-/// "Last sync" with one row per system — WISA, Smartschool, Azure — each on its
-/// own line showing whether it was refreshed by a sync or a drift check, the
-/// time, and which operator ran it. This replaces the old run-on freshness line
-/// that packed all three systems into a single wrapped sentence.
+/// The shared per-system last-sync box (#188): a bordered card headed
+/// "Laatste synchronisatie" with one row per system — WISA, Smartschool,
+/// Azure — each on its own line showing whether it was refreshed by a sync or a
+/// drift check, the time, and which operator ran it. This replaces the old
+/// run-on freshness line that packed all three systems into a single wrapped
+/// sentence.
 ///
 /// Read from the materialized store so it names *whichever* operator last synced
 /// each system — not just this session (#108). WISA is the Synchronise target;
@@ -353,7 +355,7 @@ class _LastSyncBox extends StatelessWidget {
             children: <Widget>[
               Icon(Icons.schedule_outlined, size: 18, color: colors.primary),
               const SizedBox(width: PlinkSpacing.s2),
-              Text('Last sync', style: text.titleMedium),
+              Text('Laatste synchronisatie', style: text.titleMedium),
             ],
           ),
           const SizedBox(height: PlinkSpacing.s3),
@@ -397,14 +399,14 @@ class _SystemRow extends StatelessWidget {
 
     final String status;
     if (meta == null) {
-      status = 'not synced yet';
+      status = 'nog niet gesynchroniseerd';
     } else {
       // Dated as soon as it leaves today (#192): a stamp from three days ago
       // must not read like this morning's, since a stale row is exactly what
       // this box exists to surface.
       final String when = formatFreshnessStamp(meta.at);
-      final String kind = isSync ? 'sync' : 'drift check';
-      final String by = meta.syncedBy.isEmpty ? '' : ' · by ${meta.syncedBy}';
+      final String kind = isSync ? 'synchronisatie' : 'driftcontrole';
+      final String by = meta.syncedBy.isEmpty ? '' : ' · door ${meta.syncedBy}';
       status = '$kind · $when$by';
     }
 

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -196,6 +196,10 @@ class _Header extends StatelessWidget {
     // The one class of saved setting this running session cannot adopt — the
     // connection profiles the connectors were constructed from (#246).
     final String? relaunch = controller.relaunchRequiredReason;
+    // Saved Smartschool / Azure pull inputs the next pass will adopt but no
+    // pass has yet (#259) — the gap in which Synchroniseer used to report
+    // "geen accountwijzigingen nodig" over a save it had skipped.
+    final String? pendingSettings = controller.pendingSettingsReason;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -237,6 +241,18 @@ class _Header extends StatelessWidget {
               Icon(Icons.info_outline, size: 16, color: colors.primary),
               const SizedBox(width: PlinkSpacing.s2),
               Flexible(child: Text(driftBlocked, style: text.bodySmall)),
+            ],
+          ),
+        ],
+        if (pendingSettings != null) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s3),
+          Row(
+            key: const ValueKey('reconcile-settings-pending'),
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(Icons.info_outline, size: 16, color: colors.primary),
+              const SizedBox(width: PlinkSpacing.s2),
+              Flexible(child: Text(pendingSettings, style: text.bodySmall)),
             ],
           ),
         ],

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -479,15 +479,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (widget.bootstrap == null) {
       return const _MessagePanel(
         eyebrow: 'Arcadia · instellingen',
-        title: 'Not configured',
-        message: 'Azure AD is not configured for this build, so the settings '
-            'store cannot be reached. Provide the AAD --dart-define values and '
-            'restart.',
+        title: 'Niet geconfigureerd',
+        message: 'Azure AD is niet geconfigureerd voor deze build, dus de '
+            'instellingenopslag is onbereikbaar. Geef de AAD '
+            '--dart-define-waarden mee en start opnieuw op.',
       );
     }
     final error = _error;
     if (error != null && _loaded == null) {
-      final retryNote = _attempts > 1 ? '\n\n(Attempt $_attempts failed.)' : '';
+      final retryNote = _attempts > 1 ? '\n\n(Poging $_attempts mislukt.)' : '';
       return _MessagePanel(
         eyebrow: 'Arcadia · instellingen',
         title: 'Kon de instellingen niet laden',

--- a/account_manager/lib/src/shell/app_shell.dart
+++ b/account_manager/lib/src/shell/app_shell.dart
@@ -50,18 +50,21 @@ class AppShell extends StatefulWidget {
 
 class _AppShellState extends State<AppShell> {
   late final List<ShellDestination> _destinations = <ShellDestination>[
+    // Every label is the operator's language and the name of the page behind
+    // it (#257): the rail is read together with the heading it leads to, so a
+    // rail saying "Actions" over a page titled "Acties" reads as two apps.
     ShellDestination(
-      label: 'Home',
+      label: 'Start',
       icon: Icons.home_outlined,
       builder: (_) => const HomeScreen(),
     ),
     ShellDestination(
-      label: 'Reconcile',
+      label: 'Synchronisatie',
       icon: Icons.sync_alt_outlined,
       builder: (_) => ReconcileScreen(bootstrap: widget.reconcileBootstrap),
     ),
     ShellDestination(
-      label: 'Actions',
+      label: 'Acties',
       icon: Icons.checklist_outlined,
       builder: (_) => ActionsScreen(bootstrap: widget.reconcileBootstrap),
     ),
@@ -74,12 +77,12 @@ class _AppShellState extends State<AppShell> {
       builder: (_) => ClassGroupsScreen(bootstrap: widget.reconcileBootstrap),
     ),
     ShellDestination(
-      label: 'Passwords',
+      label: 'Wachtwoorden',
       icon: Icons.password_outlined,
       builder: (_) => PasswordsScreen(bootstrap: widget.reconcileBootstrap),
     ),
     ShellDestination(
-      label: 'Settings',
+      label: 'Instellingen',
       icon: Icons.settings_outlined,
       builder: (_) => SettingsScreen(bootstrap: widget.settingsBootstrap),
     ),

--- a/account_manager/lib/src/shell/app_shell.dart
+++ b/account_manager/lib/src/shell/app_shell.dart
@@ -3,6 +3,7 @@ import 'package:plink_design_system/plink_design_system.dart';
 
 import '../reconcile/reconcile_bootstrap.dart';
 import '../screens/actions_screen.dart';
+import '../screens/class_groups_screen.dart';
 import '../screens/home_screen.dart';
 import '../screens/passwords_screen.dart';
 import '../screens/reconcile_screen.dart';
@@ -63,6 +64,14 @@ class _AppShellState extends State<AppShell> {
       label: 'Actions',
       icon: Icons.checklist_outlined,
       builder: (_) => ActionsScreen(bootstrap: widget.reconcileBootstrap),
+    ),
+    // The class inventory (#227). A destination of its own rather than a node
+    // inside Acties: it lists *every* class, so it answers "is this right?",
+    // which the action list structurally cannot.
+    ShellDestination(
+      label: 'Klasgroepen',
+      icon: Icons.groups_outlined,
+      builder: (_) => ClassGroupsScreen(bootstrap: widget.reconcileBootstrap),
     ),
     ShellDestination(
       label: 'Passwords',

--- a/account_manager/test/auth/sign_in_gate_test.dart
+++ b/account_manager/test/auth/sign_in_gate_test.dart
@@ -48,7 +48,7 @@ void main() {
     await tester.pumpWidget(host(SignInSession(stuck), resource: graph));
     await tester.pump();
 
-    expect(find.text('Signing in…'), findsOneWidget);
+    expect(find.text('Aanmelden…'), findsOneWidget);
     expect(find.text('APP CONTENT'), findsNothing);
   });
 
@@ -68,11 +68,11 @@ void main() {
     await tester.pumpWidget(host(SignInSession(broker), resource: graph));
     await tester.pumpAndSettle();
 
-    expect(find.text('Could not sign in'), findsOneWidget);
+    expect(find.text('Kon je niet aanmelden'), findsOneWidget);
     expect(find.text('network down'), findsOneWidget);
     expect(find.text('APP CONTENT'), findsNothing);
 
-    await tester.tap(find.text('Try again'));
+    await tester.tap(find.text('Probeer opnieuw'));
     await tester.pumpAndSettle();
 
     expect(find.text('APP CONTENT'), findsOneWidget);
@@ -91,7 +91,7 @@ void main() {
     await tester.pumpWidget(host(SignInSession(broker), resource: graph));
     await tester.pumpAndSettle();
 
-    expect(find.text('Sign-in was cancelled.'), findsOneWidget);
+    expect(find.text('Het aanmelden is geannuleerd.'), findsOneWidget);
   });
 
   testWidgets('reveals the app directly when AAD is not configured',

--- a/account_manager/test/reconcile/log_buffer_test.dart
+++ b/account_manager/test/reconcile/log_buffer_test.dart
@@ -12,11 +12,11 @@ void main() {
     final entry = LogEntry(
       time: DateTime(2026, 7, 1, 9, 4, 7),
       origin: Origin.wisa,
-      message: 'Syncing WISA...',
+      message: 'WISA ophalen...',
       isError: false,
     );
 
-    expect(entry.line, '09:04:07  [wisa]  Syncing WISA...');
+    expect(entry.line, '09:04:07  [wisa]  WISA ophalen...');
   });
 
   test('an empty buffer copies as the empty string', () {

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -576,8 +576,12 @@ void main() {
       );
       expect(klas3C(h.controller).pendingCount, 1,
           reason: "the refused write left Sam's name as it was");
-      expect(h.controller.groupRollup, isNull,
+      // The node itself stays: since #227 it aggregates the class *inventory*,
+      // so the classes are still there — with nothing left to do on them.
+      expect(h.controller.groupRollup!.pendingCount, 0,
           reason: 'the class-group work that did land is gone');
+      expect(h.controller.groupRollup!.accountCount, greaterThan(0),
+          reason: 'the classes themselves did not disappear with their work');
     });
 
     test(
@@ -1238,9 +1242,8 @@ void main() {
       expect(h.controller.groupRollup!.accountCount, groups.length);
     });
 
-    test(
-        'a passive session opens the Klasgroepen drill-down with no pull or '
-        'link()', () async {
+    test('a passive session reads the class inventory with no pull or link()',
+        () async {
       final snapshots = InMemorySnapshotStore();
       final linkedStore = InMemoryLinkedStore();
 
@@ -1258,20 +1261,33 @@ void main() {
 
       expect(s2.controller.groupRollup, isNotNull,
           reason: 'the group rollup came from the shared store');
+      expect(s2.controller.groupDocs, isNull,
+          reason: 'the inventory is read when the Klasgroepen tab asks for it');
 
-      await s2.controller.openGroups();
+      await s2.controller.loadGroups();
 
-      expect(s2.controller.showingGroups, isTrue);
       expect(s2.controller.groupDocs, isNotEmpty);
       // No connector pull and no linked view derived this session.
       expect(s2.wisaSyncs, 0);
       expect(s2.ssSyncs, 0);
       expect(s2.azSyncs, 0);
       expect(s2.controller.linked, isNull);
+    });
 
-      s2.controller.closeGroups();
-      expect(s2.controller.showingGroups, isFalse);
-      expect(s2.controller.groupDocs, isNull);
+    test('a sync drops the cached inventory so the tab re-reads it (#227)',
+        () async {
+      final h = ReconcileHarness();
+      // The tab is open before anything has been materialized: an empty
+      // inventory, read from an empty store.
+      await h.controller.loadGroups();
+      expect(h.controller.groupDocs, isEmpty);
+
+      await h.controller.sync();
+
+      expect(h.controller.groupDocs, isNull,
+          reason: 'the pre-sync inventory must not linger on screen');
+      await h.controller.loadGroups();
+      expect(h.controller.groupDocs, isNotEmpty);
     });
   });
 

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -103,7 +103,8 @@ void main() {
           reason: 'the existing linked view is kept, no re-link');
       expect(
         h.log.entries.map((e) => e.message),
-        contains(contains('no account changes needed')),
+        contains('WISA is ongewijzigd sinds de vorige synchronisatie — '
+            'geen accountwijzigingen nodig.'),
       );
     });
 
@@ -182,6 +183,77 @@ void main() {
     });
   });
 
+  group('the pass reports itself in Dutch (#258)', () {
+    // The Log panel is one running account of one pass, so it cannot change
+    // language halfway through it: the terminal line #253 translated used to
+    // land under a stack of English pull/link lines. Every step the operator
+    // reads is pinned here, exactly as the panel renders it.
+    test('a sync names each system it pulls and what it linked', () async {
+      final h = ReconcileHarness();
+
+      await h.controller.sync();
+
+      final messages = h.log.entries.map((e) => e.message).toList();
+      expect(
+        messages,
+        containsAllInOrder(<String>[
+          'WISA ophalen…',
+          'WISA opgehaald: 1 leerling(en), 0 personeelsleden, 0 klassen.',
+          'Smartschool ophalen…',
+          'Azure AD ophalen…',
+        ]),
+      );
+      expect(messages, contains(startsWith('Gekoppeld: ')));
+      // Not one line of the pass fell back to the English it used to log.
+      expect(messages.where((m) => m.startsWith('Syncing ')), isEmpty);
+      expect(messages.where((m) => m.startsWith('Linked: ')), isEmpty);
+    });
+
+    test('a drift check names both systems it re-reads', () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+      h.log.clear();
+
+      await h.controller.checkDrift();
+
+      expect(
+        h.log.entries.map((e) => e.message),
+        containsAllInOrder(<String>[
+          'Smartschool controleren op drift…',
+          'Azure AD controleren op drift…',
+        ]),
+      );
+    });
+
+    test('a dry-run keeps the "Dry-run" of the Acties buttons', () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+      h.log.clear();
+
+      await h.controller.dryRun();
+
+      final messages = h.log.entries.map((e) => e.message).toList();
+      expect(messages.first, startsWith('Dry-run gestart voor '));
+      expect(messages.last, startsWith('Dry-run klaar: '));
+      expect(messages.last, contains(' gelukt, '));
+      expect(messages.last, endsWith(' mislukt.'));
+    });
+
+    test('an apply says "Toepassen", the verb those same buttons use',
+        () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+      h.log.clear();
+
+      await h.controller.applyAll();
+
+      final messages = h.log.entries.map((e) => e.message).toList();
+      expect(messages.first, startsWith('Toepassen gestart voor '));
+      expect(messages, contains(startsWith('Toepassen klaar: ')));
+      expect(messages.where((m) => m.startsWith('Apply ')), isEmpty);
+    });
+  });
+
   group('persist resilience (#168)', () {
     test(
         'a stalled writeMaterialized times out, logs it, and returns the pass '
@@ -203,7 +275,9 @@ void main() {
       // The operator sees the timeout, not silence.
       expect(
         h.log.entries.where((e) => e.isError).map((e) => e.message),
-        contains(contains('timed out')),
+        contains(contains(
+          'Het opslaan van het gedeelde overzicht duurde langer dan',
+        )),
       );
       // The in-memory linked view is still usable this session.
       expect(h.controller.linked, isNotNull);
@@ -223,7 +297,7 @@ void main() {
       expect(h.controller.phase, ReconcilePhase.ready);
       expect(
         h.log.entries.where((e) => e.isError).map((e) => e.message),
-        contains(contains('Could not persist the linked view')),
+        contains(contains('Kon het gedeelde overzicht niet opslaan')),
       );
       expect(h.controller.linked, isNotNull);
     });
@@ -280,6 +354,12 @@ void main() {
           reason: 'the managed mark is the operator\'s, never rewritten');
       expect(saved.wisaSchools.last.virtual, isTrue);
       expect(h.log.entries.where((e) => e.isError), isEmpty);
+      // And the repair says so in the operator's own language (#258).
+      expect(
+        h.log.entries.map((e) => e.message),
+        contains('Naam en code van 2 WISA-school(en) bijgewerkt in de '
+            'instellingen (id 25, 27).'),
+      );
     });
 
     test('the unchanged-WISA shortcut still repairs the document', () async {
@@ -336,7 +416,10 @@ void main() {
       expect(h.controller.linked, isNotNull);
       expect(
         h.log.entries.where((e) => e.isError).map((e) => e.message),
-        contains(contains('cosmos 503')),
+        contains(
+          'Kon de WISA-schoolnamen niet bijwerken in de instellingen: '
+          'Bad state: cosmos 503',
+        ),
       );
     });
   });
@@ -1882,7 +1965,7 @@ void main() {
       expect(h.controller.linked, isNotNull);
       expect(
         h.log.entries.map((e) => e.message),
-        contains(contains('Could not publish a change signal')),
+        contains(contains('Kon geen wijzigingssignaal versturen')),
       );
     });
   });

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -584,31 +584,192 @@ void main() {
           reason: 'the classes themselves did not disappear with their work');
     });
 
-    test(
-        'the refreshed counts are local — the shared store keeps its generation '
-        '(#236, shared half in #254)', () async {
-      // A deliberate choice, not an oversight: rewriting ~9.6k documents per
-      // apply is not affordable, and bumping this session's generation would
-      // gate out the very `onStoreChanged` that should overrule this
-      // correction. Other operators catch up on the next sync.
-      final h = appliedClassWorkHarness();
-      Future<Rollup> stored3C() async => (await h.linkedStore.readRollups())
-          .singleWhere((r) => r.classroom == '3C' && r.school == '1');
+    /// The stored counterpart of [klas3C]: 3C's node as the *shared* view holds
+    /// it, which is what every other operator reads.
+    Future<Rollup?> stored3C(ReconcileHarness h) async {
+      for (final r in await h.linkedStore.readRollups()) {
+        if (r.classroom == '3C' && r.school == '1') return r;
+      }
+      return null;
+    }
 
+    test(
+        'the applied work leaves the shared store too, not just this session '
+        '(#254)', () async {
+      // #236 fixed the local half and deliberately stopped there: rewriting
+      // ~9.6k documents per apply was not affordable and there was no narrower
+      // seam. `writeApplied` is that seam, so the stored counts now move with
+      // the session's — and every other operator stops being offered work that
+      // has already been applied.
+      final h = appliedClassWorkHarness();
       await h.controller.sync();
+      expect((await stored3C(h))!.pendingCount, 1);
       final before = await h.linkedStore.readSyncState();
 
       await h.controller.applyEntry(samEntry(h.controller));
 
+      expect(h.controller.error, isNull);
+      expect((await stored3C(h))!.pendingCount, 0,
+          reason:
+              'the stored view used to stay pre-apply until someone synced');
+      expect((await h.linkedStore.readSyncState()).generation,
+          before.generation + 1);
+      expect(h.controller.syncState.generation, before.generation + 1,
+          reason: 'a session that wrote the view is current, not ahead of it');
+      expect(klas3C(h.controller).pendingCount, 0);
+    });
+
+    test('the stored account document drops the applied candidate (#254)',
+        () async {
+      // The badge is a sum over documents, so the document has to move with it —
+      // a passive session reads the per-account docs, not just the rollups.
+      final h = appliedClassWorkHarness();
+      await h.controller.sync();
+      final entry = samEntry(h.controller);
+      final before =
+          await h.linkedStore.readClassroom(school: '1', classroom: '3C');
       expect(
-          (await h.linkedStore.readSyncState()).generation, before.generation,
-          reason: 'no write, so no new generation');
+        before.singleWhere((a) => a.id.value == entry.targetId).candidates,
+        isNotEmpty,
+      );
+
+      await h.controller.applyEntry(entry);
+
+      final after =
+          await h.linkedStore.readClassroom(school: '1', classroom: '3C');
+      expect(
+        after.singleWhere((a) => a.id.value == entry.targetId).candidates,
+        isEmpty,
+      );
+      expect(after, hasLength(before.length),
+          reason: 'the class still holds everyone it held');
+    });
+
+    test('the write-back is scoped to what the pass touched (#254)', () async {
+      // A one-row apply must not republish this session's whole picture of the
+      // view: everything it did not write to is left exactly as the last sync
+      // put it — including the class-group half, which since #227 is a document
+      // per class rather than per class with work.
+      final h = appliedClassWorkHarness();
+      await h.controller.sync();
+      final groupsBefore = await h.linkedStore.readGroups();
+
+      await h.controller.applyEntry(samEntry(h.controller));
+
+      final klasgroepen = (await h.linkedStore.readRollups())
+          .singleWhere((r) => r.level == RollupLevel.groups);
+      expect(klasgroepen.pendingCount, 4,
+          reason: 'a re-derivation of what changed, not a blanket reset');
+      expect(await h.linkedStore.readGroups(), hasLength(groupsBefore.length));
+      final threeD =
+          await h.linkedStore.readClassroom(school: '1', classroom: '3D');
+      expect(threeD, hasLength(1), reason: 'the untouched class is intact');
+    });
+
+    test('a dry-run writes nothing to the shared store either (#254)',
+        () async {
+      final h = appliedClassWorkHarness();
+      await h.controller.sync();
+      final before = await h.linkedStore.readSyncState();
+
+      await h.controller.dryRun();
+
+      expect(
+          (await h.linkedStore.readSyncState()).generation, before.generation);
+      expect((await stored3C(h))!.pendingCount, 1);
+    });
+
+    test('an apply stands down while another operator is syncing (#254)',
+        () async {
+      // The apply path does not take the sync lease — it is frequent and
+      // concurrent by design (#108/#121). So the write-back has to notice one:
+      // that pass is republishing the whole view from a fresher link, and a
+      // narrow patch bumping the generation past it would be exactly the local
+      // correction outranking the shared view this must not create.
+      final h = appliedClassWorkHarness();
+      await h.controller.sync();
+      final before = await h.linkedStore.readSyncState();
+      await h.linkedStore
+          .acquireLease(owner: 'mieke@school', now: kFixtureDate);
+
+      await h.controller.applyEntry(samEntry(h.controller));
+
+      expect(h.controller.error, isNull,
+          reason: 'the writes to Smartschool and Office 365 really happened');
+      expect(
+          (await h.linkedStore.readSyncState()).generation, before.generation);
       expect(h.controller.syncState.generation, before.generation,
-          reason: 'the session must stay behind the store, never ahead of it');
-      expect((await stored3C()).pendingCount, 1,
-          reason: 'the stored view stays pre-apply until someone syncs (#254)');
+          reason: 'never ahead of the store');
+      expect((await stored3C(h))!.pendingCount, 1);
       expect(klas3C(h.controller).pendingCount, 0,
-          reason: '…while this session already reads the corrected count');
+          reason: "#236's local correction still stands for this session");
+      expect(
+        h.log.entries.map((e) => e.message),
+        contains(contains('mieke@school')),
+      );
+    });
+
+    test('a failing write-back is logged and never fails the pass (#254)',
+        () async {
+      final failing = StallingLinkedStore(failWith: StateError('cosmos down'));
+      final h = ReconcileHarness(controllerStore: failing);
+      await h.controller.sync();
+
+      await h.controller.applyAll();
+
+      expect(failing.appliedWriteAttempted, isTrue);
+      expect(h.controller.phase, ReconcilePhase.ready);
+      expect(h.controller.error, isNull,
+          reason: 'the connector writes succeeded; only the share failed');
+      expect(
+        h.log.entries.map((e) => e.message),
+        contains(contains('gedeelde overzicht')),
+      );
+    });
+
+    test(
+        'a stalled write-back times out and the pass still reaches ready '
+        '(#254)', () async {
+      final stalling = StallingLinkedStore();
+      final h = ReconcileHarness(
+        controllerStore: stalling,
+        persistTimeout: const Duration(milliseconds: 50),
+      );
+      await h.controller.sync();
+
+      await h.controller.applyAll();
+
+      expect(stalling.appliedWriteAttempted, isTrue);
+      expect(h.controller.phase, ReconcilePhase.ready);
+      expect(
+        h.log.entries.map((e) => e.message),
+        contains(contains('gedeelde overzicht')),
+      );
+    });
+
+    test(
+        'an operator decision on a touched account survives the write-back '
+        '(#254)', () async {
+      // The derived documents are replaced wholesale, so a decision the store
+      // holds for exactly the account a pass touched would be silently stripped
+      // if the patch did not re-attach it — the very clobber decisions live in
+      // their own documents to avoid.
+      final h = appliedClassWorkHarness();
+      await h.controller.sync();
+      final entry = samEntry(h.controller);
+      final decision = AccountDecision(
+        accountId: core.LinkedAccountId(entry.targetId),
+        kind: DecisionKind.acceptedDuplicate,
+        targetKind: 'duplicate-mail',
+        decidedBy: 'mieke@school',
+        decidedAt: kFixtureDate,
+      );
+      await h.linkedStore.putDecision(decision);
+
+      await h.controller.applyEntry(entry);
+
+      expect(await h.linkedStore.readDecisions(), hasLength(1),
+          reason: 'the decision document itself is never touched here');
     });
 
     test('informational group actions are listed but never applied', () async {
@@ -1723,6 +1884,188 @@ void main() {
         h.log.entries.map((e) => e.message),
         contains(contains('Could not publish a change signal')),
       );
+    });
+  });
+
+  group('an apply reaches the other operators (#254)', () {
+    /// 3C's node as [c] currently renders it, or null when the tree no longer
+    /// carries the class at all.
+    Rollup? klas3C(ReconcileController c) {
+      for (final school in c.studentRollups) {
+        for (final klas in c.studentChildrenOf(school)) {
+          if (klas.classroom == '3C') return klas;
+        }
+      }
+      return null;
+    }
+
+    test(
+        'a passive session catches up from the signal alone — no sync, no pull',
+        () async {
+      // The bug, at the level it is actually felt: operator B keeps being
+      // offered work operator A already applied, until *somebody* runs a full
+      // Synchroniseer. Two sessions, one shared store, one realtime hub.
+      final hub = InMemorySignalHub();
+      final snapshots = InMemorySnapshotStore();
+      final linkedStore = InMemoryLinkedStore();
+      final a = appliedClassWorkHarness(
+        store: snapshots,
+        linkedStore: linkedStore,
+        hub: hub,
+      );
+      await a.controller.sync();
+
+      final b = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+        hub: hub,
+      );
+      await b.controller.loadOverview();
+      expect(klas3C(b.controller)?.pendingCount, 1,
+          reason: "B is offered Sam's stale Office 365 name");
+
+      // A applies it. B is told, and refetches the changed shard.
+      final entry =
+          a.controller.pendingEntries.singleWhere((e) => e.family == 'student');
+      await a.controller.applyEntry(entry);
+      await pumpEventQueue();
+
+      expect(b.controller.syncState.generation, 2);
+      expect(klas3C(b.controller)?.pendingCount, 0,
+          reason: 'B used to keep offering it until someone re-synced');
+      expect(b.wisaSyncs, 0, reason: 'the nudge never triggers a pull');
+      expect(b.ssSyncs, 0);
+      expect(b.azSyncs, 0);
+    });
+
+    test("a passive session's open classroom drops the applied entry",
+        () async {
+      // The drill-down is read from the per-account documents, not the rollups,
+      // so the write-back has to move both or B opens 3C and still sees the
+      // work on the card.
+      final hub = InMemorySignalHub();
+      final snapshots = InMemorySnapshotStore();
+      final linkedStore = InMemoryLinkedStore();
+      final a = appliedClassWorkHarness(
+        store: snapshots,
+        linkedStore: linkedStore,
+        hub: hub,
+      );
+      await a.controller.sync();
+
+      final b = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+        hub: hub,
+      );
+      await b.controller.loadOverview();
+      await b.controller.openClassroom(klas3C(b.controller)!);
+      expect(
+        b.controller.classroomAccounts!
+            .expand((acc) => acc.candidates)
+            .where((c) => c.canApply),
+        hasLength(1),
+      );
+
+      await a.controller.applyEntry(a.controller.pendingEntries
+          .singleWhere((e) => e.family == 'student'));
+      await pumpEventQueue();
+
+      expect(
+        b.controller.classroomAccounts!.expand((acc) => acc.candidates),
+        isEmpty,
+        reason: 'the open drill-down followed the shard it was told about',
+      );
+    });
+
+    test('the apply broadcasts the classroom it changed, not the whole view',
+        () async {
+      final hub = InMemorySignalHub();
+      final h = appliedClassWorkHarness(hub: hub);
+      await h.controller.sync();
+      final before = hub.published.length;
+
+      await h.controller.applyEntry(
+        h.controller.pendingEntries.singleWhere((e) => e.family == 'student'),
+      );
+
+      final published = hub.published.sublist(before);
+      expect(published.map((s) => s.kind), [ChangeSignalKind.viewChanged],
+          reason: 'an apply takes no lease, so it opens and closes nothing');
+      final signal = published.single;
+      expect(signal.generation, 2);
+      expect(signal.shard?.school, '1');
+      expect(signal.shard?.classroom, '3C');
+      expect(signal.shard?.accountId, isNotNull,
+          reason: 'a one-row apply can name the very account it wrote');
+    });
+
+    test('a shard rules an unrelated open classroom out of the refetch',
+        () async {
+      // What the shard is for: a session with 3D open is told about a change in
+      // 3C, and does not pay for a drill-down read it can prove is pointless.
+      final snapshots = InMemorySnapshotStore();
+      final linkedStore = InMemoryLinkedStore();
+      await appliedClassWorkHarness(store: snapshots, linkedStore: linkedStore)
+          .controller
+          .sync();
+
+      final b = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      await b.controller.loadOverview();
+      final threeD = b.controller.studentRollups
+          .expand(b.controller.studentChildrenOf)
+          .singleWhere((r) => r.classroom == '3D');
+      await b.controller.openClassroom(threeD);
+      final opened = b.controller.classroomAccounts;
+
+      await b.controller.onStoreChanged(
+        99,
+        shard: const ShardRef(school: '1', classroom: '3C'),
+      );
+
+      expect(b.controller.syncState.generation, 1,
+          reason: 'the overview itself is always re-read');
+      expect(identical(b.controller.classroomAccounts, opened), isTrue,
+          reason: '3D was never re-read — the shard ruled it out');
+
+      // …while a shard that cannot rule it out does re-read it.
+      await b.controller.onStoreChanged(
+        100,
+        shard: const ShardRef(school: '1'),
+      );
+      expect(identical(b.controller.classroomAccounts, opened), isFalse);
+    });
+
+    test('a class-group apply reaches the stored group document', () async {
+      // A group entry is keyed by the class's display name, the document by the
+      // materializer's namespaced `group|<name>`. Cross that wrong and the patch
+      // writes a document nothing reads.
+      final h = appliedClassWorkHarness();
+      await h.controller.sync();
+      final entry =
+          h.controller.pendingEntries.firstWhere((e) => e.family == 'group');
+      final id = materializedGroupId(entry.targetId);
+      expect(
+        (await h.linkedStore.readGroups())
+            .singleWhere((g) => g.id.value == id)
+            .candidates,
+        isNotEmpty,
+      );
+
+      await h.controller.applyEntry(entry);
+
+      final stored = (await h.linkedStore.readGroups())
+          .singleWhere((g) => g.id.value == id);
+      expect(stored.hasPending, isFalse,
+          reason: 'the very document the Klasgroepen tab reads has moved');
+      expect(
+          (await h.linkedStore.readRollups())
+              .singleWhere((r) => r.level == RollupLevel.groups)
+              .pendingCount,
+          lessThan(4));
     });
   });
 

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -973,11 +973,23 @@ ReconcileHarness twoSchoolHarness() => ReconcileHarness(
 ///
 /// [applyGate] is awaited before every action, as everywhere else — a test that
 /// needs one write refused throws from it on the call it picks.
+///
+/// [store] / [linkedStore] / [hub] are forwarded so a second session can be
+/// resumed over the same shared state and the same realtime fan-out — what the
+/// post-apply write-back is *for* (#254).
 ReconcileHarness appliedClassWorkHarness({
   Future<void> Function()? applyGate,
+  SnapshotStore? store,
+  InMemoryLinkedStore? linkedStore,
+  InMemorySignalHub? hub,
+  String syncedBy = 'operator@school.example',
 }) =>
     ReconcileHarness(
       applyGate: applyGate,
+      store: store,
+      linkedStore: linkedStore,
+      hub: hub,
+      syncedBy: syncedBy,
       wisa: wisaSnap(
         students: [
           wisaStudent(
@@ -1928,20 +1940,24 @@ class InMemorySnapshotStore implements SnapshotStore {
   }
 }
 
-/// A [LinkedStore] whose [writeMaterialized] never completes (a hung Cosmos
-/// write) or throws, while every read delegates to an inner [InMemoryLinkedStore]
-/// — the persist-stall the reconcile controller must survive (#168).
+/// A [LinkedStore] whose **writes** never complete (a hung Cosmos write) or
+/// throw, while every read delegates to an inner [InMemoryLinkedStore] — the
+/// persist-stall the reconcile controller must survive (#168), and since #254
+/// the same for the narrow post-apply write-back.
 class StallingLinkedStore implements LinkedStore {
   StallingLinkedStore({InMemoryLinkedStore? inner, this.failWith})
       : _in = inner ?? InMemoryLinkedStore();
 
   final InMemoryLinkedStore _in;
 
-  /// When set, [writeMaterialized] throws this instead of hanging.
+  /// When set, a write throws this instead of hanging.
   final Object? failWith;
 
   /// True once a write was attempted — proves the controller reached persist.
   bool writeAttempted = false;
+
+  /// True once the post-apply write-back was attempted (#254).
+  bool appliedWriteAttempted = false;
 
   @override
   Future<void> writeMaterialized(
@@ -1953,10 +1969,24 @@ class StallingLinkedStore implements LinkedStore {
     void Function(String message)? onProgress,
   }) {
     writeAttempted = true;
+    return _stall<void>();
+  }
+
+  @override
+  Future<AppliedWrite> writeApplied(
+    AppliedPatch patch, {
+    required String appliedBy,
+    required DateTime at,
+  }) {
+    appliedWriteAttempted = true;
+    return _stall<AppliedWrite>();
+  }
+
+  Future<T> _stall<T>() {
     final fail = failWith;
-    if (fail != null) return Future<void>.error(fail);
+    if (fail != null) return Future<T>.error(fail);
     // Never completes: models a wedged store write the controller must time out.
-    return Completer<void>().future;
+    return Completer<T>().future;
   }
 
   @override

--- a/account_manager/test/reconcile/reconcile_live_settings_test.dart
+++ b/account_manager/test/reconcile/reconcile_live_settings_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
 import 'package:account_state/account_state.dart';
@@ -524,10 +526,10 @@ void main() {
     test('the Smartschool import rules are read at pull time', () async {
       // #241 authored them; before #246 the pull closed over the bootstrap
       // document, so a rule saved in Instellingen pruned nothing until the next
-      // launch. The pass that adopts it is **Check for drift** — the one that
-      // re-reads Smartschool at all (#99's smart sync leaves it alone once this
-      // session has it) — and a rule change never arms #238's WISA gate, so
-      // drift is offered.
+      // launch. Check for drift re-reads Smartschool unconditionally, so it is
+      // one of the two passes that adopt a rule — and a rule change never arms
+      // #238's WISA gate, so drift is offered. (Since #259 Synchroniseer adopts
+      // it too; that is the group below.)
       final wire = GroupTreeSoap();
       final live = LiveSettings(_settings());
       final harness =
@@ -593,6 +595,184 @@ void main() {
       ]));
 
       expect(harness.controller.schoolProfiles.single.code, 'ISMAA');
+    });
+  });
+
+  group('Synchroniseer re-pulls a system whose settings moved (#259)', () {
+    test('a saved import rule prunes the very next Synchroniseer', () async {
+      // The reported bug. #99's smart sync leaves a system this session already
+      // holds alone, so the operator saved a `DiscardSmartschoolGroup`, pressed
+      // Synchroniseer, and got "geen accountwijzigingen nodig" — over the very
+      // save it had skipped. Only Check for drift adopted it, and nothing said
+      // so.
+      final wire = GroupTreeSoap();
+      final live = LiveSettings(_settings());
+      final harness =
+          ReconcileHarness(smartschoolTransport: wire, liveSettings: live);
+
+      await harness.controller.sync();
+      expect(harness.ssSyncs, 1);
+      expect(
+        harness.app.smartschool.snapshot?.groups.map((g) => g.id.value),
+        <String>['SCH', 'ORG', 'HID', 'KLA', 'C1A'],
+      );
+
+      live.publish(_settings().copyWith(
+        smartschoolRules: const <ss.SmartschoolImportRule>[
+          ss.DiscardSmartschoolGroup('Organisatie'),
+        ],
+      ));
+      await harness.controller.sync();
+
+      expect(
+        harness.app.smartschool.snapshot?.groups.map((g) => g.id.value),
+        <String>['SCH', 'KLA', 'C1A'],
+        reason: 'the pass the operator reached for applied the saved rule',
+      );
+      expect(harness.ssSyncs, 2);
+      // …and it did not claim there was nothing to do, which is the
+      // user-visible half of the bug.
+      expect(harness.controller.noChangesNeeded, isFalse);
+      expect(
+        harness.log.entries
+            .map((e) => e.message)
+            .where((m) => m.contains('geen accountwijzigingen nodig')),
+        isEmpty,
+      );
+      // The re-pull says why it happened, in the panel the operator reads.
+      expect(
+        harness.log.entries.map((e) => e.message),
+        contains('Smartschool-instellingen gewijzigd — Smartschool wordt '
+            'opnieuw opgehaald.'),
+      );
+    });
+
+    test('a saved school prefix re-scopes the very next Synchroniseer',
+        () async {
+      final wire = RecordingGraph();
+      final live = LiveSettings(_settings());
+      final harness =
+          ReconcileHarness(azureTransport: wire, liveSettings: live);
+
+      await harness.controller.sync();
+      expect(_userFilters(wire).last, contains('GBS'));
+
+      live.publish(_settings().copyWith(schoolPrefix: 'SSM'));
+      await harness.controller.sync();
+
+      expect(_userFilters(wire).last, contains('SSM'),
+          reason: 'no drift check needed, and no relaunch');
+      expect(harness.azSyncs, 2);
+      expect(harness.controller.noChangesNeeded, isFalse);
+    });
+
+    test('the smart sync still skips a system nothing asked for', () async {
+      // The behaviour #99 exists for has to survive: an unchanged WISA and an
+      // untouched settings document is still "nothing to do", with no re-pull
+      // of the two systems this session already holds.
+      final harness = ReconcileHarness(liveSettings: LiveSettings(_settings()));
+      await harness.controller.sync();
+      expect((harness.ssSyncs, harness.azSyncs), (1, 1));
+
+      await harness.controller.sync();
+
+      expect((harness.ssSyncs, harness.azSyncs), (1, 1));
+      expect(harness.controller.noChangesNeeded, isTrue);
+    });
+
+    test('a WISA-only save leaves Smartschool and Azure alone', () async {
+      // The fingerprints are per system on purpose: a werkdatum is a WISA pull
+      // input and must not cost a Smartschool read or a full tenant re-read.
+      final live = LiveSettings(_settings());
+      final harness = ReconcileHarness(liveSettings: live);
+      await harness.controller.sync();
+
+      live.publish(_settings(workDate: _pinned(DateTime(2026, 9, 1))));
+
+      expect(harness.controller.systemsAwaitingSettings, isEmpty);
+      expect(harness.controller.pendingSettingsReason, isNull);
+      await harness.controller.sync();
+      expect((harness.ssSyncs, harness.azSyncs), (1, 1));
+    });
+
+    test('the screen names the systems waiting, until a pass applies them',
+        () async {
+      final live = LiveSettings(_settings());
+      final harness = ReconcileHarness(liveSettings: live);
+      await harness.controller.sync();
+      expect(harness.controller.pendingSettingsReason, isNull);
+
+      live.publish(_settings().copyWith(
+        schoolPrefix: 'SSM',
+        smartschoolRules: const <ss.SmartschoolImportRule>[
+          ss.DiscardSmartschoolGroup('Organisatie'),
+        ],
+      ));
+
+      expect(
+        harness.controller.systemsAwaitingSettings,
+        <core.Origin>{core.Origin.smartschool, core.Origin.azure},
+      );
+      expect(
+        harness.controller.pendingSettingsReason,
+        'Instellingen voor Smartschool en Azure AD gewijzigd — '
+        'synchroniseer om ze toe te passen.',
+      );
+      // Nothing is refused meanwhile — the next pass adopts them by itself.
+      expect(harness.controller.canCheckDrift, isTrue);
+
+      await harness.controller.sync();
+      expect(harness.controller.pendingSettingsReason, isNull);
+    });
+
+    test('a drift check clears it too, so no sync re-pulls for it twice',
+        () async {
+      // Drift re-reads both systems unconditionally, so it really has adopted
+      // the save; the stamp has to record that or the next Synchroniseer would
+      // pay for a change already applied.
+      final live = LiveSettings(_settings());
+      final harness = ReconcileHarness(liveSettings: live);
+      await harness.controller.sync();
+
+      live.publish(_settings().copyWith(schoolPrefix: 'SSM'));
+      expect(harness.controller.pendingSettingsReason, isNotNull);
+
+      await harness.controller.checkDrift();
+      expect(harness.controller.pendingSettingsReason, isNull);
+      expect(harness.azSyncs, 2);
+
+      await harness.controller.sync();
+      expect(harness.azSyncs, 2, reason: 'the drift pass already applied it');
+    });
+
+    test('a save landing mid-pull stays pending rather than being credited',
+        () async {
+      // The stamp names the settings the pull *started* with, exactly as #238's
+      // WISA one does — a document published while Smartschool was on the wire
+      // was never asked for.
+      final live = LiveSettings(_settings());
+      final gate = Completer<void>();
+      final harness = ReconcileHarness(liveSettings: live, azureGate: gate);
+
+      final pass = harness.controller.sync();
+      await Future<void>.delayed(Duration.zero);
+      live.publish(_settings().copyWith(schoolPrefix: 'SSM'));
+      gate.complete();
+      await pass;
+
+      expect(
+        harness.controller.systemsAwaitingSettings,
+        contains(core.Origin.azure),
+        reason: 'the pull that was already in flight never saw the save',
+      );
+    });
+
+    test('a harness with no settings holder never arms it', () async {
+      final harness = ReconcileHarness();
+      await harness.controller.sync();
+
+      expect(harness.controller.systemsAwaitingSettings, isEmpty);
+      expect(harness.controller.pendingSettingsReason, isNull);
     });
   });
 

--- a/account_manager/test/reconcile/reconcile_live_settings_test.dart
+++ b/account_manager/test/reconcile/reconcile_live_settings_test.dart
@@ -202,7 +202,7 @@ void main() {
       expect(wire.werkdatums, <String>['01/09/2025']);
       expect(
         harness.log.entries.map((e) => e.message),
-        contains('Pulling WISA with werkdatum 01/09/2025.'),
+        contains('WISA ophalen met werkdatum 01/09/2025.'),
       );
     });
 
@@ -221,7 +221,7 @@ void main() {
       expect(
         harness.log.entries.map((e) => e.message),
         // The harness clock is fixed at kFixtureDate (2026-07-01).
-        contains('Pulling WISA with werkdatum 01/07/2026.'),
+        contains('WISA ophalen met werkdatum 01/07/2026.'),
       );
     });
 
@@ -245,8 +245,8 @@ void main() {
       expect(wire.werkdatums, <String>['01/09/2026', '01/10/2026']);
       expect(
         harness.log.entries.map((e) => e.message),
-        contains('Pulling WISA with werkdatum 01/09/2026; virtuele werkdatum '
-            '01/10/2026 for V.'),
+        contains('WISA ophalen met werkdatum 01/09/2026; virtuele werkdatum '
+            '01/10/2026 voor V.'),
       );
     });
 
@@ -266,7 +266,7 @@ void main() {
       await harness.controller.sync();
 
       final messages = harness.log.entries.map((e) => e.message);
-      expect(messages, contains('Pulling WISA with werkdatum 01/09/2026.'));
+      expect(messages, contains('WISA ophalen met werkdatum 01/09/2026.'));
       expect(messages.where((m) => m.contains('virtuele werkdatum')), isEmpty);
     });
 
@@ -281,8 +281,8 @@ void main() {
           workDate: DateTime(2026, 9, 1),
           virtualWorkDate: DateTime(2026, 10, 1),
         ),
-        'Pulling WISA with werkdatum 01/09/2026; virtuele werkdatum '
-        '01/10/2026 for Virtuele school, school 8.',
+        'WISA ophalen met werkdatum 01/09/2026; virtuele werkdatum '
+        '01/10/2026 voor Virtuele school, school 8.',
       );
     });
   });

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -498,7 +498,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
     expect(
-      find.textContaining('Syncing WISA', skipOffstage: false),
+      find.textContaining('WISA ophalen', skipOffstage: false),
       findsOneWidget,
     );
 

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -29,7 +29,7 @@ void main() {
     await tester.pumpWidget(_wrap(const ReconcileScreen(bootstrap: null)));
     await tester.pumpAndSettle();
 
-    expect(find.text('Not configured'), findsOneWidget);
+    expect(find.text('Niet geconfigureerd'), findsOneWidget);
     expect(find.byKey(const ValueKey('reconcile-sync')), findsNothing);
   });
 
@@ -52,7 +52,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text('Could not prepare the reconcile screen'),
+      find.text('Kan het Synchronisatie-scherm niet openen'),
       findsOneWidget,
     );
     expect(find.textContaining('wisa.password'), findsOneWidget);
@@ -72,12 +72,12 @@ void main() {
     )));
     await tester.pumpAndSettle();
 
-    expect(find.textContaining('(Attempt'), findsNothing);
+    expect(find.textContaining('(Poging'), findsNothing);
 
     await tester.tap(find.byKey(const ValueKey('reconcile-bootstrap-retry')));
     await tester.pumpAndSettle();
 
-    expect(find.textContaining('(Attempt 2 failed.)'), findsOneWidget);
+    expect(find.textContaining('(Poging 2 mislukt.)'), findsOneWidget);
   });
 
   testWidgets(
@@ -207,10 +207,11 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    // The freshness now renders as a dedicated box headed "Last sync", with one
-    // row per system rather than a run-on line (#188).
+    // The freshness now renders as a dedicated box headed "Laatste
+    // synchronisatie", with one row per system rather than a run-on line
+    // (#188).
     expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
-    expect(find.text('Last sync'), findsOneWidget);
+    expect(find.text('Laatste synchronisatie'), findsOneWidget);
     expect(
         find.byKey(const ValueKey('reconcile-last-sync-wisa')), findsOneWidget);
     expect(find.byKey(const ValueKey('reconcile-last-sync-smartschool')),
@@ -221,7 +222,7 @@ void main() {
     expect(find.text('Smartschool'), findsOneWidget);
     expect(find.text('Azure'), findsOneWidget);
     // Each row names the operator who last synced it.
-    expect(find.textContaining('by operator@school.example'), findsWidgets);
+    expect(find.textContaining('door operator@school.example'), findsWidgets);
   });
 
   testWidgets(
@@ -259,10 +260,10 @@ void main() {
 
     // WISA is the sync; Smartschool and Azure are drift checks — each on its
     // own row, no longer packed into one wrapped sentence.
-    expect(rowText('wisa'), contains('sync'));
-    expect(rowText('wisa'), isNot(contains('drift check')));
-    expect(rowText('smartschool'), contains('drift check'));
-    expect(rowText('azure'), contains('drift check'));
+    expect(rowText('wisa'), contains('synchronisatie'));
+    expect(rowText('wisa'), isNot(contains('driftcontrole')));
+    expect(rowText('smartschool'), contains('driftcontrole'));
+    expect(rowText('azure'), contains('driftcontrole'));
   });
 
   testWidgets(
@@ -300,7 +301,7 @@ void main() {
         .join(' ');
 
     // Today: unchanged, still the short time-only form.
-    expect(rowText('wisa'), contains('sync · 09:14'));
+    expect(rowText('wisa'), contains('synchronisatie · 09:14'));
     expect(rowText('wisa'), isNot(contains('/')));
     expect(rowText('wisa'), isNot(contains('gisteren')));
 
@@ -308,7 +309,7 @@ void main() {
     expect(rowText('smartschool'), contains('gisteren 08:05'));
     expect(rowText('azure'), contains('15/08/${now.year - 1} 16:40'));
     // …and the operator is still named on every row.
-    expect(rowText('azure'), contains('by operator@school.example'));
+    expect(rowText('azure'), contains('door operator@school.example'));
   });
 
   testWidgets('the last-sync box survives a restart / passive session (#162)',
@@ -326,10 +327,10 @@ void main() {
 
     expect(passive.wisaSyncs, 0, reason: 'a passive session pulls nothing');
     expect(find.byKey(const ValueKey('reconcile-last-sync')), findsOneWidget);
-    expect(find.text('Last sync'), findsOneWidget);
+    expect(find.text('Laatste synchronisatie'), findsOneWidget);
     expect(
         find.byKey(const ValueKey('reconcile-last-sync-wisa')), findsOneWidget);
-    expect(find.textContaining('by operator@school.example'), findsWidgets);
+    expect(find.textContaining('door operator@school.example'), findsWidgets);
   });
 
   testWidgets(

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -572,10 +572,12 @@ void main() {
       harness.controller.totalPendingCount,
     );
 
-    // Default tab = Leerlingen: the merged grade-year is the drill root (#210)
-    // and the class-groups node shows; the staff ("Personeel") node does not.
+    // Default tab = Leerlingen: the merged grade-year is the drill root (#210);
+    // the staff ("Personeel") node does not show. Neither does a class-groups
+    // node — since #227 the classes are a top-level tab of their own, so this
+    // tree carries accounts only.
     expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
-    expect(find.byKey(const ValueKey('rollup-groups')), findsWidgets);
+    expect(find.byKey(const ValueKey('rollup-groups')), findsNothing);
     expect(
         find.byKey(const ValueKey('rollup-school-school|staff')), findsNothing);
 
@@ -1174,75 +1176,6 @@ void main() {
   });
 
   testWidgets(
-      'the Klasgroepen drill-down proposes only classes of the schools we '
-      'manage, and describes ours rather than the sibling class that shares '
-      'its name (#205)', (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final harness = foreignClassGroupHarness();
-    await harness.controller.sync();
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
-
-    // Our own populated class is the one and only proposal… and it reads as
-    // the create side of the either/or choice #244 collapsed it into.
-    expect(find.text('1A'), findsOneWidget);
-    expect(find.text('Voeg deze klas toe aan Smartschool (keuze)'),
-        findsOneWidget);
-    // …and the sibling school's class is never offered: applying it would
-    // create another school's class in our Smartschool.
-    expect(find.text('9Z'), findsNothing);
-
-    // Expanding it shows *our* class's data — the sibling `1A` used to arrive
-    // first and shadow ours, so the proposal described the wrong class.
-    await tester.tap(find.byKey(const ValueKey('entry-group-1A')));
-    await tester.pumpAndSettle();
-    expect(find.textContaining('Onze eerste klas'), findsOneWidget);
-    expect(find.textContaining('Klas van een andere school'), findsNothing);
-  });
-
-  testWidgets(
-      'a passive session surfaces the Klasgroepen node and opens the group '
-      'detail (#119/#154)', (WidgetTester tester) async {
-    // Tall, like its siblings: the top-level filter switch #226 added above the
-    // family tab bar costs the group tiles their place on an 800×600 fold, and
-    // this test is about which node opened, not about where the fold falls.
-    _useTallWindow(tester);
-    final snapshots = InMemorySnapshotStore();
-    final linkedStore = InMemoryLinkedStore();
-    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
-        .controller
-        .sync();
-
-    final s2 = await ReconcileHarness.resume(
-      store: snapshots,
-      linkedStore: linkedStore,
-    );
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: s2.bootstrap)));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const ValueKey('rollup-groups')), findsOneWidget);
-    expect(find.text('Klasgroepen'), findsWidgets);
-
-    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
-    expect(find.text('2B'), findsWidgets);
-    expect(
-        find.textContaining('Deze klas bestaat in Smartschool'), findsWidgets);
-    expect(s2.controller.linked, isNull);
-
-    await tester.tap(find.byKey(const ValueKey('actions-groups-back')));
-    await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-groups')), findsOneWidget);
-  });
-
-  testWidgets(
       'a read-only session badges an either/or once and lists it as the one '
       'choice it is (#251)', (WidgetTester tester) async {
     // A passive session over a departed student's stored doc: it carries the
@@ -1537,34 +1470,6 @@ void main() {
       Theme.of(tester.element(readOnly)).disabledColor,
       reason: 'a summary nobody can act on is not rendered as live body text',
     );
-  });
-
-  testWidgets(
-      'the passive Klasgroepen drill-down carries the same read-only '
-      'announcement (#214)', (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final snapshots = InMemorySnapshotStore();
-    final linkedStore = InMemoryLinkedStore();
-    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
-        .controller
-        .sync();
-
-    final s2 = await ReconcileHarness.resume(
-      store: snapshots,
-      linkedStore: linkedStore,
-    );
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: s2.bootstrap)));
-    await tester.pumpAndSettle();
-
-    await tester.ensureVisible(find.byKey(const ValueKey('rollup-groups')));
-    await tester.tap(find.byKey(const ValueKey('rollup-groups')));
-    await tester.pumpAndSettle();
-
-    expect(s2.controller.linked, isNull);
-    expect(find.byKey(const ValueKey('actions-groups-back')), findsOneWidget);
-    expect(readOnly, findsOneWidget,
-        reason: 'the group drill-down falls back to the same static tiles');
-    expect(find.byIcon(Icons.lock_outline), findsWidgets);
   });
 
   testWidgets(

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -1,0 +1,248 @@
+import 'package:account_manager/src/screens/class_groups_screen.dart';
+import 'package:account_state/account_state.dart' show InMemoryLinkedStore;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../reconcile/reconcile_fakes.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+/// A tall viewport so the whole inventory lays out without the assertions
+/// tripping on the fold.
+void _useTallWindow(WidgetTester tester) {
+  tester.view.physicalSize = const Size(1000, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+final Finder _readOnly = find.byKey(const ValueKey('class-groups-read-only'));
+final Finder _filter =
+    find.byKey(const ValueKey('class-groups-only-attention'));
+
+void main() {
+  testWidgets('shows the not-configured panel when AAD is absent, in Dutch',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_wrap(const ClassGroupsScreen(bootstrap: null)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Niet geconfigureerd'), findsOneWidget);
+    expect(_filter, findsNothing);
+  });
+
+  testWidgets('a failed bootstrap offers a retry, in Dutch',
+      (WidgetTester tester) async {
+    var attempts = 0;
+    await tester.pumpWidget(_wrap(ClassGroupsScreen(bootstrap: () async {
+      attempts++;
+      if (attempts == 1) throw StateError('geen verbinding');
+      return ReconcileHarness().bootstrap();
+    })));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Kan het Klasgroepen-scherm niet openen'), findsOneWidget);
+    await tester
+        .tap(find.byKey(const ValueKey('class-groups-bootstrap-retry')));
+    await tester.pumpAndSettle();
+
+    expect(attempts, 2);
+    expect(find.text('Klasgroepen'), findsOneWidget);
+  });
+
+  testWidgets(
+      'the inventory lists every class, not only the ones with work (#227)',
+      (WidgetTester tester) async {
+    // The fixture: `1A` is correct in all three systems, the sub-grouped `2F`
+    // (`2F ECO` + `2F MAW`) has no Office 365 group, and `GBS-9Z` is the group
+    // of a class that no longer exists.
+    _useTallWindow(tester);
+    final harness = azureClassGroupHarness(withStaleGroup: true);
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // Every class is a row — including `1A`, which raises nothing at all and so
+    // had no document whatsoever before this issue.
+    expect(find.byKey(const ValueKey('class-row-1A')), findsOneWidget);
+    expect(find.byKey(const ValueKey('class-row-2F MAW')), findsOneWidget);
+    expect(find.byKey(const ValueKey('class-row-2F ECO')), findsOneWidget);
+    expect(find.byKey(const ValueKey('class-row-GBS-9Z')), findsOneWidget);
+    // A class with work carries the interactive tile inside its row, keyed the
+    // way the Acties entry tiles are — so it is inspected and applied here.
+    expect(find.byKey(const ValueKey('entry-group-2F ECO')), findsOneWidget);
+    expect(find.byKey(const ValueKey('entry-group-GBS-9Z')), findsOneWidget);
+    expect(find.byKey(const ValueKey('entry-group-1A')), findsNothing,
+        reason: 'nothing is wrong with 1A, so there is nothing to act on');
+
+    // The header counts the whole inventory and how much of it needs attention.
+    expect(find.textContaining('4 klas(sen), waarvan 2 aandacht vragen'),
+        findsOneWidget);
+  });
+
+  testWidgets('each row carries three presence columns (#227)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = azureClassGroupHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    final row = find.byKey(const ValueKey('class-row-1A'));
+    for (final system in const ['WISA', 'Smartschool', 'Office 365']) {
+      expect(
+        find.descendant(of: row, matching: find.text(system)),
+        findsOneWidget,
+      );
+    }
+    // A class that is right everywhere reads as three ticks and its group name.
+    expect(
+      find.descendant(
+          of: row, matching: find.byIcon(Icons.check_circle_outline)),
+      findsNWidgets(3),
+    );
+    expect(find.descendant(of: row, matching: find.text('GBS-1A')),
+        findsOneWidget);
+    expect(find.descendant(of: row, matching: find.text('Eerste jaar A')),
+        findsOneWidget);
+  });
+
+  testWidgets(
+      "a sub-group names the parent class's Office 365 group rather than one of "
+      'its own (#227/#228)', (WidgetTester tester) async {
+    // `2F ECO` and `2F MAW` are sub-groups of `2F`, and sub-groups get no group
+    // of their own: both rows are served by the single `GBS-2F`. Four rows each
+    // looking like they own a group is exactly what the issue asked us not to
+    // show.
+    _useTallWindow(tester);
+    final harness = azureClassGroupHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('deelgroep van 2F'), findsNWidgets(2));
+    expect(find.text('nog geen groep voor 2F'), findsNWidgets(2));
+    // `1A` owns its group, so it is not anybody's sub-group.
+    expect(find.textContaining('deelgroep van 1A'), findsNothing);
+  });
+
+  testWidgets(
+      'the attention filter is off by default and hides the classes that are '
+      'in order when switched on (#227)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = azureClassGroupHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<Switch>(_filter).value, isFalse,
+        reason: "this tab's job is the full picture");
+    expect(find.byKey(const ValueKey('class-row-1A')), findsOneWidget);
+
+    await tester.tap(_filter);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('class-row-1A')), findsNothing);
+    expect(find.byKey(const ValueKey('entry-group-2F ECO')), findsOneWidget);
+
+    await tester.tap(_filter);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('class-row-1A')), findsOneWidget);
+  });
+
+  testWidgets(
+      'a class that needs work is inspected and applied without leaving the '
+      'tab (#227)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = azureClassGroupHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    const entry = ValueKey('entry-group-2F ECO');
+    expect(
+      find.descendant(
+        of: find.byKey(entry),
+        matching: find.text('Maak de Office 365-groep GBS-2F voor klas 2F'),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(entry));
+    await tester.pumpAndSettle();
+    final apply = find.byKey(const ValueKey('entry-apply-2F ECO'));
+    await tester.ensureVisible(apply);
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
+    expect(harness.graph.createdGroups, hasLength(1));
+    expect(harness.graph.createdGroups.single['displayName'], 'GBS-2F');
+  });
+
+  testWidgets(
+      'a passive session says it is read-only and renders static rows (#214)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+        .controller
+        .sync();
+
+    final s2 = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(_wrap(ClassGroupsScreen(bootstrap: s2.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(s2.controller.linked, isNull);
+    expect(_readOnly, findsOneWidget);
+    expect(find.text('Alleen-lezen overzicht'), findsOneWidget);
+    expect(find.byIcon(Icons.lock_outline), findsWidgets);
+    // The stored classes are there, with their stored candidates marked exactly
+    // as Acties marks them (#255).
+    expect(find.byKey(const ValueKey('class-row-2B')), findsOneWidget);
+    expect(
+        find.textContaining('Deze klas bestaat in Smartschool'), findsWidgets);
+    expect(find.textContaining('(manueel)'), findsWidgets);
+    // Nothing interactive: a passive session has nothing to apply.
+    expect(find.byKey(const ValueKey('entry-group-2B')), findsNothing);
+  });
+
+  testWidgets(
+      'the inventory holds only classes of the schools we manage, described as '
+      'ours (#205)', (WidgetTester tester) async {
+    // WISA hands this session a sibling school's `1A` and `9Z` first and our own
+    // `1A` last; only school 1 is managed. The sibling `1A` used to shadow ours,
+    // so the proposal described the wrong school's class.
+    _useTallWindow(tester);
+    final harness = foreignClassGroupHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('1A'), findsOneWidget);
+    expect(find.text('9Z'), findsNothing);
+    expect(find.text('Voeg deze klas toe aan Smartschool (keuze)'),
+        findsOneWidget);
+    expect(find.text('Onze eerste klas'), findsOneWidget);
+    expect(find.textContaining('Klas van een andere school'), findsNothing);
+  });
+
+  testWidgets('classes sort by year, numerically (#227)',
+      (WidgetTester tester) async {
+    expect(compareClassNames('2A', '10A'), lessThan(0));
+    expect(compareClassNames('2F', '2F ECO'), lessThan(0));
+    expect(compareClassNames('OKAN', '3C'), greaterThan(0),
+        reason: 'a non-numeric class sorts after every numbered year');
+    expect(compareClassNames('3C', '3c'), 0);
+  });
+}

--- a/account_manager/test/screens/passwords_screen_test.dart
+++ b/account_manager/test/screens/passwords_screen_test.dart
@@ -63,7 +63,7 @@ void main() {
     await tester.pumpWidget(_wrap(const PasswordsScreen(bootstrap: null)));
     await tester.pumpAndSettle();
 
-    expect(find.text('Not configured'), findsOneWidget);
+    expect(find.text('Niet geconfigureerd'), findsOneWidget);
     expect(
         find.byKey(const ValueKey('passwords-tab-leerlingen')), findsNothing);
   });

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -53,7 +53,7 @@ void main() {
     await tester.pumpWidget(_wrap(const SettingsScreen(bootstrap: null)));
     await tester.pumpAndSettle();
 
-    expect(find.text('Not configured'), findsOneWidget);
+    expect(find.text('Niet geconfigureerd'), findsOneWidget);
     expect(find.byKey(const ValueKey('settings-save')), findsNothing);
   });
 

--- a/account_manager/test/widget_test.dart
+++ b/account_manager/test/widget_test.dart
@@ -18,11 +18,12 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // The shell and its single Home destination are present.
+    // The shell and its single Home destination are present, the rail naming
+    // it in the operator's language (#257).
     expect(find.byType(AppShell), findsOneWidget);
     expect(find.byType(HomeScreen), findsOneWidget);
     expect(find.byType(NavigationRail), findsOneWidget);
-    expect(find.text('Home'), findsOneWidget);
+    expect(find.text('Start'), findsOneWidget);
 
     // The per-product accent is layered on the Plink foundations.
     final BuildContext context = tester.element(find.byType(HomeScreen));

--- a/packages/account_state/lib/src/cosmos/cosmos_containers.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_containers.dart
@@ -41,7 +41,7 @@ const List<CosmosContainerSpec> linkedStoreContainers = [
 /// A separate seam from the materialized-view [linkedStoreContainers], but it
 /// shared their 404-on-first-write gap: a never-provisioned snapshots container
 /// surfaced only when the sync tried to persist a fresh snapshot mid-run —
-/// `[smartschool] Snapshot store: CosmosException(404 NotFound)` (#151), the
+/// `[smartschool] Snapshotopslag: CosmosException(404 NotFound)` (#151), the
 /// same failure #150 hit on the operator `decisions` container.
 const List<CosmosContainerSpec> snapshotStoreContainers = [
   CosmosContainerSpec(snapshotsContainer, '/id'),

--- a/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:account_core/account_core.dart' as core;
 import 'package:crypto/crypto.dart';
 
+import '../materialize/linked_state_materializer.dart';
 import '../materialize/linked_store.dart';
 import '../materialize/materialized_state.dart';
 import 'cosmos_client.dart';
@@ -82,6 +83,13 @@ void _writeCanonical(StringBuffer out, Object? value) {
 /// bump — which stays unconditional — is what #116 uses to detect a
 /// mid-flight change); the sync/drift lease (#108) serializes writers so two
 /// rewrites never interleave.
+///
+/// [writeApplied] (#254) is the other write path: an apply's handful of touched
+/// documents plus the rollup nodes above them, run **unleased** and concurrently
+/// with every other operator's apply. It is safe there precisely because it does
+/// none of the above — it stands down for a live sync lease, moves counts by
+/// delta rather than by replacement, and conditions every write on the ETag of
+/// the version it replaces.
 class CosmosLinkedStore implements LinkedStore {
   /// [governor] is the shared throttling state (#196): pass the *same* instance
   /// that was wired into the [CosmosClient], so the fan-out narrows in response
@@ -238,6 +246,241 @@ class CosmosLinkedStore implements LinkedStore {
         ).toJson(),
       },
     );
+  }
+
+  @override
+  Future<AppliedWrite> writeApplied(
+    AppliedPatch patch, {
+    required String appliedBy,
+    required DateTime at,
+  }) async {
+    // Rule 1: stand down for a sync. That pass republishes the whole view from a
+    // fresher link than ours, so a narrow patch must not land on top of it — nor
+    // bump the generation past it (#254).
+    final lease = await readLease(at);
+    if (lease != null && lease.owner != appliedBy) {
+      return AppliedWrite.deferred(lease);
+    }
+    if (patch.isEmpty) return const AppliedWrite.unchanged();
+
+    // Rule 3: every document write is conditioned on the version it replaces, and
+    // that very version is what the delta below is computed against — so a
+    // concurrent writer can never split the pair.
+    final storedAccounts = <MaterializedAccount>[];
+    for (final fresh in patch.accounts) {
+      final before = await _replaceDocument(
+        container: linkedAccountsContainer,
+        id: fresh.id.value,
+        partitionKey: fresh.school,
+        body: fresh.toJson(),
+      );
+      if (before != null) {
+        storedAccounts.add(MaterializedAccount.fromJson(before));
+      }
+    }
+    for (final id in patch.removedAccountIds) {
+      // No partition key to point at: the document is gone from the fresh view,
+      // so where it used to sit is only knowable from the store itself.
+      final before = await _removeDocument(
+        container: linkedAccountsContainer,
+        id: id,
+      );
+      if (before != null) {
+        storedAccounts.add(MaterializedAccount.fromJson(before));
+      }
+    }
+
+    final storedGroups = <MaterializedGroup>[];
+    for (final fresh in patch.groups) {
+      final before = await _replaceDocument(
+        container: linkedGroupsContainer,
+        id: fresh.id.value,
+        partitionKey: groupsPartition,
+        body: fresh.toJson(),
+      );
+      if (before != null) storedGroups.add(MaterializedGroup.fromJson(before));
+    }
+    for (final id in patch.removedGroupIds) {
+      final before = await _removeDocument(
+        container: linkedGroupsContainer,
+        id: id,
+        partitionKey: groupsPartition,
+      );
+      if (before != null) storedGroups.add(MaterializedGroup.fromJson(before));
+    }
+
+    // Rule 2: the rollups move by delta, so two operators clearing different
+    // work in the same class compose instead of overwriting each other.
+    for (final change in rollupChangesFor(
+      storedAccounts: storedAccounts,
+      freshAccounts: patch.accounts,
+      storedGroups: storedGroups,
+      freshGroups: patch.groups,
+    )) {
+      await _adjustRollup(change);
+    }
+
+    // Last, as in [writeMaterialized]: a reader that sees the new generation
+    // also sees the patched documents.
+    return AppliedWrite.written(await _bumpGeneration(appliedBy, at));
+  }
+
+  /// Creates-or-replaces one derived document, returning the document it
+  /// replaced (or `null` when there was none).
+  ///
+  /// Conditioned throughout: an absent document is claimed with an atomic
+  /// create, a present one with an `If-Match` on the ETag just read. A loser
+  /// re-reads and retries — every iteration means some writer committed, so it
+  /// converges, exactly as [putDecision] does. The returned "before" is what the
+  /// caller's rollup delta must be computed against, which is why this returns
+  /// it rather than the caller reading it separately.
+  Future<Map<String, dynamic>?> _replaceDocument({
+    required String container,
+    required String id,
+    required String partitionKey,
+    required Map<String, dynamic> body,
+  }) async {
+    final document = {...body, contentHashField: materializedContentHash(body)};
+    while (true) {
+      final existing = await _client.readDocument(
+        container: container,
+        id: id,
+        partitionKey: partitionKey,
+      );
+      if (existing == null) {
+        final created = await _client.createDocument(
+          container: container,
+          partitionKey: partitionKey,
+          document: document,
+        );
+        if (created) return null;
+        continue; // another writer created it first — condition on theirs
+      }
+      final outcome = await _client.upsertDocument(
+        container: container,
+        partitionKey: partitionKey,
+        document: document,
+        ifMatch: existing['_etag'] as String?,
+      );
+      if (outcome.applied) return existing;
+    }
+  }
+
+  /// Deletes one derived document, returning what it held (or `null` when it was
+  /// already gone). With no [partitionKey] the document is located by a
+  /// cross-partition read on its id — the case where the fresh view no longer
+  /// says where it used to sit.
+  Future<Map<String, dynamic>?> _removeDocument({
+    required String container,
+    required String id,
+    String? partitionKey,
+  }) async {
+    Map<String, dynamic>? existing;
+    if (partitionKey != null) {
+      existing = await _client.readDocument(
+        container: container,
+        id: id,
+        partitionKey: partitionKey,
+      );
+    } else {
+      final found = await _client.queryDocuments(
+        container: container,
+        query: 'SELECT * FROM c WHERE c.id = @id',
+        parameters: {'@id': id},
+      );
+      existing = found.isEmpty ? null : found.first;
+    }
+    if (existing == null) return null;
+    await _client.deleteDocument(
+      container: container,
+      id: id,
+      partitionKey: partitionKey ?? (existing['pk'] as String?) ?? id,
+    );
+    return existing;
+  }
+
+  /// Folds one [RollupChange] into the node the store currently holds, under the
+  /// same ETag discipline as the documents beneath it: a losing write re-reads
+  /// the winner's node and adds its delta on top, so concurrent applies to one
+  /// class accumulate rather than clobber. A node left with no documents is
+  /// deleted — the sync path would not emit it either.
+  Future<void> _adjustRollup(RollupChange change) async {
+    while (true) {
+      final existing = await _client.readDocument(
+        container: rollupsContainer,
+        id: change.key,
+        partitionKey: change.school,
+      );
+      final next =
+          change.applyTo(existing == null ? null : Rollup.fromJson(existing));
+      if (next == null) {
+        if (existing != null) {
+          await _client.deleteDocument(
+            container: rollupsContainer,
+            id: change.key,
+            partitionKey: change.school,
+          );
+        }
+        return;
+      }
+      final body = next.toJson();
+      final document = {
+        ...body,
+        contentHashField: materializedContentHash(body),
+      };
+      if (existing == null) {
+        final created = await _client.createDocument(
+          container: rollupsContainer,
+          partitionKey: change.school,
+          document: document,
+        );
+        if (created) return;
+        continue;
+      }
+      final outcome = await _client.upsertDocument(
+        container: rollupsContainer,
+        partitionKey: change.school,
+        document: document,
+        ifMatch: existing['_etag'] as String?,
+      );
+      if (outcome.applied) return;
+    }
+  }
+
+  /// Bumps the shared generation for an apply and returns what it wrote.
+  ///
+  /// Conditioned, unlike the sync path's unconditional stamp: two applies
+  /// finishing together must produce two distinct generations, or the second
+  /// would broadcast a number a receiver has already seen and gate its own
+  /// refetch out.
+  Future<int> _bumpGeneration(String appliedBy, DateTime at) async {
+    while (true) {
+      final existing = await _client.readDocument(
+        container: syncStateContainer,
+        id: syncStateDocumentId,
+        partitionKey: syncStateDocumentId,
+      );
+      final next =
+          (existing == null ? SyncState.initial : SyncState.fromJson(existing))
+              .bumped(at: at, by: appliedBy);
+      final document = {'id': syncStateDocumentId, ...next.toJson()};
+      if (existing == null) {
+        final created = await _client.createDocument(
+          container: syncStateContainer,
+          partitionKey: syncStateDocumentId,
+          document: document,
+        );
+        if (created) return next.generation;
+        continue;
+      }
+      final outcome = await _client.upsertDocument(
+        container: syncStateContainer,
+        partitionKey: syncStateDocumentId,
+        document: document,
+        ifMatch: existing['_etag'] as String?,
+      );
+      if (outcome.applied) return next.generation;
+    }
   }
 
   @override

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -13,12 +13,13 @@ import 'materialized_state.dart';
 /// drill-down.
 ///
 /// Pure — no I/O. The sync process calls this after `link()`, then hands the
-/// result (with decisions merged in) to the `LinkedStore`. Group actions target
-/// a `LinkedGroup`, not an account, so they do not fit the per-account/classroom
-/// shape: each targeted group becomes its own [MaterializedGroup] in the
-/// [groupsPartition], and a single group [Rollup] ("Klasgroepen") surfaces them
-/// in the drill-down beside the school tree (#119). The account, staff, and
-/// group families — everything the drill-down renders — are covered.
+/// result (with decisions merged in) to the `LinkedStore`. A class group is a
+/// `LinkedGroup`, not an account, so it does not fit the per-account/classroom
+/// shape: every linked class becomes its own [MaterializedGroup] in the
+/// [groupsPartition] — one document per class since #227, not one per class with
+/// work — and a single group [Rollup] ("Klasgroepen") aggregates them for the
+/// Klasgroepen tab (#119). The account, staff, and group families — everything
+/// the views render — are covered.
 ///
 /// [schoolLabels] maps a WISA school id to its human label — the long name
 /// with its short code, built by [wisaSchoolLabels] from the operator's
@@ -122,7 +123,8 @@ MaterializedView materialize(
     ));
   }
 
-  final groups = _materializeGroups(linked.groupActions);
+  final groups =
+      _materializeGroups(linked.snapshot.groups, linked.groupActions);
 
   final rollups = buildRollups(accounts);
   final groupsRollup = _buildGroupsRollup(groups);
@@ -136,15 +138,30 @@ MaterializedView materialize(
   );
 }
 
-/// Turns the dispatched group actions into one [MaterializedGroup] per targeted
-/// class group, in first-seen (snapshot) order. Each targeted group carries the
-/// candidate actions raised against it — including the informational ones
-/// (`canApply == false`), which surface an orphan/empty-class notice.
+/// Turns the **linked class groups** into one [MaterializedGroup] each, in
+/// snapshot order, with the dispatched group actions joined on.
+///
+/// The input used to be the actions alone (#119), so a class with nothing wrong
+/// had no document at all: the persisted group partition held "the classes with
+/// work", never the class inventory. That is what #227 needed — an operator
+/// cannot tell a correct proposal from a wrong one without seeing what is
+/// already in place — so the linked group list drives it now and the actions are
+/// joined on by key. A class with no candidates is the healthy, normal case.
+///
+/// Each group still carries every candidate raised against it, including the
+/// informational ones (`canApply == false`) that surface an orphan/empty-class
+/// notice or a class Smartschool already has (#225/#250).
+///
+/// An action whose target is somehow not in [groups] still gets a document, so a
+/// dispatched action can never be dropped on the floor by the join.
 List<MaterializedGroup> _materializeGroups(
+  List<core.LinkedGroup> groups,
   List<actions.GroupAction> groupActions,
 ) {
   final byGroup = <String, List<CandidateAction>>{};
-  final targets = <String, core.LinkedGroup>{};
+  final targets = <String, core.LinkedGroup>{
+    for (final g in groups) _groupKey(g): g,
+  };
   for (final a in groupActions) {
     final key = _groupKey(a.target);
     (byGroup[key] ??= <CandidateAction>[]).add(_candidate(
@@ -166,16 +183,22 @@ List<MaterializedGroup> _materializeGroups(
         inWisa: entry.value.wisa != null,
         inSmartschool: entry.value.smartschool != null,
         inAzure: entry.value.azure != null,
-        candidates: byGroup[entry.key]!,
+        description: _groupDescription(entry.value),
+        className: entry.value.className,
+        // The Office 365 group is per *class*, so every sub-group record of a
+        // split class names the one group its parent owns (#228).
+        azureGroupName: entry.value.azure?.displayName,
+        candidates: byGroup[entry.key] ?? const [],
       ),
   ];
 }
 
 /// The single "Klasgroepen" [Rollup] over every [MaterializedGroup], or `null`
-/// when no group has a pending action (nothing to drill into). [accountCount] is
-/// the number of group docs, [pendingCount] the **decisions** they carry
-/// ([pendingDecisionCount], #251) — since #244 every new class of the school
-/// year is one create-or-ignore either/or, which counted as two.
+/// when there is no class at all. Since #227 [accountCount] is the size of the
+/// whole class inventory (it used to be "classes with work"); [pendingCount] is
+/// the **decisions** they carry ([pendingDecisionCount], #251) — since #244
+/// every new class of the school year is one create-or-ignore either/or, which
+/// counted as two.
 Rollup? _buildGroupsRollup(List<MaterializedGroup> groups) {
   if (groups.isEmpty) return null;
   var pending = 0;
@@ -402,6 +425,13 @@ String _groupKey(core.LinkedGroup g) => 'group|${_groupName(g) ?? '?'}';
 
 /// Display label for a group — its WISA / Smartschool / Azure name.
 String _groupLabel(core.LinkedGroup g) => _groupName(g) ?? '(groep)';
+
+/// The class's human description — WISA's wording first (it is the system of
+/// record for a class), Smartschool's as a fallback for an orphan (#227).
+String _groupDescription(core.LinkedGroup g) =>
+    _nonEmpty(g.wisa?.description ?? '') ??
+    _nonEmpty(g.smartschool?.description ?? '') ??
+    '';
 
 String? _groupName(core.LinkedGroup g) =>
     _nonEmpty(g.wisa?.name ?? '') ??

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -273,6 +273,178 @@ List<Rollup> buildRollups(List<MaterializedAccount> accounts) {
   ];
 }
 
+/// One rollup node's share of what a **real apply** changed, expressed as a
+/// *delta* rather than as a recomputed count (#254).
+///
+/// An apply's session only ever holds its own link, which is a snapshot of the
+/// three systems as they stood when it last synced. Writing rollups derived from
+/// that snapshot back into the shared view would publish this session's whole
+/// picture of a node — resurrecting the work another operator applied and wrote
+/// in the meantime. A delta cannot: two operators each subtract only what their
+/// own pass cleared, and the store folds both into whatever it currently holds.
+///
+/// [applyTo] is the fold, so the arithmetic lives in one place and both the
+/// in-memory and the Cosmos store run exactly the same rule.
+class RollupChange {
+  RollupChange._({
+    required this.level,
+    required this.key,
+    required this.parentKey,
+    required this.school,
+    required this.label,
+    required this.gradeYear,
+    required this.classroom,
+  });
+
+  final RollupLevel level;
+
+  /// The node's stable key — the [Rollup.key] this change applies to.
+  final String key;
+  final String? parentKey;
+  final String school;
+
+  /// The label to give the node when the store has none yet; an existing node
+  /// keeps the label the sync path gave it (see [applyTo]).
+  final String label;
+
+  final String gradeYear;
+  final String classroom;
+
+  int _accounts = 0;
+  int _pending = 0;
+
+  /// How many documents this node gained (positive) or lost (negative).
+  int get accountDelta => _accounts;
+
+  /// How far this node's pending-decision total moved.
+  int get pendingDelta => _pending;
+
+  void _add({required int accounts, required int pending}) {
+    _accounts += accounts;
+    _pending += pending;
+  }
+
+  /// This node as it must be stored once the delta is folded into [current] —
+  /// the node the store holds right now, or `null` when it has none yet — or
+  /// `null` when the node is left with no documents at all and its record should
+  /// be deleted (an empty node is one the sync path would not emit either).
+  ///
+  /// The label, not being a count, is **not** ours to move: an apply changes who
+  /// is pending, never what a school is called, so an existing node keeps the
+  /// label the last materialize gave it.
+  Rollup? applyTo(Rollup? current) {
+    final accounts = (current?.accountCount ?? 0) + _accounts;
+    if (accounts <= 0) return null;
+    final pending = (current?.pendingCount ?? 0) + _pending;
+    return Rollup(
+      level: level,
+      key: key,
+      parentKey: parentKey,
+      school: school,
+      label: current?.label ?? label,
+      gradeYear: gradeYear,
+      classroom: classroom,
+      accountCount: accounts,
+      // A delta computed against a document another writer had already
+      // corrected can only ever over-subtract; never advertise a negative badge.
+      pendingCount: pending < 0 ? 0 : pending,
+    );
+  }
+}
+
+/// The rollup-node deltas one real apply makes, from the documents the **store**
+/// held for the ids the pass touched ([storedAccounts] / [storedGroups]) and the
+/// ones the refreshed link produced for them ([freshAccounts] / [freshGroups]).
+///
+/// Pure and total: a document present only in the stored set counts as removed,
+/// one present only in the fresh set as added, and one in both contributes the
+/// difference of its [pendingDecisionCount]. Every node above a touched document
+/// — its classroom, its grade-year and its school, or the single Klasgroepen
+/// node for a class group — gets its share, so the badges above a drill-down
+/// stay the sum of what is under them.
+///
+/// Nodes whose counts do not move at all are left out, so a pass that wrote
+/// nothing of consequence touches no rollup document.
+List<RollupChange> rollupChangesFor({
+  Iterable<MaterializedAccount> storedAccounts = const [],
+  Iterable<MaterializedAccount> freshAccounts = const [],
+  Iterable<MaterializedGroup> storedGroups = const [],
+  Iterable<MaterializedGroup> freshGroups = const [],
+}) {
+  final changes = <String, RollupChange>{};
+
+  void foldAccount(MaterializedAccount a, int sign) {
+    final pending = pendingDecisionCount(a.candidates) * sign;
+    final schoolKey = _schoolKey(a.school);
+    final gradeKey = _gradeKey(a.school, a.gradeYear);
+    final classKey = _classroomKey(a.school, a.gradeYear, a.classroom);
+    (changes[schoolKey] ??= RollupChange._(
+      level: RollupLevel.school,
+      key: schoolKey,
+      parentKey: null,
+      school: a.school,
+      label: a.schoolLabel,
+      gradeYear: '',
+      classroom: '',
+    ))
+        ._add(accounts: sign, pending: pending);
+    (changes[gradeKey] ??= RollupChange._(
+      level: RollupLevel.gradeYear,
+      key: gradeKey,
+      parentKey: schoolKey,
+      school: a.school,
+      label: a.gradeYear,
+      gradeYear: a.gradeYear,
+      classroom: '',
+    ))
+        ._add(accounts: sign, pending: pending);
+    (changes[classKey] ??= RollupChange._(
+      level: RollupLevel.classroom,
+      key: classKey,
+      parentKey: gradeKey,
+      school: a.school,
+      label: a.classroom,
+      gradeYear: a.gradeYear,
+      classroom: a.classroom,
+    ))
+        ._add(accounts: sign, pending: pending);
+  }
+
+  void foldGroup(MaterializedGroup g, int sign) {
+    (changes[groupsPartition] ??= RollupChange._(
+      level: RollupLevel.groups,
+      key: groupsPartition,
+      parentKey: null,
+      school: groupsPartition,
+      label: _groupsLabel,
+      gradeYear: '',
+      classroom: '',
+    ))
+        ._add(
+      accounts: sign,
+      pending: pendingDecisionCount(g.candidates) * sign,
+    );
+  }
+
+  for (final a in storedAccounts) {
+    foldAccount(a, -1);
+  }
+  for (final a in freshAccounts) {
+    foldAccount(a, 1);
+  }
+  for (final g in storedGroups) {
+    foldGroup(g, -1);
+  }
+  for (final g in freshGroups) {
+    foldGroup(g, 1);
+  }
+
+  return [
+    for (final c in changes.values)
+      if (c.accountDelta != 0 || c.pendingDelta != 0) c,
+  ];
+}
+
 // ---------------------------------------------------------------------------
 // Placement.
 // ---------------------------------------------------------------------------
@@ -421,7 +593,17 @@ String _staffMemberLabel(core.LinkedStaff s) {
 /// The stable cross-system key for a group document (#119): its name (the
 /// linker's cross-system match key), namespaced so it never collides with an
 /// account id. A group always carries at least one system record.
-String _groupKey(core.LinkedGroup g) => 'group|${_groupName(g) ?? '?'}';
+String _groupKey(core.LinkedGroup g) =>
+    materializedGroupId(_groupName(g) ?? '?');
+
+/// The [MaterializedGroup.id] of the class group displayed as [name].
+///
+/// Exposed because the reconcile controller keys its pending group entries by
+/// the group's *display name* (that is what the operator sees and what the
+/// widget keys use), while the stored document is keyed by this namespaced form
+/// — so a post-apply write-back (#254) has to cross from one to the other, and
+/// must do it through the very expression the materializer itself uses.
+String materializedGroupId(String name) => 'group|$name';
 
 /// Display label for a group — its WISA / Smartschool / Azure name.
 String _groupLabel(core.LinkedGroup g) => _groupName(g) ?? '(groep)';

--- a/packages/account_state/lib/src/materialize/linked_store.dart
+++ b/packages/account_state/lib/src/materialize/linked_store.dart
@@ -1,16 +1,19 @@
 import 'package:account_core/account_core.dart' as core;
 
+import 'linked_state_materializer.dart';
 import 'materialized_state.dart';
 
 /// The persistence seam for the materialized reconcile view (#115, keystone of
 /// #112).
 ///
-/// The write path (sync / check-for-drift only) replaces the derived per-account
-/// docs and rollups and bumps the generation; the read path (every passive
-/// session) reads the rollups and lazily loads one classroom's accounts, with
-/// **no connector pull and no `link()`**. Operator [AccountDecision]s live in
-/// their own documents so a re-sync never clobbers them — [writeMaterialized]
-/// only deletes the ones a merge dropped.
+/// The full write path (sync / check-for-drift only) replaces the derived
+/// per-account docs and rollups and bumps the generation; the narrow write path
+/// ([writeApplied], #254) patches just the documents one apply changed and moves
+/// the rollups above them by delta; the read path (every passive session) reads
+/// the rollups and lazily loads one classroom's accounts, with **no connector
+/// pull and no `link()`**. Operator [AccountDecision]s live in their own
+/// documents so a re-sync never clobbers them — [writeMaterialized] only deletes
+/// the ones a merge dropped.
 ///
 /// Kept an interface with an in-memory [InMemoryLinkedStore] fake and the
 /// Cosmos-backed `CosmosLinkedStore` production implementation, mirroring the
@@ -104,6 +107,115 @@ abstract interface class LinkedStore {
   /// Releases the lease if it is [owner]'s. A no-op when someone else already
   /// holds it (a taken-over lease must not be released out from under them).
   Future<void> releaseLease({required String owner});
+
+  /// Writes back the **narrow slice** of the materialized view one real apply
+  /// changed (#254): the touched per-account / per-group documents, the rollup
+  /// nodes above them, and a bumped generation.
+  ///
+  /// The counterpart of [writeMaterialized], and deliberately nothing like it.
+  /// A sync recomputes and republishes the whole ~9.6k-document view under the
+  /// coarse sync lease; an apply writes one row (or a classroom's worth) and
+  /// runs unleased and concurrently with every other operator's apply. Doing
+  /// that through [writeMaterialized] was not affordable, which is exactly why
+  /// #236 kept its correction local and left the shared view stale for everyone
+  /// else — this is the seam that closes it.
+  ///
+  /// Three rules make it safe to run without the lease:
+  ///
+  /// 1. **It stands down for a sync.** When another operator holds a live
+  ///    sync/drift lease as of [at], nothing is written and the holder comes
+  ///    back in [AppliedWrite.deferredTo]. That pass is rewriting the whole view
+  ///    from a *fresher* link than this session's, so letting a narrow patch
+  ///    land on top of it — or worse, bump the generation past it — would be
+  ///    precisely the "a local correction outranks the shared view" this issue
+  ///    must not create. The applied writes are real regardless; the shared
+  ///    counts simply catch up when that sync finishes.
+  /// 2. **The rollups move by delta, never by replacement.** What each touched
+  ///    document contributed *in the store* is subtracted and what it
+  ///    contributes now is added ([rollupChangesFor]), so two operators clearing
+  ///    different work in the same class compose instead of overwriting each
+  ///    other's counts.
+  /// 3. **Every document write is conditioned on the version it replaces**, so
+  ///    the delta and the document it was computed from cannot come apart under
+  ///    a concurrent writer: a losing write re-reads and recomputes.
+  ///
+  /// What it does **not** attempt is a merge of two operators' candidate lists
+  /// for the *same* account: the last writer's document wins there, and the next
+  /// full sync — which recomputes everything from scratch — is what heals it.
+  ///
+  /// Returns the generation it wrote so the caller can adopt it (a session that
+  /// wrote the view is current, not ahead of it) and name it in a
+  /// [ChangeSignal.viewChanged]; an empty patch writes nothing and bumps
+  /// nothing.
+  Future<AppliedWrite> writeApplied(
+    AppliedPatch patch, {
+    required String appliedBy,
+    required DateTime at,
+  });
+}
+
+/// The slice of the materialized view one **real apply** changed (#254) — the
+/// input to [LinkedStore.writeApplied].
+///
+/// Built by the reconcile controller from the targets its pass resolved: for
+/// each one, the freshly re-derived document, or its id in the `removed…` lists
+/// when the refreshed link no longer has a document for it at all (a student
+/// whose last account was just deleted, a class group that is gone).
+class AppliedPatch {
+  const AppliedPatch({
+    this.accounts = const [],
+    this.groups = const [],
+    this.removedAccountIds = const [],
+    this.removedGroupIds = const [],
+  });
+
+  /// Freshly derived documents for the accounts/staff the pass wrote to.
+  final List<MaterializedAccount> accounts;
+
+  /// Freshly derived documents for the class groups the pass wrote to (#119).
+  final List<MaterializedGroup> groups;
+
+  /// Ids the pass wrote to whose account document the refreshed link no longer
+  /// produces — the stored document must go with them.
+  final List<String> removedAccountIds;
+
+  /// The same for class-group documents.
+  final List<String> removedGroupIds;
+
+  /// True when the patch names no document at all, so there is nothing to write
+  /// and no reason to bump the generation.
+  bool get isEmpty =>
+      accounts.isEmpty &&
+      groups.isEmpty &&
+      removedAccountIds.isEmpty &&
+      removedGroupIds.isEmpty;
+
+  bool get isNotEmpty => !isEmpty;
+}
+
+/// What one [LinkedStore.writeApplied] did (#254).
+class AppliedWrite {
+  const AppliedWrite._(this.generation, this.deferredTo);
+
+  /// The patch landed and the shared view is now at [generation].
+  const AppliedWrite.written(int generation) : this._(generation, null);
+
+  /// Nothing was written because [lease]'s holder is mid sync/drift — they are
+  /// republishing the whole view from a fresher link, so a narrow patch must not
+  /// land on top of it.
+  const AppliedWrite.deferred(SyncLease lease) : this._(null, lease);
+
+  /// Nothing was written because the patch named no document.
+  const AppliedWrite.unchanged() : this._(null, null);
+
+  /// The generation the patch wrote, or `null` when nothing was written.
+  final int? generation;
+
+  /// The sync lease this write stood down for, when it did.
+  final SyncLease? deferredTo;
+
+  /// Whether the shared view actually moved.
+  bool get written => generation != null;
 }
 
 /// The stable document id for a decision: one per account + kind + situation.
@@ -113,9 +225,16 @@ String decisionDocId(AccountDecision d) =>
 /// An in-memory [LinkedStore] for tests and headless runs.
 ///
 /// Models the store's contract with no infra: a global replace on
-/// [writeMaterialized] (a sync recomputes the whole view), point reads for the
-/// rollups/classrooms, and a decision map keyed by [decisionDocId]. The Cosmos
-/// wire behaviour is covered separately by `CosmosLinkedStore`'s unit tests.
+/// [writeMaterialized] (a sync recomputes the whole view), a per-document patch
+/// with delta'd rollups on [writeApplied] (an apply corrects what it wrote),
+/// point reads for the rollups/classrooms, and a decision map keyed by
+/// [decisionDocId]. The Cosmos wire behaviour is covered separately by
+/// `CosmosLinkedStore`'s unit tests.
+///
+/// Each method runs to completion with no `await` between its reads and its
+/// writes, so — exactly as on the event loop the real sessions share — two
+/// "operators" driving one instance interleave only between calls, never inside
+/// one.
 class InMemoryLinkedStore implements LinkedStore {
   final Map<String, MaterializedAccount> _accounts = {};
   final Map<String, MaterializedGroup> _groups = {};
@@ -179,6 +298,70 @@ class InMemoryLinkedStore implements LinkedStore {
       // Merge: a system not pulled this pass keeps its earlier stamp.
       systems: {..._syncState.systems, ...systemSyncs},
     );
+  }
+
+  @override
+  Future<AppliedWrite> writeApplied(
+    AppliedPatch patch, {
+    required String appliedBy,
+    required DateTime at,
+  }) async {
+    final lease = _lease;
+    if (lease != null && lease.isLiveAt(at) && lease.owner != appliedBy) {
+      return AppliedWrite.deferred(lease);
+    }
+    if (patch.isEmpty) return const AppliedWrite.unchanged();
+
+    // What the store holds for the touched ids *right now* — the only honest
+    // basis for the delta, because it already includes whatever another operator
+    // applied and wrote since this session linked.
+    final storedAccounts = <MaterializedAccount>[
+      for (final id in <String>[
+        for (final a in patch.accounts) a.id.value,
+        ...patch.removedAccountIds,
+      ])
+        if (_accounts[id] case final stored?) stored,
+    ];
+    final storedGroups = <MaterializedGroup>[
+      for (final id in <String>[
+        for (final g in patch.groups) g.id.value,
+        ...patch.removedGroupIds,
+      ])
+        if (_groups[id] case final stored?) stored,
+    ];
+    final changes = rollupChangesFor(
+      storedAccounts: storedAccounts,
+      freshAccounts: patch.accounts,
+      storedGroups: storedGroups,
+      freshGroups: patch.groups,
+    );
+
+    for (final a in patch.accounts) {
+      _accounts[a.id.value] = a;
+    }
+    for (final id in patch.removedAccountIds) {
+      _accounts.remove(id);
+    }
+    for (final g in patch.groups) {
+      _groups[g.id.value] = g;
+    }
+    for (final id in patch.removedGroupIds) {
+      _groups.remove(id);
+    }
+
+    final byKey = <String, Rollup>{for (final r in _rollups) r.key: r};
+    for (final change in changes) {
+      final next = change.applyTo(byKey[change.key]);
+      if (next == null) {
+        byKey.remove(change.key);
+      } else {
+        byKey[change.key] = next;
+      }
+    }
+    _rollups = List.of(byKey.values);
+
+    _syncState = _syncState.bumped(at: at, by: appliedBy);
+    return AppliedWrite.written(_syncState.generation);
   }
 
   @override

--- a/packages/account_state/lib/src/materialize/materialized_state.dart
+++ b/packages/account_state/lib/src/materialize/materialized_state.dart
@@ -393,12 +393,19 @@ const String unassignedPartition = 'unassigned';
 /// One linked **class group** as a stored document (#119).
 ///
 /// The group-family counterpart of [MaterializedAccount]: where a per-account
-/// doc drills down through school / grade-year / classroom, a group action
-/// targets a `LinkedGroup` (an orphan Smartschool class, a WISA class that needs
-/// creating downstream, a class whose data drifted), which does not fit that
-/// per-account shape. So the materializer emits these as their own documents in
-/// the [groupsPartition], surfaced by the passive drill-down under a single
-/// "Klasgroepen" node rather than inside a classroom.
+/// doc drills down through school / grade-year / classroom, a group record is a
+/// `LinkedGroup` (a WISA class, an orphan Smartschool class, an Azure group left
+/// behind by a class that is gone), which does not fit that per-account shape.
+/// So the materializer emits these as their own documents in the
+/// [groupsPartition], surfaced by the Klasgroepen tab rather than inside a
+/// classroom.
+///
+/// Since #227 there is **one document per linked class**, not one per class with
+/// work: the docs used to be derived from the dispatched actions, so a class with
+/// nothing wrong had no document at all and could not be verified — which is
+/// exactly how a wrong proposal (#225's `2G`) passed unnoticed in a list where
+/// every row was a change. A class with no [candidates] is the normal, healthy
+/// case now.
 ///
 /// Like [MaterializedAccount] it is rewritten wholesale every sync, carries the
 /// per-system presence and the computed [candidates], and re-attaches the
@@ -411,6 +418,9 @@ class MaterializedGroup {
     required this.inWisa,
     required this.inSmartschool,
     required this.inAzure,
+    this.description = '',
+    this.className,
+    this.azureGroupName,
     this.candidates = const [],
     this.decisions = const [],
   });
@@ -428,6 +438,26 @@ class MaterializedGroup {
   final bool inSmartschool;
   final bool inAzure;
 
+  /// The class's description as WISA (or Smartschool) spells it — the human
+  /// line beside the bare name in the inventory (#227). Empty when neither
+  /// system carries one.
+  final String description;
+
+  /// The **bare** class name this record belongs to (`2F` for `2F ECO`), copied
+  /// off `LinkedGroup.className` (#228); `null` for a record with no WISA class
+  /// behind it (a Smartschool-only orphan).
+  ///
+  /// The Office 365 column is per *class*, not per linked group: the sub-groups
+  /// `2F ECO` / `2F MAW` / `2F MOW` / `2F STEMW` all map to the one group
+  /// `<PREFIX>-2F`. Carrying the bare name lets the inventory say so, instead of
+  /// showing four rows that each look like they own a group.
+  final String? className;
+
+  /// The display name of the Office 365 group this class is served by, when one
+  /// exists (`GBS-2F` for every sub-group of `2F`); `null` when the class has no
+  /// group yet. Not 1:1 with the row — see [className].
+  final String? azureGroupName;
+
   /// The computed candidate group actions (e.g. an orphan-class notice, a
   /// create/modify). Some are informational (`canApply == false`).
   final List<CandidateAction> candidates;
@@ -444,6 +474,16 @@ class MaterializedGroup {
   /// has not switched to.
   bool get hasPending => pendingDecisionCount(candidates) > 0;
 
+  /// Whether this class asks anything of the operator at all (#227) — the
+  /// predicate the Klasgroepen filter and the row highlight use.
+  ///
+  /// Deliberately **wider** than [hasPending]: a class can carry an
+  /// informational-only notice (`ClassExistsAsSmartschoolGroup` and friends,
+  /// #225/#250), which is real manual work with no automated write, so it adds
+  /// nothing to the pending count. Filtering on the pending count alone would
+  /// bury exactly the notices those issues exist to surface.
+  bool get needsAttention => candidates.isNotEmpty;
+
   MaterializedGroup withDecisions(List<AccountDecision> decisions) =>
       MaterializedGroup(
         id: id,
@@ -452,6 +492,9 @@ class MaterializedGroup {
         inWisa: inWisa,
         inSmartschool: inSmartschool,
         inAzure: inAzure,
+        description: description,
+        className: className,
+        azureGroupName: azureGroupName,
         candidates: candidates,
         decisions: decisions,
       );
@@ -464,6 +507,9 @@ class MaterializedGroup {
         'inWisa': inWisa,
         'inSmartschool': inSmartschool,
         'inAzure': inAzure,
+        if (description.isNotEmpty) 'description': description,
+        if (className != null) 'className': className,
+        if (azureGroupName != null) 'azureGroupName': azureGroupName,
         if (candidates.isNotEmpty)
           'candidates': [for (final c in candidates) c.toJson()],
         if (decisions.isNotEmpty)
@@ -478,6 +524,9 @@ class MaterializedGroup {
         inWisa: json['inWisa'] as bool? ?? false,
         inSmartschool: json['inSmartschool'] as bool? ?? false,
         inAzure: json['inAzure'] as bool? ?? false,
+        description: json['description'] as String? ?? '',
+        className: json['className'] as String?,
+        azureGroupName: json['azureGroupName'] as String?,
         candidates: [
           for (final c in (json['candidates'] as List? ?? const []))
             CandidateAction.fromJson(c as Map<String, dynamic>),

--- a/packages/account_state/lib/src/realtime/change_signal.dart
+++ b/packages/account_state/lib/src/realtime/change_signal.dart
@@ -35,12 +35,15 @@ enum ChangeSignalKind {
 /// so a receiver can refetch only that shard rather than the whole view.
 ///
 /// A **null** shard on a `viewChanged` signal means the entire materialized view
-/// was rewritten — which is what the current sync/materialize path does (it
-/// replaces every per-account doc and rollup in one pass), so its signal names
-/// no narrower shard. A **named** shard (a school, a classroom, or a single
-/// account) is the forward-compatible hook the apply-level per-record signals
-/// (#109 / #110) will use to wake only one document; those are independent of the
-/// sync lease and land with the write UIs.
+/// was rewritten — which is what the sync/materialize path does (it replaces
+/// every per-account doc and rollup in one pass), so its signal names no
+/// narrower shard. A **named** shard (a school, a classroom, or a single
+/// account) is what a real apply broadcasts since #254: its write-back touches
+/// only the documents it changed, so a receiver can skip re-reading a
+/// drill-down the shard proves it cannot have moved. An apply that spans several
+/// classrooms, or that removed a document (whose partition the writer no longer
+/// knows), widens back to the whole view rather than naming a shard it cannot
+/// vouch for.
 class ShardRef {
   const ShardRef({this.school, this.classroom, this.accountId});
 
@@ -57,6 +60,22 @@ class ShardRef {
   /// True when this ref names nothing — a whole-view change (the sync path).
   bool get isWholeView =>
       school == null && classroom == null && accountId == null;
+
+  /// Whether a change in this shard **could** have touched the [school]
+  /// partition. True for a whole-view change and for any shard that names no
+  /// school; false only when this shard positively names a different one.
+  ///
+  /// Deliberately permissive: a receiver uses it to *skip* re-reads it can prove
+  /// pointless, so an unknown shard must always read as "might have".
+  bool touchesPartition(String school) =>
+      this.school == null || this.school == school;
+
+  /// Whether a change in this shard could have touched [classroom] of [school] —
+  /// the test a session with a classroom open uses to decide whether the drilled
+  /// -in list has to be re-read at all (#254).
+  bool touchesClassroom({required String school, required String classroom}) =>
+      touchesPartition(school) &&
+      (this.classroom == null || this.classroom == classroom);
 
   Map<String, dynamic> toJson() => {
         if (school != null) 'school': school,

--- a/packages/account_state/lib/src/settings/live_settings.dart
+++ b/packages/account_state/lib/src/settings/live_settings.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'app_settings.dart';
+import 'import_rule_codec.dart';
 import 'work_date.dart';
 
 /// A mutable holder for the operator's [AppSettings], shared between the
@@ -72,6 +74,46 @@ String wisaPullFingerprint(AppSettings settings) {
 
 String _workDateKey(WorkDateSetting setting) =>
     setting.isNow ? 'now' : (setting.date?.toIso8601String() ?? 'unset');
+
+/// A stable identity for the settings a **Smartschool** pull depends on: the
+/// operator's import rules (#259).
+///
+/// The counterpart of [wisaPullFingerprint] for the second connector. #99's
+/// smart sync re-pulls Smartschool only when this session does not hold a
+/// snapshot yet, so a `DiscardSmartschoolGroup` authored in Instellingen used
+/// to be adopted by **Check for drift** and not by the Synchroniseer the
+/// operator reaches for — which meanwhile reported "geen accountwijzigingen
+/// nodig" over the save it had not applied. A moved fingerprint is what tells
+/// the smart sync that leaving the held snapshot alone is no longer valid.
+///
+/// Order-sensitive on purpose: the rules are applied in sequence, so two
+/// permutations of the same set are two different pulls.
+String smartschoolPullFingerprint(AppSettings settings) =>
+    'regels=${jsonEncode(<Map<String, dynamic>>[
+          for (final rule in settings.smartschoolRules)
+            encodeSmartschoolRule(rule),
+        ])}';
+
+/// A stable identity for the settings an **Azure** pull depends on: the school
+/// prefix the whole read is scoped by, and the managed-school set the
+/// transferred-account back-fill derives its expected `employeeId`s from
+/// (#259).
+///
+/// Both are genuine inputs to the pull rather than to the link that follows it.
+/// The prefix scopes the `/users` `$filter` and — since #246 — drops the delta
+/// token when it moves, because `/users/delta` filters client-side and an
+/// incremental pass would keep the previous school's users under the new
+/// prefix. The managed-school set decides which WISA ids the `employeeId in (…)`
+/// lookups (#224/#231) ask about, so a school flipped **beheerd** changes what
+/// the pull can see even when Azure itself has not moved.
+///
+/// The ids are sorted, so a settings document that merely reorders its school
+/// rows does not read as a changed pull.
+String azurePullFingerprint(AppSettings settings) {
+  final managed = settings.managedWisaSchoolIds.toList()..sort();
+  return 'schoolPrefix=${settings.schoolPrefix.trim()};'
+      'beheerdeScholen=${managed.join(',')}';
+}
 
 /// A stable identity for the settings a running session **cannot** adopt: the
 /// endpoints and credential refs the three connectors were constructed from

--- a/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
@@ -15,12 +15,19 @@ Map<String, dynamic> _projection(Map<String, dynamic> doc, String query) => {
     };
 
 /// A small in-memory [CosmosClient] covering the query shapes
-/// [CosmosLinkedStore] issues: `SELECT * FROM c`, the classroom filter, and the
-/// `SELECT c.id, c.pk, c.contentHash FROM c` projection — honouring
+/// [CosmosLinkedStore] issues: `SELECT * FROM c`, the classroom filter, the
+/// cross-partition `WHERE c.id = @id` lookup a post-apply removal uses (#254),
+/// and the `SELECT c.id, c.pk, c.contentHash FROM c` projection — honouring
 /// [partitionKey] scoping via each document's `pk` field.
 class _FakeClient implements CosmosClient {
   final Map<String, Map<String, Map<String, dynamic>>> _store = {};
   int deletes = 0;
+
+  /// Runs once, before the first upsert into [beforeUpsertIn] (any container
+  /// when that is null), so a test can slip another operator's whole write in
+  /// between this store's read and its conditioned write.
+  Future<void> Function()? beforeUpsert;
+  String? beforeUpsertIn;
 
   /// Upserts per container, so a test can assert what a re-sync actually wrote
   /// (#200) rather than only what the container ended up holding.
@@ -74,6 +81,12 @@ class _FakeClient implements CosmosClient {
     required String partitionKey,
     String? ifMatch,
   }) async {
+    final hook = beforeUpsert;
+    if (hook != null &&
+        (beforeUpsertIn == null || beforeUpsertIn == container)) {
+      beforeUpsert = null;
+      await hook();
+    }
     final id = document['id'] as String;
     if (ifMatch != null && _c(container)[id]?['_etag'] != ifMatch) {
       staleWrites++;
@@ -107,6 +120,13 @@ class _FakeClient implements CosmosClient {
       rows = [
         for (final d in rows)
           if (d['classroom'] == want) d
+      ];
+    }
+    if (query.contains('c.id = @id')) {
+      final want = parameters['@id'];
+      rows = [
+        for (final d in rows)
+          if (d['id'] == want) d
       ];
     }
     if (query.contains('SELECT c.id, c.pk')) {
@@ -469,8 +489,20 @@ Future<void> _settle() async {
 
 final DateTime _d = DateTime.utc(2026, 7, 1);
 
-MaterializedAccount _account(String id,
-        {String school = '1', String classroom = '3C', String? schoolLabel}) =>
+const CandidateAction _move = CandidateAction(
+  family: 'student',
+  kind: 'MoveToSmartschoolClassGroup',
+  system: core.Origin.smartschool,
+  summary: 'Move',
+);
+
+MaterializedAccount _account(
+  String id, {
+  String school = '1',
+  String classroom = '3C',
+  String? schoolLabel,
+  List<CandidateAction> candidates = const [_move],
+}) =>
     MaterializedAccount(
       id: core.LinkedAccountId(id),
       school: school,
@@ -484,14 +516,7 @@ MaterializedAccount _account(String id,
       inWisa: true,
       inSmartschool: true,
       inAzure: true,
-      candidates: const [
-        CandidateAction(
-          family: 'student',
-          kind: 'MoveToSmartschoolClassGroup',
-          system: core.Origin.smartschool,
-          summary: 'Move',
-        ),
-      ],
+      candidates: candidates,
     );
 
 MaterializedGroup _group(String name) => MaterializedGroup(
@@ -1021,6 +1046,176 @@ void main() {
       expect(state.generation, 1, reason: 'metadata touch is not a view write');
       expect(state.systems[core.Origin.wisa]?.syncedBy, 'jan@school');
       expect(state.systems[core.Origin.azure]?.syncedBy, 'mieke@school');
+    });
+  });
+
+  group('CosmosLinkedStore writeApplied — the narrow post-apply write (#254)',
+      () {
+    /// A store already holding a small view: three students in 3C and one in
+    /// 3D, each with one pending decision.
+    Future<({_FakeClient client, CosmosLinkedStore store})> seeded() async {
+      final client = _FakeClient();
+      final store = CosmosLinkedStore(client);
+      await store.writeMaterialized(
+        _view([
+          _account('p0'),
+          _account('p1'),
+          _account('p2'),
+          _account('p3', classroom: '3D'),
+        ]),
+        syncedBy: 'jan@school',
+        at: _d,
+      );
+      return (client: client, store: store);
+    }
+
+    Future<Rollup?> node(CosmosLinkedStore store, String key) async {
+      for (final r in await store.readRollups()) {
+        if (r.key == key) return r;
+      }
+      return null;
+    }
+
+    test('writes the one touched document, not the container', () async {
+      // The affordability argument the whole seam rests on: a one-row apply must
+      // not cost what a re-sync costs.
+      final s = await seeded();
+      final accountWrites = s.client.upsertsTo(linkedAccountsContainer);
+      final rollupWrites = s.client.upsertsTo(rollupsContainer);
+
+      final write = await s.store.writeApplied(
+        AppliedPatch(accounts: [_account('p0', candidates: const [])]),
+        appliedBy: 'jan@school',
+        at: _d,
+      );
+
+      expect(write.generation, 2);
+      expect(s.client.upsertsTo(linkedAccountsContainer), accountWrites + 1,
+          reason: 'exactly one account document');
+      expect(s.client.upsertsTo(rollupsContainer), rollupWrites + 3,
+          reason: 'its classroom, its grade-year and its school — no more');
+      expect(s.client.deletes, 0);
+      expect((await node(s.store, 'class|1|3|3C'))!.pendingCount, 2);
+      expect((await node(s.store, 'class|1|3|3D'))!.pendingCount, 1,
+          reason: 'a class this pass never touched is not rewritten at all');
+      expect((await node(s.store, 'school|1'))!.pendingCount, 3);
+    });
+
+    test(
+        'the patched document carries a content hash, so the next sync skips '
+        'it (#200)', () async {
+      final s = await seeded();
+      await s.store.writeApplied(
+        AppliedPatch(accounts: [_account('p0', candidates: const [])]),
+        appliedBy: 'jan@school',
+        at: _d,
+      );
+      final before = s.client.upsertsTo(linkedAccountsContainer);
+
+      // The next full sync agrees with what the apply left behind.
+      await s.store.writeMaterialized(
+        _view([
+          _account('p0', candidates: const []),
+          _account('p1'),
+          _account('p2'),
+          _account('p3', classroom: '3D'),
+        ], generation: 3),
+        syncedBy: 'jan@school',
+        at: _d,
+      );
+
+      expect(s.client.upsertsTo(linkedAccountsContainer), before,
+          reason: 'not one document was rewritten — the hashes all match');
+    });
+
+    test('stands down for another operator\'s sync lease', () async {
+      final s = await seeded();
+      await s.store.acquireLease(owner: 'mieke@school', now: _d);
+
+      final write = await s.store.writeApplied(
+        AppliedPatch(accounts: [_account('p0', candidates: const [])]),
+        appliedBy: 'jan@school',
+        at: _d,
+      );
+
+      expect(write.written, isFalse);
+      expect(write.deferredTo?.owner, 'mieke@school');
+      expect((await s.store.readSyncState()).generation, 1);
+      expect((await node(s.store, 'class|1|3|3C'))!.pendingCount, 3);
+    });
+
+    test('a rollup another operator moved mid-write is folded onto, not over',
+        () async {
+      // The race the ETag loop exists for: between this store's read of the 3C
+      // node and its conditioned write, a second operator's apply commits its
+      // own subtraction. A blind write would put that operator's cleared work
+      // straight back.
+      final s = await seeded();
+      final other = CosmosLinkedStore(s.client);
+      s.client.beforeUpsertIn = rollupsContainer;
+      s.client.beforeUpsert = () async {
+        await other.writeApplied(
+          AppliedPatch(accounts: [_account('p1', candidates: const [])]),
+          appliedBy: 'mieke@school',
+          at: _d,
+        );
+      };
+
+      await s.store.writeApplied(
+        AppliedPatch(accounts: [_account('p0', candidates: const [])]),
+        appliedBy: 'jan@school',
+        at: _d,
+      );
+
+      expect(s.client.staleWrites, greaterThanOrEqualTo(1),
+          reason: 'the two writers really did collide on a document');
+      expect((await node(s.store, 'class|1|3|3C'))!.pendingCount, 1,
+          reason: 'both subtractions landed: 3 − 1 − 1');
+      expect((await node(s.store, 'school|1'))!.pendingCount, 2);
+      expect((await s.store.readSyncState()).generation, 3,
+          reason: 'each apply broadcast a generation of its own');
+    });
+
+    test(
+        'a removed account is found across partitions, deleted, and its node '
+        'emptied with it', () async {
+      // The fresh view no longer has a document, so it cannot say which school
+      // partition the stored one sat in — only the store can.
+      final s = await seeded();
+
+      await s.store.writeApplied(
+        const AppliedPatch(removedAccountIds: ['p3']),
+        appliedBy: 'jan@school',
+        at: _d,
+      );
+
+      expect(
+          await s.store.readClassroom(school: '1', classroom: '3D'), isEmpty);
+      expect(await node(s.store, 'class|1|3|3D'), isNull);
+      expect((await node(s.store, 'school|1'))!.accountCount, 3);
+      expect(s.client.deletes, 2,
+          reason: 'the account document and the class node it emptied');
+    });
+
+    test('an id the store never had is written as a fresh document', () async {
+      // A first apply against a view this account was not part of: the create
+      // path, and the rollup node built from the document itself.
+      final client = _FakeClient();
+      final store = CosmosLinkedStore(client);
+
+      final write = await store.writeApplied(
+        AppliedPatch(accounts: [_account('p9')]),
+        appliedBy: 'jan@school',
+        at: _d,
+      );
+
+      expect(write.generation, 1, reason: 'from the initial generation 0');
+      expect(await store.readClassroom(school: '1', classroom: '3C'),
+          hasLength(1));
+      final klas = (await store.readRollups())
+          .singleWhere((r) => r.level == RollupLevel.classroom);
+      expect(klas.accountCount, 1);
+      expect(klas.pendingCount, 1);
     });
   });
 

--- a/packages/account_state/test/live_settings_test.dart
+++ b/packages/account_state/test/live_settings_test.dart
@@ -1,4 +1,5 @@
 import 'package:account_state/account_state.dart';
+import 'package:smartschool_api/smartschool_api.dart';
 import 'package:test/test.dart';
 
 AppSettings _settings({
@@ -121,6 +122,122 @@ void main() {
       expect(
         wisaPullFingerprint(_settings(schools: const [a, b])),
         wisaPullFingerprint(_settings(schools: const [b, a])),
+      );
+    });
+  });
+
+  group('smartschoolPullFingerprint (#259)', () {
+    test('changes when the operator authors an import rule', () {
+      final before = smartschoolPullFingerprint(_settings());
+      final after = smartschoolPullFingerprint(_settings().copyWith(
+        smartschoolRules: const [DiscardSmartschoolGroup('Organisatie')],
+      ));
+      expect(after, isNot(before));
+    });
+
+    test('changes when a rule is retargeted, not merely counted', () {
+      final a = smartschoolPullFingerprint(_settings().copyWith(
+        smartschoolRules: const [DiscardSmartschoolGroup('Organisatie')],
+      ));
+      final b = smartschoolPullFingerprint(_settings().copyWith(
+        smartschoolRules: const [DiscardSmartschoolGroup('Personeel')],
+      ));
+      expect(a, isNot(b));
+    });
+
+    test('is order-sensitive, because the rules are applied in sequence', () {
+      const a = DiscardSmartschoolGroup('Organisatie');
+      const b = NoSmartschoolSubgroups('Klassen');
+      expect(
+        smartschoolPullFingerprint(
+            _settings().copyWith(smartschoolRules: const [a, b])),
+        isNot(smartschoolPullFingerprint(
+            _settings().copyWith(smartschoolRules: const [b, a]))),
+      );
+    });
+
+    test('ignores settings a Smartschool pull does not depend on', () {
+      // The pull takes the rules and nothing else; the class tree, the prefix
+      // and the werkdatum all feed other readers and must not force a re-pull.
+      final base = _settings();
+      expect(
+        smartschoolPullFingerprint(base.copyWith(
+          schoolPrefix: 'GBS',
+          smartschool: base.smartschool.copyWith(studentGroup: 'SCHOOL'),
+          wisa: base.wisa.copyWith(
+            workDate: WorkDateSetting(isNow: false, date: DateTime(2026, 9)),
+          ),
+        )),
+        smartschoolPullFingerprint(base),
+      );
+    });
+
+    test('is stable across two reads of the same document', () {
+      final settings = _settings().copyWith(
+        smartschoolRules: const [DiscardSmartschoolGroup('Organisatie')],
+      );
+      expect(
+        smartschoolPullFingerprint(settings),
+        smartschoolPullFingerprint(settings),
+      );
+    });
+  });
+
+  group('azurePullFingerprint (#259)', () {
+    test('changes when the school prefix moves', () {
+      expect(
+        azurePullFingerprint(_settings().copyWith(schoolPrefix: 'SSM')),
+        isNot(azurePullFingerprint(_settings().copyWith(schoolPrefix: 'GBS'))),
+      );
+    });
+
+    test("changes when a school's beheerd mark is flipped", () {
+      // The managed set decides which WISA ids the `employeeId in (…)`
+      // back-fill asks Azure about (#224/#231), so it is a pull input too.
+      const school = WisaSchoolProfile(schoolId: 1, code: 'A', name: 'A');
+      expect(
+        azurePullFingerprint(_settings(schools: const [school])),
+        isNot(azurePullFingerprint(_settings(schools: const [
+          WisaSchoolProfile(schoolId: 1, code: 'A', name: 'A', ours: true),
+        ]))),
+      );
+    });
+
+    test('is insensitive to the order the managed schools are stored in', () {
+      const a =
+          WisaSchoolProfile(schoolId: 1, code: 'A', name: 'A', ours: true);
+      const b =
+          WisaSchoolProfile(schoolId: 2, code: 'B', name: 'B', ours: true);
+      expect(
+        azurePullFingerprint(_settings(schools: const [a, b])),
+        azurePullFingerprint(_settings(schools: const [b, a])),
+      );
+    });
+
+    test('is insensitive to whitespace an operator typed around the prefix',
+        () {
+      expect(
+        azurePullFingerprint(_settings().copyWith(schoolPrefix: '  GBS  ')),
+        azurePullFingerprint(_settings().copyWith(schoolPrefix: 'GBS')),
+      );
+    });
+
+    test('ignores settings an Azure pull does not depend on', () {
+      // The virtual mark and the import rules belong to the other two pulls;
+      // neither may cost the operator a full tenant re-read.
+      final base = _settings();
+      expect(
+        azurePullFingerprint(base.copyWith(
+          smartschoolRules: const [DiscardSmartschoolGroup('Organisatie')],
+          wisaSchools: const [
+            WisaSchoolProfile(schoolId: 1, code: 'A', name: 'A', virtual: true),
+          ],
+        )),
+        azurePullFingerprint(base.copyWith(
+          wisaSchools: const [
+            WisaSchoolProfile(schoolId: 1, code: 'A', name: 'A'),
+          ],
+        )),
       );
     });
   });

--- a/packages/account_state/test/materialize/linked_store_test.dart
+++ b/packages/account_state/test/materialize/linked_store_test.dart
@@ -1,11 +1,65 @@
+/// Unit coverage for the multi-operator behaviour the [InMemoryLinkedStore]
+/// models: the sync/drift lease (acquire / renew / expire / block, #108), the
+/// per-system last-sync metadata merge, and the narrow post-apply write-back
+/// (#254). The Cosmos wire shape is covered separately by
+/// `cosmos_linked_store_test`.
+library;
+
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart';
 import 'package:test/test.dart';
 
-/// Unit coverage for the multi-operator coordination the [InMemoryLinkedStore]
-/// models (#108): the sync/drift lease (acquire / renew / expire / block) and
-/// the per-system last-sync metadata merge. The Cosmos wire shape is covered
-/// separately by `cosmos_linked_store_test`.
+/// A student document in [classroom] of school [school], carrying [pending]
+/// applyable candidates.
+MaterializedAccount _account(
+  String id, {
+  String school = '1',
+  String gradeYear = '3',
+  String classroom = '3C',
+  int pending = 0,
+}) =>
+    MaterializedAccount(
+      id: core.LinkedAccountId(id),
+      school: school,
+      schoolLabel: 'School $school',
+      gradeYear: gradeYear,
+      classroom: classroom,
+      role: core.PersonRole.student,
+      isStaff: false,
+      confidence: core.LinkConfidence.high,
+      label: 'Jane $id',
+      inWisa: true,
+      inSmartschool: true,
+      inAzure: true,
+      candidates: [
+        for (var i = 0; i < pending; i++)
+          CandidateAction(
+            family: 'student',
+            kind: 'Candidate$i',
+            system: core.Origin.smartschool,
+            summary: 'Do thing $i',
+          ),
+      ],
+    );
+
+MaterializedGroup _group(String name, {int pending = 0}) => MaterializedGroup(
+      id: core.LinkedAccountId(materializedGroupId(name)),
+      label: name,
+      confidence: core.LinkConfidence.high,
+      inWisa: true,
+      inSmartschool: true,
+      inAzure: true,
+      candidates: [
+        for (var i = 0; i < pending; i++)
+          CandidateAction(
+            family: 'group',
+            kind: 'GroupCandidate$i',
+            system: core.Origin.smartschool,
+            summary: 'Fix thing $i',
+          ),
+      ],
+    );
+
 void main() {
   final t0 = DateTime.utc(2026, 7, 4, 9, 0);
   MaterializedView view({int generation = 1}) => MaterializedView(
@@ -13,6 +67,51 @@ void main() {
         accounts: const [],
         rollups: const [],
       );
+
+  /// A store already holding a materialized view: two students in 3C (one with
+  /// work), one in 3D (with work), and two class groups (one with work).
+  Future<InMemoryLinkedStore> seeded() async {
+    final store = InMemoryLinkedStore();
+    final accounts = [
+      _account('p0', pending: 1),
+      _account('p1'),
+      _account('p2', classroom: '3D', pending: 1),
+    ];
+    final groups = [_group('3C', pending: 1), _group('3D')];
+    await store.writeMaterialized(
+      MaterializedView(
+        generation: 1,
+        accounts: accounts,
+        groups: groups,
+        rollups: [
+          ...buildRollups(accounts),
+          // The single Klasgroepen node `materialize` adds over the group docs.
+          Rollup(
+            level: RollupLevel.groups,
+            key: groupsPartition,
+            parentKey: null,
+            school: groupsPartition,
+            label: 'Klasgroepen',
+            gradeYear: '',
+            classroom: '',
+            accountCount: groups.length,
+            pendingCount: 1,
+          ),
+        ],
+      ),
+      syncedBy: 'jan@school',
+      at: t0,
+    );
+    return store;
+  }
+
+  Future<Rollup?> node(InMemoryLinkedStore store, String key) async {
+    final rollups = await store.readRollups();
+    for (final r in rollups) {
+      if (r.key == key) return r;
+    }
+    return null;
+  }
 
   group('sync/drift lease', () {
     test('acquire succeeds when free and readLease returns the live lease',
@@ -169,6 +268,219 @@ void main() {
       final state = await store.readSyncState();
       expect(state.generation, 1, reason: 'a metadata touch is not a new view');
       expect(state.systems[core.Origin.wisa]?.at, t1);
+    });
+  });
+
+  group('writeApplied — the narrow post-apply write (#254)', () {
+    test('patches only the touched document and the nodes above it', () async {
+      // The seam exists because the alternative — republishing the whole ~9.6k
+      // -document view per apply — is not affordable. So a one-row apply must
+      // leave every other document and every other node exactly as it was.
+      final store = await seeded();
+
+      final write = await store.writeApplied(
+        AppliedPatch(accounts: [_account('p0')]),
+        appliedBy: 'jan@school',
+        at: t0,
+      );
+
+      expect(write.written, isTrue);
+      expect((await node(store, 'class|1|3|3C'))!.pendingCount, 0,
+          reason: "p0's work is done");
+      expect((await node(store, 'class|1|3|3C'))!.accountCount, 2,
+          reason: 'nobody left the class');
+      expect((await node(store, 'grade|1|3'))!.pendingCount, 1,
+          reason: "p2's work in 3D is untouched and still summed above");
+      expect((await node(store, 'school|1'))!.pendingCount, 1);
+      expect((await node(store, 'class|1|3|3D'))!.pendingCount, 1);
+      expect((await node(store, groupsPartition))!.pendingCount, 1,
+          reason: 'the class groups were not part of this pass');
+      final threeC = await store.readClassroom(school: '1', classroom: '3C');
+      expect(
+        threeC.singleWhere((a) => a.id.value == 'p0').candidates,
+        isEmpty,
+        reason: 'the stored document itself dropped the applied candidate',
+      );
+      expect(threeC.singleWhere((a) => a.id.value == 'p1').hasPending, isFalse);
+    });
+
+    test('bumps the generation once and stamps who applied it', () async {
+      final store = await seeded();
+
+      final write = await store.writeApplied(
+        AppliedPatch(accounts: [_account('p0')]),
+        appliedBy: 'mieke@school',
+        at: t0,
+      );
+
+      expect(write.generation, 2);
+      final state = await store.readSyncState();
+      expect(state.generation, 2,
+          reason: 'the session that wrote it is current, not ahead of it');
+      expect(state.updatedBy, 'mieke@school');
+      expect(state.updatedAt, t0);
+    });
+
+    test('stands down while another operator holds the sync lease', () async {
+      // That pass is republishing the whole view from a fresher link than ours;
+      // a narrow patch on top of it — let alone a generation bump past it —
+      // would be a local correction outranking the shared view.
+      final store = await seeded();
+      await store.acquireLease(owner: 'mieke@school', now: t0);
+
+      final write = await store.writeApplied(
+        AppliedPatch(accounts: [_account('p0')]),
+        appliedBy: 'jan@school',
+        at: t0,
+      );
+
+      expect(write.written, isFalse);
+      expect(write.deferredTo?.owner, 'mieke@school');
+      expect((await store.readSyncState()).generation, 1);
+      expect((await node(store, 'class|1|3|3C'))!.pendingCount, 1,
+          reason: 'nothing was written');
+    });
+
+    test('our own lease does not block us', () async {
+      final store = await seeded();
+      await store.acquireLease(owner: 'jan@school', now: t0);
+
+      final write = await store.writeApplied(
+        AppliedPatch(accounts: [_account('p0')]),
+        appliedBy: 'jan@school',
+        at: t0,
+      );
+      expect(write.written, isTrue);
+    });
+
+    test('an expired lease does not block either', () async {
+      final store = await seeded();
+      await store.acquireLease(owner: 'mieke@school', now: t0);
+      final afterExpiry = t0.add(syncLeaseTtl).add(const Duration(seconds: 1));
+
+      final write = await store.writeApplied(
+        AppliedPatch(accounts: [_account('p0')]),
+        appliedBy: 'jan@school',
+        at: afterExpiry,
+      );
+      expect(write.written, isTrue);
+    });
+
+    test('two operators applying different work compose, never clobber',
+        () async {
+      // The reason the rollups move by delta. Both sessions linked when 3C and
+      // 3D each carried one pending decision; each clears its own. A rollup
+      // written from either session's *own* picture of school 1 would put the
+      // other's back.
+      final store = await seeded();
+      final a = await store.writeApplied(
+        AppliedPatch(accounts: [_account('p0')]),
+        appliedBy: 'jan@school',
+        at: t0,
+      );
+      final b = await store.writeApplied(
+        AppliedPatch(accounts: [_account('p2', classroom: '3D')]),
+        appliedBy: 'mieke@school',
+        at: t0,
+      );
+
+      expect([a.generation, b.generation], [2, 3],
+          reason: 'each apply gets a generation of its own to broadcast');
+      expect((await node(store, 'school|1'))!.pendingCount, 0);
+      expect((await node(store, 'class|1|3|3C'))!.pendingCount, 0);
+      expect((await node(store, 'class|1|3|3D'))!.pendingCount, 0);
+      expect((await node(store, 'school|1'))!.accountCount, 3,
+          reason: 'nobody was invented or lost along the way');
+    });
+
+    test('a document the apply removed is deleted and its node emptied',
+        () async {
+      // A student whose last account was just deleted has no document any more;
+      // #227 aside, the same holds for a class group that is gone.
+      final store = await seeded();
+
+      await store.writeApplied(
+        const AppliedPatch(removedAccountIds: ['p2']),
+        appliedBy: 'jan@school',
+        at: t0,
+      );
+
+      expect(await store.readClassroom(school: '1', classroom: '3D'), isEmpty);
+      expect(await node(store, 'class|1|3|3D'), isNull,
+          reason: 'an empty class is not a node the tree should offer');
+      expect((await node(store, 'grade|1|3'))!.accountCount, 2);
+      expect((await node(store, 'grade|1|3'))!.pendingCount, 1,
+          reason: "p0's own work in 3C is nothing to do with p2's departure");
+    });
+
+    test('a class group patch moves the Klasgroepen node only', () async {
+      final store = await seeded();
+
+      await store.writeApplied(
+        AppliedPatch(groups: [_group('3C')]),
+        appliedBy: 'jan@school',
+        at: t0,
+      );
+
+      final groups = await store.readGroups();
+      expect(groups, hasLength(2), reason: 'the inventory keeps every class');
+      expect(
+        groups.singleWhere((g) => g.label == '3C').candidates,
+        isEmpty,
+      );
+      expect((await node(store, groupsPartition))!.pendingCount, 0);
+      expect((await node(store, groupsPartition))!.accountCount, 2);
+      expect((await node(store, 'school|1'))!.pendingCount, 2,
+          reason: 'the student half of the view was not part of this pass');
+    });
+
+    test('an empty patch writes nothing and bumps nothing', () async {
+      // A pass whose every write was refused changed no document, so there is
+      // nothing to nudge anybody about.
+      final store = await seeded();
+
+      final write = await store.writeApplied(
+        const AppliedPatch(),
+        appliedBy: 'jan@school',
+        at: t0,
+      );
+
+      expect(write.written, isFalse);
+      expect(write.deferredTo, isNull);
+      expect((await store.readSyncState()).generation, 1);
+    });
+
+    test('a decision carried on the patched document survives the write',
+        () async {
+      // The derived documents are rewritten wholesale here as everywhere else,
+      // so anything the caller does not re-attach is lost — which for an
+      // operator decision would be silent data loss on exactly the accounts a
+      // pass touched.
+      final store = await seeded();
+      final decision = AccountDecision(
+        accountId: const core.LinkedAccountId('p0'),
+        kind: DecisionKind.chosenAlternative,
+        targetKind: 'Candidate0',
+        decidedBy: 'jan@school',
+        decidedAt: t0,
+      );
+      await store.putDecision(decision);
+
+      await store.writeApplied(
+        AppliedPatch(
+          accounts: [
+            _account('p0', pending: 1).withDecisions([decision])
+          ],
+        ),
+        appliedBy: 'jan@school',
+        at: t0,
+      );
+
+      final stored = (await store.readClassroom(school: '1', classroom: '3C'))
+          .singleWhere((a) => a.id.value == 'p0');
+      expect(stored.decisions, hasLength(1));
+      expect(await store.readDecisions(), hasLength(1),
+          reason: 'the decision documents themselves are never touched here');
     });
   });
 

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -76,12 +76,21 @@ az.AzureUser _azUser({String id = 'az1', String? employeeId = '1'}) =>
       companyName: 'GBS',
     );
 
-core.Group _ssGroup(String name, {String? code}) => core.Group(
+core.Group _ssGroup(
+  String name, {
+  String? code,
+  String description = '',
+  String? instituteNumber,
+  String untis = '',
+}) =>
+    core.Group(
       id: core.GroupId(code ?? name),
       name: name,
-      description: '',
+      description: description,
       type: core.GroupType.classGroup,
       official: true,
+      instituteNumber: instituteNumber,
+      untis: untis,
       origin: core.Origin.smartschool,
     );
 
@@ -151,6 +160,62 @@ LinkedState _modifyPendingLinked() => LinkedState.recompute(
         memberships: const [],
       ),
       azure: az.AzureSnapshot(fetchedAt: _d, users: const [], groups: const []),
+      resolver: _SeqResolver(),
+      studentConfig: _studentConfig,
+      staffConfig: _staffConfig,
+    );
+
+/// A class that is **entirely in order**: present in WISA, in Smartschool with
+/// matching institute number / untis / description, and in Office 365 as
+/// `GBS-3C` with its one student already in it. So the group dispatch raises
+/// nothing at all for it — the shape that used to have no document whatsoever
+/// (#227), which is why the class inventory could not be verified.
+LinkedState _cleanClassLinked() => LinkedState.recompute(
+      wisa: wapi.WisaSnapshot(
+        fetchedAt: _d,
+        students: [_wStudent()],
+        staff: const [],
+        classGroups: [
+          const wapi.WisaClassGroup(
+            name: '3C',
+            groupName: '00',
+            description: 'Derde jaar C',
+            adminCode: '',
+            schoolCode: '123',
+            schoolId: 1,
+          ),
+        ],
+        schools: const [],
+      ),
+      smartschool: ss.SmartschoolSnapshot(
+        fetchedAt: _d,
+        groups: [
+          _ssGroup(
+            '3C',
+            code: '3C_ss',
+            description: 'Derde jaar C',
+            instituteNumber: '123',
+            untis: '3C',
+          ),
+        ],
+        accounts: [_ssAccount()],
+        memberships: const [
+          ss.SmartschoolMembership(uid: 'jane', groupId: core.GroupId('3C_ss')),
+        ],
+      ),
+      azure: az.AzureSnapshot(
+        fetchedAt: _d,
+        users: [_azUser()],
+        groups: [
+          az.AzureGroup(
+            id: 'az-GBS-3C',
+            displayName: 'GBS-3C',
+            mail: 'GBS-3C@school.example',
+            mailNickname: 'GBS-3C',
+            memberIds: const ['az1'],
+          ),
+        ],
+      ),
       resolver: _SeqResolver(),
       studentConfig: _studentConfig,
       staffConfig: _staffConfig,
@@ -383,7 +448,7 @@ void main() {
       expect(rollup.pendingCount, greaterThan(0));
     });
 
-    test('no group actions → no group docs and no group rollup', () {
+    test('no class groups at all → no group docs and no group rollup', () {
       final view = materialize(_noGroupsLinked(), generation: 1);
       expect(view.groups, isEmpty);
       expect(view.rollups.where((r) => r.level == RollupLevel.groups), isEmpty);
@@ -397,6 +462,60 @@ void main() {
       expect(restored.label, group.label);
       expect(restored.inSmartschool, isTrue);
       expect(restored.candidates, hasLength(group.candidates.length));
+    });
+  });
+
+  group('the class inventory covers every class (#227)', () {
+    test('a class with nothing wrong still gets a document', () {
+      // The whole point of the tab: the documents come from the linked class
+      // list, not from the dispatched actions, so a healthy class is on the
+      // inventory — with a tick in all three columns and no candidate at all.
+      final view = materialize(_cleanClassLinked(), generation: 1);
+
+      expect(view.groups, hasLength(1));
+      final group = view.groups.single;
+      expect(group.label, '3C');
+      expect(group.candidates, isEmpty,
+          reason: 'nothing is wrong with this class');
+      expect(group.hasPending, isFalse);
+      expect(group.needsAttention, isFalse);
+      expect(group.inWisa, isTrue);
+      expect(group.inSmartschool, isTrue);
+      expect(group.inAzure, isTrue);
+    });
+
+    test('the row carries its description, bare class name and O365 group', () {
+      final group =
+          materialize(_cleanClassLinked(), generation: 1).groups.single;
+      expect(group.description, 'Derde jaar C');
+      expect(group.className, '3C');
+      expect(group.azureGroupName, 'GBS-3C',
+          reason: 'the Office 365 column names the group, not just a tick');
+
+      final restored = MaterializedGroup.fromJson(group.toJson());
+      expect(restored.description, 'Derde jaar C');
+      expect(restored.className, '3C');
+      expect(restored.azureGroupName, 'GBS-3C');
+    });
+
+    test('the Klasgroepen rollup counts every class, pending only the work',
+        () {
+      // accountCount used to mean "classes with work"; it is the inventory size
+      // now, while pendingCount still counts decisions (#251).
+      final view = materialize(_cleanClassLinked(), generation: 1);
+      final rollup =
+          view.rollups.firstWhere((r) => r.level == RollupLevel.groups);
+      expect(rollup.accountCount, 1);
+      expect(rollup.pendingCount, 0);
+    });
+
+    test('an informational-only notice is attention, not pending work', () {
+      // #225/#250: a class Smartschool already holds carries manual work with no
+      // automated write, so it must not be filtered away with the pending count.
+      final group =
+          materialize(_movePendingLinked(), generation: 1).groups.single;
+      expect(group.hasPending, isFalse);
+      expect(group.needsAttention, isTrue);
     });
   });
 

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -983,6 +983,199 @@ void main() {
     });
   });
 
+  group('rollupChangesFor — the post-apply deltas (#254)', () {
+    MaterializedGroup mGroup(
+      String name, {
+      List<CandidateAction> candidates = const [],
+    }) =>
+        MaterializedGroup(
+          id: core.LinkedAccountId(materializedGroupId(name)),
+          label: name,
+          confidence: core.LinkConfidence.high,
+          inWisa: true,
+          inSmartschool: true,
+          inAzure: true,
+          candidates: candidates,
+        );
+
+    RollupChange changeAt(List<RollupChange> changes, String key) =>
+        changes.singleWhere((c) => c.key == key);
+
+    test('a cleared candidate subtracts one from the class, grade and school',
+        () {
+      // The whole point of a delta: it says "one fewer pending here", not "here
+      // is my session's picture of this class".
+      final changes = rollupChangesFor(
+        storedAccounts: [
+          _account(candidates: const [_moveCandidate])
+        ],
+        freshAccounts: [_account()],
+      );
+
+      expect(changes.map((c) => c.key), <String>{
+        'school|1',
+        'grade|1|3',
+        'class|1|3|3C',
+      });
+      for (final change in changes) {
+        expect(change.pendingDelta, -1);
+        expect(change.accountDelta, 0,
+            reason: 'the account is still there — only its work is gone');
+      }
+    });
+
+    test('an account that stayed exactly as it was moves nothing', () {
+      // A refused write leaves the document identical, and a node nothing
+      // changed at must not be written at all.
+      final changes = rollupChangesFor(
+        storedAccounts: [
+          _account(candidates: const [_moveCandidate])
+        ],
+        freshAccounts: [
+          _account(candidates: const [_moveCandidate])
+        ],
+      );
+      expect(changes, isEmpty);
+    });
+
+    test('a document that vanished takes its account count with it', () {
+      final changes = rollupChangesFor(
+        storedAccounts: [
+          _account(candidates: const [_moveCandidate])
+        ],
+      );
+
+      final klas = changeAt(changes, 'class|1|3|3C');
+      expect(klas.accountDelta, -1);
+      expect(klas.pendingDelta, -1);
+    });
+
+    test('applyTo folds the delta into whatever the store currently holds', () {
+      // Two operators clearing different work in the same class: each subtracts
+      // only its own, and the second folds onto the first's result rather than
+      // replacing it.
+      final change = changeAt(
+        rollupChangesFor(
+          storedAccounts: [
+            _account(candidates: const [_moveCandidate])
+          ],
+          freshAccounts: [_account()],
+        ),
+        'class|1|3|3C',
+      );
+      const stored = Rollup(
+        level: RollupLevel.classroom,
+        key: 'class|1|3|3C',
+        parentKey: 'grade|1|3',
+        school: '1',
+        label: '3C',
+        gradeYear: '3',
+        classroom: '3C',
+        accountCount: 20,
+        pendingCount: 5,
+      );
+
+      final next = change.applyTo(stored)!;
+      expect(next.pendingCount, 4);
+      expect(next.accountCount, 20);
+      expect(next.label, '3C');
+    });
+
+    test('applyTo deletes a node its last document just left', () {
+      final change = changeAt(
+        rollupChangesFor(storedAccounts: [_account()]),
+        'class|1|3|3C',
+      );
+      const stored = Rollup(
+        level: RollupLevel.classroom,
+        key: 'class|1|3|3C',
+        parentKey: 'grade|1|3',
+        school: '1',
+        label: '3C',
+        gradeYear: '3',
+        classroom: '3C',
+        accountCount: 1,
+        pendingCount: 0,
+      );
+
+      expect(change.applyTo(stored), isNull,
+          reason: 'an empty node is one the sync path would not emit either');
+    });
+
+    test('applyTo never advertises a negative badge', () {
+      // The one way the arithmetic can drift: another operator already cleared
+      // this work and wrote it, so our subtraction lands on a count that no
+      // longer carries it. Under-counting is survivable; a negative badge is not.
+      final change = changeAt(
+        rollupChangesFor(
+          storedAccounts: [
+            _account(candidates: const [_moveCandidate])
+          ],
+          freshAccounts: [_account()],
+        ),
+        'class|1|3|3C',
+      );
+      const alreadyCleared = Rollup(
+        level: RollupLevel.classroom,
+        key: 'class|1|3|3C',
+        parentKey: 'grade|1|3',
+        school: '1',
+        label: '3C',
+        gradeYear: '3',
+        classroom: '3C',
+        accountCount: 3,
+        pendingCount: 0,
+      );
+
+      expect(change.applyTo(alreadyCleared)!.pendingCount, 0);
+    });
+
+    test('a node the store has never seen is created from the fresh document',
+        () {
+      final change = changeAt(
+        rollupChangesFor(
+          freshAccounts: [
+            _account(candidates: const [_moveCandidate])
+          ],
+        ),
+        'class|1|3|3C',
+      );
+
+      final created = change.applyTo(null)!;
+      expect(created.level, RollupLevel.classroom);
+      expect(created.parentKey, 'grade|1|3');
+      expect(created.school, '1');
+      expect(created.label, '3C');
+      expect(created.accountCount, 1);
+      expect(created.pendingCount, 1);
+    });
+
+    test("a class group's cleared work moves only the Klasgroepen node", () {
+      // Since #227 the group half of the view is one document per *class*, not
+      // per class with work — so applying a class's work leaves the inventory
+      // size alone and only the pending total moves.
+      const modify = CandidateAction(
+        family: 'group',
+        kind: 'ModifySmartschoolData',
+        system: core.Origin.smartschool,
+        summary: 'Fix the class data',
+      );
+      final changes = rollupChangesFor(
+        storedGroups: [
+          mGroup('3C', candidates: const [modify])
+        ],
+        freshGroups: [mGroup('3C')],
+      );
+
+      final node = changes.single;
+      expect(node.key, groupsPartition);
+      expect(node.level, RollupLevel.groups);
+      expect(node.pendingDelta, -1);
+      expect(node.accountDelta, 0,
+          reason: 'the class is still on the inventory (#227)');
+    });
+  });
+
   group('InMemoryLinkedStore', () {
     test('write then read: sync state, rollups, and a classroom drill-down',
         () async {

--- a/packages/account_state/test/realtime/realtime_test.dart
+++ b/packages/account_state/test/realtime/realtime_test.dart
@@ -73,6 +73,32 @@ void main() {
       expect(const ShardRef(school: 'GBS').isWholeView, isFalse);
       expect(const ShardRef(accountId: 'p1').isWholeView, isFalse);
     });
+
+    test('a shard only excludes what it positively names elsewhere (#254)', () {
+      // The receiver uses these to *skip* re-reads, so the safe answer to
+      // "might this have changed?" is always yes unless the shard says
+      // otherwise. A whole-view change says nothing, so it touches everything.
+      const whole = ShardRef();
+      expect(whole.touchesPartition('1'), isTrue);
+      expect(whole.touchesClassroom(school: '1', classroom: '3C'), isTrue);
+
+      const oneClass = ShardRef(school: '1', classroom: '3C');
+      expect(oneClass.touchesClassroom(school: '1', classroom: '3C'), isTrue);
+      expect(oneClass.touchesClassroom(school: '1', classroom: '3D'), isFalse);
+      expect(oneClass.touchesClassroom(school: '2', classroom: '3C'), isFalse);
+      expect(oneClass.touchesPartition('1'), isTrue);
+      expect(oneClass.touchesPartition(groupsPartition), isFalse,
+          reason: 'a student apply says nothing about the class inventory');
+
+      // A school-wide shard cannot rule any of its classrooms out.
+      const oneSchool = ShardRef(school: '1');
+      expect(oneSchool.touchesClassroom(school: '1', classroom: '3D'), isTrue);
+      expect(oneSchool.touchesClassroom(school: '2', classroom: '3D'), isFalse);
+
+      // …and one that names only an account narrows nothing by partition.
+      const oneAccount = ShardRef(accountId: 'p1');
+      expect(oneAccount.touchesPartition('anything'), isTrue);
+    });
   });
 
   group('InMemorySignalHub', () {


### PR DESCRIPTION
Batch chunk E — five issues, one commit each, each individually green on the full local gates. Follows chunks A (#242), B (#249), C (#256) and D (#260).

This chunk closes **#227**, the Klasgroepen inventory tab that was one of the five issues this batch started from, and which needed #228's Office 365 groups (chunk B) to have a real third column.

## What changed

**`f01a7f1` — #227 a Klasgroepen tab listing every class**
The blocker named in the issue's Scope section was real: `_materializeGroups` derived its documents from the dispatched *actions*, so a class with nothing wrong had no `MaterializedGroup` at all and an inventory could not exist. It now derives from `linked.snapshot.groups` with the actions joined on by key — one document per linked class. `MaterializedGroup` gains `description`, `className`, `azureGroupName` and a `needsAttention` getter (candidates, not pending count), and the Klasgroepen `Rollup.accountCount` is the inventory size while `pendingCount` still counts decisions.

The new shell destination lists every class name-sorted (year-numeric) with its description and three presence cells, highlights rows needing attention, works read-only in a passive session, and embeds the existing interactive entry tiles so a class is inspected, dry-run and applied without leaving the tab. Its filter switch defaults **off** — this tab's job is the full picture.

The Office 365 column is honest about #228's one-group-per-class rule: `2F ECO` and `2F MAW` read "deelgroep van 2F" and then either `GBS-2F` or "nog geen groep voor 2F", so four sub-group rows do not each read as a class missing its own group. An Azure-only leftover is deliberately not treated as somebody's sub-group.

**Decision on the issue's open question:** the Klasgroepen node **leaves** the Acties → Leerlingen drill-down. The tab is a strict superset — same interactive tiles, same bulk headers, plus the classes that are fine — so a second entry point would be the same list maintained twice. The rollup node stays in the store, still feeding the Synchronisatie category tile.

The shared tile vocabulary (pending badge, read-only notice, entry tile and radios, situation header, confirm/progress dialogs, freshness line) moved to a new `action_tiles.dart` rather than being duplicated across the two screens.

**`09db17d` — #254 an apply left the shared view stale for every other operator**
The other half of #236, which corrected the rollups locally and deliberately did not write back. `LinkedStore.writeApplied(AppliedPatch, …)` is the narrow seam that was missing: the touched documents plus the rollup nodes above them, a generation bump, and a sharded `ChangeSignal`. Three rules make it safe when an apply holds no sync lease:

- **It stands down for a sync.** A live foreign lease means someone is republishing the whole view from a fresher link, so the patch is skipped and the operator told — this is what stops a local correction from bumping past a fresher shared view.
- **Rollups move by delta, not replacement**, so two operators clearing different work in one class compose; an emptied node is deleted and a count cannot go negative.
- **Every document write is conditioned on the version it replaces**, and that same version is what its delta was computed against, so a loser re-reads and recomputes.

The session then adopts the generation it wrote (current, never ahead) and re-reads rollups from the store, so another operator's correction outranks this session's picture. A deferred or failed write leaves #236's local correction standing and never fails the pass.

**`9768ac9` — #259 Synchroniseer skipped a re-pull the settings needed**
#99's smart sync re-pulled Smartschool/Azure only when `snapshot == null`, and the "WISA unchanged" shortcut returned before those pulls — so a saved import rule or school prefix was adopted only by Check for drift, while Synchroniseer reported "geen accountwijzigingen nodig" over the skipped save. Added per-system pull fingerprints beside #238's WISA one (`smartschoolPullFingerprint` over the rules, order-sensitive; `azurePullFingerprint` over the prefix and the managed-school set, which decides the back-fill's expected ids). `systemsAwaitingSettings` is the targeted equivalent of `snapshot == null`, and the shortcut no longer fires while it is non-empty — removing the false message together with the skipped pull. `checkDrift` stamps what it adopts, so a following sync does not re-pull for the same change.

**`0bb8ff0` — #257 the rest of the app was English**
Nav rail (`Start` / `Synchronisatie` / `Acties` / `Wachtwoorden` / `Instellingen`), the `_MessagePanel` states on three screens, the sign-in gate in full, and the last-sync box. The rail's `Reconcile` was listed as English, but the app also used "Reconcile" as the screen's proper name inside Dutch copy — so the screen was renamed rather than leaving the rail bilingual, which is why the diff reaches four extra files. About 161 assertion lines moved.

**`3953a14` — #258 the Log panel switched language mid-pass**
Every string the Flutter app writes to `LogBuffer` — pull steps, the smart-diff shortcut, drift steps, the relink summary, the apply pass, persist failures, the lease/signal errors sitting beside #108's already-Dutch lease lines, and #239's pull line, which was itself half-and-half. The rule applied: a string reaching `LogBuffer` is operator-facing and is Dutch; exception messages, doc comments, API names and test names stay English.

Two vacuous assertions were found and fixed along the way — `contains('timed out')` and a `textContaining('Could not persist')` asserted *absent* would both have kept passing against the new Dutch text.

## Test plan

Every commit was verified individually before landing; the numbers below are the final state of the branch.

- `dart format --set-exit-if-changed .` — clean, 303 files, 0 changed
- `dart analyze --fatal-infos --fatal-warnings` — clean
- `dart test` across the 8 packages — 1234 pass, 11 skipped (opt-in live, deliberately not run)
- `flutter test` (account_manager widget) — 417 pass
- `flutter test integration_test/app_launch_test.dart -d windows` — 86 pass, including new e2e cases for #227, #254, #257, #258 and #259
- Each issue's new test was confirmed **failing on unpatched code** — for #254 the unpatched run leaves 3C still badged after another operator applied its work, which is the bug.

No live WISA / Smartschool / Azure / Cosmos / SignalR hosts were contacted.

## Follow-ups filed during this chunk

**#261**, **#262**, **#263**, **#264**, **#265**, **#266** — none blocking. #266 is the connector-layer counterpart of #258: about 40 English `ILog` lines across four `packages/*` connectors that reach the same Log panel, left out of this commit because translating them moves those packages' own unit tests.

Closes #227
Closes #254
Closes #257
Closes #258
Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)
