### PR TITLE
fix(azure): never write a staff department — it is owned elsewhere and lists every school (#237)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -5754,33 +5754,35 @@ void main() {
   });
 
   testWidgets(
-      'an adopted staff account is stamped with our department, so the repair '
-      'sticks instead of depending on the back-fill forever (#233)',
-      (WidgetTester tester) async {
-    // The third piece of the transferred-account problem, and the one the staff
-    // family never had. #231 made the pull *find* Anna Smit's existing account
-    // by employeeId, but nothing wrote our marker onto it: her `department`
-    // still names the sibling group school, so neither leg of the connector's
-    // `$filter` matches and every single pass has to re-adopt her by back-fill.
-    // Once she leaves WISA her id drops out of `managedStaffEmployeeIds`, the
-    // back-fill stops asking, and the account is invisible for good — no
-    // RemoveStaffFromAzure would ever be proposed for it.
+      "a moved staff member's Azure department is left exactly as the other "
+      'software wrote it (#237)', (WidgetTester tester) async {
+    // The counterpart of the #231 test above, one pass later: Anna Smit's
+    // record is now complete (WISA + Smartschool + Azure), so the modify branch
+    // is live, and her `department` still reads `GBS,SSM` — the comma-separated
+    // list of the schools she is active at, maintained by other software and
+    // read-only from here. Our prefix being second in it is the ordinary state,
+    // not a defect.
     //
-    // Here the record is complete (WISA + Smartschool + Azure), which is the
-    // pass after AddStaffToSmartschool ran, so the modify branch is live.
+    // #233 briefly shipped a repair for this. It fired on any list our prefix
+    // did not lead, and its rewrite split on a ` - ` a comma list has none of,
+    // so one apply turned `SSM,GBS` into `GBS` and deleted the sibling school's
+    // claim. This is the layer that proves the operator is no longer offered
+    // that: the whole pass must raise nothing and write nothing.
     useTallWindow(tester);
     final azureWire = TransferredAccountGraph(
       employeeId: '42',
       upn: 'smit.anna@other.example',
       displayName: 'Smit Anna',
-      department: 'OTHER - Wiskunde',
+      // The harness school is `GBS`, so this is the destructive case exactly:
+      // we are on the list, just not first.
+      department: 'SSM,GBS',
     );
     final harness = ReconcileHarness(
       wisa: wisaSnap(students: const [], staff: [wisaStaff()]),
       smartschool: ssSnap(
         groups: const [],
-        // Her Smartschool mail already matches the adopted UPN, so the only
-        // thing left wrong about this staff member is the Azure department.
+        // Her Smartschool mail already matches the adopted UPN, so nothing else
+        // about this staff member is out of step either.
         accounts: [ssStaffAccount(mail: 'smit.anna@other.example')],
         memberships: const [],
       ),
@@ -5799,73 +5801,44 @@ void main() {
     await tester.pumpAndSettle();
     expect(harness.controller.error, isNull);
 
-    // The starting state: invisible to the school-scoped read, present only
-    // because the #231 back-fill went looking for her by employeeId.
-    expect(azureWire.bulkReads, 1);
+    // She is in the snapshot — found by the #231 back-fill, since the
+    // school-scoped `$filter` leg is `startswith(department, …)` and her list
+    // does not lead with us.
     expect(azureWire.employeeIdLookups, <String>["employeeId in ('42')"]);
     final linked = harness.controller.linked!.snapshot.staff.single;
     expect(linked.wisa, isNotNull);
     expect(linked.smartschool, isNotNull);
     expect(linked.azure?.id, 'az-transferred');
-    expect(harness.app.azure.snapshot!.users.single.department,
-        'OTHER - Wiskunde');
+    expect(harness.app.azure.snapshot!.users.single.department, 'SSM,GBS');
 
-    // Acties → Personeel: the operator is offered the repair.
+    // Nothing anywhere in the pass proposes touching the school field — this
+    // staff member is fully synced, so she raises no to-do at all.
+    expect(
+      harness.controller.pendingEntries
+          .expand((e) => e.choices)
+          .expand((c) => c.alternatives)
+          .map((a) => a.kind),
+      isNot(contains('ModifyStaffAzureSchool')),
+    );
+    expect(
+      harness.controller.pendingEntries.where((e) => e.family == 'staff'),
+      isEmpty,
+    );
+
+    // And the operator sees it: Acties has no staff work to show.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
-    final staffSchool =
-        find.byKey(const ValueKey('rollup-school-school|staff'));
-    await tester.ensureVisible(staffSchool);
-    await tester.tap(staffSchool);
-    await tester.pumpAndSettle();
-    await tester
-        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
-    await tester.pumpAndSettle();
-    final staffClass = find
-        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
-    await tester.ensureVisible(staffClass);
-    await tester.tap(staffClass);
-    await tester.pumpAndSettle();
-    expect(find.text('Wijzig de school in Azure'), findsOneWidget);
+    expect(find.text('Wijzig de school in Azure'), findsNothing);
 
-    // Apply just that row.
-    final entry = harness.controller.pendingEntries
-        .firstWhere((e) => e.family == 'staff');
-    final id = entry.targetId;
-    await tester.ensureVisible(find.byKey(ValueKey('entry-staff-$id')));
-    await tester.tap(find.byKey(ValueKey('entry-staff-$id')));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
-    await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-    await tester.pumpAndSettle();
-    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
-
-    // One PATCH, touching `department` only, with our prefix at the head and
-    // the subject the other school wrote still on it.
-    final patches =
-        harness.graph.requests.where((r) => r.method == 'PATCH').toList();
-    expect(patches, hasLength(1));
-    expect(patches.single.url.path, contains('az-transferred'));
+    // No write reached Azure, so the list the other software maintains is
+    // exactly as it was.
     expect(
-      jsonDecode(patches.single.body!) as Map<String, dynamic>,
-      <String, dynamic>{'department': 'GBS - Wiskunde'},
+      harness.graph.requests.where((r) => r.method == 'PATCH'),
+      isEmpty,
+      reason: 'department belongs to the software that maintains the list',
     );
-    expect(azureWire.bulkReads, 1, reason: 'the repair is a write, not a read');
-
-    // Prefix-first is what makes it stick: that is exactly the
-    // `startswith(department,'GBS')` leg of UserManager.filterFor, so the next
-    // school-scoped bulk read returns the account on its own — no employeeId
-    // back-fill required, and a later departure can raise a removal.
-    final repaired = harness.app.azure.snapshot!.users.single.department!;
-    expect(repaired, 'GBS - Wiskunde');
-    expect(repaired.startsWith('GBS'), isTrue);
-    // …and the re-linked view the operator now sees carries it too.
-    expect(harness.controller.linked!.snapshot.staff.single.azure?.id,
-        'az-transferred');
   });
 
   testWidgets(

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -127,7 +127,7 @@ The flat shape mirrors Smartschool's SOAP contract. It must **not** leak past th
 | `givenName` | `String` | |
 | `surname` | `String` | |
 | `companyName` | `String?` | School prefix; used to identify former members to remove |
-| `department` | `String?` | Holds school prefix for staff |
+| `department` | `String?` | Staff: a **comma-separated list of school prefixes** (`GBS,SSM`) — every school the teacher is currently active at. Owned by other software: we read it (`contains`, INV-22) and never write it on an existing account (#237); only account *creation* stamps our prefix. Students: the class group. |
 
 ### 3.7 `Group` and `Membership` — major redesign
 

--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -110,8 +110,8 @@ than `else`, but sets `OK = false` inside the missing branch, so the two
 branches are mutually exclusive just like the student parser. The staff
 lifecycle set is `AddStaffToAzure`, `AddStaffToSmartschool`,
 `RemoveStaffFromSmartschool`, `DontImportStaffFromWisa`, `RemoveStaffFromAzure`;
-the modify set is `ModifyStaffAzureSchool`, `UpdateStaffWisaName`,
-`ModifySmartschoolStaffEmail`, `SetStaffCopyCode`. Staff bridge to Smartschool
+the modify set is `UpdateStaffWisaName`, `ModifySmartschoolStaffEmail`,
+`SetStaffCopyCode`. Staff bridge to Smartschool
 by `WisaStaff.code` (not `wisaId`) — `AddStaffToSmartschool` and
 `UpdateStaffWisaName` write the code into `accountId` (spec §4, OQ-1), while the
 numeric `wisaId` becomes the copy-code.
@@ -248,21 +248,22 @@ own those).
   the action converges after one apply.
 - **Staff gender on create.** Legacy `AddToSmartschool` hard-codes `Female` for
   new staff (WISA staff rows carry no gender); preserved verbatim.
-- **`ModifyStaffAzureSchool` is an addition, not a port.** The legacy staff
-  family has no `department` repair, so an Azure account adopted by the
-  `employeeId` back-fill (#231) never carried our marker and stayed invisible to
-  the school-scoped bulk read forever (#233). It fires when `department` does not
-  *start with* the school prefix — a missing one included, mirroring what #224
-  taught the student `ModifyAzureSchool` about a null `companyName` — and it is
-  `startswith`, not the linker's laxer `contains`, because that is the exact
-  server-side test `UserManager.filterFor` applies. **Assumed value shape:**
-  `<school>` or `<school> - <suffix>` (real data carries a subject suffix,
-  `Arcadia - Wiskunde`), so only the leading school segment is replaced and any
-  suffix is preserved. Legacy's staff `RemoveFromAzure` renders the field under
-  an "Active Schools" header and both linkers test it with `contains`, so it may
-  instead enumerate several schools — in which case replacing the head segment
-  evicts a sibling school's claim and this needs to become a prepend. Tracked as
-  #237.
+- **No staff `department` repair — the field is not ours to write (#237).** A
+  staff member's Azure `department` is maintained by other software and holds a
+  **comma-separated list of school prefixes** (`GBS,SSM`), one per school the
+  teacher is currently active at. We read it — the linker's `contains` test
+  (INV-22) is exactly the right question, "is this teacher active at our
+  school?" — and we never write it on an account that already exists.
+  `ModifyStaffAzureSchool` (#233) did, and it was destructive: it fired whenever
+  the list did not *start with* our prefix, which is every teacher we are not
+  listed first for, and its "repair" split on a ` - ` separator a comma list has
+  none of, so `GBS,SSM` was rewritten to a bare `SSM` — deleting the sibling
+  school's claim. Removed whole rather than narrowed. `AddStaffToAzure` still
+  writes the bare prefix when it **creates** an account, which destroys nothing.
+  The two problems #233 was actually aimed at — the bulk read's
+  `startswith(department, …)` leg missing staff whose list does not lead with us,
+  and a staff member who leaves WISA going invisible instead of raising
+  `RemoveStaffFromAzure` — are tracked as their own issues.
 - Smartschool `uid` uniqueness for new accounts is the caller's concern (the
   State layer holds the account set); the default builder is deliberately
   simple.

--- a/packages/account_actions/lib/src/staff_action.dart
+++ b/packages/account_actions/lib/src/staff_action.dart
@@ -574,83 +574,31 @@ class DontImportStaffFromWisa extends StaffAction {
 // Modify actions — evaluated only when all three systems are present (§6.3).
 // ---------------------------------------------------------------------------
 
-/// Stamp the school prefix on a staff member's Azure `department` — the staff
-/// counterpart of [ModifyAzureSchool], which the legacy family never had
-/// (#233).
-///
-/// **Why the family needs one.** Students carry the school marker in
-/// `companyName`; staff carry it in `department`. #231 taught the Azure pull to
-/// adopt a moved staff member's existing account by `employeeId`, but nothing
-/// then wrote our marker onto it, so the account stayed invisible to the
-/// school-scoped bulk read (`UserManager.filterFor`'s
-/// `startswith(department, <prefix>)` leg) and had to be re-adopted by the
-/// back-fill on *every* pass. Worse, once the member leaves WISA their id drops
-/// out of `managedStaffEmployeeIds`, the back-fill stops asking, and the account
-/// goes invisible for good — no `RemoveStaffFromAzure` is ever proposed. Setting
-/// the field is what makes the adoption stick.
-///
-/// **Trigger.** A `department` that does not *start with* the prefix — a
-/// **missing** one included, exactly as #224 taught [ModifyAzureSchool] to treat
-/// a null `companyName`. `startswith` (not the linker's laxer `contains`) is the
-/// criterion on purpose: it is precisely the server-side test the next bulk read
-/// applies, so one apply is guaranteed to make the account visible on its own.
-///
-/// **What it writes — an assumption worth stating.** Staff `department` values
-/// in real data carry a suffix (`Arcadia - Wiskunde`) where a student's
-/// `companyName` is flat, so overwriting the field with the bare prefix would
-/// discard whatever the other school wrote there. This action assumes the shape
-/// `<school>` or `<school> - <suffix>` and replaces **only** the leading school
-/// segment, preserving the rest: `OTHER - Wiskunde` → `<prefix> - Wiskunde`, a
-/// bare `OTHER` → `<prefix>`, and an unset field → `<prefix>` (what
-/// [AddStaffToAzure] writes on create). The legacy staff `RemoveFromAzure`
-/// renders this field under a **"Active Schools"** header and both linkers test
-/// it with `contains`, which hints it might instead enumerate several schools —
-/// in which case replacing the head segment evicts a sibling school's claim and
-/// this is the line to revisit. Filed as #237; nothing in either codebase ever
-/// writes such a value today.
-class ModifyStaffAzureSchool extends StaffAction {
-  const ModifyStaffAzureSchool(super.staff, super.config);
-
-  /// The repaired `department`: our prefix, plus whatever the field already
-  /// carried after the first ` - `.
-  String get _department =>
-      _withSchoolPrefix(_az.department, config.schoolPrefix);
-
-  @override
-  bool evaluate() {
-    final prefix = _n(config.schoolPrefix);
-    // No prefix configured: there is nothing to stamp, and blanking the field
-    // would only make the account less findable than it already is.
-    if (prefix == null) return false;
-    final department = _n(_az.department);
-    return department == null || !department.startsWith(prefix);
-  }
-
-  @override
-  ChangeSet describeChanges() => ChangeSet(
-        system: Origin.azure,
-        summary: 'Wijzig de school in Azure',
-        fields: [
-          FieldChange(
-            'department',
-            before: _az.department,
-            after: _department,
-          ),
-        ],
-      );
-
-  @override
-  Future<ActionResult> apply(Connectors connectors, ApplyOptions options) {
-    final department = _department;
-    return _azurePatch(
-      connectors,
-      options,
-      describeChanges(),
-      (users) => users.updateUser(_az.id, department: department),
-      () => _az.copyWith(department: department),
-    );
-  }
-}
+// There is deliberately **no** staff `department` repair here (#237). A staff
+// member's `department` is not ours to write: it is maintained by other
+// software as a comma-separated list of the school prefixes the teacher is
+// currently active at (`GBS,SSM`), and we only ever *read* it — the linker's
+// `contains` test (INV-22) is the correct way to ask "is this teacher active at
+// our school?".
+//
+// The `ModifyStaffAzureSchool` action added in #233 wrote it, and both halves
+// were wrong. It fired whenever `department` did not *start with* our prefix,
+// so it fired for every teacher whose list merely names us second — an ordinary
+// state, not an edge case. And its repair looked for a ` - ` separator that a
+// comma list does not contain, so applying it collapsed `GBS,SSM` to a bare
+// `SSM` and silently destroyed the sibling school's claim in a field we do not
+// own. Removed whole rather than narrowed: there is no value of this field we
+// are entitled to write onto an account that already exists.
+//
+// [AddStaffToAzure] still writes the bare prefix when it *creates* an account,
+// which cannot destroy anything — the account, and therefore the field, did not
+// exist a moment earlier.
+//
+// The two real problems #233 was aimed at survive the removal and are tracked
+// separately: the bulk read's `startswith(department, …)` leg misses staff
+// whose list does not lead with us, and a staff member who leaves WISA drops
+// out of the `employeeId` back-fill and so goes invisible instead of raising a
+// [RemoveStaffFromAzure].
 
 /// Correct the Smartschool internal number to equal the WISA staff
 /// [wapi.WisaStaff.code] (staff bridge to Smartschool, spec §4). Ported from
@@ -825,37 +773,10 @@ class SetStaffCopyCode extends StaffAction {
 // Shared apply helpers for the modify actions.
 // ---------------------------------------------------------------------------
 
-extension _AzurePatch on StaffAction {
-  /// Runs an Azure PATCH ([write]) unless dry-run, and returns the projected
-  /// [record] as the mutated source record.
-  Future<ActionResult> _azurePatch(
-    Connectors connectors,
-    ApplyOptions options,
-    ChangeSet changes,
-    Future<void> Function(az.UserManager users) write,
-    az.AzureUser Function() record,
-  ) async {
-    if (options.dryRun) {
-      return ActionResult(
-        outcome: ActionOutcome.dryRun,
-        changes: changes,
-        system: Origin.azure,
-        azure: record(),
-      );
-    }
-    try {
-      await write(_requireAzure(connectors).users);
-      return ActionResult(
-        outcome: ActionOutcome.applied,
-        changes: changes,
-        system: Origin.azure,
-        azure: record(),
-      );
-    } on Object catch (e) {
-      return _failed(changes, Origin.azure, e);
-    }
-  }
-}
+// The staff family has no Azure-PATCH helper: the only staff modify action that
+// ever wrote to Azure was the `department` repair removed in #237, and
+// `RemoveStaffFromAzure` deletes rather than patches. The student family keeps
+// its own `_azurePatch`.
 
 extension _SmartschoolSave on StaffAction {
   /// Saves [updated] to Smartschool (`saveUser` with an unchanged password)
@@ -912,22 +833,6 @@ String _copyCode(String? wisaId) {
     code = '0$code';
   }
   return code;
-}
-
-/// Separates the school segment of a staff `department` from the rest of the
-/// value (`Arcadia - Wiskunde`). See [ModifyStaffAzureSchool] for the shape
-/// this assumes.
-const String _departmentSeparator = ' - ';
-
-/// [department] with its leading school segment replaced by [schoolPrefix], the
-/// suffix after the first [_departmentSeparator] preserved verbatim. A value
-/// with no separator is all school segment, so it is replaced whole; a blank or
-/// missing one becomes the bare prefix (what [AddStaffToAzure] writes on
-/// create).
-String _withSchoolPrefix(String? department, String schoolPrefix) {
-  final current = department?.trim() ?? '';
-  final at = current.indexOf(_departmentSeparator);
-  return at < 0 ? schoolPrefix : '$schoolPrefix${current.substring(at)}';
 }
 
 /// Trims + lower-cases for case-insensitive comparison (INV-12); blank → null.

--- a/packages/account_actions/lib/src/staff_action_config.dart
+++ b/packages/account_actions/lib/src/staff_action_config.dart
@@ -11,6 +11,11 @@ class StaffActionConfig {
   /// The school prefix stamped on a staff member's Azure `department` when a
   /// new account is created (legacy `CreateStaffMember` sets
   /// `Department = Connector.Prefix`).
+  ///
+  /// **Create only** (#237). On an account that already exists, `department` is
+  /// read-only from our side: other software maintains it as a comma-separated
+  /// list of every school prefix the teacher is active at, so writing our prefix
+  /// over it would evict a sibling school's claim. No staff action patches it.
   final String schoolPrefix;
 
   /// The base UPN domain, e.g. `arcadiascholen.be`. New staff UPNs are minted

--- a/packages/account_actions/lib/src/staff_dispatch.dart
+++ b/packages/account_actions/lib/src/staff_dispatch.dart
@@ -20,10 +20,12 @@ import 'staff_action_config.dart';
 /// dispatched here: they evaluate against Office 365 group membership, which a
 /// [LinkedStaff] does not carry (see the package README).
 ///
-/// [ModifyStaffAzureSchool] has no legacy counterpart at all — the staff family
-/// never had a `department` repair (#233). Like the student `ModifyAzureSchool`
-/// it sits in the modify branch, so an adopted account is stamped on the pass
-/// *after* its Smartschool side is built and the record is complete.
+/// The modify branch has **no** Azure `department` repair, and must not grow one
+/// (#237): a staff member's `department` is owned by other software and holds a
+/// comma-separated list of the school prefixes they are active at, so the only
+/// correct thing to do with it is read it. The `ModifyStaffAzureSchool` this
+/// branch briefly carried (#233) fired for every teacher our prefix did not lead
+/// the list for, and rewrote `GBS,SSM` to a bare `SSM`.
 ///
 /// A staff member with no Smartschool account raises [DontImportStaffFromWisa]
 /// *and* exactly one of [AddStaffToAzure] / [AddStaffToSmartschool]. Those are
@@ -42,7 +44,6 @@ List<StaffAction> staffActionsFor(
 
   final candidates = complete
       ? <StaffAction>[
-          ModifyStaffAzureSchool(staff, config),
           UpdateStaffWisaName(staff, config),
           ModifySmartschoolStaffEmail(staff, config),
           SetStaffCopyCode(staff, config),

--- a/packages/account_actions/test/staff_apply_test.dart
+++ b/packages/account_actions/test/staff_apply_test.dart
@@ -49,25 +49,6 @@ void main() {
       expect(transport.soapActions, isEmpty);
     });
 
-    test('ModifyStaffAzureSchool dry run: no PATCH, repaired value projected',
-        () async {
-      final transport = RecordingGraphTransport();
-      final connectors = Connectors(azure: azureConnector(transport));
-      final action = ModifyStaffAzureSchool(
-        linkedStaff(
-          wisa: wisaStaff(),
-          smartschool: ssStaff(),
-          azure: azureStaff(department: 'OTHER - Wiskunde'),
-        ),
-        cfg,
-      );
-
-      final result = await action.apply(connectors, ApplyOptions.dry);
-      expect(result.outcome, ActionOutcome.dryRun);
-      expect(transport.requests, isEmpty);
-      expect((result.azure! as az.AzureUser).department, 'SSM - Wiskunde');
-    });
-
     test('SetStaffCopyCode dry run: no write, padded fax projected', () async {
       final transport = RecordingSmartschoolTransport();
       final connectors =
@@ -344,38 +325,40 @@ void main() {
     });
 
     test(
-        'ModifyStaffAzureSchool: PATCHes department so the next bulk read can '
-        'see the account (#233)', () async {
-      final transport = RecordingGraphTransport();
-      final connectors = Connectors(azure: azureConnector(transport));
-      final action = ModifyStaffAzureSchool(
-        linkedStaff(
-          wisa: wisaStaff(),
-          smartschool: ssStaff(),
-          azure: azureStaff(id: 'az-moved', department: 'OTHER - Wiskunde'),
-        ),
-        cfg,
-      );
-
-      final result = await action.apply(connectors, const ApplyOptions());
-      expect(result.outcome, ActionOutcome.applied);
-      expect(result.system, Origin.azure);
-
-      final patch = transport.requests
-          .singleWhere((r) => r.method == 'PATCH', orElse: () => throw 'none');
-      expect(patch.url.path, contains('az-moved'));
-      expect(
-        jsonDecode(patch.body!) as Map<String, dynamic>,
-        {'department': 'SSM - Wiskunde'},
-        reason: 'only the department is touched, prefix first',
-      );
-      // Prefix-first is the whole point: it is the `startswith(department, …)`
-      // leg of UserManager.filterFor, so the school-scoped pull now returns the
-      // account without the employeeId back-fill having to find it (#231).
-      expect(
-        (result.azure! as az.AzureUser).department!.startsWith('SSM'),
-        isTrue,
-      );
+        'no staff action ever PATCHes an existing account\'s department (#237)',
+        () async {
+      // `department` is owned by other software and lists every school the
+      // teacher is active at (`GBS,SSM`). The removed #233 repair fired on any
+      // list our prefix did not lead and rewrote it to a bare `SSM`, deleting
+      // the sibling school's claim. Nothing may write it again — asserted over
+      // the whole staff family, not one action, so a reintroduction anywhere
+      // fails here.
+      for (final department in <String?>[
+        'GBS,SSM',
+        'SSM,GBS',
+        'GBS',
+        'OTHER - Wiskunde',
+        null,
+      ]) {
+        final transport = RecordingGraphTransport();
+        final connectors = Connectors(
+          azure: azureConnector(transport),
+          smartschool: smartschoolConnector(RecordingSmartschoolTransport()),
+        );
+        final staff = linkedStaff(
+          wisa: wisaStaff(code: 'SMIT', wisaId: '42'),
+          smartschool: ssStaff(accountId: 'OLD', fax: '9999'),
+          azure: azureStaff(id: 'az-moved', department: department),
+        );
+        for (final action in staffActionsFor(staff, cfg)) {
+          await action.apply(connectors, const ApplyOptions());
+        }
+        expect(
+          transport.requests.where((r) => r.method == 'PATCH'),
+          isEmpty,
+          reason: 'department: $department',
+        );
+      }
     });
 
     test('RemoveStaffFromAzure: deletes the user', () async {

--- a/packages/account_actions/test/staff_dispatch_test.dart
+++ b/packages/account_actions/test/staff_dispatch_test.dart
@@ -51,20 +51,19 @@ void main() {
       expect(actions.whereType<UpdateStaffWisaName>(), isEmpty);
       expect(actions.whereType<ModifySmartschoolStaffEmail>(), isEmpty);
       expect(actions.whereType<SetStaffCopyCode>(), isEmpty);
-      expect(actions.whereType<ModifyStaffAzureSchool>(), isEmpty);
     });
 
     test(
-        'an adopted account with another school\'s department is not repaired '
-        'until the record is complete (#233)', () {
+        "an adopted account carrying another school's department raises the "
+        'ordinary create, and nothing about the department (#237)', () {
       // WISA + Azure, no Smartschool — the state #231's back-fill leaves a
-      // moved staff member in. The mutually exclusive branches (§6.3) mean the
-      // department repair waits for the pass after AddStaffToSmartschool, the
-      // same way the student `ModifyAzureSchool` does.
+      // moved staff member in. `department` is the sibling school's to maintain
+      // (it lists every school the teacher is active at), so the only thing
+      // still missing here is the Smartschool account.
       final actions = staffActionsFor(
         linkedStaff(
           wisa: wisaStaff(),
-          azure: azureStaff(department: 'OTHER - Wiskunde'),
+          azure: azureStaff(department: 'GBS'),
         ),
         cfg,
       );
@@ -123,29 +122,29 @@ void main() {
       expect(types(actions), [SetStaffCopyCode]);
     });
 
-    test(
-        "an Azure department naming another school → only "
-        'ModifyStaffAzureSchool (#233)', () {
-      final actions = staffActionsFor(
-        linkedStaff(
-          wisa: wisaStaff(),
-          smartschool: ssStaff(),
-          azure: azureStaff(department: 'OTHER - Wiskunde'),
-        ),
-        cfg,
-      );
-      expect(types(actions), [ModifyStaffAzureSchool]);
-    });
-
-    test('a fully-synced staff member with our prefix raises no repair (#233)',
-        () {
-      // The default fixture's `department` is exactly the prefix, so the new
-      // action must not turn every clean staff record into a pending item.
-      expect(
-        staffActionsFor(fullySyncedStaff(), cfg)
-            .whereType<ModifyStaffAzureSchool>(),
-        isEmpty,
-      );
+    test('an Azure department naming other schools raises nothing (#237)', () {
+      // `department` is a comma-separated list of the schools the teacher is
+      // active at, maintained by other software. Our prefix appearing second —
+      // or not at all on a record the back-fill adopted by employeeId — is not
+      // a defect we may "repair": the write that used to do it (#233) collapsed
+      // the list to our prefix alone and destroyed the sibling school's claim.
+      for (final department in <String?>[
+        'GBS,SSM',
+        'SSM,GBS',
+        'GBS',
+        'OTHER - Wiskunde',
+        null,
+      ]) {
+        final actions = staffActionsFor(
+          linkedStaff(
+            wisa: wisaStaff(),
+            smartschool: ssStaff(),
+            azure: azureStaff(department: department),
+          ),
+          cfg,
+        );
+        expect(actions, isEmpty, reason: 'department: $department');
+      }
     });
 
     test('present-branch never emits a lifecycle action', () {
@@ -232,7 +231,7 @@ void main() {
         linkedStaff(
           wisa: wisaStaff(code: 'SMIT', wisaId: '42'),
           smartschool: ssStaff(accountId: 'OLD', fax: '9999'),
-          azure: azureStaff(department: 'OTHER - Wiskunde'),
+          azure: azureStaff(),
         ),
       ]) {
         for (final action in staffActionsFor(staff, cfg)) {
@@ -296,7 +295,7 @@ void main() {
         linkedStaff(
           wisa: wisaStaff(code: 'SMIT', wisaId: '42'),
           smartschool: ssStaff(accountId: 'OLD', fax: '9999'),
-          azure: azureStaff(department: 'OTHER - Wiskunde'),
+          azure: azureStaff(),
         ),
       ]) {
         for (final action in staffActionsFor(staff, cfg)) {
@@ -321,7 +320,7 @@ void main() {
         linkedStaff(
           wisa: wisaStaff(code: 'SMIT', wisaId: '42'),
           smartschool: ssStaff(accountId: 'OLD', fax: '9999'),
-          azure: azureStaff(department: 'OTHER - Wiskunde'),
+          azure: azureStaff(),
         ),
       ]) {
         for (final action in staffActionsFor(staff, cfg)) {

--- a/packages/account_actions/test/staff_purity_test.dart
+++ b/packages/account_actions/test/staff_purity_test.dart
@@ -97,86 +97,37 @@ void main() {
     });
   });
 
-  group('ModifyStaffAzureSchool stamps our prefix on `department` (#233)', () {
-    ModifyStaffAzureSchool actionFor(String? department) =>
-        ModifyStaffAzureSchool(
-          linkedStaff(
-            wisa: wisaStaff(),
-            smartschool: ssStaff(),
-            azure: azureStaff(department: department),
-          ),
-          cfg,
-        );
-
-    test('a missing department counts as differing and becomes the prefix', () {
-      // The self-perpetuating case: an account with no `department` is
-      // invisible to the next sync's `$filter`, so if the one action that would
-      // stamp our prefix refused to fire on null, the adoption could never
-      // stick. Same lesson #224 taught the student `companyName` repair.
-      final action = actionFor(null);
-      expect(action.evaluate(), isTrue);
-      final change = action.describeChanges();
-      expect(change.system, Origin.azure);
-      final field = change.fields.single;
-      expect(field.field, 'department');
-      expect(field.before, isNull);
-      expect(field.after, 'SSM');
-    });
-
-    test('another school + a subject suffix keeps the suffix', () {
-      // What a move from a sibling group school leaves behind. Overwriting the
-      // whole field with the bare prefix would throw away 'Wiskunde', which the
-      // other school wrote and WISA cannot tell us.
-      final action = actionFor('OTHER - Wiskunde');
-      expect(action.evaluate(), isTrue);
-      expect(action.describeChanges().fields.single.after, 'SSM - Wiskunde');
-    });
-
-    test('another school with no suffix is replaced whole', () {
-      final action = actionFor('OTHER');
-      expect(action.evaluate(), isTrue);
-      expect(action.describeChanges().fields.single.after, 'SSM');
-    });
-
-    test('a department already carrying our prefix does not fire', () {
-      expect(actionFor('SSM').evaluate(), isFalse);
-      expect(actionFor('SSM - Wiskunde').evaluate(), isFalse);
-      // Trimmed + case-insensitive, like every other comparison (INV-12).
-      expect(actionFor('  ssm - Wiskunde ').evaluate(), isFalse);
-    });
-
-    test('it converges: the repaired value re-evaluates to false', () {
-      final repaired =
-          actionFor('OTHER - Wiskunde').describeChanges().fields.single.after;
-      expect(actionFor(repaired).evaluate(), isFalse);
-    });
-
-    test('no configured prefix → nothing to stamp, so it never fires', () {
-      // Blanking the field would only make the account harder to find than the
-      // misconfiguration already makes it.
-      final action = ModifyStaffAzureSchool(
-        linkedStaff(
+  group("a staff member's Azure `department` is never written (#237)", () {
+    // `department` belongs to other software: it is a comma-separated list of
+    // the school prefixes the teacher is active at, so our prefix appearing
+    // anywhere in it is the *normal* state and any write of ours would evict
+    // another school's claim. The action that used to do this
+    // (`ModifyStaffAzureSchool`, #233) fired on `!startsWith(prefix)` and
+    // "repaired" `GBS,SSM` to a bare `SSM`. Nothing may propose a department
+    // change again.
+    for (final department in <String?>[
+      null,
+      'GBS,SSM', // our school, listed second — the ordinary multi-school case
+      'SSM,GBS',
+      'GBS',
+      'OTHER - Wiskunde',
+      '',
+    ]) {
+      test('no action touches `department` == ${department ?? '<null>'}', () {
+        final staff = linkedStaff(
           wisa: wisaStaff(),
           smartschool: ssStaff(),
-          azure: azureStaff(department: 'OTHER'),
-        ),
-        staffConfig(schoolPrefix: '  '),
-      );
-      expect(action.evaluate(), isFalse);
-    });
-
-    test('describeChanges leaves the bound Azure record untouched (INV-42)',
-        () {
-      final azure = azureStaff(department: 'OTHER - Wiskunde');
-      final staff = linkedStaff(
-        wisa: wisaStaff(),
-        smartschool: ssStaff(),
-        azure: azure,
-      );
-      ModifyStaffAzureSchool(staff, cfg).describeChanges();
-      expect(identical(staff.azure, azure), isTrue);
-      expect(azure.department, 'OTHER - Wiskunde');
-    });
+          azure: azureStaff(department: department),
+        );
+        for (final action in staffActionsFor(staff, cfg)) {
+          expect(
+            action.describeChanges().fields.map((f) => f.field),
+            isNot(contains('department')),
+            reason: '${action.runtimeType} proposes a department write',
+          );
+        }
+      });
+    }
   });
 
   group('staffActions over a LinkedSnapshot', () {

--- a/packages/azure_api/README.md
+++ b/packages/azure_api/README.md
@@ -64,14 +64,19 @@ The bulk `$filter` is:
 companyName eq '<prefix>' or startswith(department,'<prefix>')
 ```
 
-Students carry the prefix in `companyName`; staff carry it at the **start** of
-`department` (the legacy convention sets staff `department` to exactly the
-prefix). Graph supports `eq` and `startswith` server-side on these properties,
-but **not** `contains`. If an installation buries the prefix mid-string in
-`department`, server-side `startswith` would miss those staff — use
-`UserManager.loadClientFiltered`, which pulls with `$select` only and filters
-client-side. The delta path always filters client-side, because `/users/delta`
-does not honour these property filters.
+Students carry the prefix in `companyName`. Staff carry it in `department`,
+which other software maintains as a **comma-separated list of every school
+prefix the teacher is active at** (`GBS,SSM`) — so our prefix is at the *start*
+of the value only when we happen to be listed first. Graph supports `eq` and
+`startswith` server-side on these properties, but **not** `contains`, so the
+`startswith` leg misses every staff member whose list does not lead with us;
+today they are picked up by the `employeeId` back-fill (#231) instead.
+`UserManager.loadClientFiltered` — which pulls with `$select` only and filters
+client-side — is the documented fallback. The delta path always filters
+client-side, because `/users/delta` does not honour these property filters.
+
+Note the field is read-only from here: writing our prefix over the list would
+evict a sibling school's claim (#237). Only account creation stamps it.
 
 ## Authentication
 

--- a/packages/azure_api/lib/src/user_manager.dart
+++ b/packages/azure_api/lib/src/user_manager.dart
@@ -86,13 +86,15 @@ class UserManager {
   };
 
   /// Server-side `$filter` selecting the school's users: students carry the
-  /// prefix in `companyName`; staff carry it at the start of `department`.
+  /// prefix in `companyName`; staff carry it somewhere in `department`.
   ///
-  /// `startswith` matches the legacy convention where staff `department` is set
-  /// to exactly the prefix. Graph does **not** support `contains` server-side
-  /// on these properties, so an installation that buries the prefix mid-string
-  /// in `department` must use [loadClientFiltered] instead (documented in the
-  /// README).
+  /// Staff `department` is maintained by other software as a comma-separated
+  /// list of every school prefix the teacher is active at (`GBS,SSM`), so
+  /// `startswith` matches only when we happen to be listed first. Graph does
+  /// **not** support `contains` server-side on these properties, so the staff
+  /// this leg misses are found by the `employeeId` back-fill (#231) instead;
+  /// [loadClientFiltered] is the documented fallback for an installation that
+  /// needs the bulk read itself to see them.
   static String filterFor(String schoolPrefix) {
     final p = _escapeODataString(schoolPrefix);
     return "companyName eq '$p' or startswith(department,'$p')";


### PR DESCRIPTION
Removes `ModifyStaffAzureSchool`, added in `a0a7036` (#233, merged in #249).

## Why

The owner ruled on #237: **we should not write a staff `department` at all.** It is set by other software and holds one or more school prefixes separated by commas — several prefixes simply means the teacher is active at several schools. We *read* it to tell whether a teacher is active at our school; we do not own it.

Under those semantics the merged action was not merely unnecessary, it destroyed data:

- `evaluate()` fired when `!department.startsWith(prefix)`, so it fired for **every** teacher whose department listed our school anywhere but first — `GBS,SSM` when we are `SSM`. Not an edge case.
- `_withSchoolPrefix` looked for a `" - "` separator, found none in a comma list, and returned the bare prefix. Applying it rewrote `GBS,SSM` to `SSM`, silently dropping the sibling school's claim.

The reasoning it came from was sound in isolation and is worth recording: after #231 taught the Azure pull to find a moved staff member by `employeeId`, the adopted account still matched neither leg of `UserManager.filterFor`, so it had to be re-found by the back-fill on every pass — and once the member leaves WISA their id drops out of `managedStaffEmployeeIds`, the back-fill stops asking, and the account goes invisible with no `RemoveStaffFromAzure` ever proposed. Stamping our marker on the account was meant to make the repair stick, mirroring the student-side `ModifyAzureSchool`, which writes `companyName` — a field we *do* own. The mistake was assuming `department` was the staff equivalent of `companyName`.

## What changed

Removed the action, its registration in `staffActionsFor`, the `_withSchoolPrefix` / `_departmentSeparator` helpers, and the `_AzurePatch` extension that existed only for it (`RemoveStaffFromAzure` deletes rather than patches, so leaving it would trip `unused_element`). Doc text corrected in `staff_action.dart`, `staff_dispatch.dart`, `staff_action_config.dart`, both package READMEs, `user_manager.dart`'s `filterFor` doc, and the `department` row of `docs/domain-model.md` §3.6.

**Reading `department` is unchanged and correct** — the linker's `_departmentMatchesPrefix` tests it with `contains`, which is right for a comma-separated list.

Rather than deleting the tests, each affected suite now asserts the **negative across the whole staff family**: for `department` values `SSM,GBS`, `GBS,SSM`, `GBS`, `OTHER - Wiskunde` and null, no staff action proposes a `department` field change, none issues an Azure PATCH, and an end-to-end pass raises nothing. Reintroducing this anywhere fails a test.

## Two things for the owner

**1. The create path is unchanged and needs a nod.** `AddStaffToAzure` writes `department: config.schoolPrefix` (the bare prefix) when it creates a brand-new account, matching legacy `CreateStaffMember`'s `Department = Connector.Prefix`. It only runs when `staff.azure == null`, so there is nothing to mangle, and under the rule above it looks correct — but if the other software would rather populate the field itself even on accounts we create, this is the line to change.

**2. The two real gaps #233 was aimed at survive this revert** and are filed rather than papered over:
- **#268** — the bulk pull misses staff whose department does not *start* with our prefix. Graph has no server-side `contains` for this property, so today only #231's `employeeId` back-fill finds them.
- **#269** — a staff member who leaves WISA becomes invisible, so no `RemoveStaffFromAzure` is ever proposed.

## Test plan

- `dart format --set-exit-if-changed .` — clean, 303 files, 0 changed
- `dart analyze` — clean
- `dart test` — account_actions 202 pass, azure_api 112 pass (1 skipped live)
- `flutter test` (account_manager) — 417 pass
- `flutter test integration_test/app_launch_test.dart -d windows` — 86 pass

The e2e fixture uses `SSM,GBS` against the harness prefix `GBS` — our prefix listed second, precisely the case the removed action fired on and destroyed. No live hosts contacted.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)
