### PR TITLE
Batch: Klasgroepen search, WISA rule authoring, sync fixes and Dutch chrome (#262 #263 #264 #274 #265 #266 #273)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -43,7 +43,8 @@ import 'package:azure_api/azure_api.dart'
     show AzureCredentials, StaticAuthProvider;
 import 'package:smartschool_api/smartschool_api.dart'
     show DiscardSmartschoolGroup, SmartschoolConnector;
-import 'package:wisa_api/wisa_api.dart' show WisaSchool, parseSchoolRow;
+import 'package:wisa_api/wisa_api.dart'
+    show DontImportClass, WisaImportRule, WisaSchool, parseSchoolRow;
 import 'package:flutter/gestures.dart' show PointerDeviceKind, kSecondaryButton;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -5378,6 +5379,120 @@ void main() {
         'opgehaald.',
       ),
       findsOneWidget,
+    );
+  });
+
+  testWidgets(
+      'a WISA import rule on the shared settings document prunes the very next '
+      'Synchroniseer, and Check for drift refuses until it has (#263)',
+      (WidgetTester tester) async {
+    // The reported bug, driven end-to-end over the *production* WISA pull.
+    // `bootstrapReconcile` seeded the shared `WisaImportRules` holder from the
+    // document it read at startup and nothing ever published a saved document
+    // back into it, so a WISA import rule on the settings document reached the
+    // pull only after a relaunch — and nothing on screen said so.
+    //
+    // Both bootstraps share one LiveSettings, exactly as `main()` wires them,
+    // and every step after the shared-store write is the operator's own: open
+    // Instellingen, press **Herladen**, read the rule back, press
+    // **Synchroniseer**.
+    useTallWindow(tester);
+    final stored = AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9, 1)),
+      ),
+    );
+    final live = LiveSettings(stored);
+    final wire = RecordingWisaSoap();
+    final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+    final settings = SettingsHarness(initial: stored, liveSettings: live);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // A first Synchroniseer, on the rules as they stand: the whole roster comes
+    // in, class 3C included.
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining(
+        'WISA opgehaald: 1 leerling(en), 0 personeelsleden, 1 klassen.',
+      ),
+      findsOneWidget,
+    );
+
+    // Instellingen → Wisa carries no import rule yet.
+    await tester.tap(find.text('Instellingen'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    expect(
+      find.byKey(const ValueKey('settings-wisa-rules-empty')),
+      findsOneWidget,
+    );
+
+    // Another operator writes one into the shared settings document — the WISA
+    // rules are read-only in this view, so the store is where they arrive.
+    await settings.store.save(stored.copyWith(
+      wisaRules: const <WisaImportRule>[DontImportClass('3C')],
+    ));
+
+    // The operator pulls it into this session with **Herladen**, the affordance
+    // the view offers for exactly that, and reads it back on the Wisa tab.
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-reload')));
+    await tester.tap(find.byKey(const ValueKey('settings-reload')));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    expect(
+      find.text('• Klas niet importeren uit WISA: 3C'),
+      findsOneWidget,
+    );
+
+    // Back on Reconcile the change is *visible*: a drift pass never re-reads
+    // WISA, so running one now would relink the roster the rule never reached
+    // and publish that to every other operator.
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('reconcile-drift-blocked')),
+      findsOneWidget,
+    );
+    expect(
+      find.text('WISA-instellingen gewijzigd — synchroniseer eerst.'),
+      findsOneWidget,
+    );
+    expect(
+      tester
+          .widget<OutlinedButton>(find.byKey(const ValueKey('reconcile-drift')))
+          .onPressed,
+      isNull,
+    );
+
+    // Pressing Synchroniseer pulls WISA with the rule — no relaunch — and the
+    // roster it landed is the pruned one.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining(
+        'WISA opgehaald: 1 leerling(en), 0 personeelsleden, 0 klassen.',
+      ),
+      findsOneWidget,
+    );
+    // …and the drift check is offered again.
+    expect(find.byKey(const ValueKey('reconcile-drift-blocked')), findsNothing);
+    expect(
+      tester
+          .widget<OutlinedButton>(find.byKey(const ValueKey('reconcile-drift')))
+          .onPressed,
+      isNotNull,
     );
   });
 

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -116,6 +116,32 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  /// Authors one WISA import rule the way the operator does (#273): the
+  /// **Toevoegen** menu, the rule type keyed [kind], then the field prompt —
+  /// one value per field, in order.
+  Future<void> addWisaRule(
+    WidgetTester tester,
+    String kind,
+    List<String> values,
+  ) async {
+    final add = find.byKey(const ValueKey('settings-wisa-rule-add'));
+    await tester.ensureVisible(add);
+    await tester.pumpAndSettle();
+    await tester.tap(add);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(ValueKey('settings-wisa-rule-add-$kind')));
+    await tester.pumpAndSettle();
+    for (var i = 0; i < values.length; i++) {
+      await tester.enterText(
+        find.byKey(ValueKey('settings-wisa-rule-value-$i')),
+        values[i],
+      );
+    }
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-confirm')));
+    await tester.pumpAndSettle();
+  }
+
   testWidgets('the app launches into the Plink-themed Home shell',
       (WidgetTester tester) async {
     // The real main(): with no --dart-define config, AAD is not configured, so
@@ -5651,7 +5677,7 @@ void main() {
     await tester.pumpAndSettle();
     await openSettingsTab(tester, 'settings-tab-wisa');
     expect(
-      find.text('• Klas niet importeren uit WISA: 3C'),
+      find.text('Klas niet importeren uit WISA: 3C'),
       findsOneWidget,
     );
 
@@ -5693,6 +5719,111 @@ void main() {
           .onPressed,
       isNotNull,
     );
+  });
+
+  testWidgets(
+      'a WISA import rule authored in Instellingen prunes the very next '
+      'Synchroniseer (#273)', (WidgetTester tester) async {
+    // #263 wired a *persisted* WISA rule through to the pull, but nothing in the
+    // app could put one there: the Wisa tab's rule list was titled "Importregels
+    // (alleen-lezen)" and `_collect` handed `base.wisaRules` straight back, so
+    // the only authoring surface was the Cosmos settings document itself. #263's
+    // own end-to-end had to write the rule into the shared store behind the UI's
+    // back for exactly that reason.
+    //
+    // Nothing is written behind anyone's back here. Every step is the operator's
+    // own — Instellingen → Wisa → **Toevoegen** → *Klas niet importeren* → 3C →
+    // **Opslaan** → **Synchroniseer** — over the production WISA pull.
+    useTallWindow(tester);
+    final stored = AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9, 1)),
+      ),
+    );
+    final live = LiveSettings(stored);
+    final wire = RecordingWisaSoap();
+    final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+    final settings = SettingsHarness(initial: stored, liveSettings: live);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // A first Synchroniseer, on the rules as they stand: the whole roster comes
+    // in, class 3C included.
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining(
+        'WISA opgehaald: 1 leerling(en), 0 personeelsleden, 1 klassen.',
+      ),
+      findsOneWidget,
+    );
+
+    // Instellingen → Wisa: no rule yet, and an editor to author one in.
+    await tester.tap(find.text('Instellingen'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    expect(
+      find.byKey(const ValueKey('settings-wisa-rules-empty')),
+      findsOneWidget,
+    );
+    expect(find.textContaining('alleen-lezen'), findsNothing);
+
+    // The operator authors the rule that drops 3C, and saves.
+    await addWisaRule(tester, 'dontImportClass', <String>['3C']);
+    expect(find.text('Klas niet importeren uit WISA: 3C'), findsOneWidget);
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    // It landed on the settings document, on the wire shape #263's pull reads.
+    final saved = await settings.store.load();
+    expect(saved.wisaRules.single, isA<DontImportClass>());
+    expect((saved.wisaRules.single as DontImportClass).className, '3C');
+
+    // Back on Reconcile the save is *visible*: a drift pass never re-reads WISA,
+    // so running one now would relink the roster the rule never reached.
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('reconcile-drift-blocked')),
+      findsOneWidget,
+    );
+    expect(
+      find.text('WISA-instellingen gewijzigd — synchroniseer eerst.'),
+      findsOneWidget,
+    );
+
+    // Synchroniseer pulls WISA with the authored rule — no relaunch, no
+    // hand-carried document — and the roster it landed is the pruned one.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining(
+        'WISA opgehaald: 1 leerling(en), 0 personeelsleden, 0 klassen.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('reconcile-drift-blocked')), findsNothing);
+
+    // …and it survives a reload of the document, so the next session (and every
+    // other operator) gets the same pull.
+    await tester.tap(find.text('Instellingen'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-reload')));
+    await tester.tap(find.byKey(const ValueKey('settings-reload')));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    expect(find.text('Klas niet importeren uit WISA: 3C'), findsOneWidget);
   });
 
   testWidgets(

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2091,6 +2091,100 @@ void main() {
   });
 
   testWidgets(
+      'the Klasgroepen inventory is searchable by class name and description, '
+      'composing with the attention switch end-to-end (#262)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation, real rail, real keyboard
+    // input. The search is a filter over the *composed* inventory: the rows
+    // come from the stored documents, the interactive halves and the "same
+    // situation" bulk headers from the live dispatch, and the switch is a
+    // second filter over the same list — a widget test sees the row builder,
+    // not what a needle does to all four of those at once.
+    //
+    // Our school runs `1A` ("Eerste jaar A"), the sub-grouped `2F`
+    // (`2F ECO` + `2F MAW`, both "Tweede jaar F") and the leftover `GBS-9Z`.
+    useTallWindow(tester);
+    final harness = azureClassGroupHarness(withStaleGroup: true);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+    expect(harness.controller.error, isNull);
+
+    final search = find.byKey(const ValueKey('class-groups-search'));
+    final filter = find.byKey(const ValueKey('class-groups-only-attention'));
+    Finder row(String klas) => find.byKey(ValueKey('class-row-$klas'));
+    Future<void> type(String needle) async {
+      await tester.ensureVisible(search);
+      await tester.enterText(search, needle);
+      await tester.pumpAndSettle();
+    }
+
+    expect(search, findsOneWidget);
+    expect(row('1A'), findsOneWidget);
+    expect(row('2F ECO'), findsOneWidget);
+    expect(row('GBS-9Z'), findsOneWidget);
+
+    // By name: one class out of the whole inventory, which is the question the
+    // operator arrived with ("is `1A` right?") and used to answer by scrolling.
+    await type('1a');
+    expect(row('1A'), findsOneWidget);
+    expect(row('2F ECO'), findsNothing);
+    expect(row('2F MAW'), findsNothing);
+    expect(row('GBS-9Z'), findsNothing);
+
+    // By description — "tweede" is in no class *name* at all, and a class is
+    // looked up by what it teaches as often as by its code.
+    await type('tweede');
+    expect(row('2F ECO'), findsOneWidget);
+    expect(row('2F MAW'), findsOneWidget);
+    expect(row('1A'), findsNothing);
+
+    // Per-part and order-independent, exactly like the two Personeel searches
+    // (#187/#215/#217), and one needle may span name and description.
+    await type('maw tweede');
+    expect(row('2F MAW'), findsOneWidget);
+    expect(row('2F ECO'), findsNothing);
+
+    // Nothing matched says so — and not in the words of an inventory that was
+    // never synced, nor of a school where everything is in order.
+    await type('1a tweede');
+    expect(
+        find.text('Geen klassen die aan de filter voldoen.'), findsOneWidget);
+    expect(find.textContaining('Nog geen klasinventaris'), findsNothing);
+    expect(find.textContaining('Elke klas staat in orde'), findsNothing);
+
+    // The two filters compose (#262): the switch narrows what the search left.
+    // `2F ECO` carries the missing-group work; `2F MAW` shares that group and
+    // so asks nothing of its own.
+    await type('2f');
+    expect(row('2F ECO'), findsOneWidget);
+    expect(row('2F MAW'), findsOneWidget);
+    await tester.ensureVisible(filter);
+    await tester.tap(filter);
+    await tester.pumpAndSettle();
+    expect(row('2F ECO'), findsOneWidget);
+    expect(row('2F MAW'), findsNothing);
+    expect(row('GBS-9Z'), findsNothing,
+        reason: 'it needs attention, but the search is still on');
+
+    // Clearing the box restores the inventory the switch still governs.
+    await tester.ensureVisible(search);
+    await tester.tap(find.byKey(const ValueKey('class-groups-search-clear')));
+    await tester.pumpAndSettle();
+    expect(row('GBS-9Z'), findsOneWidget);
+    expect(row('1A'), findsNothing, reason: 'the switch survives the clear');
+    await tester.ensureVisible(filter);
+    await tester.tap(filter);
+    await tester.pumpAndSettle();
+    expect(row('1A'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       "a student's Office 365 class group is reported on their own account "
       'end-to-end, pointing at the one class-level write (#245)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -5635,6 +5635,92 @@ void main() {
   });
 
   testWidgets(
+      'a reconcile stack assembled with no settings holder still launches, '
+      'syncs and drifts, and arms none of the settings gates (#274)',
+      (WidgetTester tester) async {
+    // `ReconcileController` has documented a null [liveSettings] since #238 —
+    // "the harnesses that do not model settings at all; the gate is then never
+    // armed and drift behaves exactly as before" — and #274 found that mode had
+    // never once been entered: the constructor stamped its WISA fingerprint from
+    // a helper that fell back to the very `late` field being assigned, so an
+    // unwired controller threw `LateInitializationError` and the app never
+    // reached its first frame.
+    //
+    // Only this layer proves the mode is real end to end: the app is launched
+    // over a stack built without the holder, the operator saves in Instellingen
+    // and comes back, and the two passes are pressed for real.
+    useTallWindow(tester);
+    final stored = AppSettings(
+      wisa: const WisaConnection(server: 'wisa.example', port: '9000'),
+      azure: const AzureConnection(domain: 'oud.example'),
+      wisaSchools: const <WisaSchoolProfile>[
+        WisaSchoolProfile(
+            schoolId: 1, code: 'S1', name: 'Sint-Jan', ours: true),
+      ],
+    );
+    final live = LiveSettings(stored);
+    // The whole point: the pulls and the applier read `live`, the controller is
+    // handed nothing. Constructing this harness is what used to throw.
+    final harness = ReconcileHarness(modelsSettings: false, liveSettings: live);
+    final settings = SettingsHarness(initial: stored, liveSettings: live);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // The app is up and the screen the controller drives renders.
+    expect(find.byType(AccountManagerApp), findsOneWidget);
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    expect(find.byType(ReconcileScreen), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Sync voltooid'), findsOneWidget);
+
+    // Instellingen: the operator moves the school to a new Azure domain and
+    // saves — a change that arms the link gate for a *wired* session (#264).
+    await tester.tap(find.text('Instellingen'));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-azure');
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-az-domain')),
+      'nieuw.example',
+    );
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    expect((await settings.store.load()).azure.domain, 'nieuw.example');
+
+    // Back on Synchronisatie nothing nags and nothing is refused: a controller
+    // with no document to compare against holds no opinion about a save.
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('reconcile-drift-blocked')), findsNothing);
+    expect(
+      find.byKey(const ValueKey('reconcile-settings-pending')),
+      findsNothing,
+    );
+
+    // …and **Check for drift** is genuinely live, not merely un-nagged: the pass
+    // runs and advances the two systems it re-reads.
+    final driftAt = kFixtureDate.add(const Duration(hours: 3));
+    harness.ssResult = ssSnap(fetchedAt: driftAt);
+    harness.azResult = azSnap(fetchedAt: driftAt);
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.pumpAndSettle();
+
+    final systems = harness.controller.syncState.systems;
+    expect(systems[Origin.wisa]?.at, kFixtureDate);
+    expect(systems[Origin.smartschool]?.at, driftAt);
+    expect(systems[Origin.azure]?.at, driftAt);
+  });
+
+  testWidgets(
       'a Synchroniseer says in the Log panel which werkdatum it pulled, and '
       'names the virtuele werkdatum where a virtual school used it (#239)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -148,6 +148,22 @@ void main() {
     expect(display?.fontFamily, contains('Fraunces'));
     expect(find.text('Account Manager'), findsOneWidget);
 
+    // The Start placeholder is the first screen the operator lands on, and it
+    // was the last one left in English (#265) — eyebrow and body both.
+    expect(find.text('ARCADIA · ACCOUNTSYNCHRONISATIE'), findsOneWidget);
+    expect(
+      find.textContaining('Stemt gebruikersaccounts en klasgroepen op elkaar '
+          'af tussen WISA, Smartschool en Azure AD / Office 365.'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('te beginnen met aanmelden en het tabblad '
+          'Synchronisatie.'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Reconciles user accounts'), findsNothing);
+    expect(find.textContaining('Phase C slice'), findsNothing);
+
     // Every destination on the rail names itself in the operator's language
     // (#257). The rail is read together with the heading it leads to, and it
     // used to read Home / Reconcile / Actions over pages titled in Dutch.
@@ -188,6 +204,75 @@ void main() {
   });
 
   testWidgets(
+      'the Synchronisatie tab names its own controls in the operator\'s '
+      'language end-to-end, log panel and smart-diff notice included (#265)',
+      (WidgetTester tester) async {
+    // #257 renamed the rail destination and the heading under it, but not the
+    // screen's own controls — so the tab read Dutch and the buttons on it read
+    // English. Driven through the real shell on purpose: these strings are read
+    // together with the rail label that leads to them, which is exactly the
+    // composition a widget test of ReconcileScreen alone cannot see.
+    useTallWindow(tester);
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+
+    // The two buttons under the heading. The idle explainer that names them in
+    // prose is translated with them but is not assertable here: `loadOverview`
+    // moves the phase off `idle` before the operator's first frame, so the
+    // paragraph never reaches the screen at all (#275).
+    expect(find.text('Synchroniseer'), findsOneWidget);
+    expect(find.text('Controleer op drift'), findsOneWidget);
+
+    // The log panel's own chrome, empty state included.
+    expect(find.text('Logboek'), findsOneWidget);
+    expect(find.text('Alles kopiëren'), findsOneWidget);
+    expect(find.text('Wissen'), findsOneWidget);
+    expect(find.text('Nog geen berichten.'), findsOneWidget);
+
+    // Not one English label survives on the screen.
+    for (final String english in <String>[
+      'Synchronise',
+      'Check for drift',
+      'Overview',
+      'Log',
+      'Copy all',
+      'Clear',
+      'No messages yet.',
+    ]) {
+      expect(find.text(english), findsNothing,
+          reason: '"$english" is the English label #265 replaced');
+    }
+
+    // A sync heads the counts section the way the Acties tree heads its own.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(find.text('Overzicht'), findsOneWidget);
+    expect(find.text('Overview'), findsNothing);
+
+    // A second pass over unchanged WISA raises the smart-diff notice, which
+    // now says what the Log line beside it says (#258).
+    harness.wisaResult =
+        wisaSnap(fetchedAt: kFixtureDate.add(const Duration(hours: 1)));
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining('WISA is ongewijzigd sinds de vorige '
+          'synchronisatie — geen accountwijzigingen nodig.'),
+      findsWidgets,
+    );
+    expect(find.textContaining('no account changes needed'), findsNothing);
+  });
+
+  testWidgets(
       'the reconcile flow runs end-to-end: sign-in → sync → overview on '
       'Reconcile → actions via the Actions tab drill-down → dry-run → apply → '
       'unchanged re-sync (#154)', (WidgetTester tester) async {
@@ -220,7 +305,7 @@ void main() {
     // The per-category overview renders on Reconcile from the rollups (#163):
     // students / staff / class-groups, the one fixture student summed with a
     // pending indicator.
-    expect(find.text('Overview'), findsOneWidget);
+    expect(find.text('Overzicht'), findsOneWidget);
     expect(find.byKey(const ValueKey('reconcile-category-students')),
         findsOneWidget);
     expect(find.text('2 openstaande acties'), findsOneWidget);
@@ -238,7 +323,16 @@ void main() {
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.byType(ActionsScreen), findsOneWidget);
-    expect(find.text('Overzicht'), findsOneWidget);
+    // Scoped to this screen: since #265 the Synchronisatie tab heads its own
+    // counts section "Overzicht" too, and the shell keeps a visited screen
+    // alive in the IndexedStack.
+    expect(
+      find.descendant(
+        of: find.byType(ActionsScreen),
+        matching: find.text('Overzicht'),
+      ),
+      findsOneWidget,
+    );
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
     await tester.ensureVisible(find.text('3C'));
@@ -271,9 +365,14 @@ void main() {
     await tester.ensureVisible(find.byKey(const ValueKey('reconcile-sync')));
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
-    // The on-screen banner is #265's to translate; the Log *line* beside it is
-    // Dutch since #258.
-    expect(find.textContaining('no account changes needed'), findsOneWidget);
+    // The on-screen banner reads word for word the Log line beside it: #265
+    // gave it the Dutch #258 had already written for the log.
+    expect(
+      find.textContaining('WISA is ongewijzigd sinds de vorige '
+          'synchronisatie — geen accountwijzigingen nodig.'),
+      findsWidgets,
+    );
+    expect(find.textContaining('no account changes needed'), findsNothing);
     expect(harness.ssSyncs, 1);
     expect(harness.azSyncs, 1);
 
@@ -1180,7 +1279,15 @@ void main() {
 
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    expect(find.text('Overzicht'), findsOneWidget);
+    // Scoped to this screen — the Synchronisatie tab behind it has an
+    // "Overzicht" heading of its own since #265.
+    expect(
+      find.descendant(
+        of: find.byType(ActionsScreen),
+        matching: find.text('Overzicht'),
+      ),
+      findsOneWidget,
+    );
     // The non-managed school is not a node in the drill-down…
     expect(find.text('School 2'), findsNothing,
         reason: 'school 2 is not managed → no node in Actions');
@@ -3477,7 +3584,7 @@ void main() {
   });
 
   testWidgets(
-      'a resumed session trusts the stored state: Synchronise pulls no '
+      'a resumed session trusts the stored state: Synchroniseer pulls no '
       'Smartschool/Azure (#107)', (WidgetTester tester) async {
     // Session 1 (offline harness over a shared cold-snapshot store): a full
     // sync persists all three connector snapshots.
@@ -3505,7 +3612,7 @@ void main() {
     expect(resumed.wisaSyncs, 1);
     expect(resumed.ssSyncs, 0, reason: 'Smartschool seeded from the store');
     expect(resumed.azSyncs, 0, reason: 'Azure seeded from the store');
-    expect(find.text('Overview'), findsOneWidget);
+    expect(find.text('Overzicht'), findsOneWidget);
   });
 
   testWidgets(
@@ -3592,7 +3699,7 @@ void main() {
 
     // The per-category overview renders straight from the stored rollups — no
     // Synchronise tapped, and link() is never called in a passive session.
-    expect(find.text('Overview'), findsOneWidget);
+    expect(find.text('Overzicht'), findsOneWidget);
     expect(find.byKey(const ValueKey('reconcile-category-students')),
         findsOneWidget);
     expect(
@@ -4796,7 +4903,7 @@ void main() {
 
   testWidgets(
       'the operator drag-selects two log lines and copies them one per line, '
-      'then Copy all takes the whole buffer end-to-end (#193)',
+      'then Alles kopiëren takes the whole buffer end-to-end (#193)',
       (WidgetTester tester) async {
     // The real app composition — real fonts, real window, real text layout —
     // is where a "selectable" log panel drifts: the line metrics a drag is
@@ -4867,7 +4974,8 @@ void main() {
     expect(copied, hasLength(1));
     expect(copied.single, '${onScreen.first}\n${onScreen[1]}');
 
-    // Copy all reaches past what is laid out: the whole buffer, oldest first.
+    // Alles kopiëren reaches past what is laid out: the whole buffer, oldest
+    // first.
     await tester.tap(find.byKey(const ValueKey('reconcile-log-copy-all')));
     await tester.pumpAndSettle();
     expect(copied.last, harness.log.toPlainText());
@@ -4877,8 +4985,8 @@ void main() {
   });
 
   testWidgets(
-      'the operator right-clicks one log line and Copy line puts just that '
-      'message on the clipboard end-to-end (#197)',
+      'the operator right-clicks one log line and Regel kopiëren puts just '
+      'that message on the clipboard end-to-end (#197)',
       (WidgetTester tester) async {
     // Grabbing a single message was already possible after #193 - a
     // triple-click selects one paragraph, which is one entry - but nothing on
@@ -4946,8 +5054,8 @@ void main() {
 
     // The affordance is on screen, and it takes exactly the entry under the
     // pointer: one line, neither neighbour, no trailing newline.
-    expect(find.text('Copy line'), findsOneWidget);
-    await tester.tap(find.text('Copy line'));
+    expect(find.text('Regel kopiëren'), findsOneWidget);
+    await tester.tap(find.text('Regel kopiëren'));
     await tester.pumpAndSettle();
 
     expect(copied, hasLength(1));
@@ -5935,7 +6043,7 @@ void main() {
     // overview the operator came for is on screen.
     expect(harness.controller.error, isNull);
     expect(harness.controller.busy, isFalse);
-    expect(find.text('Overview'), findsOneWidget);
+    expect(find.text('Overzicht'), findsOneWidget);
 
     // The dead token was tried exactly once and then given up on, and the
     // fallback was the $filter-scoped bulk read (PAIN-2 holds while recovering).

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -19,6 +19,7 @@ import 'package:account_manager/src/shell/app_shell.dart';
 import 'package:account_state/account_state.dart'
     show
         AppSettings,
+        AzureConnection,
         ChangeSignal,
         CosmosThrottleGovernor,
         InMemoryLinkedStore,
@@ -5493,6 +5494,143 @@ void main() {
           .widget<OutlinedButton>(find.byKey(const ValueKey('reconcile-drift')))
           .onPressed,
       isNotNull,
+    );
+  });
+
+  testWidgets(
+      'an Azure domain saved in Instellingen re-links the very next '
+      'Synchroniseer, with no pull behind it (#264)',
+      (WidgetTester tester) async {
+    // The reported bug, driven the way the operator lives it. #259 gave the two
+    // pulls their own settings fingerprints; the domain has no pull at all —
+    // only `link()` reads it, through `ApplierSettings.studentConfig` — so with
+    // WISA unchanged the smart sync returned before `_relink()` and the saved
+    // domain was adopted by **Check for drift** alone, while Synchroniseer
+    // reported "geen accountwijzigingen nodig" over it.
+    //
+    // Only this layer sees the whole thing: the save is made in Instellingen,
+    // the two bootstraps share one LiveSettings exactly as `main()` wires them,
+    // and what has to change is a UPN the operator reads off an Acties tile.
+    useTallWindow(tester);
+    final stored = AppSettings(
+      wisa: const WisaConnection(server: 'wisa.example', port: '9000'),
+      azure: const AzureConnection(domain: 'oud.example'),
+      wisaSchools: const <WisaSchoolProfile>[
+        WisaSchoolProfile(
+            schoolId: 1, code: 'S1', name: 'Sint-Jan', ours: true),
+      ],
+    );
+    final live = LiveSettings(stored);
+    // A new intake: one WISA student with no Office 365 account yet, so the
+    // pass proposes creating one — and names the UPN it would create.
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
+        schools: [wisaSchool(1, ours: true)],
+      ),
+      smartschool: ssSnap(
+        groups: [ssGroup('3C', code: '3C_ss')],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+      liveSettings: live,
+    );
+    final settings = SettingsHarness(initial: stored, liveSettings: live);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    /// Opens Acties → Jaar 3 → 3C and expands the student's pending row, which
+    /// is where the proposed `userPrincipalName` is written out.
+    Future<void> openStudentRow() async {
+      await tester.tap(find.text('Acties'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Jaar 3'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('3C'));
+      await tester.pumpAndSettle();
+      final id = harness.controller.pendingEntries
+          .firstWhere((e) => e.family == 'student')
+          .targetId;
+      final row = find.byKey(ValueKey('entry-student-$id'));
+      await tester.ensureVisible(row);
+      await tester.tap(row);
+      await tester.pumpAndSettle();
+    }
+
+    // A first Synchroniseer, on the domain as it stands.
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    await openStudentRow();
+    expect(
+      find.textContaining(
+          'userPrincipalName: ∅ → jane.doe@student.oud.example'),
+      findsOneWidget,
+    );
+
+    // Instellingen → Azure → the school moves to its new domain → Opslaan.
+    await tester.tap(find.text('Instellingen'));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-azure');
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-az-domain')),
+      'nieuw.example',
+    );
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    expect((await settings.store.load()).azure.domain, 'nieuw.example');
+
+    // Back on Reconcile the screen names the save that is still waiting — and
+    // names it as the *link*, because no pull is involved. Nothing is refused:
+    // the domain is not a WISA pull input, so #238's drift gate stays open.
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('reconcile-drift-blocked')), findsNothing);
+    expect(
+      find.byKey(const ValueKey('reconcile-settings-pending')),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('Instellingen voor de koppeling gewijzigd'),
+      findsOneWidget,
+    );
+
+    // The operator presses **Synchroniseer**, the pass they reach for. WISA
+    // comes back unchanged, which is exactly the case that used to end here.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('geen accountwijzigingen nodig'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('reconcile-settings-pending')),
+      findsNothing,
+    );
+    expect(
+      find.textContaining('Koppelingsinstellingen gewijzigd — de koppeling '
+          'wordt opnieuw berekend.'),
+      findsOneWidget,
+    );
+
+    // …and the account the pass would create now carries the saved domain, with
+    // no drift check, no hand-off and no relaunch anywhere in this test.
+    await openStudentRow();
+    expect(
+      find.textContaining(
+          'userPrincipalName: ∅ → jane.doe@student.nieuw.example'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('jane.doe@student.oud.example'),
+      findsNothing,
     );
   });
 

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -419,6 +419,83 @@ void main() {
   });
 
   testWidgets(
+      'a Synchroniseer over the production connectors fills the Log panel with '
+      'Dutch to the bottom — the connector packages included (#266)',
+      (WidgetTester tester) async {
+    // #258 made the app layer's lines Dutch, which left the panel switching
+    // language one layer *down*: `packages/wisa_api`, `smartschool_api` and
+    // `azure_api` take an `ILog` at construction and bootstrap hands them this
+    // very LogBuffer, so a single Synchroniseer still produced Dutch app lines
+    // over English connector ones.
+    //
+    // All three pulls here are the **production** ones — a real WisaConnector,
+    // SmartschoolConnector and AzureConnector over scripted wires — so what the
+    // panel renders is what the packages themselves wrote, not a fixture.
+    useTallWindow(tester);
+    final harness = ReconcileHarness(
+      wisaTransport: RecordingWisaSoap(),
+      smartschoolTransport: GroupTreeSoap(),
+      azureTransport: StaleDeltaTokenGraph(),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('reconcile-log-panel')), findsOneWidget);
+    final List<String> logged =
+        harness.log.entries.map((e) => e.message).toList();
+
+    // One line from each of the three packages, exactly as it was written.
+    for (final String line in <String>[
+      // wisa_api — the school named by its short code, as since #208.
+      'Klassen opgehaald uit S1.',
+      '1 leerling(en) opgehaald uit S1.',
+      '0 personeelsleden opgehaald uit S1.',
+      // smartschool_api — the wire answers code 19 for every group.
+      'Geen rechtstreekse accounts in School.',
+      // azure_api — both managers, on the full-read path.
+      'Azure: 0 groepen opgehaald voor "GBS".',
+      'Azure: 1 gebruikers opgehaald voor "GBS".',
+    ]) {
+      expect(logged, contains(line), reason: line);
+    }
+
+    // …and they really are on screen, in the panel, under the app's own Dutch.
+    expect(find.textContaining('leerling(en) opgehaald uit S1.'), findsWidgets);
+    expect(find.textContaining('Geen rechtstreekse accounts in'), findsWidgets);
+    expect(find.textContaining('gebruikers opgehaald voor'), findsWidgets);
+    expect(find.textContaining('WISA opgehaald: '), findsWidgets);
+    expect(find.textContaining('Gekoppeld: '), findsWidgets);
+
+    // Not one entry of the pass — at any severity — is still the English the
+    // connectors used to write.
+    for (final String english in <String>[
+      'Loading ',
+      'succeeded.',
+      'No direct accounts',
+      'Added ',
+      'Azure: loaded ',
+      'Azure: delta for',
+      'Connection Succeeded',
+      'empty result',
+    ]) {
+      expect(
+        logged.where((String m) => m.contains(english)),
+        isEmpty,
+        reason: english,
+      );
+    }
+  });
+
+  testWidgets(
       'while a sync runs the reconcile header shows a determinate progress bar '
       'that has advanced past the start end-to-end (#176)',
       (WidgetTester tester) async {
@@ -1024,10 +1101,15 @@ void main() {
     );
     expect(find.textContaining('Sync voltooid'), findsOneWidget);
 
-    // Throttling was reported as progress, not silence (#196.5).
+    // Throttling was reported as progress, not silence (#196.5) — in Dutch
+    // like the rest of the panel since #266.
     expect(
       harness.log.entries.map((e) => e.message),
-      contains(contains('throttling')),
+      contains(contains('Cosmos beperkt het tempo')),
+    );
+    expect(
+      harness.log.entries.map((e) => e.message),
+      isNot(contains(contains('throttling'))),
     );
 
     // …and the shared state is *whole*: every account document landed, plus the
@@ -1105,10 +1187,15 @@ void main() {
       harness.log.entries.where((e) => e.isError).map((e) => e.message),
       isEmpty,
     );
-    // The operator is told the pass was a no-op rather than seeing silence.
+    // The operator is told the pass was a no-op rather than seeing silence —
+    // in Dutch, like the rest of the panel, since #266.
     expect(
       harness.log.entries.map((e) => e.message),
-      contains(contains('120 unchanged')),
+      contains(contains('Opslaan van accounts: 120 ongewijzigd')),
+    );
+    expect(
+      harness.log.entries.map((e) => e.message),
+      isNot(contains(contains('Persisting'))),
     );
   });
 
@@ -5193,14 +5280,17 @@ void main() {
     // typo is visible rather than silent.
     expect(
       find.textContaining(
-        'Import rule "Sportclub" matched no Smartschool group in this pull',
+        'Importregel "Sportclub" kwam bij deze ophaalbeurt met geen enkele '
+        'Smartschool-groep overeen',
       ),
       findsOneWidget,
     );
+    // …in Dutch, like every other line of the pass around it (#266).
+    expect(find.textContaining('matched no Smartschool group'), findsNothing);
     // The two that did fire are not reported — that is the distinction the
     // operator could not make before.
-    expect(find.textContaining('Import rule "organisatie"'), findsNothing);
-    expect(find.textContaining('Import rule "KLASSEN"'), findsNothing);
+    expect(find.textContaining('Importregel "organisatie"'), findsNothing);
+    expect(find.textContaining('Importregel "KLASSEN"'), findsNothing);
   });
 
   testWidgets(
@@ -6066,9 +6156,14 @@ void main() {
     // …and the operator is told why the full read happened, with the rejected
     // token's age — the diagnostic that says whether Graph expired a genuinely
     // old token or the app had stopped advancing it.
-    expect(find.textContaining('Graph rejected the stored delta token'),
+    // …in Dutch since #266, the age in Dutch units with it.
+    expect(find.textContaining('Graph weigerde het bewaarde deltatoken'),
         findsOneWidget);
-    expect(find.textContaining('stored 15h'), findsOneWidget);
+    expect(find.textContaining('bewaard 15u'), findsOneWidget);
+    expect(
+      find.textContaining('Graph rejected the stored delta token'),
+      findsNothing,
+    );
 
     // …and that is *all* the operator sees about it (#229). The recovery
     // worked, so nothing in the panel is red: the transport used to log the raw
@@ -6091,8 +6186,10 @@ void main() {
       harness.log.entries.map((e) => e.message),
       contains(allOf(
         contains('users/delta'),
+        // The Graph body verbatim, with the client's own Dutch clause on it
+        // (#266) rather than the English "(handled — …)" it used to append.
         contains('DeltaLink older than 30 days'),
-        contains('handled'),
+        contains('(afgehandeld — de synchronisatie herstelt hiervan)'),
       )),
     );
 

--- a/account_manager/lib/src/reconcile/log_buffer.dart
+++ b/account_manager/lib/src/reconcile/log_buffer.dart
@@ -73,7 +73,7 @@ class LogBuffer extends ChangeNotifier implements ILog {
   bool get hasErrors => _entries.any((e) => e.isError);
 
   /// The whole buffer as plain text, oldest first, one [LogEntry.line] per
-  /// line — what the panel's **Copy all** writes to the clipboard (#193).
+  /// line — what the panel's **Alles kopiëren** writes to the clipboard (#193).
   ///
   /// Reads the entries rather than the rendered selection on purpose: the
   /// panel only lays out what fits, so a selection can never reach the older

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -360,7 +360,13 @@ Future<ReconcileServices> bootstrapReconcile({
     log: logBuffer,
   );
 
-  final wisaRules = WisaImportRules(initial: settings.wisaRules);
+  // Only the rules *this session* earns — the `DontImportFromWisa` applies.
+  // The operator's persisted rules are deliberately not seeded in here (#263):
+  // nothing ever republished a saved document into this holder, so seeding it
+  // froze `settings.wisaRules` for the life of the process. The pull reads them
+  // from the live document instead, so a rule saved (or removed) in the settings
+  // document reaches the very next pull rather than the next launch.
+  final wisaRules = WisaImportRules();
 
   // Seed each SystemState from the stored cold snapshot so a fresh session
   // trusts the persisted state (#107): WISA seeds the smart-diff baseline,
@@ -617,10 +623,16 @@ String smartschoolSiteFrom(String uri) {
 ///
 /// - the import [rules], so a `DontImportFromWisa` apply reaches the re-sync it
 ///   triggers (#72);
-/// - the operator's [settings] — the werkdatum, the virtuele werkdatum, and the
-///   per-school virtual marks (#203). Before #238 these were closed over as an
-///   immutable `AppSettings` read once at bootstrap, so saving a new werkdatum
-///   in Instellingen changed nothing until the app was relaunched.
+/// - the operator's [settings] — the werkdatum, the virtuele werkdatum, the
+///   per-school virtual marks (#203), and the persisted WISA import rules
+///   (#263). Before #238 these were closed over as an immutable `AppSettings`
+///   read once at bootstrap, so saving a new werkdatum in Instellingen changed
+///   nothing until the app was relaunched.
+///
+/// The two rule sources are unioned here, per pull, rather than merged once at
+/// wiring time (#263): [rules] holds what this session accumulated, the live
+/// document holds what the operator persisted, and only reading both at call
+/// time lets either move under a running session.
 ///
 /// Schools are re-read per sync so a WISA-side school change is picked up;
 /// `MarkAsVirtual` rules and the operator's virtual marks are applied to them
@@ -641,7 +653,7 @@ Syncer<wapi.WisaSnapshot> wisaSyncer(
       // One consistent read for the whole pull: a save landing mid-pull must not
       // split the school list and the work dates across two documents.
       final current = settings.current;
-      final importRules = rules.rules;
+      final importRules = rules.unionWith(current.wisaRules);
       final schools = markVirtualSchools(
         wapi.WisaConnector.applySchoolRules(
           await connector.loadSchools(),

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -1074,13 +1074,21 @@ class ReconcileController extends ChangeNotifier {
   /// The operator (UPN) holding the sync/drift lease, when [syncLockedByOther].
   String? get syncLockOwner => _lock?.owner;
 
-  /// The [wisaPullFingerprint] of the live settings, or the stamped one when no
-  /// [liveSettings] holder is wired (which leaves the gate permanently open).
+  /// The [wisaPullFingerprint] of the live settings, or the empty sentinel when
+  /// no [liveSettings] holder is wired — which makes every comparison equal and
+  /// leaves [driftBlockedReason] silent for the harnesses that model no settings
+  /// at all, exactly as [_settingsFingerprint] (#259) and
+  /// [_currentLinkFingerprint] (#264) do.
+  ///
+  /// The sentinel is what makes that mode reachable at all (#274). This method
+  /// is what the constructor stamps [_wisaPullFingerprint] *from*, so falling
+  /// back to that field read a `late` in the middle of its own initialisation:
+  /// building the controller without a holder threw a `LateInitializationError`
+  /// before it could return. Both answers leave the gate permanently open —
+  /// only this one lets the controller exist.
   String _wisaFingerprint() {
     final live = liveSettings;
-    return live == null
-        ? _wisaPullFingerprint
-        : wisaPullFingerprint(live.current);
+    return live == null ? '' : wisaPullFingerprint(live.current);
   }
 
   /// Why **Check for drift** is unavailable right now, or `null` when it can

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -353,7 +353,9 @@ class CategorySummary {
 /// session **or when their own settings inputs have moved** ([
 /// systemsAwaitingSettings], #259); re-reading them for drift somebody else
 /// introduced through another tool is the explicit [checkDrift] action, not the
-/// default.
+/// default. The shortcut also stands down when a setting only the link consumes
+/// has moved ([linkAwaitingSettings], #264) — that falls through to the re-link
+/// without pulling anything.
 class ReconcileController extends ChangeNotifier {
   ReconcileController({
     required this.app,
@@ -381,6 +383,10 @@ class ReconcileController extends ChangeNotifier {
     // made *from here on* asks for a re-pull.
     _smartschoolPullFingerprint = _settingsFingerprint(core.Origin.smartschool);
     _azurePullFingerprint = _settingsFingerprint(core.Origin.azure);
+    // …and for the settings only the link consumes (#264), whose "pull" is the
+    // relink itself. Nothing is linked yet at this point, so this merely means
+    // a save made from here on is what arms it.
+    _linkFingerprint = _currentLinkFingerprint();
     // The endpoints and credential refs the connectors in hand were built from
     // (#246). Unlike everything else, a later change to these cannot be adopted
     // — see [relaunchRequiredReason].
@@ -499,6 +505,12 @@ class ReconcileController extends ChangeNotifier {
   /// document to arm [systemsAwaitingSettings].
   late String _smartschoolPullFingerprint;
   late String _azurePullFingerprint;
+
+  /// The [linkFingerprint] of the settings the linked view in hand was built
+  /// with (#264). Re-stamped on every [_relink]; compared against the live
+  /// document to arm [linkAwaitingSettings], which is what makes the
+  /// unchanged-WISA shortcut fall through to a re-link.
+  late String _linkFingerprint;
 
   ReconcilePhase _phase = ReconcilePhase.idle;
   double _progress = 0.0;
@@ -1134,22 +1146,57 @@ class ReconcileController extends ChangeNotifier {
           core.Origin.azure,
       };
 
+  /// The [linkFingerprint] of the live document, or the empty sentinel when no
+  /// [liveSettings] holder is wired — which makes every comparison equal and
+  /// leaves [linkAwaitingSettings] false for the harnesses that model no
+  /// settings at all.
+  String _currentLinkFingerprint() {
+    final live = liveSettings;
+    return live == null ? '' : linkFingerprint(live.current);
+  }
+
+  /// Whether a saved setting that only the **link** consumes has moved since
+  /// the linked view in hand was built (#264).
+  ///
+  /// The link's counterpart of [systemsAwaitingSettings], and the reason it is
+  /// separate: the Azure domain every proposed UPN carries and the Smartschool
+  /// class tree a new class hangs under reach no connector, so no pull
+  /// fingerprint covers them. Saving one used to be adopted by **Check for
+  /// drift** — which re-links unconditionally — and not by the Synchroniseer
+  /// the operator reaches for, because a sync over an unchanged WISA returns
+  /// before [_relink]. True means the next [sync] skips that shortcut and
+  /// re-links, which costs no pull at all.
+  bool get linkAwaitingSettings =>
+      _currentLinkFingerprint() != _linkFingerprint;
+
   /// Which saved settings are waiting for a Synchroniseer to be applied, or
-  /// `null` when none are (#259).
+  /// `null` when none are (#259/#264).
   ///
   /// Nothing is refused — the next [sync] adopts them by itself, and so does a
   /// [checkDrift]. This only ends the silence between the save and that pass,
   /// the way [driftBlockedReason] and [relaunchRequiredReason] name their own
   /// situations.
+  ///
+  /// The link is named beside the two systems rather than as a system of its
+  /// own: it is not a pull, and what waits on it is a recomputation this
+  /// session can do without touching the network.
   String? get pendingSettingsReason {
     final systems = systemsAwaitingSettings;
-    if (systems.isEmpty) return null;
     final names = <String>[
       if (systems.contains(core.Origin.smartschool)) 'Smartschool',
       if (systems.contains(core.Origin.azure)) 'Azure AD',
+      if (linkAwaitingSettings) 'de koppeling',
     ];
-    return 'Instellingen voor ${names.join(' en ')} gewijzigd — '
+    if (names.isEmpty) return null;
+    return 'Instellingen voor ${_andList(names)} gewijzigd — '
         'synchroniseer om ze toe te passen.';
+  }
+
+  /// `a`, `a en b`, `a, b en c` — the Dutch enumeration [pendingSettingsReason]
+  /// names what is waiting with.
+  static String _andList(List<String> names) {
+    if (names.length < 2) return names.join();
+    return '${names.sublist(0, names.length - 1).join(', ')} en ${names.last}';
   }
 
   /// Why this session must be relaunched before it can honour the settings as
@@ -1196,6 +1243,12 @@ class ReconcileController extends ChangeNotifier {
       _azurePullFingerprint = fingerprint;
     }
   }
+
+  /// The same record for the link (#264): [fingerprint] is read *before*
+  /// `applier.link()` samples the settings, so a save landing mid-link stays
+  /// pending. That errs towards one redundant re-link rather than towards a
+  /// save no pass ever adopts, which is the failure this exists to end.
+  void _stampLink(String fingerprint) => _linkFingerprint = fingerprint;
 
   /// Whether the store holds a materialized overview (rollups) to drill into —
   /// true after any session has synced, even without a pull this session.
@@ -1506,6 +1559,9 @@ class ReconcileController extends ChangeNotifier {
       // publishes a repaired document of its own (#207) — can never be mistaken
       // for the operator changing something.
       final stale = systemsAwaitingSettings;
+      // …and whether a setting only the link consumes moved (#264), sampled at
+      // the same instant and for the same reason.
+      final linkStale = linkAwaitingSettings;
       log.addMessage(core.Origin.wisa, 'WISA ophalen…');
       final fresh = await app.sync(core.Origin.wisa) as wapi.WisaSnapshot;
       _stampWisaPull(pulledWith);
@@ -1526,10 +1582,15 @@ class ReconcileController extends ChangeNotifier {
       // "Nothing to do" is only honest while every input is the one the view in
       // hand was built from. A saved import rule or school prefix (#259) is a
       // change this pass has to apply, so it falls through to the re-pull below
-      // instead of reporting "geen accountwijzigingen nodig" over it.
+      // instead of reporting "geen accountwijzigingen nodig" over it — and so
+      // is a saved Azure domain or Smartschool class tree (#264), which no pull
+      // asks about but every link does. That one falls through to [_relink]
+      // alone: it needs no network, and skipping it left the save adopted only
+      // by **Check for drift**, the very asymmetry #259 set out to remove.
       if (previous != null &&
           _linked != null &&
           stale.isEmpty &&
+          !linkStale &&
           wisaSnapshotUnchanged(previous, fresh)) {
         _noChangesNeeded = true;
         log.addMessage(
@@ -1582,6 +1643,16 @@ class ReconcileController extends ChangeNotifier {
       }
       _setProgress(0.65);
 
+      if (linkStale) {
+        // The pass says why it is re-linking, in the panel the operator reads —
+        // the counterpart of the two re-pull lines above, and the only visible
+        // sign that a save with no pull behind it was applied (#264).
+        log.addMessage(
+          core.Origin.all,
+          'Koppelingsinstellingen gewijzigd — de koppeling wordt opnieuw '
+          'berekend.',
+        );
+      }
       await _relink();
       _logSyncComplete();
       _finish(ReconcilePhase.ready);
@@ -2020,7 +2091,12 @@ class ReconcileController extends ChangeNotifier {
     _phase = ReconcilePhase.linking;
     _setProgress(0.75);
     notifyListeners();
+    // Read before the link, stamped after it: `applier.link()` samples the very
+    // same document, so this names exactly the settings the view about to be
+    // built was linked with (#264).
+    final linkedWith = _currentLinkFingerprint();
     _linked = await applier.link();
+    _stampLink(linkedWith);
     final s = _linked!.snapshot;
     log.addMessage(
       core.Origin.all,

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -451,8 +451,9 @@ class ReconcileController extends ChangeNotifier {
   /// at pull time and the Settings view publishes into on every load and save.
   ///
   /// The controller uses it for one thing: to tell whether the WISA pull inputs
-  /// (werkdatum, virtuele werkdatum, virtual-school marks) have moved since the
-  /// snapshot this session holds was pulled. A drift pass never re-reads WISA —
+  /// (werkdatum, virtuele werkdatum, virtual-school marks, and since #263 the
+  /// persisted import rules) have moved since the snapshot this session holds
+  /// was pulled. A drift pass never re-reads WISA —
   /// that is what Synchroniseer is for — so once they have, a drift check would
   /// silently relink against a roster built with the old settings and publish
   /// the result to every other operator. [driftBlockedReason] refuses instead.
@@ -1076,7 +1077,8 @@ class ReconcileController extends ChangeNotifier {
   /// A drift pass deliberately re-reads only Smartschool and Azure: the WISA
   /// roster it links them against is whatever this session already holds, cold
   /// seed included. So once the operator saves a werkdatum — or a virtuele
-  /// werkdatum, or a school's virtual mark — that roster is not the one their
+  /// werkdatum, or a school's virtual mark, or a WISA import rule (#263) —
+  /// that roster is not the one their
   /// change asks for, and a drift pass would relink against the old one,
   /// materialize the result, bump the generation and broadcast it to every other
   /// operator. Refusing until a full [sync] has pulled WISA with the new

--- a/account_manager/lib/src/screens/class_groups_screen.dart
+++ b/account_manager/lib/src/screens/class_groups_screen.dart
@@ -8,6 +8,7 @@ import 'package:plink_design_system/plink_design_system.dart';
 
 import '../reconcile/reconcile_bootstrap.dart';
 import '../reconcile/reconcile_controller.dart';
+import '../search/name_query.dart';
 import 'action_tiles.dart';
 
 /// The **Klasgroepen** tab (#227): the full class inventory.
@@ -30,7 +31,9 @@ import 'action_tiles.dart';
 ///   like they own one.
 /// - **The filter defaults *off*.** Acties has the same switch on by default
 ///   (#226) because it answers "what needs doing?"; this tab answers "is the
-///   inventory right?", which only the full list can.
+///   inventory right?", which only the full list can. The name search (#262) is
+///   what makes those few hundred rows navigable without shortening them, and it
+///   composes with the switch rather than replacing it.
 /// - **Informational notices are not buried.** A class Smartschool already
 ///   holds, or an Office 365 group left behind by a class that is gone, is real
 ///   manual work with no automated write, so it contributes nothing to a pending
@@ -149,6 +152,15 @@ class _ClassRowModel {
   /// informational notice is work too (#225/#250).
   bool attentionIn({required bool active}) =>
       active ? entry != null : group.needsAttention;
+
+  /// What the name search (#262) matches this row against: the class name and
+  /// its description, as one haystack.
+  ///
+  /// Both, because a class is looked up either way — `3TSO-B` by its code, but
+  /// just as often "handel", which only the description carries. Joining them
+  /// rather than testing them separately also lets one needle span the two
+  /// ("2f handel"), which is how an operator who half-remembers both types it.
+  String get searchText => '${group.label} ${group.description}';
 }
 
 class _ClassGroupsBody extends StatefulWidget {
@@ -166,20 +178,40 @@ class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
   /// keeps only the classes that ask something of the operator.
   bool _onlyAttention = false;
 
+  /// The class name search (#262). Unlike [_onlyAttention] this is not a mode
+  /// but a lookup *inside* this list: the tab lists every class of the school
+  /// group — a few hundred rows — and the filter that would shorten it is off by
+  /// design, so "is `3TSO-B` right?" is otherwise answered by scrolling.
+  final TextEditingController _search = TextEditingController();
+
   ReconcileController get controller => widget.controller;
 
   @override
   void initState() {
     super.initState();
     controller.addListener(_ensureLoaded);
+    _search.addListener(_onSearchChanged);
     _ensureLoaded();
   }
 
   @override
   void dispose() {
     controller.removeListener(_ensureLoaded);
+    _search
+      ..removeListener(_onSearchChanged)
+      ..dispose();
     super.dispose();
   }
+
+  void _onSearchChanged() {
+    if (mounted) setState(() {});
+  }
+
+  /// The typed needle, parsed. Matching is per whitespace-separated part and
+  /// order-independent — the same [NameQuery] the two Personeel searches use
+  /// (#187/#215/#217), so the three searches in this app behave identically
+  /// rather than each having its own idea of what a needle means.
+  NameQuery get _query => NameQuery(_search.text);
 
   /// Whether a read is already queued, so a burst of notifications schedules
   /// one.
@@ -254,12 +286,22 @@ class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
     final rows = _rows();
     final int attention =
         rows.where((r) => r.attentionIn(active: active)).length;
+    // The two filters compose rather than replace one another (#262): the
+    // search narrows the inventory to the classes the operator is looking for,
+    // and the switch — if they turned it on — keeps the ones asking something.
+    final NameQuery query = _query;
+    final searched = query.isEmpty
+        ? rows
+        : <_ClassRowModel>[
+            for (final r in rows)
+              if (query.matches(r.searchText)) r,
+          ];
     final visible = _onlyAttention
         ? <_ClassRowModel>[
-            for (final r in rows)
+            for (final r in searched)
               if (r.attentionIn(active: active)) r,
           ]
-        : rows;
+        : searched;
 
     final slivers = <Widget>[
       _gap(PlinkSpacing.s6),
@@ -269,6 +311,8 @@ class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
         attention: attention,
       )),
       _gap(PlinkSpacing.s4),
+      _section(_ClassSearchBar(searchController: _search)),
+      _gap(PlinkSpacing.s3),
       _section(_AttentionFilterBar(
         onlyAttention: _onlyAttention,
         onChanged: (v) => setState(() => _onlyAttention = v),
@@ -305,11 +349,19 @@ class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
         ..add(_gap(PlinkSpacing.s6));
     }
 
-    slivers.addAll(_bulkSlivers(active));
+    slivers.addAll(_bulkSlivers(
+      active,
+      <String>{for (final r in searched) r.group.label},
+    ));
 
     if (visible.isEmpty) {
-      slivers.add(_section(const EmptyLine(
-        'Elke klas staat in orde — er is niets dat aandacht vraagt.',
+      // A search that finds nothing has to say so in its own words (#262). The
+      // line below it — "elke klas staat in orde" — is a statement about the
+      // inventory, and reading it after a typo would be a lie about the school.
+      slivers.add(_section(EmptyLine(
+        query.isEmpty
+            ? 'Elke klas staat in orde — er is niets dat aandacht vraagt.'
+            : _noMatchLabel,
       )));
     } else {
       slivers.add(SliverPadding(
@@ -330,6 +382,13 @@ class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
     return slivers;
   }
 
+  /// The line shown when the search (alone or with the switch) hides every class
+  /// of a non-empty inventory (#262) — deliberately not the "nog geen
+  /// klasinventaris" line, which says the sync never ran, nor the "elke klas
+  /// staat in orde" one, which says the school is fine. Worded as Acties words
+  /// the same state one tab away (#187).
+  static const String _noMatchLabel = 'Geen klassen die aan de filter voldoen.';
+
   /// The "same situation" bulk affordances (#110/#252), collected above the
   /// inventory instead of interleaved in it.
   ///
@@ -338,12 +397,22 @@ class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
   /// run of rows to put a header on. They are still worth one click ("create
   /// every new class of the year"), so they sit here, each acting on exactly the
   /// classes it names.
-  List<Widget> _bulkSlivers(bool active) {
+  ///
+  /// [shown] is the set of class names the search left standing, and a subset is
+  /// narrowed to it: a button that acts on "exactly the classes it names" must
+  /// not quietly write to classes the operator filtered off the screen, and a
+  /// subset left with one class is no longer a bulk affordance at all — its one
+  /// row carries the same action.
+  List<Widget> _bulkSlivers(bool active, Set<String> shown) {
     if (!active) return const <Widget>[];
-    final subsets = <List<PendingAccountEntry>>[
-      for (final subset in controller.groupPendingSituations)
-        if (subset.length > 1) subset,
-    ];
+    final subsets = <List<PendingAccountEntry>>[];
+    for (final subset in controller.groupPendingSituations) {
+      final kept = <PendingAccountEntry>[
+        for (final e in subset)
+          if (shown.contains(e.targetId)) e,
+      ];
+      if (kept.length > 1) subsets.add(kept);
+    }
     if (subsets.isEmpty) return const <Widget>[];
     return <Widget>[
       _section(const _SectionTitle('Klassen in dezelfde situatie')),
@@ -466,6 +535,45 @@ class _ClassGroupsHeader extends StatelessWidget {
           Text(freshness, style: text.bodySmall),
         ],
       ],
+    );
+  }
+}
+
+/// The class name search above the inventory (#262).
+///
+/// Same box, same wording and same matching as the two Personeel searches one
+/// tab away (#187/#215/#217) — the operator will not remember which list has
+/// which kind of search, so all three must behave identically. It sits *above*
+/// the switch because it is the more common act on this tab: the switch answers
+/// "what needs doing?", the search answers "is this one class right?", which is
+/// the question that brought the operator to a few hundred rows.
+class _ClassSearchBar extends StatelessWidget {
+  const _ClassSearchBar({required this.searchController});
+
+  final TextEditingController searchController;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      key: const ValueKey('class-groups-search'),
+      controller: searchController,
+      decoration: InputDecoration(
+        isDense: true,
+        prefixIcon: const Icon(Icons.search, size: 18),
+        // Names *and* descriptions: a class is looked up by its code as often as
+        // by what it teaches, and a search box that silently ignores half of
+        // what is on the row is worse than none (#215/#217).
+        hintText: 'Zoek op klas of omschrijving…',
+        border: const OutlineInputBorder(),
+        suffixIcon: searchController.text.isEmpty
+            ? null
+            : IconButton(
+                key: const ValueKey('class-groups-search-clear'),
+                icon: const Icon(Icons.close, size: 18),
+                tooltip: 'Wis zoekopdracht',
+                onPressed: searchController.clear,
+              ),
+      ),
     );
   }
 }

--- a/account_manager/lib/src/screens/home_screen.dart
+++ b/account_manager/lib/src/screens/home_screen.dart
@@ -23,15 +23,18 @@ class HomeScreen extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              Eyebrow('Arcadia · account synchronisation', onInk: ink),
+              // The operator's language, like every other screen (#265): Start
+              // is the first thing they land on, so it cannot be the one page
+              // that greets them in English.
+              Eyebrow('Arcadia · accountsynchronisatie', onInk: ink),
               const SizedBox(height: PlinkSpacing.s4),
               Text('Account Manager', style: text.displaySmall),
               const SizedBox(height: PlinkSpacing.s4),
               Text(
-                'Reconciles user accounts and class groups across WISA, '
-                'Smartschool and Azure AD / Office 365. Views are added as '
-                'each Phase C slice lands — starting with sign-in and the '
-                'reconcile screen.',
+                'Stemt gebruikersaccounts en klasgroepen op elkaar af tussen '
+                'WISA, Smartschool en Azure AD / Office 365. De schermen '
+                'worden stap voor stap toegevoegd — te beginnen met aanmelden '
+                'en het tabblad Synchronisatie.',
                 style: text.bodyLarge,
               ),
             ],

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -197,8 +197,10 @@ class _Header extends StatelessWidget {
     // connection profiles the connectors were constructed from (#246).
     final String? relaunch = controller.relaunchRequiredReason;
     // Saved Smartschool / Azure pull inputs the next pass will adopt but no
-    // pass has yet (#259) — the gap in which Synchroniseer used to report
-    // "geen accountwijzigingen nodig" over a save it had skipped.
+    // pass has yet (#259), and since #264 the ones only the link consumes (the
+    // Azure domain, the Smartschool class tree) — the gap in which
+    // Synchroniseer used to report "geen accountwijzigingen nodig" over a save
+    // it had skipped.
     final String? pendingSettings = controller.pendingSettingsReason;
 
     return Column(

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -190,8 +190,8 @@ class _Header extends StatelessWidget {
     final bool ink = Theme.of(context).brightness == Brightness.dark;
     final bool hasFreshness = controller.syncState.systems.isNotEmpty;
     final lockedByOther = controller.syncLockedByOther;
-    // Why Check for drift is unavailable, when it is the WISA settings rather
-    // than another operator's lease that blocks it (#238).
+    // Why "Controleer op drift" is unavailable, when it is the WISA settings
+    // rather than another operator's lease that blocks it (#238).
     final String? driftBlocked = controller.driftBlockedReason;
     // The one class of saved setting this running session cannot adopt — the
     // connection profiles the connectors were constructed from (#246).
@@ -221,7 +221,11 @@ class _Header extends StatelessWidget {
               onPressed:
                   controller.busy || lockedByOther ? null : controller.sync,
               icon: const Icon(Icons.sync),
-              label: const Text('Synchronise'),
+              // The screen's own controls speak the operator's language, like
+              // the rail that leads here and the heading above them (#265).
+              // "Synchroniseer" is what the Acties read-only banner already
+              // calls this very action.
+              label: const Text('Synchroniseer'),
             ),
             OutlinedButton.icon(
               key: const ValueKey('reconcile-drift'),
@@ -231,7 +235,9 @@ class _Header extends StatelessWidget {
               onPressed:
                   controller.canCheckDrift ? controller.checkDrift : null,
               icon: const Icon(Icons.difference_outlined),
-              label: const Text('Check for drift'),
+              // The pass the last-sync box already calls a "driftcontrole",
+              // phrased as the imperative its neighbour is (#265).
+              label: const Text('Controleer op drift'),
             ),
           ],
         ),
@@ -316,18 +322,18 @@ class _Header extends StatelessWidget {
 /// sentence.
 ///
 /// Read from the materialized store so it names *whichever* operator last synced
-/// each system — not just this session (#108). WISA is the Synchronise target;
-/// Smartschool and Azure are refreshed by Check for drift, so a later WISA-only
-/// smart-sync reads as "synced then, drift-checked earlier" per row rather than
-/// an unexplained gap between timestamps (#170). Only rendered once at least one
-/// system has been synced.
+/// each system — not just this session (#108). WISA is what **Synchroniseer**
+/// targets; Smartschool and Azure are refreshed by **Controleer op drift**, so a
+/// later WISA-only smart-sync reads as "synced then, drift-checked earlier" per
+/// row rather than an unexplained gap between timestamps (#170). Only rendered
+/// once at least one system has been synced.
 class _LastSyncBox extends StatelessWidget {
   const _LastSyncBox({required this.controller});
 
   final ReconcileController controller;
 
   /// The systems in display order, each with its label and whether it is
-  /// refreshed by Synchronise (`isSync`) or by Check for drift.
+  /// refreshed by **Synchroniseer** (`isSync`) or by **Controleer op drift**.
   static const List<(core.Origin, String, bool)> _rows =
       <(core.Origin, String, bool)>[
     (core.Origin.wisa, 'WISA', true),
@@ -485,8 +491,11 @@ class _StatusBanner extends StatelessWidget {
             const SizedBox(width: PlinkSpacing.s3),
             Expanded(
               child: Text(
-                'WISA is unchanged since the previous sync — '
-                'no account changes needed.',
+                // Word for word the Log line #258 already writes beside it, so
+                // the banner and the log do not say the same thing twice in
+                // two different phrasings (#265).
+                'WISA is ongewijzigd sinds de vorige synchronisatie — '
+                'geen accountwijzigingen nodig.',
                 style: text.bodyMedium,
               ),
             ),
@@ -496,9 +505,10 @@ class _StatusBanner extends StatelessWidget {
     }
     if (controller.phase == ReconcilePhase.idle) {
       return Text(
-        'Synchronise pulls WISA and diffs it against the previous snapshot; '
-        'Smartschool and Azure are read once per session. Use "Check for '
-        'drift" when accounts were edited through another tool.',
+        'Synchroniseer haalt WISA op en vergelijkt het met de vorige '
+        'momentopname; Smartschool en Azure worden één keer per sessie '
+        'gelezen. Gebruik "Controleer op drift" wanneer accounts via een '
+        'ander programma zijn aangepast.',
         style: text.bodyMedium,
       );
     }
@@ -544,7 +554,9 @@ class _OverviewSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Overview', style: text.titleMedium),
+        // The same word the Acties tree heads itself with (#253), so the two
+        // tabs name the same kind of section the same way (#265).
+        Text('Overzicht', style: text.titleMedium),
         const SizedBox(height: PlinkSpacing.s3),
         Wrap(
           spacing: PlinkSpacing.s4,
@@ -885,8 +897,8 @@ class _LogPanelState extends State<_LogPanel> {
     );
   }
 
-  /// The panel's right-click menu: the framework's own items plus **Copy
-  /// line**, which takes the single entry under the pointer (#197).
+  /// The panel's right-click menu: the framework's own items plus **Regel
+  /// kopiëren**, which takes the single entry under the pointer (#197).
   ///
   /// Grabbing one message was already possible — the entries render as one
   /// paragraph (#193), so a triple-click selects exactly one line — but
@@ -913,7 +925,7 @@ class _LogPanelState extends State<_LogPanel> {
       items.insert(
         0,
         ContextMenuButtonItem(
-          label: 'Copy line',
+          label: 'Regel kopiëren',
           onPressed: () {
             region.hideToolbar();
             _copy(entry.line);
@@ -948,7 +960,7 @@ class _LogPanelState extends State<_LogPanel> {
             ),
             child: Row(
               children: <Widget>[
-                Text('Log', style: text.titleSmall),
+                Text('Logboek', style: text.titleSmall),
                 const Spacer(),
                 ListenableBuilder(
                   listenable: log,
@@ -959,12 +971,12 @@ class _LogPanelState extends State<_LogPanel> {
                         TextButton(
                           key: const ValueKey('reconcile-log-copy-all'),
                           onPressed: empty ? null : _copyAll,
-                          child: const Text('Copy all'),
+                          child: const Text('Alles kopiëren'),
                         ),
                         TextButton(
                           key: const ValueKey('reconcile-log-clear'),
                           onPressed: empty ? null : log.clear,
-                          child: const Text('Clear'),
+                          child: const Text('Wissen'),
                         ),
                       ],
                     );
@@ -983,7 +995,7 @@ class _LogPanelState extends State<_LogPanel> {
                     padding: const EdgeInsets.symmetric(
                       horizontal: PlinkSpacing.s4,
                     ),
-                    child: Text('No messages yet.', style: text.bodySmall),
+                    child: Text('Nog geen berichten.', style: text.bodySmall),
                   );
                 }
                 // Newest first, anchored to the top — reads like a tail.

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -29,12 +29,25 @@ import '../settings/settings_bootstrap.dart';
 ///   [LiveSettings] holder, so the reconcile stack's WISA pull honours it on the
 ///   very next Synchroniseer rather than on the next app launch (#238).
 ///
-/// The **Smartschool** import rules are authored here (#202): add / edit /
-/// remove the two rules the legacy app offers (`DiscardSmartschoolGroup`,
-/// `NoSmartschoolSubgroups`), persisted through the existing rule codec and
-/// applied by the connector on the next Smartschool pull. The **WISA** rules
-/// stay read-only (they are accumulated by `DontImportFromWisa` applies during
-/// reconcile); editing those is a later slice.
+/// Both connectors' import rules are authored here — add / edit / remove,
+/// persisted through the existing rule codecs and applied on the next pull:
+///
+/// - **Smartschool** (#202): the two rules the legacy app offers
+///   (`DiscardSmartschoolGroup`, `NoSmartschoolSubgroups`).
+/// - **WISA** (#273): the three rules with no other surface —
+///   `DontImportClass`, `DontImportUserFromWisa` and `ReplaceInstitute`. The two
+///   school-marking rules (`MarkAsVirtual`, `MarkAsOurs`) stay editable and
+///   removable but are *not* offered under **Toevoegen**: the WISA-scholen grid
+///   above already marks a school virtual/beheerd per school **id**, and for
+///   `beheerd` that grid is authoritative (`managedSchoolIdsOf` ignores the
+///   snapshot's `MarkAsOurs` flags as soon as the grid holds one school), so a
+///   rule authored here would be a control that silently does nothing.
+///
+/// The WISA list shows the **persisted** rules — the operator's standing
+/// configuration, which is what a pull unions with whatever this session earned.
+/// A rule a `DontImportFromWisa` apply accumulates lives in the reconcile
+/// stack's `WisaImportRules` holder for the life of the process and is on no
+/// settings document, so it does not appear here (#273).
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key, required this.bootstrap});
 
@@ -91,6 +104,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   // list below is handled. Empty means the whole Smartschool group tree is
   // imported — which is what every install did while nothing could author one.
   List<SmartschoolImportRule> _ssRules = const <SmartschoolImportRule>[];
+
+  // The WISA import rules (#273): the same working-copy treatment. These are the
+  // *persisted* rules — the operator's standing configuration, which `wisaSyncer`
+  // unions with the session's own `WisaImportRules` holder at pull time (#263) —
+  // so authoring one here reaches the very next Synchroniseer.
+  List<WisaImportRule> _wisaRules = const <WisaImportRule>[];
 
   // Azure profile.
   final _azClientId = TextEditingController();
@@ -219,6 +238,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           i < s.smartschool.years.length ? s.smartschool.years[i] : '';
     }
     _ssRules = List<SmartschoolImportRule>.of(s.smartschoolRules);
+    _wisaRules = List<WisaImportRule>.of(s.wisaRules);
 
     _azClientId.text = s.azure.clientId;
     _azTenantId.text = s.azure.tenantId;
@@ -290,6 +310,57 @@ class _SettingsScreenState extends State<SettingsScreen> {
     return showDialog<String>(
       context: context,
       builder: (_) => _RuleGroupNameDialog(kind: kind, initial: initial),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // WISA import rules (#273)
+  // ---------------------------------------------------------------------------
+
+  /// Prompts for the rule's field(s) and appends a new rule of [kind].
+  /// Cancelling the prompt leaves the list untouched.
+  Future<void> _addWisaRule(_WisaRuleKind kind) async {
+    final values = await _promptWisaRule(kind: kind);
+    if (values == null || !mounted) return;
+    toggle(() => _wisaRules = <WisaImportRule>[..._wisaRules, kind(values)]);
+  }
+
+  /// Re-prompts for the field(s) of the rule at [index], keeping its kind. Every
+  /// kind is editable, including the two school-marking ones **Toevoegen** does
+  /// not offer — a document that already carries one must stay correctable.
+  Future<void> _editWisaRule(int index) async {
+    final rule = _wisaRules[index];
+    final kind = _WisaRuleKind.of(rule);
+    final values = await _promptWisaRule(
+      kind: kind,
+      initial: _wisaRuleValues(rule),
+    );
+    if (values == null || !mounted) return;
+    toggle(() {
+      _wisaRules = List<WisaImportRule>.of(_wisaRules)..[index] = kind(values);
+    });
+  }
+
+  /// Drops the WISA rule at [index] from the working list.
+  void _removeWisaRule(int index) {
+    toggle(() {
+      _wisaRules = List<WisaImportRule>.of(_wisaRules)..removeAt(index);
+    });
+  }
+
+  /// Asks for the one or two values a WISA rule matches on. Returns the trimmed
+  /// values in field order, or `null` when the operator cancels.
+  ///
+  /// Free text for the same reason the Smartschool prompt is: this view holds no
+  /// WISA snapshot to pick a class name or institute code from, and a rule has to
+  /// be authorable *before* the first pull.
+  Future<List<String>?> _promptWisaRule({
+    required _WisaRuleKind kind,
+    List<String> initial = const <String>[],
+  }) {
+    return showDialog<List<String>>(
+      context: context,
+      builder: (_) => _WisaRuleDialog(kind: kind, initial: initial),
     );
   }
 
@@ -372,7 +443,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       )..sort((a, b) => a.schoolId.compareTo(b.schoolId));
 
   /// Assembles an [AppSettings] from the form, preserving the loaded document's
-  /// secret refs and its (read-only) WISA import rules.
+  /// secret refs.
   AppSettings _collect(AppSettings base) {
     return base.copyWith(
       schoolPrefix: _schoolPrefix.text.trim(),
@@ -404,6 +475,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         domain: _azDomain.text.trim(),
       ),
       smartschoolRules: List<SmartschoolImportRule>.of(_ssRules),
+      wisaRules: List<WisaImportRule>.of(_wisaRules),
       wisaSchools: List<WisaSchoolProfile>.of(_wisaSchools),
     );
   }
@@ -508,20 +580,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
         progress: true,
       );
     }
-    return _SettingsForm(
-      state: this,
-      settings: loaded,
-    );
+    return _SettingsForm(state: this);
   }
 }
 
 /// The scrolling settings form. A thin view over [_SettingsScreenState]'s
-/// controllers so all mutation stays in one place.
+/// controllers and working copies, so all mutation — and, since #273, every
+/// value the form renders — stays in one place.
 class _SettingsForm extends StatelessWidget {
-  const _SettingsForm({required this.state, required this.settings});
+  const _SettingsForm({required this.state});
 
   final _SettingsScreenState state;
-  final AppSettings settings;
 
   @override
   Widget build(BuildContext context) {
@@ -675,7 +744,7 @@ class _SettingsForm extends StatelessWidget {
   }
 
   /// WISA connector config: connection, credentials, managed-school list, and
-  /// the WISA import rules (read-only).
+  /// the WISA import-rule editor (#273).
   Widget _wisaTab() {
     return _tab('settings-tab-wisa-body', <Widget>[
       _Section(
@@ -716,12 +785,9 @@ class _SettingsForm extends StatelessWidget {
         ],
       ),
       _Section(
-        title: 'Importregels (alleen-lezen)',
+        title: 'Importregels',
         children: <Widget>[
-          _RulesList(
-            emptyKey: const ValueKey('settings-wisa-rules-empty'),
-            wisaRules: settings.wisaRules,
-          ),
+          _WisaRulesEditor(state: state),
         ],
       ),
     ]);
@@ -980,47 +1046,281 @@ class _WorkDateField extends StatelessWidget {
   }
 }
 
-class _RulesList extends StatelessWidget {
-  const _RulesList({
-    required this.emptyKey,
-    this.wisaRules = const <WisaImportRule>[],
+/// How one WISA import rule reads in the settings list.
+String _describeWisaRule(WisaImportRule rule) => switch (rule) {
+      DontImportClass(:final className) =>
+        'Klas niet importeren uit WISA: $className',
+      DontImportUserFromWisa(:final userCode) =>
+        'Gebruiker niet importeren uit WISA: $userCode',
+      ReplaceInstitute(:final original, :final replacement) =>
+        'Vervang instituut: $original → $replacement',
+      MarkAsVirtual(:final schoolCode) => 'Markeer als virtueel: $schoolCode',
+      MarkAsOurs(:final schoolCode) => 'Markeer als beheerd: $schoolCode',
+    };
+
+/// The value(s) a WISA rule matches on, in the field order [_WisaRuleKind]
+/// declares — what the edit prompt opens on. The sealed base type carries no
+/// shared field, so a switch over the five cases is where they meet.
+List<String> _wisaRuleValues(WisaImportRule rule) => switch (rule) {
+      DontImportClass(:final className) => <String>[className],
+      DontImportUserFromWisa(:final userCode) => <String>[userCode],
+      ReplaceInstitute(:final original, :final replacement) => <String>[
+          original,
+          replacement,
+        ],
+      MarkAsVirtual(:final schoolCode) => <String>[schoolCode],
+      MarkAsOurs(:final schoolCode) => <String>[schoolCode],
+    };
+
+/// The five WISA import rules, with the Dutch labels and the field prompts the
+/// editor authors them through (#273). Calling a kind builds its rule from the
+/// values the prompt collected, in [fields] order.
+///
+/// [authorable] is what **Toevoegen** offers. The two school-marking rules are
+/// deliberately not on that menu: the WISA-scholen grid above already marks a
+/// school virtueel/beheerd per school **id**, and for `beheerd` that grid wins
+/// outright — `managedSchoolIdsOf` stops consulting the snapshot's `MarkAsOurs`
+/// flags the moment the grid holds a single school, so a rule authored here
+/// would persist and then do nothing. They stay editable and removable, so a
+/// document that already carries one can be corrected or cleaned up.
+enum _WisaRuleKind {
+  dontImportClass(
+    label: 'Klas niet importeren',
+    explanation: 'De klasgroep wordt niet uit WISA ingelezen.',
+    fields: <String>['Klasnaam'],
+    hints: <String>['Naam zoals ze in WISA staat'],
+  ),
+  dontImportUser(
+    label: 'Personeelslid niet importeren',
+    explanation: 'Het personeelslid wordt niet uit WISA ingelezen.',
+    fields: <String>['Personeelscode'],
+    hints: <String>['De WISA-code van het personeelslid'],
+  ),
+  replaceInstitute(
+    label: 'Vervang instituut',
+    explanation: 'Klasgroepen van het eerste instituut worden ingelezen alsof '
+        'ze bij het tweede horen.',
+    fields: <String>['Oude instituutcode', 'Nieuwe instituutcode'],
+    hints: <String>['Code zoals WISA ze levert', 'Code zoals wij ze willen'],
+  ),
+  markAsVirtual(
+    label: 'Markeer als virtueel',
+    explanation: 'De school met deze code wordt met de virtuele werkdatum '
+        'opgehaald.',
+    fields: <String>['Schoolcode'],
+    hints: <String>['De korte WISA-code van de school'],
+    authorable: false,
+  ),
+  markAsOurs(
+    label: 'Markeer als beheerd',
+    explanation: 'De school met deze code telt als een school die wij beheren.',
+    fields: <String>['Schoolcode'],
+    hints: <String>['De korte WISA-code van de school'],
+    authorable: false,
+  );
+
+  const _WisaRuleKind({
+    required this.label,
+    required this.explanation,
+    required this.fields,
+    required this.hints,
+    this.authorable = true,
   });
 
-  /// Key stamped on the "no rules yet" placeholder, so each connector tab's
-  /// empty state is addressable on its own.
-  final Key emptyKey;
-  final List<WisaImportRule> wisaRules;
+  /// The menu / dialog label.
+  final String label;
 
-  static String _describeWisa(WisaImportRule rule) => switch (rule) {
-        DontImportClass(:final className) =>
-          'Klas niet importeren uit WISA: $className',
-        DontImportUserFromWisa(:final userCode) =>
-          'Gebruiker niet importeren uit WISA: $userCode',
-        ReplaceInstitute(:final original, :final replacement) =>
-          'Vervang instituut: $original → $replacement',
-        MarkAsVirtual(:final schoolCode) => 'Markeer als virtueel: $schoolCode',
-        MarkAsOurs(:final schoolCode) => 'Markeer als beheerd: $schoolCode',
+  /// One line telling the operator what the rule does to the import.
+  final String explanation;
+
+  /// The prompt's field labels, in the order [call] consumes them.
+  final List<String> fields;
+
+  /// Per-field placeholder text, parallel to [fields].
+  final List<String> hints;
+
+  /// Whether **Toevoegen** offers this kind.
+  final bool authorable;
+
+  /// The kinds **Toevoegen** offers.
+  static List<_WisaRuleKind> get addable => <_WisaRuleKind>[
+        for (final kind in _WisaRuleKind.values)
+          if (kind.authorable) kind,
+      ];
+
+  WisaImportRule call(List<String> values) => switch (this) {
+        _WisaRuleKind.dontImportClass => DontImportClass(values[0]),
+        _WisaRuleKind.dontImportUser => DontImportUserFromWisa(values[0]),
+        _WisaRuleKind.replaceInstitute => ReplaceInstitute(
+            original: values[0],
+            replacement: values[1],
+          ),
+        _WisaRuleKind.markAsVirtual => MarkAsVirtual(values[0]),
+        _WisaRuleKind.markAsOurs => MarkAsOurs(values[0]),
       };
+
+  static _WisaRuleKind of(WisaImportRule rule) => switch (rule) {
+        DontImportClass() => _WisaRuleKind.dontImportClass,
+        DontImportUserFromWisa() => _WisaRuleKind.dontImportUser,
+        ReplaceInstitute() => _WisaRuleKind.replaceInstitute,
+        MarkAsVirtual() => _WisaRuleKind.markAsVirtual,
+        MarkAsOurs() => _WisaRuleKind.markAsOurs,
+      };
+}
+
+/// Editor for the WISA import rules (#273).
+///
+/// #263 wired a persisted WISA rule through to the very next pull — the syncer
+/// unions the settings document's rules with the session's own holder, and
+/// `wisaPullFingerprint` covers them so a save arms the drift gate. Nothing in
+/// the app could *author* one, though: this list was titled "Importregels
+/// (alleen-lezen)" and `_collect` handed `base.wisaRules` straight back, so the
+/// only way to add a rule was editing the Cosmos settings document by hand.
+class _WisaRulesEditor extends StatelessWidget {
+  const _WisaRulesEditor({required this.state});
+
+  final _SettingsScreenState state;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     final ColorScheme colors = Theme.of(context).colorScheme;
-    if (wisaRules.isEmpty) {
-      return Text(
-        'Nog geen importregels verzameld.',
-        key: emptyKey,
-        style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
-      );
-    }
+    final rules = state._wisaRules;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        for (final r in wisaRules)
-          Padding(
-            padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
-            child: Text('• ${_describeWisa(r)}', style: text.bodyMedium),
+        Text(
+          'Regels snoeien en herschrijven wat er uit WISA wordt ingelezen. Ze '
+          'gelden vanaf de volgende synchronisatie.',
+          style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+        ),
+        const SizedBox(height: PlinkSpacing.s3),
+        if (rules.isEmpty)
+          Text(
+            'Nog geen WISA-importregels ingesteld.',
+            key: const ValueKey('settings-wisa-rules-empty'),
+            style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+          )
+        else
+          for (var i = 0; i < rules.length; i++)
+            _RuleRow(
+              keyPrefix: 'settings-wisa-rule',
+              index: i,
+              description: _describeWisaRule(rules[i]),
+              onEdit: () => state._editWisaRule(i),
+              onRemove: () => state._removeWisaRule(i),
+            ),
+        const SizedBox(height: PlinkSpacing.s4),
+        MenuAnchor(
+          menuChildren: <Widget>[
+            for (final kind in _WisaRuleKind.addable)
+              MenuItemButton(
+                key: ValueKey('settings-wisa-rule-add-${kind.name}'),
+                onPressed: () => state._addWisaRule(kind),
+                child: Text(kind.label),
+              ),
+          ],
+          builder: (_, MenuController menu, __) => OutlinedButton.icon(
+            key: const ValueKey('settings-wisa-rule-add'),
+            onPressed: () => menu.isOpen ? menu.close() : menu.open(),
+            icon: const Icon(Icons.add),
+            label: const Text('Toevoegen'),
           ),
+        ),
+        const SizedBox(height: PlinkSpacing.s3),
+        Text(
+          'Virtueel en beheerd markeer je per school hierboven bij '
+          '"WISA-scholen", niet met een regel: die lijst gaat per school en is '
+          'voor "beheerd" doorslaggevend.',
+          key: const ValueKey('settings-wisa-rules-school-note'),
+          style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+        ),
+      ],
+    );
+  }
+}
+
+/// Prompts for the one or two values a WISA rule matches on, popping them
+/// trimmed and in field order (or nothing when cancelled). A blank value is
+/// refused on every field: a rule that matches nothing would silently do no
+/// work, exactly as for the Smartschool prompt.
+class _WisaRuleDialog extends StatefulWidget {
+  const _WisaRuleDialog({required this.kind, required this.initial});
+
+  final _WisaRuleKind kind;
+  final List<String> initial;
+
+  @override
+  State<_WisaRuleDialog> createState() => _WisaRuleDialogState();
+}
+
+class _WisaRuleDialogState extends State<_WisaRuleDialog> {
+  late final List<TextEditingController> _values = <TextEditingController>[
+    for (var i = 0; i < widget.kind.fields.length; i++)
+      TextEditingController(
+        text: i < widget.initial.length ? widget.initial[i] : '',
+      ),
+  ];
+
+  @override
+  void dispose() {
+    for (final c in _values) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  bool get _complete => _values.every((c) => c.text.trim().isNotEmpty);
+
+  void _submit() {
+    if (!_complete) return;
+    Navigator.of(context).pop(<String>[for (final c in _values) c.text.trim()]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final fields = widget.kind.fields;
+    return AlertDialog(
+      key: const ValueKey('settings-wisa-rule-dialog'),
+      title: Text(widget.kind.label),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(widget.kind.explanation, style: text.bodyMedium),
+          for (var i = 0; i < fields.length; i++) ...<Widget>[
+            const SizedBox(height: PlinkSpacing.s3),
+            TextField(
+              key: ValueKey('settings-wisa-rule-value-$i'),
+              controller: _values[i],
+              autofocus: i == 0,
+              onSubmitted: (_) => _submit(),
+              decoration: InputDecoration(
+                labelText: fields[i],
+                hintText: widget.kind.hints[i],
+                border: const OutlineInputBorder(),
+              ),
+            ),
+          ],
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          key: const ValueKey('settings-wisa-rule-cancel'),
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Annuleren'),
+        ),
+        // Every field feeds the enabled state, so the two-field rule cannot be
+        // saved half-filled.
+        AnimatedBuilder(
+          animation: Listenable.merge(_values),
+          builder: (_, __) => FilledButton(
+            key: const ValueKey('settings-wisa-rule-confirm'),
+            onPressed: _complete ? _submit : null,
+            child: const Text('Bewaren'),
+          ),
+        ),
       ],
     );
   }
@@ -1108,7 +1408,13 @@ class _SmartschoolRulesEditor extends StatelessWidget {
           )
         else
           for (var i = 0; i < rules.length; i++)
-            _RuleRow(state: state, index: i, rule: rules[i]),
+            _RuleRow(
+              keyPrefix: 'settings-ss-rule',
+              index: i,
+              description: _describeSmartschoolRule(rules[i]),
+              onEdit: () => state._editSmartschoolRule(i),
+              onRemove: () => state._removeSmartschoolRule(i),
+            ),
         const SizedBox(height: PlinkSpacing.s4),
         MenuAnchor(
           menuChildren: <Widget>[
@@ -1131,19 +1437,23 @@ class _SmartschoolRulesEditor extends StatelessWidget {
   }
 }
 
-/// One configured Smartschool rule: its description plus the edit and remove
-/// affordances. Keyed by position so a widget/integration test can drive a
-/// specific row.
+/// One configured import rule — either connector's: its description plus the
+/// edit and remove affordances. Keyed `<keyPrefix>-<index>` so a
+/// widget/integration test can drive a specific row on a specific tab.
 class _RuleRow extends StatelessWidget {
   const _RuleRow({
-    required this.state,
+    required this.keyPrefix,
     required this.index,
-    required this.rule,
+    required this.description,
+    required this.onEdit,
+    required this.onRemove,
   });
 
-  final _SettingsScreenState state;
+  final String keyPrefix;
   final int index;
-  final SmartschoolImportRule rule;
+  final String description;
+  final VoidCallback onEdit;
+  final VoidCallback onRemove;
 
   @override
   Widget build(BuildContext context) {
@@ -1154,22 +1464,22 @@ class _RuleRow extends StatelessWidget {
         children: <Widget>[
           Expanded(
             child: Text(
-              _describeSmartschoolRule(rule),
-              key: ValueKey('settings-ss-rule-$index'),
+              description,
+              key: ValueKey('$keyPrefix-$index'),
               style: text.bodyMedium,
             ),
           ),
           IconButton(
-            key: ValueKey('settings-ss-rule-$index-edit'),
+            key: ValueKey('$keyPrefix-$index-edit'),
             tooltip: 'Bewerken',
             icon: const Icon(Icons.edit_outlined),
-            onPressed: () => state._editSmartschoolRule(index),
+            onPressed: onEdit,
           ),
           IconButton(
-            key: ValueKey('settings-ss-rule-$index-remove'),
+            key: ValueKey('$keyPrefix-$index-remove'),
             tooltip: 'Verwijderen',
             icon: const Icon(Icons.delete_outline),
-            onPressed: () => state._removeSmartschoolRule(index),
+            onPressed: onRemove,
           ),
         ],
       ),
@@ -1329,6 +1639,20 @@ class _WisaSchoolsEditor extends StatelessWidget {
     );
   }
 
+  /// Whether a `MarkAsVirtual` import rule in the working list already flags the
+  /// school with [code] (#273).
+  ///
+  /// The two surfaces mark by different keys — the grid by school id, the rule by
+  /// the short WISA code — and `wisaSyncer` unions them, so a rule really does
+  /// make the school virtual whatever this grid's checkbox says. The cell has to
+  /// show that rather than contradict it.
+  bool _virtualByRule(String code) {
+    final trimmed = code.trim();
+    if (trimmed.isEmpty) return false;
+    return state._wisaRules
+        .any((r) => r is MarkAsVirtual && r.schoolCode == trimmed);
+  }
+
   /// Lays the known schools out as rows of [_columns] cells, padding the final
   /// row with empty slots so the grid columns stay aligned. Each cell toggles
   /// its school's managed (`ours`) and virtual flags inline.
@@ -1340,7 +1664,12 @@ class _WisaSchoolsEditor extends StatelessWidget {
         final i = start + col;
         cells.add(Expanded(
           child: i < schools.length
-              ? _SchoolCell(state: state, index: i, profile: schools[i])
+              ? _SchoolCell(
+                  state: state,
+                  index: i,
+                  profile: schools[i],
+                  virtualByRule: _virtualByRule(schools[i].code),
+                )
               : const SizedBox.shrink(),
         ));
       }
@@ -1374,11 +1703,18 @@ class _SchoolCell extends StatelessWidget {
     required this.state,
     required this.index,
     required this.profile,
+    this.virtualByRule = false,
   });
 
   final _SettingsScreenState state;
   final int index;
   final WisaSchoolProfile profile;
+
+  /// Whether a `MarkAsVirtual` import rule already flags this school by its code
+  /// (#273). The cell then renders the flag as set and locks the checkbox: the
+  /// pull unions both surfaces, so an unticked box would be a lie and unticking
+  /// it would not stick. Removing the rule under **Importregels** is the undo.
+  final bool virtualByRule;
 
   @override
   Widget build(BuildContext context) {
@@ -1426,13 +1762,15 @@ class _SchoolCell extends StatelessWidget {
             dense: true,
             visualDensity: VisualDensity.compact,
             title: Text(
-              'virtueel',
+              virtualByRule ? 'virtueel (importregel)' : 'virtueel',
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
             ),
-            value: profile.virtual,
-            onChanged: (v) => state._toggleSchoolVirtual(index, v ?? false),
+            value: profile.virtual || virtualByRule,
+            onChanged: virtualByRule
+                ? null
+                : (v) => state._toggleSchoolVirtual(index, v ?? false),
           ),
         ),
       ],

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -2378,6 +2378,7 @@ class ReconcileHarness {
     Set<int>? ourSchoolIds,
     List<WisaSchoolProfile> schoolProfiles = const <WisaSchoolProfile>[],
     this.settingsStore,
+    this.modelsSettings = true,
     LiveSettings? liveSettings,
   })  : wisaResult = (wisa ?? wisaSnap()),
         ssResult = (smartschool ?? ssSnap()),
@@ -2649,8 +2650,9 @@ class ReconcileHarness {
       schoolProfiles: schoolProfiles,
       settingsStore: settingsStore,
       // The same holder the WISA pull reads, so the drift gate sees a save the
-      // moment Instellingen publishes it (#238).
-      liveSettings: this.liveSettings,
+      // moment Instellingen publishes it (#238) — unless this harness models no
+      // settings at all (#274), which is the documented null-holder mode.
+      liveSettings: modelsSettings ? this.liveSettings : null,
       publisher: publisher ?? signalHub?.publisher(),
       subscriber: subscriber ?? signalHub?.subscriber(),
       persistTimeout: persistTimeout ?? const Duration(minutes: 10),
@@ -2731,6 +2733,21 @@ class ReconcileHarness {
   /// operator saving in Instellingen mid-session — the real Settings view does
   /// exactly that, into the very same holder.
   final LiveSettings liveSettings;
+
+  /// Whether the [ReconcileController] is handed [liveSettings] at all.
+  ///
+  /// False builds it with **no** holder — the mode `ReconcileController` has
+  /// documented since #238 ("null in the harnesses that do not model settings at
+  /// all") and which #274 found had never once been exercised: every harness got
+  /// a holder whether the caller supplied one or not, so the tests that say
+  /// "a harness with no settings holder" only ever proved that an *empty
+  /// document* arms nothing. Constructing the controller for real without one
+  /// threw a `LateInitializationError`.
+  ///
+  /// The rest of the stack keeps reading [liveSettings] — the pulls and the
+  /// applier need a document to derive from, and an embedder that skips the
+  /// controller's gate has one too. Only the gate goes unwired.
+  final bool modelsSettings;
 
   /// The operator's Smartschool import rules, applied by the production pull
   /// [smartschoolTransport] enables — the settings document's

--- a/account_manager/test/reconcile/reconcile_live_settings_test.dart
+++ b/account_manager/test/reconcile/reconcile_live_settings_test.dart
@@ -446,6 +446,139 @@ void main() {
       rules.add(const wapi.DontImportClass('3C'));
       expect((await syncer(null)).classGroups, isEmpty);
     });
+
+    test("unions the persisted rules with the session's own (#263)", () async {
+      // Both halves reach one pull: the `MarkAsVirtual` this session earned and
+      // the `DontImportClass` the operator saved a moment ago.
+      final wire = RecordingWisaSoap();
+      final rules = WisaImportRules()..add(const wapi.MarkAsVirtual('S1'));
+      final live = LiveSettings(_settings());
+      final syncer = wisaSyncer(
+        wapi.WisaConnector.fromParts(
+          server: 'wisa.example',
+          port: 9000,
+          database: 'db',
+          username: 'u',
+          password: 'p',
+          transport: wire,
+        ),
+        settings: live,
+        rules: rules,
+      );
+
+      final first = await syncer(null);
+      expect(first.schools.single.isVirtual, isTrue,
+          reason: 'the session rule already marks the school virtual');
+      expect(first.classGroups, hasLength(1));
+
+      live.publish(_settings().copyWith(
+        wisaRules: const <wapi.WisaImportRule>[wapi.DontImportClass('3C')],
+      ));
+
+      final pruned = await syncer(null);
+      expect(pruned.classGroups, isEmpty,
+          reason: 'the saved rule reached the pull');
+      expect(pruned.schools.single.isVirtual, isTrue,
+          reason: 'and the session rule was not lost composing it');
+    });
+  });
+
+  group('a WISA import rule saved in Instellingen reaches the pull (#263)', () {
+    test('the very next pull applies it, with no relaunch', () async {
+      // The reported bug. `bootstrapReconcile` seeded the shared
+      // `WisaImportRules` holder from the document it loaded at startup and
+      // nothing ever published a saved document back into it, so a rule on the
+      // settings document only ever reached the pull of the *next* launch.
+      final wire = RecordingWisaSoap();
+      final live = LiveSettings(_settings());
+      final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+
+      await harness.controller.sync();
+      expect(
+        (harness.app.wisa.snapshot as wapi.WisaSnapshot).classGroups,
+        hasLength(1),
+      );
+
+      live.publish(_settings().copyWith(
+        wisaRules: const <wapi.WisaImportRule>[wapi.DontImportClass('3C')],
+      ));
+      await harness.controller.sync();
+
+      expect(
+        (harness.app.wisa.snapshot as wapi.WisaSnapshot).classGroups,
+        isEmpty,
+        reason: 'the pass the operator reached for applied the saved rule',
+      );
+    });
+
+    test('a rule dropped from the document stops applying too', () async {
+      // The other half of the freeze: a holder seeded once could never let go
+      // of a rule, so un-ignoring a class needed a relaunch as well.
+      final live = LiveSettings(_settings().copyWith(
+        wisaRules: const <wapi.WisaImportRule>[wapi.DontImportClass('3C')],
+      ));
+      final harness = ReconcileHarness(
+        wisaTransport: RecordingWisaSoap(),
+        liveSettings: live,
+      );
+
+      await harness.controller.sync();
+      expect(
+        (harness.app.wisa.snapshot as wapi.WisaSnapshot).classGroups,
+        isEmpty,
+      );
+
+      live.publish(_settings());
+      await harness.controller.sync();
+
+      expect(
+        (harness.app.wisa.snapshot as wapi.WisaSnapshot).classGroups,
+        hasLength(1),
+      );
+    });
+
+    test('blocks Check for drift until a Synchroniseer has pulled with it',
+        () async {
+      // A drift pass never re-reads WISA, so between the save and the sync it
+      // would relink the roster the rule never reached — and publish that to
+      // every other operator.
+      final live = LiveSettings(_settings());
+      final harness = ReconcileHarness(
+        wisaTransport: RecordingWisaSoap(),
+        liveSettings: live,
+      );
+      await harness.controller.sync();
+      expect(harness.controller.canCheckDrift, isTrue);
+
+      live.publish(_settings().copyWith(
+        wisaRules: const <wapi.WisaImportRule>[wapi.DontImportClass('3C')],
+      ));
+
+      expect(
+        harness.controller.driftBlockedReason,
+        'WISA-instellingen gewijzigd — synchroniseer eerst.',
+      );
+      expect(harness.controller.canCheckDrift, isFalse);
+
+      await harness.controller.sync();
+      expect(harness.controller.driftBlockedReason, isNull);
+    });
+
+    test('a rule an apply earned never arms the drift gate', () async {
+      // Session rules are not on any settings document, and the apply that
+      // earns one re-syncs WISA itself — so the gate must stay open.
+      final live = LiveSettings(_settings());
+      final harness = ReconcileHarness(
+        wisaTransport: RecordingWisaSoap(),
+        liveSettings: live,
+      );
+      await harness.controller.sync();
+
+      harness.applier.wisaRules.add(const wapi.DontImportClass('3C'));
+
+      expect(harness.controller.driftBlockedReason, isNull);
+      expect(harness.controller.canCheckDrift, isTrue);
+    });
   });
 
   group('the rest of the reconcile stack reads settings live too (#246)', () {

--- a/account_manager/test/reconcile/reconcile_live_settings_test.dart
+++ b/account_manager/test/reconcile/reconcile_live_settings_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_manager/src/reconcile/reconcile_bootstrap.dart';
+import 'package:account_manager/src/reconcile/reconcile_controller.dart';
 import 'package:account_state/account_state.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:smartschool_api/smartschool_api.dart' as ss;
@@ -178,7 +179,11 @@ void main() {
               'only a controller notification can disable its drift button');
     });
 
-    test('a harness with no settings holder never arms the gate', () async {
+    // Named for what it is since #274: the harness has always supplied a
+    // holder, so this is an *empty document*, not the null-holder mode. That
+    // mode has its own group at the bottom of this file.
+    test('a harness with an empty settings document never arms the gate',
+        () async {
       final harness = ReconcileHarness();
       await harness.controller.sync();
       expect(harness.controller.driftBlockedReason, isNull);
@@ -900,7 +905,7 @@ void main() {
       );
     });
 
-    test('a harness with no settings holder never arms it', () async {
+    test('a harness with an empty settings document never arms it', () async {
       final harness = ReconcileHarness();
       await harness.controller.sync();
 
@@ -1127,7 +1132,7 @@ void main() {
       expect(harness.controller.linkAwaitingSettings, isFalse);
     });
 
-    test('a harness with no settings holder never arms it', () async {
+    test('a harness with an empty settings document never arms it', () async {
       final harness = ReconcileHarness();
       await harness.controller.sync();
 
@@ -1177,8 +1182,83 @@ void main() {
       expect(harness.controller.canCheckDrift, isTrue);
     });
 
-    test('a harness with no settings holder never nags', () {
+    test('a harness with an empty settings document never nags', () {
       expect(ReconcileHarness().controller.relaunchRequiredReason, isNull);
+    });
+  });
+
+  group('a controller wired to no settings holder at all (#274)', () {
+    test('can be constructed', () {
+      // The reported crash. `_wisaFingerprint()` fell back to
+      // `_wisaPullFingerprint` — the very `late String` the constructor was
+      // assigning it to — so this construction threw a `LateInitializationError`
+      // before it ever returned, and the mode the doc comment has promised since
+      // #238 could not be entered.
+      //
+      // Built from a harness's parts rather than through the harness, because
+      // the harness has always supplied a holder whether the caller wanted one
+      // or not: that is why every "no settings holder" test in this file has in
+      // fact exercised an *empty document*.
+      final parts = ReconcileHarness();
+      final unwired = ReconcileController(
+        app: parts.app,
+        applier: parts.applier,
+        log: parts.log,
+        store: parts.linkedStore,
+      );
+      addTearDown(unwired.dispose);
+
+      // And with no document to compare against, no gate is armed — the
+      // behaviour the comment describes: "drift behaves exactly as before".
+      expect(unwired.driftBlockedReason, isNull);
+      expect(unwired.canCheckDrift, isTrue);
+      expect(unwired.systemsAwaitingSettings, isEmpty);
+      expect(unwired.linkAwaitingSettings, isFalse);
+      expect(unwired.pendingSettingsReason, isNull);
+      expect(unwired.relaunchRequiredReason, isNull);
+    });
+
+    test('syncs, links and keeps every gate silent afterwards', () async {
+      final harness = ReconcileHarness(modelsSettings: false);
+      await harness.controller.sync();
+
+      expect(harness.controller.linked, isNotNull);
+      // The stamps a pass leaves behind are the sentinel too, so a second pass
+      // cannot decide the settings "moved" between them.
+      expect(harness.controller.driftBlockedReason, isNull);
+      expect(harness.controller.canCheckDrift, isTrue);
+      expect(harness.controller.systemsAwaitingSettings, isEmpty);
+      expect(harness.controller.linkAwaitingSettings, isFalse);
+      expect(harness.controller.pendingSettingsReason, isNull);
+    });
+
+    test('a save into a document it was never given arms nothing', () async {
+      // The rest of the stack still reads the document — an embedder that skips
+      // the gate has settings, it just did not hand them to the controller — so
+      // this models a save that moves every one of the four fingerprints at
+      // once. A wired session would refuse the drift and name all three waits.
+      final live = LiveSettings(_settings());
+      final harness =
+          ReconcileHarness(modelsSettings: false, liveSettings: live);
+      await harness.controller.sync();
+
+      live.publish(
+        _settings(workDate: _pinned(DateTime(2026, 9, 1))).copyWith(
+          azure: const AzureConnection(domain: 'nieuw.example'),
+          schoolPrefix: 'XYZ',
+          smartschoolRules: const <ss.SmartschoolImportRule>[
+            ss.DiscardSmartschoolGroup('Archief'),
+          ],
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(harness.controller.driftBlockedReason, isNull);
+      expect(harness.controller.canCheckDrift, isTrue);
+      expect(harness.controller.systemsAwaitingSettings, isEmpty);
+      expect(harness.controller.linkAwaitingSettings, isFalse);
+      expect(harness.controller.pendingSettingsReason, isNull);
+      expect(harness.controller.relaunchRequiredReason, isNull);
     });
   });
 }

--- a/account_manager/test/reconcile/reconcile_live_settings_test.dart
+++ b/account_manager/test/reconcile/reconcile_live_settings_test.dart
@@ -909,6 +909,233 @@ void main() {
     });
   });
 
+  group('Synchroniseer re-links when a link input moved (#264)', () {
+    /// A new intake: one WISA student of a managed school with no Azure account
+    /// yet, so the pass proposes creating one — and the proposed UPN is built
+    /// from the Azure domain, a setting **no** pull ever asks about.
+    ReconcileHarness intakeFrom(LiveSettings live) => ReconcileHarness(
+          wisa: wisaSnap(
+            students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
+            schools: [wisaSchool(1, ours: true)],
+          ),
+          smartschool: ssSnap(
+            groups: [ssGroup('3C', code: '3C_ss')],
+            accounts: const [],
+            memberships: const [],
+          ),
+          azure: azSnap(users: const []),
+          ourSchoolIds: const {1},
+          liveSettings: live,
+        );
+
+    /// The `userPrincipalName` the pending "create an Office 365 account"
+    /// proposes for the student — what the operator reads off the tile.
+    String proposedUpn(ReconcileHarness h) => h.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student')
+        .choices
+        .expand((c) => c.selected.changes.fields)
+        .firstWhere((f) => f.field == 'userPrincipalName')
+        .after!;
+
+    test('a saved Azure domain reaches the very next Synchroniseer', () async {
+      // The reported bug. Every input of the pull was unchanged, so #99's smart
+      // sync returned before `_relink()` — and the domain, which only the link
+      // consumes, was adopted by **Check for drift** alone while Synchroniseer
+      // reported "geen accountwijzigingen nodig" over the save.
+      final live = LiveSettings(_settings());
+      final harness = intakeFrom(live);
+
+      await harness.controller.sync();
+      expect(proposedUpn(harness), 'jane.doe@student.school.example');
+
+      live.publish(_settings()
+          .copyWith(azure: const AzureConnection(domain: 'nieuw.example')));
+      expect(
+        harness.controller.pendingSettingsReason,
+        'Instellingen voor de koppeling gewijzigd — '
+        'synchroniseer om ze toe te passen.',
+      );
+
+      await harness.controller.sync();
+
+      expect(proposedUpn(harness), 'jane.doe@student.nieuw.example',
+          reason: 'the pass the operator reached for adopted the save');
+      // …and it did not claim there was nothing to do, which is the
+      // user-visible half of the bug.
+      expect(harness.controller.noChangesNeeded, isFalse);
+      expect(
+        harness.log.entries
+            .map((e) => e.message)
+            .where((m) => m.contains('geen accountwijzigingen nodig')),
+        isEmpty,
+      );
+      // The re-link says why it happened, in the panel the operator reads…
+      expect(
+        harness.log.entries.map((e) => e.message),
+        contains('Koppelingsinstellingen gewijzigd — de koppeling wordt '
+            'opnieuw berekend.'),
+      );
+      // …the notice is gone, because the pass applied it…
+      expect(harness.controller.pendingSettingsReason, isNull);
+      // …and it cost no network at all: this is a re-link, not a re-pull.
+      expect((harness.ssSyncs, harness.azSyncs), (1, 1));
+    });
+
+    test('a saved Smartschool class tree is adopted too', () async {
+      // The second of the two link-only inputs: the tree decides where a newly
+      // created class hangs, and the parent it resolves to is on the tile.
+      final tree = _settings().copyWith(
+        smartschool: SmartschoolConnection(studentGroup: 'LLN'),
+      );
+      final live = LiveSettings(tree);
+      final harness = ReconcileHarness(
+        wisa: wisaSnap(
+          students: [wisaStudent(classGroup: '3C')],
+          schools: [wisaSchool(1, ours: true)],
+          classGroups: [wisaClassGroup('3C')],
+        ),
+        smartschool: ssSnap(
+          groups: [
+            ssGroup('Leerlingen',
+                code: 'LLN', official: false, type: core.GroupType.group),
+            ssGroup('School',
+                code: 'SCH', official: false, type: core.GroupType.group),
+          ],
+          accounts: const [],
+          memberships: const [],
+        ),
+        azure: azSnap(users: const []),
+        ourSchoolIds: const {1},
+        liveSettings: live,
+      );
+
+      String parentOf(ReconcileHarness h) => h.controller.pendingEntries
+          .firstWhere((e) => e.family == 'group')
+          .choices
+          .expand((c) => c.selected.changes.fields)
+          .firstWhere((f) => f.field == 'parent')
+          .after!;
+
+      await harness.controller.sync();
+      expect(parentOf(harness), 'LLN');
+
+      live.publish(tree.copyWith(
+        smartschool: SmartschoolConnection(studentGroup: 'SCH'),
+      ));
+      await harness.controller.sync();
+
+      expect(parentOf(harness), 'SCH');
+      expect((harness.ssSyncs, harness.azSyncs), (1, 1),
+          reason: 'the tree is a link input, not a pull input');
+    });
+
+    test('the smart sync still says nothing to do when no link input moved',
+        () async {
+      // The behaviour #99 exists for has to survive: a save that touches
+      // nothing any pass depends on is still "nothing to do".
+      final live = LiveSettings(_settings());
+      final harness = intakeFrom(live);
+      await harness.controller.sync();
+
+      final base = _settings();
+      live.publish(base.copyWith(
+        smartschool: base.smartschool.copyWith(testUser: 'proefaccount'),
+      ));
+
+      expect(harness.controller.linkAwaitingSettings, isFalse);
+      await harness.controller.sync();
+      expect(harness.controller.noChangesNeeded, isTrue);
+    });
+
+    test('a drift check adopts it too, so no sync re-links for it twice',
+        () async {
+      // Drift re-links unconditionally, so it really has applied the save; the
+      // stamp has to record that or the next Synchroniseer would fall through
+      // for a change already adopted.
+      final live = LiveSettings(_settings());
+      final harness = intakeFrom(live);
+      await harness.controller.sync();
+
+      live.publish(_settings()
+          .copyWith(azure: const AzureConnection(domain: 'nieuw.example')));
+      expect(harness.controller.linkAwaitingSettings, isTrue);
+
+      await harness.controller.checkDrift();
+      expect(proposedUpn(harness), 'jane.doe@student.nieuw.example');
+      expect(harness.controller.linkAwaitingSettings, isFalse);
+      expect(harness.controller.pendingSettingsReason, isNull);
+
+      await harness.controller.sync();
+      expect(harness.controller.noChangesNeeded, isTrue,
+          reason: 'the drift pass already applied it');
+    });
+
+    test('the screen names the link beside the systems waiting', () async {
+      final live = LiveSettings(_settings());
+      final harness = intakeFrom(live);
+      await harness.controller.sync();
+
+      live.publish(_settings().copyWith(
+        schoolPrefix: 'SSM',
+        azure: const AzureConnection(domain: 'nieuw.example'),
+        smartschoolRules: const <ss.SmartschoolImportRule>[
+          ss.DiscardSmartschoolGroup('Organisatie'),
+        ],
+      ));
+
+      expect(
+        harness.controller.pendingSettingsReason,
+        'Instellingen voor Smartschool, Azure AD en de koppeling gewijzigd — '
+        'synchroniseer om ze toe te passen.',
+      );
+      // Nothing is refused meanwhile — the next pass adopts them by itself.
+      expect(harness.controller.canCheckDrift, isTrue);
+    });
+
+    test('a save landing before the link is adopted by that very link',
+        () async {
+      // The fingerprint is read where `applier.link()` samples the document,
+      // not when the pass started, so a save that lands while the pass is still
+      // pulling is applied by it — and stamped, rather than left pending over a
+      // link that honoured it.
+      final live = LiveSettings(_settings());
+      final gate = Completer<void>();
+      final harness = ReconcileHarness(
+        wisa: wisaSnap(
+          students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
+          schools: [wisaSchool(1, ours: true)],
+        ),
+        smartschool: ssSnap(
+          groups: [ssGroup('3C', code: '3C_ss')],
+          accounts: const [],
+          memberships: const [],
+        ),
+        azure: azSnap(users: const []),
+        ourSchoolIds: const {1},
+        liveSettings: live,
+        azureGate: gate,
+      );
+
+      final pass = harness.controller.sync();
+      await Future<void>.delayed(Duration.zero);
+      live.publish(_settings()
+          .copyWith(azure: const AzureConnection(domain: 'nieuw.example')));
+      gate.complete();
+      await pass;
+
+      expect(proposedUpn(harness), 'jane.doe@student.nieuw.example');
+      expect(harness.controller.linkAwaitingSettings, isFalse);
+    });
+
+    test('a harness with no settings holder never arms it', () async {
+      final harness = ReconcileHarness();
+      await harness.controller.sync();
+
+      expect(harness.controller.linkAwaitingSettings, isFalse);
+      expect(harness.controller.pendingSettingsReason, isNull);
+    });
+  });
+
   group('a connection profile the session cannot adopt says so (#246)', () {
     test('stays silent while only live-adoptable values move', () async {
       final live = LiveSettings(_settings());

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -92,7 +92,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Idle: the explainer is shown, no overview yet.
-    expect(find.text('Overview'), findsNothing);
+    expect(find.text('Overzicht'), findsNothing);
     expect(find.byKey(const ValueKey('reconcile-category-students')),
         findsNothing);
 
@@ -101,7 +101,7 @@ void main() {
 
     // The per-category overview renders on Reconcile from the rollups (#163):
     // students / staff / class-groups, each with a pending indicator.
-    expect(find.text('Overview'), findsOneWidget);
+    expect(find.text('Overzicht'), findsOneWidget);
     expect(find.byKey(const ValueKey('reconcile-category-students')),
         findsOneWidget);
     expect(
@@ -130,7 +130,53 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    expect(find.textContaining('no account changes needed'), findsWidgets);
+    expect(
+      find.textContaining('geen accountwijzigingen nodig'),
+      findsWidgets,
+    );
+  });
+
+  testWidgets(
+      'the screen names its own controls in the operator\'s language, like the '
+      'rail and heading above them (#265)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = ReconcileHarness();
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: harness.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    // The two buttons under the heading. (The idle explainer that names them
+    // in prose is translated too but cannot be asserted: `loadOverview` moves
+    // the phase off `idle` before the first frame the operator sees, so the
+    // paragraph never renders — filed as #275, not this issue's to fix.)
+    expect(find.text('Synchroniseer'), findsOneWidget);
+    expect(find.text('Controleer op drift'), findsOneWidget);
+
+    // The log panel's own chrome, empty state included.
+    expect(find.text('Logboek'), findsOneWidget);
+    expect(find.text('Alles kopiëren'), findsOneWidget);
+    expect(find.text('Wissen'), findsOneWidget);
+    expect(find.text('Nog geen berichten.'), findsOneWidget);
+
+    // Nothing English is left on the screen's own chrome.
+    for (final String english in <String>[
+      'Synchronise',
+      'Check for drift',
+      'Overview',
+      'Log',
+      'Copy all',
+      'Clear',
+      'No messages yet.',
+    ]) {
+      expect(find.text(english), findsNothing,
+          reason: '"$english" is the English label #265 replaced');
+    }
+
+    // And the counts heading, once a sync has produced one.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(find.text('Overzicht'), findsOneWidget);
   });
 
   testWidgets(
@@ -352,7 +398,7 @@ void main() {
     expect(passive.controller.linked, isNull,
         reason: 'a passive session never links');
     expect(passive.wisaSyncs, 0, reason: 'a passive session pulls nothing');
-    expect(find.text('Overview'), findsOneWidget);
+    expect(find.text('Overzicht'), findsOneWidget);
     expect(find.byKey(const ValueKey('reconcile-category-students')),
         findsOneWidget);
     expect(
@@ -502,15 +548,15 @@ void main() {
       findsOneWidget,
     );
 
-    await tester.tap(find.text('Clear'));
+    await tester.tap(find.text('Wissen'));
     await tester.pumpAndSettle();
 
-    expect(find.text('No messages yet.'), findsOneWidget);
+    expect(find.text('Nog geen berichten.'), findsOneWidget);
   });
 
   testWidgets(
       'the log panel copies a multi-entry selection one line per entry, keeps '
-      'the error colour, and Copy all takes the whole buffer (#193)',
+      'the error colour, and Alles kopiëren takes the whole buffer (#193)',
       (WidgetTester tester) async {
     final List<String> copied = <String>[];
     tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
@@ -591,7 +637,7 @@ void main() {
       '00:00:00  [azure]  gamma\n00:00:00  [smartschool]  beta',
     );
 
-    // Copy all ignores the selection and takes the buffer, oldest first.
+    // Alles kopiëren ignores the selection and takes the buffer, oldest first.
     await tester.tap(find.byKey(const ValueKey('reconcile-log-copy-all')));
     await tester.pumpAndSettle();
     expect(copied, hasLength(2));
@@ -615,8 +661,8 @@ void main() {
   });
 
   testWidgets(
-      'right-clicking a log line offers Copy line and copies exactly that '
-      'entry (#197)', (WidgetTester tester) async {
+      'right-clicking a log line offers Regel kopiëren and copies exactly '
+      'that entry (#197)', (WidgetTester tester) async {
     final List<String> copied = <String>[];
     tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
       SystemChannels.platform,
@@ -655,8 +701,8 @@ void main() {
       Offset(rect.left + 8, rect.top + lineHeight * 1.5),
     );
 
-    expect(find.text('Copy line'), findsOneWidget);
-    await tester.tap(find.text('Copy line'));
+    expect(find.text('Regel kopiëren'), findsOneWidget);
+    await tester.tap(find.text('Regel kopiëren'));
     await tester.pumpAndSettle();
 
     // Exactly the one entry under the pointer — no timestamp of its
@@ -667,11 +713,11 @@ void main() {
     // The empty space under the last line has no entry to copy, so the menu
     // there offers only what the framework itself contributes.
     await _rightClickAt(tester, Offset(rect.left + 8, rect.bottom + 24));
-    expect(find.text('Copy line'), findsNothing);
+    expect(find.text('Regel kopiëren'), findsNothing);
   });
 
   testWidgets(
-      'Copy line takes the whole entry when the message soft-wraps over '
+      'Regel kopiëren takes the whole entry when the message soft-wraps over '
       'several rows (#197)', (WidgetTester tester) async {
     final List<String> copied = <String>[];
     tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
@@ -722,8 +768,8 @@ void main() {
       Offset(rect.left + 8, rect.top + oneRow * 1.5),
     );
 
-    expect(find.text('Copy line'), findsOneWidget);
-    await tester.tap(find.text('Copy line'));
+    expect(find.text('Regel kopiëren'), findsOneWidget);
+    await tester.tap(find.text('Regel kopiëren'));
     await tester.pumpAndSettle();
 
     expect(copied, hasLength(1));

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -18,6 +18,15 @@ void _useTallWindow(WidgetTester tester) {
 final Finder _readOnly = find.byKey(const ValueKey('class-groups-read-only'));
 final Finder _filter =
     find.byKey(const ValueKey('class-groups-only-attention'));
+final Finder _search = find.byKey(const ValueKey('class-groups-search'));
+
+Finder _row(String klas) => find.byKey(ValueKey('class-row-$klas'));
+
+/// Types [needle] into the inventory search box and settles.
+Future<void> _type(WidgetTester tester, String needle) async {
+  await tester.enterText(_search, needle);
+  await tester.pumpAndSettle();
+}
 
 void main() {
   testWidgets('shows the not-configured panel when AAD is absent, in Dutch',
@@ -235,6 +244,144 @@ void main() {
         findsOneWidget);
     expect(find.text('Onze eerste klas'), findsOneWidget);
     expect(find.textContaining('Klas van een andere school'), findsNothing);
+  });
+
+  testWidgets(
+      'the search finds a class by its name and by its description (#262)',
+      (WidgetTester tester) async {
+    // The fixture: `1A` ("Eerste jaar A"), the two sub-groups of `2F` (both
+    // "Tweede jaar F") and the stale `GBS-9Z`.
+    _useTallWindow(tester);
+    final harness = azureClassGroupHarness(withStaleGroup: true);
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(_search, findsOneWidget);
+    expect(_row('1A'), findsOneWidget);
+    expect(_row('2F ECO'), findsOneWidget);
+
+    // By name: the one class asked about, out of the whole inventory.
+    await _type(tester, '1a');
+    expect(_row('1A'), findsOneWidget);
+    expect(_row('2F ECO'), findsNothing);
+    expect(_row('2F MAW'), findsNothing);
+    expect(_row('GBS-9Z'), findsNothing);
+
+    // By description — a class is looked up by what it teaches as often as by
+    // its code, and "eerste" appears in no class *name* at all.
+    await _type(tester, 'tweede');
+    expect(_row('2F ECO'), findsOneWidget);
+    expect(_row('2F MAW'), findsOneWidget);
+    expect(_row('1A'), findsNothing);
+
+    // Per-part and order-independent, like the two Personeel searches
+    // (#187/#215/#217): both parts must occur, in either order, and one needle
+    // may span the name and the description.
+    await _type(tester, 'maw tweede');
+    expect(_row('2F MAW'), findsOneWidget);
+    expect(_row('2F ECO'), findsNothing);
+
+    // Clearing brings the whole inventory back.
+    await tester.tap(find.byKey(const ValueKey('class-groups-search-clear')));
+    await tester.pumpAndSettle();
+    expect(_row('1A'), findsOneWidget);
+    expect(_row('2F ECO'), findsOneWidget);
+    expect(_row('GBS-9Z'), findsOneWidget);
+  });
+
+  testWidgets('the search composes with the attention switch (#262)',
+      (WidgetTester tester) async {
+    // `2F ECO` needs work (no Office 365 group for `2F`); `2F MAW` shares that
+    // group and so asks nothing itself.
+    _useTallWindow(tester);
+    final harness = azureClassGroupHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _type(tester, '2f');
+    expect(_row('2F ECO'), findsOneWidget);
+    expect(_row('2F MAW'), findsOneWidget);
+    expect(_row('1A'), findsNothing);
+
+    // The switch narrows what the search left, rather than replacing it.
+    await tester.tap(_filter);
+    await tester.pumpAndSettle();
+    expect(_row('2F ECO'), findsOneWidget);
+    expect(_row('2F MAW'), findsNothing);
+    expect(_row('1A'), findsNothing,
+        reason: 'the search is still on while the switch filters');
+
+    // And the search still narrows what the switch left.
+    await _type(tester, '1a');
+    expect(
+        find.text('Geen klassen die aan de filter voldoen.'), findsOneWidget);
+  });
+
+  testWidgets(
+      'a search that matches nothing says so, and says something else '
+      'than an empty inventory (#262)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = azureClassGroupHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // Two parts taken from two different classes match neither.
+    await _type(tester, '1a tweede');
+    expect(_row('1A'), findsNothing);
+    expect(
+        find.text('Geen klassen die aan de filter voldoen.'), findsOneWidget);
+    expect(find.textContaining('Nog geen klasinventaris'), findsNothing,
+        reason: 'the sync ran and the school has classes — only the needle '
+            'found none');
+    expect(find.textContaining('Elke klas staat in orde'), findsNothing,
+        reason: 'a typo must not read as a statement about the school');
+
+    // While the "nothing needs attention" line is still the one shown when it
+    // is the switch, not the search, that empties the list.
+    await _type(tester, '');
+    await tester.tap(_filter);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('entry-group-2F ECO')));
+    await tester.pumpAndSettle();
+    final apply = find.byKey(const ValueKey('entry-apply-2F ECO'));
+    await tester.ensureVisible(apply);
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Elke klas staat in orde'), findsOneWidget);
+  });
+
+  testWidgets(
+      'a bulk header offers only the classes the search left standing (#262)',
+      (WidgetTester tester) async {
+    // `1A` and `1B` both need their Office 365 roster updated, so the tab
+    // collects them into one "same situation" header that acts on both.
+    _useTallWindow(tester);
+    final harness = azureClassMembershipHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
+
+    // Narrowed to one class, the bulk affordance is gone: a button that says it
+    // acts on "exactly the classes it names" must not write to a class the
+    // operator has filtered off the screen.
+    await _type(tester, '1a');
+    expect(_row('1A'), findsOneWidget);
+    expect(_row('1B'), findsNothing);
+    expect(find.text('Klassen in dezelfde situatie'), findsNothing);
+
+    await _type(tester, 'eerste jaar');
+    expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
   });
 
   testWidgets('classes sort by year, numerically (#227)',

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -47,6 +47,31 @@ Future<void> _addSmartschoolRule(
   await tester.pumpAndSettle();
 }
 
+/// Authors one WISA import rule through the editor (#273): opens **Toevoegen**,
+/// picks the rule type keyed [kind], fills the prompt's fields with [values] in
+/// order and confirms.
+Future<void> _addWisaRule(
+  WidgetTester tester,
+  String kind,
+  List<String> values,
+) async {
+  final add = find.byKey(const ValueKey('settings-wisa-rule-add'));
+  await tester.ensureVisible(add);
+  await tester.tap(add);
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(ValueKey('settings-wisa-rule-add-$kind')));
+  await tester.pumpAndSettle();
+  for (var i = 0; i < values.length; i++) {
+    await tester.enterText(
+      find.byKey(ValueKey('settings-wisa-rule-value-$i')),
+      values[i],
+    );
+  }
+  await tester.pump();
+  await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-confirm')));
+  await tester.pumpAndSettle();
+}
+
 void main() {
   testWidgets('shows the not-configured panel when AAD is absent',
       (WidgetTester tester) async {
@@ -638,7 +663,16 @@ void main() {
         find.byKey(const ValueKey('settings-wisa-school-add')), findsNothing);
     expect(find.byKey(const ValueKey('settings-wisa-school-add-btn')),
         findsNothing);
-    expect(find.text('Toevoegen'), findsNothing);
+    // The only "Toevoegen" left on this tab belongs to the import-rule editor
+    // (#273) — nothing adds a school by hand.
+    expect(find.text('Toevoegen'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('settings-wisa-rule-add')),
+        matching: find.text('Toevoegen'),
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets(
@@ -767,7 +801,7 @@ void main() {
     expect(saved.wisaSchools.single.ours, isTrue);
   });
 
-  testWidgets('accumulated import rules render read-only',
+  testWidgets('the persisted WISA import rules render in the editor',
       (WidgetTester tester) async {
     _useTallWindow(tester);
     final harness = SettingsHarness(
@@ -1052,12 +1086,114 @@ void main() {
         find.byKey(const ValueKey('settings-ss-rules-empty')), findsOneWidget);
   });
 
-  testWidgets('the WISA rule list stays read-only (#202)',
+  // ---------------------------------------------------------------------------
+  // WISA import-rule editor (#273)
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+      'the WISA import rules are an editor now, not an "alleen-lezen" list '
+      '(#273)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    expect(find.text('Importregels'), findsOneWidget);
+    expect(find.textContaining('alleen-lezen'), findsNothing);
+    expect(find.byKey(const ValueKey('settings-wisa-rules-empty')),
+        findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('settings-wisa-rule-add')), findsOneWidget);
+  });
+
+  testWidgets(
+      'Toevoegen offers the three rules with no other surface, and not the two '
+      'the WISA-scholen grid already marks (#273)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-add')));
+    await tester.pumpAndSettle();
+
+    for (final kind in const <String>[
+      'dontImportClass',
+      'dontImportUser',
+      'replaceInstitute',
+    ]) {
+      expect(
+          find.byKey(ValueKey('settings-wisa-rule-add-$kind')), findsOneWidget);
+    }
+    // `MarkAsOurs` is dead once the grid holds a school (managedSchoolIdsOf
+    // stops reading the snapshot's flags), and `MarkAsVirtual` duplicates the
+    // grid's per-school mark — neither is offered as a new rule.
+    expect(find.byKey(const ValueKey('settings-wisa-rule-add-markAsVirtual')),
+        findsNothing);
+    expect(find.byKey(const ValueKey('settings-wisa-rule-add-markAsOurs')),
+        findsNothing);
+    // …and the section says where those two live instead.
+    expect(find.byKey(const ValueKey('settings-wisa-rules-school-note')),
+        findsOneWidget);
+  });
+
+  testWidgets(
+      'authoring each WISA rule type round-trips through the existing codec '
+      '(#273)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    await _addWisaRule(tester, 'dontImportClass', <String>['OKAN']);
+    await _addWisaRule(tester, 'dontImportUser', <String>['ABC']);
+    await _addWisaRule(
+      tester,
+      'replaceInstitute',
+      <String>['ISMAA', 'ISMAB'],
+    );
+
+    // All three render in the list before the save.
+    expect(find.text('Klas niet importeren uit WISA: OKAN'), findsOneWidget);
+    expect(
+        find.text('Gebruiker niet importeren uit WISA: ABC'), findsOneWidget);
+    expect(find.text('Vervang instituut: ISMAA → ISMAB'), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('settings-wisa-rules-empty')), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.wisaRules, hasLength(3));
+    // …on the wire shape the codec already defined — no new tags (#273).
+    expect(saved.toJson()['wisaRules'], <Map<String, dynamic>>[
+      {'type': 'dontImportClass', 'className': 'OKAN'},
+      {'type': 'dontImportUserFromWisa', 'userCode': 'ABC'},
+      {
+        'type': 'replaceInstitute',
+        'original': 'ISMAA',
+        'replacement': 'ISMAB',
+      },
+    ]);
+  });
+
+  testWidgets(
+      'editing a WISA rule rewrites its values, keeping its type (#273)',
       (WidgetTester tester) async {
     _useTallWindow(tester);
     final harness = SettingsHarness(
       initial: AppSettings(
-        wisaRules: <WisaImportRule>[const DontImportClass('OKAN')],
+        wisaRules: <WisaImportRule>[
+          const ReplaceInstitute(original: 'OUD', replacement: 'NIEUW'),
+        ],
       ),
     );
     await tester
@@ -1065,7 +1201,194 @@ void main() {
     await tester.pumpAndSettle();
 
     await _openTab(tester, 'settings-tab-wisa');
-    expect(find.text('Importregels (alleen-lezen)'), findsOneWidget);
-    expect(find.byKey(const ValueKey('settings-ss-rule-add')), findsNothing);
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-0-edit')));
+    await tester.pumpAndSettle();
+    // The prompt opens on the current values, so fixing a typo is a correction
+    // rather than a re-entry — both fields, for the two-field rule.
+    expect(find.text('OUD'), findsOneWidget);
+    expect(find.text('NIEUW'), findsOneWidget);
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-wisa-rule-value-1')),
+      'ISMAB',
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-confirm')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final rule = (await harness.store.load()).wisaRules.single;
+    expect(rule, isA<ReplaceInstitute>());
+    expect((rule as ReplaceInstitute).original, 'OUD');
+    expect(rule.replacement, 'ISMAB');
+  });
+
+  testWidgets('removing a WISA rule drops it from the saved document (#273)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: AppSettings(
+        wisaRules: <WisaImportRule>[
+          const DontImportClass('OKAN'),
+          const DontImportUserFromWisa('ABC'),
+        ],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-1-remove')));
+    await tester.pumpAndSettle();
+    expect(find.text('Gebruiker niet importeren uit WISA: ABC'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    final saved = await harness.store.load();
+    expect(saved.wisaRules, hasLength(1));
+    expect((saved.wisaRules.single as DontImportClass).className, 'OKAN');
+  });
+
+  testWidgets('a WISA rule cannot be saved with an empty field (#273)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness();
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-add')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('settings-wisa-rule-add-replaceInstitute')),
+    );
+    await tester.pumpAndSettle();
+
+    FilledButton confirm() => tester.widget<FilledButton>(
+          find.byKey(const ValueKey('settings-wisa-rule-confirm')),
+        );
+    expect(confirm().onPressed, isNull);
+
+    // Half-filled is still refused: a ReplaceInstitute with no replacement
+    // rewrites a school code to nothing.
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-wisa-rule-value-0')),
+      'ISMAA',
+    );
+    await tester.pump();
+    expect(confirm().onPressed, isNull);
+
+    // Blank-only counts as empty, and a real second value arms it.
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-wisa-rule-value-1')),
+      '   ',
+    );
+    await tester.pump();
+    expect(confirm().onPressed, isNull);
+    await tester.enterText(
+      find.byKey(const ValueKey('settings-wisa-rule-value-1')),
+      'ISMAB',
+    );
+    await tester.pump();
+    expect(confirm().onPressed, isNotNull);
+
+    // Cancelling still leaves the list untouched.
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-cancel')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('settings-wisa-rules-empty')),
+        findsOneWidget);
+  });
+
+  testWidgets(
+      'a school-marking rule stays editable and removable even though '
+      'Toevoegen does not offer it (#273)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: AppSettings(
+        wisaRules: <WisaImportRule>[const MarkAsOurs('ISMAA')],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    // Editable: the prompt opens on the rule's own kind and value.
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-0-edit')));
+    await tester.pumpAndSettle();
+    expect(find.text('Markeer als beheerd'), findsOneWidget);
+    expect(find.text('ISMAA'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-cancel')));
+    await tester.pumpAndSettle();
+
+    // …and removable, so a legacy rule that contradicts the grid can go.
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-0-remove')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    expect((await harness.store.load()).wisaRules, isEmpty);
+  });
+
+  testWidgets(
+      'a MarkAsVirtual rule shows on the school it marks instead of '
+      'contradicting the grid (#273)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = SettingsHarness(
+      initial: AppSettings(
+        wisaRules: <WisaImportRule>[const MarkAsVirtual('ISMV')],
+        wisaSchools: const <WisaSchoolProfile>[
+          WisaSchoolProfile(schoolId: 1, code: 'ISMV', name: 'Virtuele school'),
+          WisaSchoolProfile(schoolId: 2, code: 'ISMAA', name: 'Sint-Maarten'),
+        ],
+      ),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+
+    // The rule-marked school reads as virtual and says where that came from;
+    // its checkbox is locked, because the pull unions both surfaces and
+    // unticking it would not stick.
+    final marked = tester.widget<CheckboxListTile>(
+      find.byKey(const ValueKey('settings-wisa-school-1-virtual')),
+    );
+    expect(marked.value, isTrue);
+    expect(marked.onChanged, isNull);
+    expect(find.text('virtueel (importregel)'), findsOneWidget);
+
+    // The school no rule names is untouched: unticked and still editable.
+    final plain = tester.widget<CheckboxListTile>(
+      find.byKey(const ValueKey('settings-wisa-school-2-virtual')),
+    );
+    expect(plain.value, isFalse);
+    expect(plain.onChanged, isNotNull);
+  });
+
+  testWidgets(
+      'authoring a WISA rule moves the pull fingerprint, so #238\'s drift gate '
+      'arms (#273)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final live = LiveSettings(const AppSettings());
+    final harness = SettingsHarness(liveSettings: live);
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    final before = wisaPullFingerprint(live.current);
+    await _openTab(tester, 'settings-tab-wisa');
+    await _addWisaRule(tester, 'dontImportClass', <String>['OKAN']);
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+
+    // The saved document is published into the shared holder the reconcile
+    // stack reads at pull time (#263), and its WISA fingerprint moved — which
+    // is what blocks a stale drift pass.
+    expect(live.current.wisaRules, hasLength(1));
+    expect(wisaPullFingerprint(live.current), isNot(before));
   });
 }

--- a/account_manager/test/widget_test.dart
+++ b/account_manager/test/widget_test.dart
@@ -25,6 +25,19 @@ void main() {
     expect(find.byType(NavigationRail), findsOneWidget);
     expect(find.text('Start'), findsOneWidget);
 
+    // …and the placeholder behind it speaks that language too (#265): the
+    // first screen the operator lands on was the last one left in English.
+    expect(find.text('ARCADIA · ACCOUNTSYNCHRONISATIE'), findsOneWidget);
+    expect(
+      find.textContaining('Stemt gebruikersaccounts en klasgroepen'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('het tabblad Synchronisatie.'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Reconciles user accounts'), findsNothing);
+
     // The per-product accent is layered on the Plink foundations.
     final BuildContext context = tester.element(find.byType(HomeScreen));
     final PlinkProductAccent? accent =

--- a/packages/account_state/lib/src/apply/wisa_import_rules.dart
+++ b/packages/account_state/lib/src/apply/wisa_import_rules.dart
@@ -1,7 +1,7 @@
 import 'package:wisa_api/wisa_api.dart';
 
 /// A mutable, de-duplicating set of [WisaImportRule]s shared between the WISA
-/// [Syncer] and the [StateApplier].
+/// [Syncer] and the [StateApplier] — the rules **this session earned**.
 ///
 /// WISA is read-only, so the `DontImportFromWisa` actions (student/staff
 /// [DontImportUserFromWisa], group [DontImportClass]) cannot write anything;
@@ -13,25 +13,38 @@ import 'package:wisa_api/wisa_api.dart';
 ///
 /// This holder is the seam that lets [StateApplier] re-sync WISA with the
 /// accumulated rules **without** re-wiring the [SystemState]. Build it once,
-/// wire the WISA syncer to read [rules] live, then hand the same instance to
+/// wire the WISA syncer to read the rules live, then hand the same instance to
 /// the applier:
 ///
 /// ```dart
-/// final importRules = WisaImportRules(initial: settings.wisaRules);
+/// final importRules = WisaImportRules();
 /// final wisa = SystemState<WisaSnapshot>(
 ///   system: Origin.wisa,
 ///   syncer: (_) => connector.sync(
 ///     schools: schools,
 ///     workDate: workDate,
-///     rules: importRules.rules, // read live, so a later add() takes effect
+///     // read live, so a later add() — and a later save — takes effect
+///     rules: importRules.unionWith(live.current.wisaRules),
 ///   ),
 /// );
 /// // ... build ApplicationState, then:
 /// final applier = StateApplier(app: app, wisaRules: importRules, ...);
 /// ```
 ///
-/// Because the syncer reads [rules] at call time, `applier` only has to
+/// Because the syncer composes the rules at call time, `applier` only has to
 /// [add] the new rule and trigger `app.sync(Origin.wisa)`.
+///
+/// ## Why the persisted rules are *not* seeded in here (#263)
+///
+/// The obvious wiring — `WisaImportRules(initial: settings.wisaRules)` at
+/// bootstrap — is what this holder used to get, and it froze the operator's
+/// persisted rules for the life of the process: nothing ever published a saved
+/// settings document back into the holder, so a rule the operator (or another
+/// operator, through the shared document) added reached the pull only after a
+/// relaunch, and a rule *removed* from the document could never be dropped at
+/// all. So the two sources stay distinct — persisted rules on the settings
+/// document, read live at pull time through [unionWith]; session-earned rules
+/// here — and the pull unions them.
 class WisaImportRules {
   WisaImportRules({Iterable<WisaImportRule> initial = const []}) {
     for (final rule in initial) {
@@ -42,10 +55,26 @@ class WisaImportRules {
   final List<WisaImportRule> _rules = [];
   final Set<String> _keys = {};
 
-  /// The accumulated rules, in insertion order. Pass this to the WISA
-  /// connector's `sync(rules: ...)` — read live so an [add] between syncs is
-  /// picked up by the next re-sync.
+  /// The rules this session accumulated, in insertion order. A pull wants
+  /// [unionWith] instead — this is only the session's own half.
   List<WisaImportRule> get rules => List.unmodifiable(_rules);
+
+  /// The rules one WISA pull should apply: the operator's [persisted] rules —
+  /// read from the live settings document at pull time — followed by the ones
+  /// this session earned, de-duplicated exactly as [add] de-duplicates (#263).
+  ///
+  /// Persisted first because they are the operator's standing configuration;
+  /// the session's own `DontImportFromWisa` rules are the increment on top. A
+  /// rule present in both collapses to one, so re-applying a `DontImportClass`
+  /// the document already carries changes nothing.
+  List<WisaImportRule> unionWith(Iterable<WisaImportRule> persisted) {
+    final keys = <String>{};
+    final merged = <WisaImportRule>[];
+    for (final rule in <WisaImportRule>[...persisted, ..._rules]) {
+      if (keys.add(_keyOf(rule))) merged.add(rule);
+    }
+    return List.unmodifiable(merged);
+  }
 
   /// Adds [rule] unless a structurally-equal rule is already present. Returns
   /// `true` if the set changed. De-duplication keeps a repeated

--- a/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_linked_store.dart
@@ -196,6 +196,9 @@ class CosmosLinkedStore implements LinkedStore {
         for (final a in view.accounts)
           a.id.value: (pk: a.school, doc: a.toJson()),
       },
+      // The labels are what the progress line names the container with, and it
+      // goes straight into the operator's Log panel (#266) — so they are the
+      // words the app already uses, not the container names.
       label: 'accounts',
       onProgress: onProgress,
     );
@@ -207,7 +210,7 @@ class CosmosLinkedStore implements LinkedStore {
         for (final g in view.groups)
           g.id.value: (pk: g.school, doc: g.toJson()),
       },
-      label: 'groups',
+      label: 'klasgroepen',
       onProgress: onProgress,
     );
     // Rollups: same replace, keyed by the rollup node key.
@@ -217,7 +220,7 @@ class CosmosLinkedStore implements LinkedStore {
       docsById: {
         for (final r in view.rollups) r.key: (pk: r.school, doc: r.toJson()),
       },
-      label: 'rollups',
+      label: 'tellingen',
       onProgress: onProgress,
     );
 
@@ -740,7 +743,9 @@ class CosmosLinkedStore implements LinkedStore {
 
     final total = writes.length;
     if (label != null && onProgress != null && unchanged > 0) {
-      onProgress('Persisting $label: $unchanged unchanged, $total to write…');
+      onProgress(
+        'Opslaan van $label: $unchanged ongewijzigd, $total te schrijven…',
+      );
     }
     await _runBounded(
       writes,
@@ -753,7 +758,7 @@ class CosmosLinkedStore implements LinkedStore {
           ? null
           : (done) {
               if (done == total || done % _progressEvery == 0) {
-                onProgress('Persisting $label: $done/$total…');
+                onProgress('Opslaan van $label: $done/$total…');
               }
             },
     );

--- a/packages/account_state/lib/src/cosmos/cosmos_retry.dart
+++ b/packages/account_state/lib/src/cosmos/cosmos_retry.dart
@@ -126,17 +126,17 @@ class CosmosThrottleGovernor {
     _limit = halved < minConcurrency ? minConcurrency : halved;
     if (wait == null) {
       _report?.call(
-        'Cosmos is still throttling after $attempt attempts — giving up on '
-        'this request.',
+        'Cosmos beperkt het tempo nog steeds na $attempt pogingen — deze '
+        'aanvraag wordt opgegeven.',
       );
       return;
     }
     // Report the start of a burst, then only every [reportEvery]th event.
     if (wasWide || _throttles % reportEvery == 0) {
       _report?.call(
-        'Cosmos is throttling (429) — retrying in ${wait.inMilliseconds} ms '
-        'and narrowing the write fan-out to $_limit '
-        '(throttled $_throttles time(s) so far).',
+        'Cosmos beperkt het tempo (429) — opnieuw proberen over '
+        '${wait.inMilliseconds} ms en het aantal gelijktijdige schrijfacties '
+        'verlaagd naar $_limit ($_throttles keer beperkt tot nu toe).',
       );
     }
   }
@@ -150,7 +150,8 @@ class CosmosThrottleGovernor {
     _limit++;
     if (!isNarrowed) {
       _report?.call(
-        'Cosmos throttling eased — write fan-out back to $_limit.',
+        'Cosmos beperkt het tempo niet meer — aantal gelijktijdige '
+        'schrijfacties terug op $_limit.',
       );
     }
   }

--- a/packages/account_state/lib/src/realtime/signalr_subscriber.dart
+++ b/packages/account_state/lib/src/realtime/signalr_subscriber.dart
@@ -92,7 +92,11 @@ class SignalRSubscriber implements SignalSubscriber {
       try {
         await _connectOnce();
       } on Object catch (e) {
-        _log?.addError(core.Origin.all, 'SignalR connection lost: $e');
+        // Kept as an error, and therefore Dutch (#266): the operator can do
+        // nothing about the transport itself, but losing the live channel is
+        // why another operator's sync stops showing up here — so the panel has
+        // to say it in the language the rest of the pass speaks.
+        _log?.addError(core.Origin.all, 'SignalR-verbinding verbroken: $e');
       }
       if (_closed) break;
       await Future<void>.delayed(_reconnectDelay);
@@ -182,8 +186,12 @@ class SignalRSubscriber implements SignalSubscriber {
       try {
         await onReconnect();
       } on Object catch (e) {
+        // The wording `ReconcileController` already uses for exactly this
+        // failure ("Kon niet bijwerken na het herverbinden: …", #258).
         _log?.addError(
-            core.Origin.all, 'SignalR reconnect catch-up failed: $e');
+          core.Origin.all,
+          'SignalR: kon niet bijwerken na het herverbinden: $e',
+        );
       }
     }());
   }

--- a/packages/account_state/lib/src/settings/live_settings.dart
+++ b/packages/account_state/lib/src/settings/live_settings.dart
@@ -130,6 +130,50 @@ String azurePullFingerprint(AppSettings settings) {
       'beheerdeScholen=${managed.join(',')}';
 }
 
+/// A stable identity for the settings only the **link** consumes — the ones no
+/// pull asks anything about (#264).
+///
+/// The third fingerprint beside the three pull ones, and the reason it exists is
+/// that [wisaPullFingerprint], [smartschoolPullFingerprint] and
+/// [azurePullFingerprint] together do *not* cover everything a saved document
+/// changes. `ApplierSettings` — sampled on every `link()` — carries two values
+/// that reach no connector at all:
+///
+/// - the Azure domain, which every proposed UPN is built from
+///   (`StudentActionConfig.azureDomain`, and the `student.<domain>` sub-domain
+///   derived from it, plus `StaffActionConfig.azureDomain`);
+/// - the Smartschool class tree — the year or grade group codes, whichever the
+///   school uses, with the student-group root as the flat fallback — which
+///   decides where a newly created class hangs.
+///
+/// Saving either used to be adopted by **Check for drift** and not by the
+/// Synchroniseer the operator reaches for: that pass re-links unconditionally,
+/// while a sync over an unchanged WISA returns before `_relink()`. A moved
+/// fingerprint is what tells the smart sync to fall through to the link — and
+/// only to the link, since nothing here needs the network.
+///
+/// The other two `ApplierSettings` inputs are deliberately absent: the school
+/// prefix and the managed-school set are already in [azurePullFingerprint],
+/// because they scope the Azure pull itself, so a save that moves either forces
+/// a re-pull *and* the re-link behind it.
+///
+/// Order-sensitive on the year/grade codes — they are positional, one per school
+/// year — and the flags are honoured exactly as `classTreeFrom` honours them, so
+/// editing a year label while the school runs on grades is not a changed tree.
+String linkFingerprint(AppSettings settings) {
+  final smartschool = settings.smartschool;
+  final years = smartschool.useYears ? smartschool.years : const <String>[];
+  final grades = smartschool.useGrades ? smartschool.grades : const <String>[];
+  // The student-group path is fingerprinted untrimmed on purpose: it goes into
+  // the tree exactly as stored, so a trailing space really is a different
+  // lookup. The domain is trimmed because bootstrap trims it before the
+  // connector and the action configs ever see it.
+  return 'azureDomein=${settings.azure.domain.trim()};'
+      'jaren=${jsonEncode(years)};'
+      'graden=${jsonEncode(grades)};'
+      'pad=${jsonEncode(smartschool.studentGroup)}';
+}
+
 /// A stable identity for the settings a running session **cannot** adopt: the
 /// endpoints and credential refs the three connectors were constructed from
 /// (#246).

--- a/packages/account_state/lib/src/settings/live_settings.dart
+++ b/packages/account_state/lib/src/settings/live_settings.dart
@@ -58,18 +58,33 @@ class LiveSettings {
 }
 
 /// A stable identity for the settings a WISA pull depends on: the werkdatum
-/// pair and the operator's virtual-school marks (#238).
+/// pair, the operator's virtual-school marks (#238), and the persisted WISA
+/// import rules (#263).
 ///
 /// Fingerprints the **settings**, not the resolved dates: `isNow: true`
 /// resolves to a different instant on every pull and would make two identical
 /// configurations compare unequal, which would leave "Check for drift"
 /// permanently blocked. Two settings documents with the same fingerprint
 /// therefore produce the same WISA query for the same instant.
+///
+/// The import rules belong here for the same reason the werkdatum does: since
+/// #263 the pull reads them from the live document, so a saved rule changes
+/// what the roster contains — and a drift pass, which never re-pulls WISA,
+/// would otherwise relink against the roster the rule never reached. Only the
+/// *persisted* rules count; the ones a `DontImportFromWisa` apply accumulates
+/// in the session's `WisaImportRules` holder trigger their own re-sync and are
+/// not part of any settings document.
+///
+/// Order-sensitive, like [smartschoolPullFingerprint]: the connector applies
+/// the rules in sequence.
 String wisaPullFingerprint(AppSettings settings) {
   final virtualSchools = settings.virtualWisaSchoolIds.toList()..sort();
   return 'werkdatum=${_workDateKey(settings.wisa.workDate)};'
       'virtueleWerkdatum=${_workDateKey(settings.wisa.virtualWorkDate)};'
-      'virtueleScholen=${virtualSchools.join(',')}';
+      'virtueleScholen=${virtualSchools.join(',')};'
+      'regels=${jsonEncode(<Map<String, dynamic>>[
+        for (final rule in settings.wisaRules) encodeWisaRule(rule),
+      ])}';
 }
 
 String _workDateKey(WorkDateSetting setting) =>

--- a/packages/account_state/test/cosmos/cosmos_client_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_client_test.dart
@@ -608,10 +608,15 @@ void main() {
       expect(governor.concurrency, 6,
           reason: '24 halved twice while the account was throttling');
       // One line for the burst, not one per 429 (a real burst is thousands).
+      // It is reported into the operator's Log panel, so it is Dutch (#266).
       expect(reported, hasLength(1));
-      expect(reported.single, contains('throttling'));
-      expect(reported.single, contains('narrowing the write fan-out to 12'),
-          reason: 'the operator sees the persist slow down, not silence');
+      expect(reported.single, contains('Cosmos beperkt het tempo (429)'));
+      expect(
+        reported.single,
+        contains('het aantal gelijktijdige schrijfacties verlaagd naar 12'),
+        reason: 'the operator sees the persist slow down, not silence',
+      );
+      expect(reported.single, isNot(contains('throttling')));
     });
   });
 
@@ -723,10 +728,23 @@ void main() {
       expect(reported, hasLength(1));
       g.recordSuccess();
       expect(reported, hasLength(2));
-      expect(reported.last, contains('eased'));
+      // All three reports go into the operator's Log panel, so all three are
+      // Dutch (#266).
+      expect(reported.last, contains('Cosmos beperkt het tempo niet meer'));
 
       g.recordThrottle(attempt: 8); // out of attempts
-      expect(reported.last, contains('giving up'));
+      expect(
+        reported.last,
+        'Cosmos beperkt het tempo nog steeds na 8 pogingen — deze aanvraag '
+        'wordt opgegeven.',
+      );
+      for (final english in <String>['throttling', 'eased', 'giving up']) {
+        expect(
+          reported.where((m) => m.contains(english)),
+          isEmpty,
+          reason: english,
+        );
+      }
     });
   });
 }

--- a/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
+++ b/packages/account_state/test/cosmos/cosmos_linked_store_test.dart
@@ -721,10 +721,21 @@ void main() {
       // The long write ticked visibly: interim lines plus a final full count for
       // the big account container.
       expect(progress, isNotEmpty);
-      expect(progress.where((m) => m.startsWith('Persisting accounts:')),
+      expect(progress.where((m) => m.startsWith('Opslaan van accounts:')),
           isNotEmpty);
-      expect(progress, contains('Persisting accounts: 1000/2500…'));
-      expect(progress, contains('Persisting accounts: 2500/2500…'));
+      expect(progress, contains('Opslaan van accounts: 1000/2500…'));
+      expect(progress, contains('Opslaan van accounts: 2500/2500…'));
+      // The line goes straight into the operator's Log panel, so it is Dutch
+      // like every other line of a pass — the container labels included, in the
+      // words the app already uses for them (#266).
+      expect(progress.where((m) => m.startsWith('Persisting')), isEmpty);
+      expect(
+        progress.where((m) => m.startsWith('Opslaan van tellingen:')),
+        isNotEmpty,
+        reason: 'the rollups container is named "tellingen"',
+      );
+      expect(progress.where((m) => m.contains('rollups')), isEmpty);
+      expect(progress.where((m) => m.contains('groups')), isEmpty);
 
       // The whole set round-trips despite the batching.
       expect((await store.readRollups()).isNotEmpty, isTrue);
@@ -845,7 +856,9 @@ void main() {
       expect(client.deletes, 0, reason: 'nothing departed, nothing deleted');
       // The operator is told the pass was a no-op rather than seeing silence.
       expect(
-          progress, contains('Persisting accounts: 50 unchanged, 0 to write…'));
+        progress,
+        contains('Opslaan van accounts: 50 ongewijzigd, 0 te schrijven…'),
+      );
       // …and the view is still whole and still readable.
       expect(await store.readClassroom(school: '1', classroom: 'c0'),
           hasLength(10));

--- a/packages/account_state/test/live_settings_test.dart
+++ b/packages/account_state/test/live_settings_test.dart
@@ -1,6 +1,7 @@
 import 'package:account_state/account_state.dart';
 import 'package:smartschool_api/smartschool_api.dart';
 import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart';
 
 AppSettings _settings({
   WorkDateSetting workDate = const WorkDateSetting(),
@@ -123,6 +124,59 @@ void main() {
         wisaPullFingerprint(_settings(schools: const [a, b])),
         wisaPullFingerprint(_settings(schools: const [b, a])),
       );
+    });
+
+    test('changes when a WISA import rule is saved (#263)', () {
+      // The rules are pull inputs since #263 — the pull reads them from the
+      // live document — so a saved rule must arm the drift gate exactly as a
+      // moved werkdatum does, or "Check for drift" would keep relinking the
+      // roster the rule never reached.
+      final before = wisaPullFingerprint(_settings());
+      final after = wisaPullFingerprint(_settings().copyWith(
+        wisaRules: const <WisaImportRule>[DontImportClass('3C')],
+      ));
+      expect(after, isNot(before));
+    });
+
+    test('distinguishes two rules of the same kind (#263)', () {
+      final base = _settings();
+      expect(
+        wisaPullFingerprint(base.copyWith(
+          wisaRules: const <WisaImportRule>[DontImportClass('3C')],
+        )),
+        isNot(wisaPullFingerprint(base.copyWith(
+          wisaRules: const <WisaImportRule>[DontImportClass('4C')],
+        ))),
+      );
+    });
+
+    test('is order-sensitive, because the connector applies rules in sequence',
+        () {
+      final base = _settings();
+      expect(
+        wisaPullFingerprint(base.copyWith(
+          wisaRules: const <WisaImportRule>[
+            DontImportClass('3C'),
+            MarkAsVirtual('V'),
+          ],
+        )),
+        isNot(wisaPullFingerprint(base.copyWith(
+          wisaRules: const <WisaImportRule>[
+            MarkAsVirtual('V'),
+            DontImportClass('3C'),
+          ],
+        ))),
+      );
+    });
+
+    test('is stable across two reads of the same rules (#263)', () {
+      final settings = _settings().copyWith(
+        wisaRules: const <WisaImportRule>[
+          DontImportClass('3C'),
+          MarkAsOurs('S1'),
+        ],
+      );
+      expect(wisaPullFingerprint(settings), wisaPullFingerprint(settings));
     });
   });
 

--- a/packages/account_state/test/live_settings_test.dart
+++ b/packages/account_state/test/live_settings_test.dart
@@ -296,6 +296,121 @@ void main() {
     });
   });
 
+  group('linkFingerprint (#264)', () {
+    test('changes when the Azure domain moves', () {
+      // Every proposed UPN is built from it — and no pull asks Azure anything
+      // about it, so nothing but this can make a sync adopt the save.
+      expect(
+        linkFingerprint(_settings()
+            .copyWith(azure: const AzureConnection(domain: 'nieuw.example'))),
+        isNot(linkFingerprint(_settings()
+            .copyWith(azure: const AzureConnection(domain: 'oud.example')))),
+      );
+    });
+
+    test('changes when the student-group root moves', () {
+      final base = _settings();
+      expect(
+        linkFingerprint(base.copyWith(
+          smartschool: base.smartschool.copyWith(studentGroup: 'LEERLINGEN'),
+        )),
+        isNot(linkFingerprint(base.copyWith(
+          smartschool: base.smartschool.copyWith(studentGroup: 'SCHOOL'),
+        ))),
+      );
+    });
+
+    test('changes when a year code moves on a school that uses years', () {
+      final base = _settings();
+      SmartschoolConnection tree(List<String> years) => base.smartschool
+          .copyWith(useYears: true, years: years, studentGroup: 'SCHOOL');
+      expect(
+        linkFingerprint(base.copyWith(
+          smartschool: tree(const ['J1', 'J2', 'J3', 'J4', 'J5', 'J6', 'J7']),
+        )),
+        isNot(linkFingerprint(base.copyWith(
+          smartschool: tree(const ['J1', 'J2', 'J3', 'J4', 'J5', 'J6', 'X7']),
+        ))),
+      );
+    });
+
+    test('ignores a year code the school does not use', () {
+      // `classTreeFrom` honours the UseYears/UseGrades flags, so a label edited
+      // on the scheme the school has switched off changes no placement — and
+      // must not cost a re-link.
+      final base = _settings();
+      expect(
+        linkFingerprint(base.copyWith(
+          smartschool: base.smartschool.copyWith(
+            years: const ['J1', 'J2', 'J3', 'J4', 'J5', 'J6', 'J7'],
+          ),
+        )),
+        linkFingerprint(base),
+      );
+    });
+
+    test('changes when the school switches from years to grades', () {
+      final base = _settings();
+      final years = base.smartschool.copyWith(
+        useYears: true,
+        years: const ['J1', 'J2', 'J3', 'J4', 'J5', 'J6', 'J7'],
+        grades: const ['G1', 'G2', 'G3'],
+      );
+      expect(
+        linkFingerprint(base.copyWith(smartschool: years)),
+        isNot(linkFingerprint(base.copyWith(
+          smartschool: years.copyWith(useYears: false, useGrades: true),
+        ))),
+      );
+    });
+
+    test('ignores the settings the three pull fingerprints already own', () {
+      // The point of the split: a werkdatum, a prefix, a beheerd mark or an
+      // import rule already forces the pull that adopts it, and the re-link
+      // behind it. Only what *no* pull sees belongs here.
+      final base = _settings();
+      expect(
+        linkFingerprint(base.copyWith(
+          schoolPrefix: 'GBS',
+          smartschoolRules: const [DiscardSmartschoolGroup('Organisatie')],
+          wisaRules: const <WisaImportRule>[DontImportClass('3C')],
+          wisaSchools: const [
+            WisaSchoolProfile(schoolId: 1, code: 'A', name: 'A', ours: true),
+          ],
+          wisa: base.wisa.copyWith(
+            workDate: WorkDateSetting(isNow: false, date: DateTime(2026, 9)),
+          ),
+        )),
+        linkFingerprint(base),
+      );
+    });
+
+    test('is insensitive to whitespace an operator typed around the domain',
+        () {
+      // Bootstrap trims it before the action configs ever see it.
+      expect(
+        linkFingerprint(_settings().copyWith(
+          azure: const AzureConnection(domain: '  school.example  '),
+        )),
+        linkFingerprint(_settings().copyWith(
+          azure: const AzureConnection(domain: 'school.example'),
+        )),
+      );
+    });
+
+    test('is stable across two reads of the same document', () {
+      final settings = _settings().copyWith(
+        azure: const AzureConnection(domain: 'school.example'),
+        smartschool: SmartschoolConnection(
+          studentGroup: 'SCHOOL',
+          useGrades: true,
+          grades: const ['G1', 'G2', 'G3'],
+        ),
+      );
+      expect(linkFingerprint(settings), linkFingerprint(settings));
+    });
+  });
+
   group('connectionFingerprint (#246)', () {
     test('moves for every endpoint half a connector is built from', () {
       final base = _settings();

--- a/packages/account_state/test/realtime/signalr_subscriber_test.dart
+++ b/packages/account_state/test/realtime/signalr_subscriber_test.dart
@@ -288,8 +288,32 @@ void main() {
 
       // The first attempt failed and a second one succeeded.
       expect(log.errors, isNotEmpty);
-      expect(log.errors.first, contains('SignalR connection lost'));
+      // Still an error, and Dutch like the rest of the panel (#266).
+      expect(log.errors.first, contains('SignalR-verbinding verbroken'));
+      expect(log.errors.first, isNot(contains('connection lost')));
       expect(connector.sockets, hasLength(1), reason: 'the retry connected');
+    });
+
+    test('a failed catch-up is logged in Dutch, not thrown (#266)', () async {
+      // The wording ReconcileController already uses for this very failure
+      // ("Kon niet bijwerken na het herverbinden", #258).
+      final log = _RecordingLog();
+      final sub = build(
+        log: log,
+        onReconnect: () async => throw StateError('shard read failed'),
+      );
+      addTearDown(sub.close);
+      sub.signals.listen((_) {});
+      await pumpEventQueue();
+
+      connector.sockets.single.serverSend(_frame(const {}));
+      await pumpEventQueue();
+
+      expect(
+        log.errors,
+        contains(contains('SignalR: kon niet bijwerken na het herverbinden')),
+      );
+      expect(log.errors, isNot(contains(contains('catch-up failed'))));
     });
 
     test('close stops the reconnect loop and closes the stream', () async {

--- a/packages/account_state/test/wisa_import_rules_test.dart
+++ b/packages/account_state/test/wisa_import_rules_test.dart
@@ -1,0 +1,82 @@
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+void main() {
+  group('WisaImportRules.add', () {
+    test('keeps insertion order and drops structural duplicates', () {
+      final rules = WisaImportRules();
+      expect(rules.add(const DontImportClass('3C')), isTrue);
+      expect(rules.add(const MarkAsOurs('S1')), isTrue);
+      expect(rules.add(const DontImportClass('3C')), isFalse);
+
+      expect(rules.rules, hasLength(2));
+      expect(rules.rules.first, isA<DontImportClass>());
+      expect(rules.rules.last, isA<MarkAsOurs>());
+    });
+  });
+
+  group('WisaImportRules.unionWith (#263)', () {
+    test('puts the persisted rules first and the session\'s own after', () {
+      // Persisted rules are the operator's standing configuration; the ones an
+      // apply earned this session are the increment on top.
+      final rules = WisaImportRules()..add(const DontImportUserFromWisa('u1'));
+
+      final merged = rules.unionWith(const <WisaImportRule>[
+        DontImportClass('3C'),
+        MarkAsVirtual('V'),
+      ]);
+
+      expect(merged.map((r) => r.runtimeType).toList(), <Type>[
+        DontImportClass,
+        MarkAsVirtual,
+        DontImportUserFromWisa,
+      ]);
+    });
+
+    test('collapses a rule the document and the session both carry', () {
+      // Applying a `DontImportClass` the settings document already carries must
+      // not grow the pull's rule list — the snapshot is the same either way.
+      final rules = WisaImportRules()..add(const DontImportClass('3C'));
+
+      final merged =
+          rules.unionWith(const <WisaImportRule>[DontImportClass('3C')]);
+
+      expect(merged, hasLength(1));
+    });
+
+    test('does not mutate the session holder', () {
+      // The union is composed per pull. Folding the persisted rules into the
+      // holder is exactly the freeze #263 removed: a rule later *removed* from
+      // the document could then never be dropped.
+      final rules = WisaImportRules();
+      rules.unionWith(const <WisaImportRule>[DontImportClass('3C')]);
+
+      expect(rules.rules, isEmpty);
+      expect(
+        rules.unionWith(const <WisaImportRule>[]),
+        isEmpty,
+        reason: 'a document that dropped the rule pulls without it',
+      );
+    });
+
+    test('reads both sources at call time', () {
+      final rules = WisaImportRules();
+      expect(rules.unionWith(const <WisaImportRule>[]), isEmpty);
+
+      rules.add(const DontImportClass('3C'));
+      expect(
+        rules.unionWith(const <WisaImportRule>[MarkAsOurs('S1')]),
+        hasLength(2),
+      );
+    });
+
+    test('hands back an unmodifiable list', () {
+      expect(
+        () => WisaImportRules().unionWith(const <WisaImportRule>[]).add(
+            const DontImportClass('3C')),
+        throwsUnsupportedError,
+      );
+    });
+  });
+}

--- a/packages/azure_api/lib/src/connector.dart
+++ b/packages/azure_api/lib/src/connector.dart
@@ -125,9 +125,9 @@ class AzureConnector {
       if (!e.isRejectedDeltaToken) rethrow;
       _log?.addMessage(
         core.Origin.azure,
-        'Azure: Graph rejected the stored delta token '
-        '(${_tokenAge(previous)}) — $e. Discarding it and re-reading all '
-        'accounts in full.',
+        'Azure: Graph weigerde het bewaarde deltatoken '
+        '(${_tokenAge(previous)}) — $e. Het wordt weggegooid en alle accounts '
+        'worden opnieuw volledig opgehaald.',
       );
       return _fullRead(groupList, expectedEmployeeIds, prefix);
     }
@@ -140,8 +140,9 @@ class AzureConnector {
     if (delta.deltaToken == null) {
       _log?.addMessage(
         core.Origin.azure,
-        'Azure: the delta response carried no deltaLink, so this sync leaves '
-        'no resume token — the next sync re-reads all accounts in full.',
+        'Azure: het delta-antwoord bevatte geen deltaLink, dus deze '
+        'synchronisatie laat geen hervattingstoken achter — de volgende '
+        'synchronisatie haalt alle accounts opnieuw volledig op.',
       );
     }
 
@@ -220,8 +221,9 @@ class AzureConnector {
     } on Object catch (e) {
       _log?.addError(
         core.Origin.azure,
-        'Azure: could not look up ${missing.length} unmatched employeeId(s) — '
-        '$e. Any existing account for them stays unseen this pass.',
+        'Azure: kon ${missing.length} niet-gekoppelde employeeId(s) niet '
+        'opzoeken — $e. Bestaande accounts daarvoor blijven deze keer '
+        'onzichtbaar.',
       );
       return current;
     }
@@ -237,8 +239,9 @@ class AzureConnector {
     if (added == 0) return current;
     _log?.addMessage(
       core.Origin.azure,
-      'Azure: adopted $added existing account(s) found by employeeId that the '
-      'school filter does not match (transferred students).',
+      'Azure: $added bestaand(e) account(s) overgenomen die via employeeId '
+      'gevonden zijn maar niet aan de schoolfilter voldoen (overgestapte '
+      'leerlingen).',
     );
     return byId.values.toList();
   }
@@ -251,15 +254,15 @@ class AzureConnector {
   /// dates the token itself thanks to the token invariant on [sync].
   static String _tokenAge(AzureSnapshot? previous) {
     final at = previous?.fetchedAt;
-    if (at == null) return 'age unknown — no previous snapshot';
+    if (at == null) return 'ouderdom onbekend — geen vorige snapshot';
     final age = _now().difference(at);
-    return 'stored ${_formatAge(age)} ago, at ${at.toIso8601String()}';
+    return 'bewaard ${_formatAge(age)} geleden, op ${at.toIso8601String()}';
   }
 
   static String _formatAge(Duration age) {
-    if (age.isNegative) return 'less than a minute';
-    if (age.inDays > 0) return '${age.inDays}d ${age.inHours % 24}h';
-    if (age.inHours > 0) return '${age.inHours}h ${age.inMinutes % 60}m';
+    if (age.isNegative) return 'minder dan een minuut';
+    if (age.inDays > 0) return '${age.inDays}d ${age.inHours % 24}u';
+    if (age.inHours > 0) return '${age.inHours}u ${age.inMinutes % 60}m';
     return '${age.inMinutes}m';
   }
 

--- a/packages/azure_api/lib/src/graph/graph_client.dart
+++ b/packages/azure_api/lib/src/graph/graph_client.dart
@@ -187,7 +187,9 @@ class GraphClient {
       if (expected != null && expected(ex)) {
         _log?.addMessage(
           core.Origin.azure,
-          '$line (handled — the sync recovers from this)',
+          // The Graph body stays exactly as Graph sent it; only the clause this
+          // client appends to it is the operator's language (#266).
+          '$line (afgehandeld — de synchronisatie herstelt hiervan)',
         );
       } else {
         _log?.addError(core.Origin.azure, line);

--- a/packages/azure_api/lib/src/group_manager.dart
+++ b/packages/azure_api/lib/src/group_manager.dart
@@ -58,7 +58,7 @@ class GroupManager {
     }
     _log?.addMessage(
       core.Origin.azure,
-      'Azure: loaded ${groups.length} groups for "$schoolPrefix".',
+      'Azure: ${groups.length} groepen opgehaald voor "$schoolPrefix".',
     );
     return groups;
   }
@@ -121,7 +121,7 @@ class GroupManager {
     final json = await _graph.postJson(_graph.uri('groups'), body);
     _log?.addMessage(
       core.Origin.azure,
-      'Azure: created Microsoft 365 group $displayName ($mailNickname).',
+      'Azure: Microsoft 365-groep $displayName ($mailNickname) aangemaakt.',
     );
     // The create response echoes the new resource; fall back to the request
     // values for anything Graph left out of its echo (as `createUser` does).
@@ -152,7 +152,7 @@ class GroupManager {
     );
     _log?.addMessage(
       core.Origin.azure,
-      'Azure: added $userId to group $groupId.',
+      'Azure: $userId toegevoegd aan groep $groupId.',
     );
   }
 
@@ -166,7 +166,7 @@ class GroupManager {
     );
     _log?.addMessage(
       core.Origin.azure,
-      'Azure: removed $userId from group $groupId.',
+      'Azure: $userId verwijderd uit groep $groupId.',
     );
   }
 
@@ -191,7 +191,7 @@ class GroupManager {
     final results = await _batch.execute(requests);
     _log?.addMessage(
       core.Origin.azure,
-      'Azure: batch-added ${userIds.length} members to group $groupId.',
+      'Azure: ${userIds.length} leden in batch toegevoegd aan groep $groupId.',
     );
     return results;
   }
@@ -213,7 +213,7 @@ class GroupManager {
     final results = await _batch.execute(requests);
     _log?.addMessage(
       core.Origin.azure,
-      'Azure: batch-removed ${userIds.length} members from group $groupId.',
+      'Azure: ${userIds.length} leden in batch verwijderd uit groep $groupId.',
     );
     return results;
   }

--- a/packages/azure_api/lib/src/user_manager.dart
+++ b/packages/azure_api/lib/src/user_manager.dart
@@ -158,8 +158,8 @@ class UserManager {
     }
     _log?.addMessage(
       core.Origin.azure,
-      'Azure: looked up ${unique.length} employeeId(s) directly — '
-      '${found.length} existing account(s) found.',
+      'Azure: ${unique.length} employeeId(s) rechtstreeks opgezocht — '
+      '${found.length} bestaand(e) account(s) gevonden.',
     );
     return found.values.toList();
   }
@@ -196,7 +196,7 @@ class UserManager {
     final users = rows.map(AzureUser.fromGraphJson).toList();
     _log?.addMessage(
       core.Origin.azure,
-      'Azure: loaded ${users.length} users for "$schoolPrefix".',
+      'Azure: ${users.length} gebruikers opgehaald voor "$schoolPrefix".',
     );
     return users;
   }
@@ -214,7 +214,7 @@ class UserManager {
         .toList();
     _log?.addMessage(
       core.Origin.azure,
-      'Azure: loaded ${users.length} users (client-filtered) for '
+      'Azure: ${users.length} gebruikers opgehaald (lokaal gefilterd) voor '
       '"$schoolPrefix".',
     );
     return users;
@@ -280,8 +280,8 @@ class UserManager {
     }
     _log?.addMessage(
       core.Origin.azure,
-      'Azure: delta for "$schoolPrefix" — ${changed.length} changed, '
-      '${removedIds.length} removed.',
+      'Azure: delta voor "$schoolPrefix" — ${changed.length} gewijzigd, '
+      '${removedIds.length} verwijderd.',
     );
     return UserDelta(
       changed: changed,
@@ -348,7 +348,7 @@ class UserManager {
     final json = await _graph.postJson(_graph.uri('users'), body);
     _log?.addMessage(
       core.Origin.azure,
-      'Azure: created user $userPrincipalName.',
+      'Azure: gebruiker $userPrincipalName aangemaakt.',
     );
     // The create response echoes the new resource; fall back to the request
     // values for any field Graph omitted from its echo.
@@ -394,13 +394,16 @@ class UserManager {
       _graph.uri('users/${Uri.encodeComponent(id)}'),
       body,
     );
-    _log?.addMessage(core.Origin.azure, 'Azure: updated user $id.');
+    _log?.addMessage(core.Origin.azure, 'Azure: gebruiker $id bijgewerkt.');
   }
 
   /// Deletes a user by object id or UPN. Mirrors legacy `DeleteUser`.
   Future<void> deleteUser(String idOrUpn) async {
     await _graph.delete(_graph.uri('users/${Uri.encodeComponent(idOrUpn)}'));
-    _log?.addMessage(core.Origin.azure, 'Azure: deleted user $idOrUpn.');
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: gebruiker $idOrUpn verwijderd.',
+    );
   }
 
   /// Resets an existing user's password (PATCH `users/{id}` with a
@@ -434,7 +437,10 @@ class UserManager {
       if (e.statusCode != 403) rethrow;
       throw AzurePasswordPermissionException(idOrUpn, e);
     }
-    _log?.addMessage(core.Origin.azure, 'Azure: reset password for $idOrUpn.');
+    _log?.addMessage(
+      core.Origin.azure,
+      'Azure: wachtwoord van $idOrUpn opnieuw ingesteld.',
+    );
   }
 
   /// Builds a unique UPN from a name, appending a numeric suffix on collision.

--- a/packages/azure_api/test/connector_test.dart
+++ b/packages/azure_api/test/connector_test.dart
@@ -336,9 +336,10 @@ void main() {
       // The operator is told what happened, with the rejected token's age —
       // the diagnostic that separates "genuinely old" from "stopped advancing".
       final recovery = log.messages.firstWhere(
-        (m) => m.contains('rejected the stored delta token'),
+        (m) => m.contains('weigerde het bewaarde deltatoken'),
       );
-      expect(recovery, contains('14h'));
+      // The age reads in Dutch units since #266 ("u", not "h").
+      expect(recovery, contains('14u'));
       expect(recovery, contains('DeltaLink older than 30 days'));
     });
 
@@ -386,10 +387,16 @@ void main() {
         log.messages,
         contains(contains('DeltaLink older than 30 days')),
       );
-      // And so is the connector's own explanation, with the token's age.
+      // And so is the connector's own explanation, with the token's age (#266
+      // made the clause Dutch; the Graph body it quotes stays as Graph sent it).
       expect(
         log.messages,
-        contains(contains('Graph rejected the stored delta token')),
+        contains(contains('Graph weigerde het bewaarde deltatoken')),
+      );
+      expect(log.messages, contains(contains('bewaard ')));
+      expect(
+        log.messages,
+        isNot(contains(contains('Graph rejected the stored delta token'))),
       );
     });
 
@@ -494,9 +501,11 @@ void main() {
       expect(adopted.companyName, isNull);
       expect(snapshot.users, hasLength(4));
       expect(
-        log.messages.any((m) => m.contains('adopted 1 existing account')),
+        log.messages
+            .any((m) => m.contains('1 bestaand(e) account(s) overgenomen')),
         isTrue,
       );
+      expect(log.messages.any((m) => m.contains('adopted ')), isFalse);
     });
 
     test('an incremental sync adopts it too — the delta path is equally blind',
@@ -568,9 +577,10 @@ void main() {
       expect(snapshot.users, hasLength(3));
       expect(snapshot.deltaToken, 'PRIMEDTOKEN123');
       expect(
-        log.errors.any((m) => m.contains('unmatched employeeId')),
+        log.errors.any((m) => m.contains('niet-gekoppelde employeeId(s)')),
         isTrue,
       );
+      expect(log.errors.any((m) => m.contains('unmatched')), isFalse);
     });
   });
 }

--- a/packages/azure_api/test/graph_client_test.dart
+++ b/packages/azure_api/test/graph_client_test.dart
@@ -156,7 +156,13 @@ void main() {
       expect(log.errors, isEmpty,
           reason: 'the caller recovers — nothing here for the operator to act '
               'on');
-      expect(log.messages.single, contains('handled'));
+      // The clause this client appends is Dutch since #266; the Graph body it
+      // is appended to is quoted exactly as Graph sent it.
+      expect(
+        log.messages.single,
+        contains('(afgehandeld — de synchronisatie herstelt hiervan)'),
+      );
+      expect(log.messages.single, isNot(contains('handled —')));
       expect(log.messages.single, contains('DeltaLink older than 30 days'));
       expect(log.messages.single, isNot(contains('DEADTOKEN')));
     });

--- a/packages/azure_api/test/group_manager_test.dart
+++ b/packages/azure_api/test/group_manager_test.dart
@@ -71,8 +71,10 @@ void main() {
       final result = await groups.listGroups('GBS');
 
       expect(result, hasLength(45));
+      // The milestone lines only: since #266 the closing summary reads
+      // "N groepen opgehaald voor …" and would otherwise match too.
       expect(
-        log.messages.where((m) => m.contains('groepen opgehaald')).toList(),
+        log.messages.where((m) => m.endsWith('groepen opgehaald…')).toList(),
         ['Azure: 20 groepen opgehaald…', 'Azure: 40 groepen opgehaald…'],
       );
     });
@@ -85,7 +87,7 @@ void main() {
       await groups.listGroups('GBS');
 
       expect(
-        log.messages.where((m) => m.contains('groepen opgehaald')),
+        log.messages.where((m) => m.endsWith('groepen opgehaald…')),
         isEmpty,
       );
     });
@@ -281,6 +283,93 @@ void main() {
       final groups = GroupManager(clientWith(transport));
       expect(await groups.removeMembers('g1', const []), isEmpty);
       expect(transport.requests, isEmpty);
+    });
+  });
+
+  // Everything this manager writes into an [ILog] lands in the app's Log panel
+  // beside the Dutch the app layer writes there (#253/#257/#258), so it is
+  // Dutch too (#266).
+  group('operator log lines are Dutch (#266)', () {
+    test('the group read reports what it pulled, for which prefix', () async {
+      final transport = FakeGraphTransport((req) {
+        if (req.url.path.contains('/members')) {
+          return jsonOk({'value': const <Object>[]});
+        }
+        return jsonOk(readFixture('groups.json'));
+      });
+      final log = RecordingLog();
+
+      await GroupManager(clientWith(transport), log: log).listGroups('GBS');
+
+      expect(log.messages, contains('Azure: 2 groepen opgehaald voor "GBS".'));
+      expect(log.messages, isNot(contains(contains('loaded '))));
+    });
+
+    test('a created class group and the membership writes are Dutch', () async {
+      final created = FakeGraphTransport((_) => jsonOk({'id': 'g-new'}));
+      final createLog = RecordingLog();
+      await GroupManager(clientWith(created), log: createLog).createGroup(
+        displayName: 'GBS-2A',
+        mailNickname: 'GBS-2A',
+      );
+      expect(
+        createLog.messages,
+        contains('Azure: Microsoft 365-groep GBS-2A (GBS-2A) aangemaakt.'),
+      );
+
+      final wrote = FakeGraphTransport.constant(noContent());
+      final writeLog = RecordingLog();
+      final groups = GroupManager(clientWith(wrote), log: writeLog);
+      await groups.addMember('g1', 'u1');
+      await groups.removeMember('g1', 'u1');
+      expect(
+        writeLog.messages,
+        containsAll(<String>[
+          'Azure: u1 toegevoegd aan groep g1.',
+          'Azure: u1 verwijderd uit groep g1.',
+        ]),
+      );
+
+      final batched = FakeGraphTransport((req) {
+        final body = jsonDecode(req.body!) as Map<String, dynamic>;
+        final requests =
+            (body['requests'] as List).cast<Map<String, dynamic>>();
+        return jsonOk({
+          'responses': [
+            for (final r in requests) {'id': r['id'], 'status': 204},
+          ],
+        });
+      });
+      final batchLog = RecordingLog();
+      final batchGroups = GroupManager(clientWith(batched), log: batchLog);
+      await batchGroups.addMembers('g1', <String>['u1', 'u2']);
+      await batchGroups.removeMembers('g1', <String>['u1', 'u2']);
+      expect(
+        batchLog.messages,
+        containsAll(<String>[
+          'Azure: 2 leden in batch toegevoegd aan groep g1.',
+          'Azure: 2 leden in batch verwijderd uit groep g1.',
+        ]),
+      );
+
+      // Not one of the five lines is still the English it used to be.
+      for (final english in <String>[
+        'created Microsoft 365 group',
+        'added ',
+        'removed ',
+        'batch-added',
+        'batch-removed',
+      ]) {
+        expect(
+          <String>[
+            ...createLog.messages,
+            ...writeLog.messages,
+            ...batchLog.messages,
+          ].where((m) => m.contains(english)),
+          isEmpty,
+          reason: english,
+        );
+      }
     });
   });
 }

--- a/packages/azure_api/test/user_manager_test.dart
+++ b/packages/azure_api/test/user_manager_test.dart
@@ -531,4 +531,122 @@ void main() {
       );
     });
   });
+
+  // Every line this manager writes into an [ILog] lands in the app's Log panel,
+  // beside the Dutch the app layer writes there (#253/#257/#258), so it is
+  // Dutch too (#266). The API and these test names are not.
+  group('operator log lines are Dutch (#266)', () {
+    test('the bulk read reports what it pulled, for which prefix', () async {
+      final transport = FakeGraphTransport(
+        (_) => jsonOk(readFixture('users_page2.json')),
+      );
+      final log = RecordingLog();
+
+      await UserManager(clientWith(transport), log: log).load('GBS');
+
+      expect(
+          log.messages, contains('Azure: 1 gebruikers opgehaald voor "GBS".'));
+      expect(log.messages, isNot(contains(contains('loaded '))));
+    });
+
+    test('the client-filtered read says so, in Dutch', () async {
+      final transport = FakeGraphTransport(
+        (_) => usersPage(startIndex: 0, count: 2),
+      );
+      final log = RecordingLog();
+
+      await UserManager(clientWith(transport), log: log)
+          .loadClientFiltered('GBS');
+
+      expect(
+        log.messages,
+        contains(contains('gebruikers opgehaald (lokaal gefilterd) voor '
+            '"GBS".')),
+      );
+      expect(log.messages, isNot(contains(contains('client-filtered'))));
+    });
+
+    test('a delta walk reports its changed/removed counts in Dutch', () async {
+      final transport = FakeGraphTransport(
+        (_) => jsonOk({
+          '@odata.deltaLink':
+              'https://graph.microsoft.com/v1.0/users/delta?\$deltatoken=T',
+          'value': const <Object>[],
+        }),
+      );
+      final log = RecordingLog();
+
+      await UserManager(clientWith(transport), log: log).delta('OLD', 'GBS');
+
+      expect(
+        log.messages,
+        contains('Azure: delta voor "GBS" — 0 gewijzigd, 0 verwijderd.'),
+      );
+      expect(log.messages, isNot(contains(contains('changed, '))));
+    });
+
+    test('the employeeId back-fill lookup reports in Dutch', () async {
+      final transport =
+          FakeGraphTransport((_) => jsonOk({'value': <Object>[]}));
+      final log = RecordingLog();
+
+      await UserManager(clientWith(transport), log: log)
+          .loadByEmployeeIds(<String>['W7']);
+
+      expect(
+        log.messages,
+        contains('Azure: 1 employeeId(s) rechtstreeks opgezocht — '
+            '0 bestaand(e) account(s) gevonden.'),
+      );
+      expect(log.messages, isNot(contains(contains('looked up'))));
+    });
+
+    test('the write lines — create, update, delete, reset — are Dutch',
+        () async {
+      final created = FakeGraphTransport.constant(
+        jsonOk({'id': 'new-id', 'userPrincipalName': 'k.l@school.example'}),
+      );
+      final createLog = RecordingLog();
+      await UserManager(clientWith(created), log: createLog).createUser(
+        userPrincipalName: 'k.l@school.example',
+        displayName: 'K L',
+        password: 'Secret123!',
+        givenName: 'K',
+        surname: 'L',
+      );
+      expect(
+        createLog.messages,
+        contains('Azure: gebruiker k.l@school.example aangemaakt.'),
+      );
+
+      final patched = FakeGraphTransport.constant(noContent());
+      final patchLog = RecordingLog();
+      final users = UserManager(clientWith(patched), log: patchLog);
+      await users.updateUser('id-1', department: '4A');
+      await users.deleteUser('id-1');
+      await users.setPassword('id-1', 'Bacoxy7!');
+      expect(
+        patchLog.messages,
+        containsAll(<String>[
+          'Azure: gebruiker id-1 bijgewerkt.',
+          'Azure: gebruiker id-1 verwijderd.',
+          'Azure: wachtwoord van id-1 opnieuw ingesteld.',
+        ]),
+      );
+      // None of the English these five lines used to be survives anywhere.
+      for (final english in <String>[
+        'created user',
+        'updated user',
+        'deleted user',
+        'reset password',
+      ]) {
+        expect(
+          <String>[...createLog.messages, ...patchLog.messages]
+              .where((m) => m.contains(english)),
+          isEmpty,
+          reason: english,
+        );
+      }
+    });
+  });
 }

--- a/packages/smartschool_api/lib/src/connector.dart
+++ b/packages/smartschool_api/lib/src/connector.dart
@@ -169,13 +169,13 @@ class SmartschoolConnector {
   ) {
     for (final rule in unmatchedImportRules(forest, rules)) {
       final effect = switch (rule) {
-        DiscardSmartschoolGroup() => 'nothing was discarded',
-        NoSmartschoolSubgroups() => 'no subgroups were pruned',
+        DiscardSmartschoolGroup() => 'er is niets weggelaten',
+        NoSmartschoolSubgroups() => 'er zijn geen subgroepen weggesnoeid',
       };
       _log?.addMessage(
         core.Origin.smartschool,
-        'Import rule "${rule.groupName}" matched no Smartschool group in this '
-        'pull — $effect. Check the group name.',
+        'Importregel "${rule.groupName}" kwam bij deze ophaalbeurt met geen '
+        'enkele Smartschool-groep overeen — $effect. Controleer de groepsnaam.',
       );
     }
   }
@@ -240,7 +240,7 @@ class SmartschoolConnector {
       if (code == _noDirectAccountsCode) {
         _log?.addMessage(
           core.Origin.smartschool,
-          'No direct accounts in $groupName',
+          'Geen rechtstreekse accounts in $groupName.',
         );
       } else if (code != 0) {
         _log?.addError(core.Origin.smartschool, await _message(code));
@@ -255,7 +255,7 @@ class SmartschoolConnector {
     ];
     _log?.addMessage(
       core.Origin.smartschool,
-      'Added ${kept.length} accounts to $groupName',
+      '${kept.length} account(s) opgehaald uit $groupName.',
     );
     return SmartschoolAccountPayload(accounts: kept, groupIds: parsed.groupIds);
   }
@@ -281,7 +281,7 @@ class SmartschoolConnector {
     if (role == null) {
       _log?.addError(
         core.Origin.smartschool,
-        'Cannot save ${account.uid}: role is unknown',
+        'Kan ${account.uid} niet opslaan: rol is onbekend.',
       );
       return false;
     }
@@ -328,7 +328,10 @@ class SmartschoolConnector {
 
     final qrOk = await updateQrCode(account.uid, account.accountId);
     if (!qrOk) {
-      _log?.addError(core.Origin.smartschool, 'Failed to update QR Code');
+      _log?.addError(
+        core.Origin.smartschool,
+        'Kon de QR-code niet bijwerken.',
+      );
     }
 
     if (account.preferredName.isNotEmpty) {
@@ -340,7 +343,7 @@ class SmartschoolConnector {
       if (!nameOk) {
         _log?.addError(
           core.Origin.smartschool,
-          'Failed to update preferred name',
+          'Kon de roepnaam niet bijwerken.',
         );
       }
     }
@@ -598,7 +601,7 @@ class SmartschoolConnector {
     } on Object catch (e) {
       _log?.addError(
         core.Origin.smartschool,
-        'Failed to load Smartschool error codes: $e',
+        'Kon de Smartschool-foutcodes niet laden: $e',
       );
     }
   }

--- a/packages/smartschool_api/lib/src/errors/error_codes.dart
+++ b/packages/smartschool_api/lib/src/errors/error_codes.dart
@@ -37,8 +37,12 @@ class SmartschoolErrorCodes {
   bool get isLoaded => _codes.isNotEmpty;
 
   /// Returns the message for [code], or a generic
-  /// `Smartschool error <code>` when the code is unknown or the table is
+  /// `Smartschool-fout <code>` when the code is unknown or the table is
   /// not loaded.
+  ///
+  /// The fallback is Dutch because it is written straight into the operator's
+  /// Log panel by the connector's `_message` (#266). The table's own values are
+  /// Smartschool's, quoted as it sends them.
   String translate(int code) =>
-      _codes[code.toString()] ?? 'Smartschool error $code';
+      _codes[code.toString()] ?? 'Smartschool-fout $code';
 }

--- a/packages/smartschool_api/test/connector_test.dart
+++ b/packages/smartschool_api/test/connector_test.dart
@@ -175,6 +175,38 @@ SmartschoolAccount _student() => SmartschoolAccount(
       status: 'actief',
     );
 
+/// An account whose role the connector cannot map, so `saveAccount` refuses it
+/// before any write goes out.
+SmartschoolAccount _roleless() => const SmartschoolAccount(
+      uid: 'x',
+      accountId: '',
+      mail: '',
+      registerId: '',
+      stemId: 0,
+      role: null,
+      givenName: '',
+      surname: '',
+      extraNames: '',
+      initials: '',
+      preferredName: '',
+      gender: core.Gender.x,
+      birthDate: null,
+      birthPlace: '',
+      birthCountry: '',
+      address: core.Address(
+        street: '',
+        houseNumber: '',
+        postalCode: '',
+        city: '',
+        country: '',
+      ),
+      mobilePhone: '',
+      homePhone: '',
+      fax: '',
+      untisId: '',
+      status: 'actief',
+    );
+
 void main() {
   group('sync', () {
     test('flattens the group tree with parentId edges', () async {
@@ -314,7 +346,7 @@ void main() {
       // A rule that matched must not be reported as doing nothing.
       expect(
         log.messages,
-        isNot(contains(contains('matched no Smartschool group'))),
+        isNot(contains(contains('kwam bij deze ophaalbeurt'))),
       );
     });
 
@@ -337,15 +369,21 @@ void main() {
       expect(
         log.messages,
         contains(
-          'Import rule "Sprot" matched no Smartschool group in this pull — '
-          'nothing was discarded. Check the group name.',
+          'Importregel "Sprot" kwam bij deze ophaalbeurt met geen enkele '
+          'Smartschool-groep overeen — er is niets weggelaten. Controleer de '
+          'groepsnaam.',
         ),
       );
       // The rule that did match is not named, even though pruning an empty
       // subtree changed nothing either — that is the distinction #241 is about.
       expect(
-        log.messages.where((m) => m.contains('matched no Smartschool group')),
+        log.messages.where((m) => m.contains('kwam bij deze ophaalbeurt')),
         hasLength(1),
+      );
+      // …and not a word of the English this line used to be (#266).
+      expect(
+        log.messages,
+        isNot(contains(contains('matched no Smartschool group'))),
       );
     });
   });
@@ -385,36 +423,7 @@ void main() {
 
     test('refuses an account with no role', () async {
       final t = _FakeTransport();
-      const account = SmartschoolAccount(
-        uid: 'x',
-        accountId: '',
-        mail: '',
-        registerId: '',
-        stemId: 0,
-        role: null,
-        givenName: '',
-        surname: '',
-        extraNames: '',
-        initials: '',
-        preferredName: '',
-        gender: core.Gender.x,
-        birthDate: null,
-        birthPlace: '',
-        birthCountry: '',
-        address: core.Address(
-          street: '',
-          houseNumber: '',
-          postalCode: '',
-          city: '',
-          country: '',
-        ),
-        mobilePhone: '',
-        homePhone: '',
-        fax: '',
-        untisId: '',
-        status: 'actief',
-      );
-      final ok = await _connector(t).saveAccount(account, password: 'p');
+      final ok = await _connector(t).saveAccount(_roleless(), password: 'p');
       expect(ok, isFalse);
       expect(t.sentTo(SmartschoolMethod.saveUser), isFalse);
     });
@@ -430,6 +439,60 @@ void main() {
       );
       expect(ok, isFalse);
       expect(log.errors.join(), contains('Gebruiker bestaat niet'));
+    });
+  });
+
+  // Everything this connector writes into an [core.ILog] lands in the app's Log
+  // panel beside the Dutch the app layer writes (#253/#257/#258), so it is
+  // Dutch too (#266). The connector's API, doc comments and test names are not.
+  group('operator log lines are Dutch (#266)', () {
+    test('the pull names each group it read, and the ones with no accounts',
+        () async {
+      final t = _FakeTransport();
+      final log = _RecordingLog();
+      await _connector(t, log: log).sync();
+
+      // "School" (SCH) answers Smartschool code 19 — no direct accounts.
+      expect(log.messages, contains('Geen rechtstreekse accounts in School.'));
+      // …while 1A's payload really did carry some.
+      expect(log.messages, contains(contains('opgehaald uit 1A.')));
+      for (final english in <String>['No direct accounts', 'Added ']) {
+        expect(
+          log.messages.where((m) => m.contains(english)),
+          isEmpty,
+          reason: english,
+        );
+      }
+    });
+
+    test('a role the connector cannot map is refused in Dutch', () async {
+      final t = _FakeTransport();
+      final log = _RecordingLog();
+      final ok = await _connector(t, log: log).saveAccount(
+        _roleless(),
+        password: 'p',
+      );
+
+      expect(ok, isFalse);
+      expect(log.errors, contains('Kan x niet opslaan: rol is onbekend.'));
+      expect(log.errors, isNot(contains(contains('role is unknown'))));
+    });
+
+    test('a failed QR-code and roepnaam write are reported in Dutch', () async {
+      // Both ride on `saveUserParameter`, so one refusing code fails the pair.
+      final t = _FakeTransport(
+        writeResults: const {SmartschoolMethod.saveUserParameter: 7},
+      );
+      final log = _RecordingLog();
+      final ok = await _connector(t, log: log).saveAccount(
+        _student(),
+        password: 'pw1',
+      );
+
+      expect(ok, isFalse);
+      expect(log.errors, contains('Kon de QR-code niet bijwerken.'));
+      expect(log.errors, contains('Kon de roepnaam niet bijwerken.'));
+      expect(log.errors, isNot(contains(contains('Failed to update'))));
     });
   });
 

--- a/packages/smartschool_api/test/errors/error_codes_test.dart
+++ b/packages/smartschool_api/test/errors/error_codes_test.dart
@@ -17,16 +17,18 @@ void main() {
       expect(codes.translate(42), '42');
     });
 
-    test('unknown code falls back to a generic message', () {
+    test('unknown code falls back to a generic Dutch message (#266)', () {
+      // The fallback is written straight into the operator's Log panel by the
+      // connector, so it is Dutch like every other line of a pass.
       final codes = SmartschoolErrorCodes.fromJson('{"1":"x"}');
-      expect(codes.translate(999), 'Smartschool error 999');
+      expect(codes.translate(999), 'Smartschool-fout 999');
     });
 
     test('empty table is not loaded and always falls back', () {
       expect(SmartschoolErrorCodes.empty.isLoaded, isFalse);
       expect(
         SmartschoolErrorCodes.empty.translate(5),
-        'Smartschool error 5',
+        'Smartschool-fout 5',
       );
     });
 

--- a/packages/wisa_api/lib/src/connector.dart
+++ b/packages/wisa_api/lib/src/connector.dart
@@ -84,11 +84,11 @@ class WisaConnector {
       if (csv.isEmpty) {
         _log?.addError(
           core.Origin.wisa,
-          'Test Connection should have at least one result',
+          'Verbindingstest leverde geen resultaat op.',
         );
         return false;
       }
-      _log?.addMessage(core.Origin.wisa, 'Connection Succeeded');
+      _log?.addMessage(core.Origin.wisa, 'Verbinding geslaagd.');
       return true;
     } on Exception catch (e) {
       _log?.addError(core.Origin.wisa, e.toString());
@@ -103,7 +103,10 @@ class WisaConnector {
   Future<List<WisaSchool>> loadSchools() async {
     final csv = await _performQuery(WisaQuery.getSchools, const []);
     if (csv.isEmpty) {
-      _log?.addError(core.Origin.wisa, 'Instellingen: empty result');
+      // "Scholen", the word Instellingen names them with (its **Scholen
+      // ophalen** button drives this very call), rather than WISA's own
+      // "instellingen" — which in this app is the settings screen.
+      _log?.addError(core.Origin.wisa, 'Scholen: leeg resultaat.');
       return const [];
     }
     final parsed = splitCsvWithHeader(csv, schoolCsvHeader);
@@ -189,7 +192,7 @@ class WisaConnector {
   ) async {
     final csv = await _performQuery(WisaQuery.syncClassGroups, params);
     if (csv.isEmpty) {
-      _log?.addError(core.Origin.wisa, 'ClassGroups: empty result');
+      _log?.addError(core.Origin.wisa, 'Klassen: leeg resultaat.');
       return const [];
     }
     final parsed = splitCsvWithHeader(csv, classGroupCsvHeader);
@@ -207,7 +210,7 @@ class WisaConnector {
       core.Origin.wisa,
       // The short code, as the sync log has always named a school — before
       // #208 that half simply sat on `school.name`.
-      'Loading classgroups from ${school.code} succeeded.',
+      'Klassen opgehaald uit ${school.code}.',
     );
     return groups;
   }
@@ -218,7 +221,7 @@ class WisaConnector {
   ) async {
     final csv = await _performQuery(WisaQuery.syncStudents, params);
     if (csv.isEmpty) {
-      _log?.addError(core.Origin.wisa, 'Students: empty result');
+      _log?.addError(core.Origin.wisa, 'Leerlingen: leeg resultaat.');
       return const [];
     }
     final parsed = splitCsvWithHeader(csv, studentCsvHeader);
@@ -234,7 +237,7 @@ class WisaConnector {
     }
     _log?.addMessage(
       core.Origin.wisa,
-      'Loading ${students.length} students from ${school.code} succeeded.',
+      '${students.length} leerling(en) opgehaald uit ${school.code}.',
     );
     return students;
   }
@@ -245,7 +248,7 @@ class WisaConnector {
   ) async {
     final csv = await _performQuery(WisaQuery.syncStaff, params);
     if (csv.isEmpty) {
-      _log?.addError(core.Origin.wisa, 'Staff: empty result');
+      _log?.addError(core.Origin.wisa, 'Personeel: leeg resultaat.');
       return const [];
     }
     final parsed = splitCsvWithHeader(csv, staffCsvHeader);
@@ -261,7 +264,7 @@ class WisaConnector {
     }
     _log?.addMessage(
       core.Origin.wisa,
-      'Loading ${staff.length} staff members from ${school.code} succeeded.',
+      '${staff.length} personeelsleden opgehaald uit ${school.code}.',
     );
     return staff;
   }

--- a/packages/wisa_api/test/connector_test.dart
+++ b/packages/wisa_api/test/connector_test.dart
@@ -390,6 +390,124 @@ void main() {
       expect(await c.testConnection(), isFalse);
     });
   });
+
+  // Everything the connector writes into an [core.ILog] ends up in the app's
+  // Log panel, beside the Dutch the app layer writes there (#253/#257/#258), so
+  // it is Dutch too (#266). The package's API, doc comments and test names are
+  // developer-facing and stay English.
+  group('operator log lines are Dutch (#266)', () {
+    WisaConnector loggingConnector(_FakeTransport t, _RecordingLog log) =>
+        WisaConnector.fromParts(
+          server: 'fake-host',
+          port: 80,
+          database: 'db',
+          username: 'user',
+          password: 'pw',
+          transport: t,
+          log: log,
+        );
+
+    test('a successful connection test says so in Dutch', () async {
+      final log = _RecordingLog();
+      final c = loggingConnector(_FakeTransport(fixtures), log);
+
+      expect(await c.testConnection(), isTrue);
+      expect(log.messages, contains('Verbinding geslaagd.'));
+      expect(log.messages, isNot(contains('Connection Succeeded')));
+    });
+
+    test('an empty connection test reports the failure in Dutch', () async {
+      final log = _RecordingLog();
+      final c = loggingConnector(
+        _FakeTransport({...fixtures, WisaQuery.testConnection: ''}),
+        log,
+      );
+
+      expect(await c.testConnection(), isFalse);
+      expect(
+          log.errors, contains('Verbindingstest leverde geen resultaat op.'));
+      expect(log.errors, isNot(contains(contains('Test Connection'))));
+    });
+
+    test('each per-school pull names what it loaded, in Dutch', () async {
+      final log = _RecordingLog();
+      final t = _FakeTransport(fixtures);
+      final c = loggingConnector(t, log);
+      final schools = await c.loadSchools();
+      await c.sync(
+        schools: [schools.firstWhere((s) => s.id == 25)],
+        workDate: DateTime(2024, 9, 1),
+      );
+
+      // The school is named by its short code, as it has been since #208. The
+      // counts are the connector's own pre-rule, pre-dedupe ones, so they are
+      // matched in shape rather than against the finished snapshot.
+      expect(log.messages, contains('Klassen opgehaald uit ISMAA.'));
+      expect(
+        log.messages,
+        contains(
+            matches(RegExp(r'^\d+ leerling\(en\) opgehaald uit ISMAA\.$'))),
+      );
+      expect(
+        log.messages,
+        contains(
+          matches(RegExp(r'^\d+ personeelsleden opgehaald uit ISMAA\.$')),
+        ),
+      );
+      // …and not one line is still the English it used to be.
+      for (final english in <String>['Loading ', 'succeeded.']) {
+        expect(
+          log.messages.where((m) => m.contains(english)),
+          isEmpty,
+          reason: english,
+        );
+      }
+    });
+
+    test('every empty result is reported in Dutch', () async {
+      final log = _RecordingLog();
+      final t = _FakeTransport({
+        ...fixtures,
+        WisaQuery.syncClassGroups: '',
+        WisaQuery.syncStudents: '',
+        WisaQuery.syncStaff: '',
+      });
+      final c = loggingConnector(t, log);
+      final schools = await c.loadSchools();
+      await c.sync(
+        schools: [schools.firstWhere((s) => s.id == 25)],
+        workDate: DateTime(2024, 9, 1),
+      );
+
+      expect(log.errors, contains('Klassen: leeg resultaat.'));
+      expect(log.errors, contains('Leerlingen: leeg resultaat.'));
+      expect(log.errors, contains('Personeel: leeg resultaat.'));
+      expect(log.errors, isNot(contains(contains('empty result'))));
+    });
+
+    test('an empty school list is reported in Dutch, as "Scholen"', () async {
+      // WISA calls them "instellingen"; Instellingen is this app's settings
+      // screen, and its **Scholen ophalen** button drives this very call.
+      final log = _RecordingLog();
+      final c = loggingConnector(
+        _FakeTransport({...fixtures, WisaQuery.getSchools: ''}),
+        log,
+      );
+
+      expect(await c.loadSchools(), isEmpty);
+      expect(log.errors, contains('Scholen: leeg resultaat.'));
+      expect(log.errors, isNot(contains(contains('Instellingen'))));
+    });
+  });
+}
+
+class _RecordingLog implements core.ILog {
+  final List<String> messages = <String>[];
+  final List<String> errors = <String>[];
+  @override
+  void addMessage(core.Origin origin, String message) => messages.add(message);
+  @override
+  void addError(core.Origin origin, String message) => errors.add(message);
 }
 
 class _FaultingTransport extends _FakeTransport {


### PR DESCRIPTION
Seven issues, one commit each, worked back-to-back by the batch runner. Two of
them (#274, #273) are follow-ups filed by workers earlier in this same batch.

## What changed

- **#262** — Klasgroepen gets a `NameQuery`-backed search box over the class
  inventory (name + description as one haystack). It composes with the
  attention switch, has its own no-match line, and narrows the "same situation"
  bulk headers so a bulk apply can't write to classes filtered off screen.
- **#263** — a WISA import rule saved in Instellingen never reached the pull:
  `bootstrapReconcile` seeded `WisaImportRules` from the startup document and
  nothing republished a saved one, freezing the persisted rules for the
  process. The holder now carries only session-earned rules and `wisaSyncer`
  unions it with `live.current.wisaRules` at pull time; `wisaPullFingerprint`
  grew to cover the persisted rules so a save arms #238's drift gate.
- **#264** — Synchroniseer's unchanged-WISA shortcut skipped a re-link that a
  settings save had asked for. New `linkFingerprint` (Azure domain +
  Smartschool class tree — the `ApplierSettings` inputs no pull fingerprint
  covered) is stamped on every `_relink()`; when it moves, the shortcut now
  falls through to the link (no pull), `pendingSettingsReason` names
  "de koppeling", and the pass logs why it re-linked.
- **#274** *(follow-up from #264)* — `ReconcileController` could not be
  constructed at all with no `LiveSettings` wired: `_wisaFingerprint()` fell
  back to `_wisaPullFingerprint`, the `late String` the constructor was
  assigning from it, throwing `LateInitializationError`. Introduced by e8177ef
  (#238). It now returns the `''` sentinel like its two siblings, and
  `ReconcileHarness` gained `modelsSettings: false` so the mode is actually
  exercised.
- **#265** — translated the Synchronisatie screen's own chrome (both buttons,
  help paragraph, Overzicht, smart-diff banner, log panel) and the Start
  placeholder into Dutch, matching #258's log-line wording verbatim where they
  overlap.
- **#266** — applied #258's rule ("a string reaching `LogBuffer` is Dutch") to
  the connector packages: ~45 strings across `wisa_api`, `smartschool_api`
  (incl. `SmartschoolErrorCodes`' generic fallback), `azure_api` (the
  `Azure: …` family, token-age units, `graph_client`'s appended clause) and
  `account_state` (Cosmos persist progress, `CosmosThrottleGovernor`'s three
  reports, both SignalR lines). APIs, ValueKeys, container/partition names and
  exception messages untouched.
- **#273** *(follow-up from #263)* — #263 wired the rules through but nothing
  in the app could author one; the Wisa tab was read-only and `_collect`
  preserved `base.wisaRules`. Added an add/edit/remove editor over the existing
  `encodeWisaRule` codec for the three rule kinds with no other surface
  (`DontImportClass`, `DontImportUserFromWisa`, `ReplaceInstitute`), keeping the
  two school-marking kinds editable-but-not-addable because the WISA-scholen
  grid supersedes them.

## Test plan

Every commit passed format + analyzer + the full unit/widget suite on its own
before landing. Final state of the branch:

- `dart format --output=none --set-exit-if-changed .` — clean, 304 files
- `dart analyze --fatal-infos --fatal-warnings` / `flutter analyze` — clean
  repo-wide
- `flutter test` (account_manager) — **445 pass** (43 in
  `settings_screen_test.dart`, 10 new for #273; 4 new Klasgroepen search widget
  tests for #262; 7 new controller cases for #264; 3 new for #274)
- `dart test` per package — wisa_api 136, smartschool_api 150, azure_api 119,
  account_state 496, account_core 82, account_actions 202, account_linker 72,
  account_store 8 — **1265 pass**
- `flutter test integration_test/app_launch_test.dart -d windows` — **93 pass**
  (was 88 at the branch point; +5 new e2e, one per user-visible issue)

Fail-without-fix was proven per issue by reverting the production lines and
confirming the new tests go red: #263 (3 `live_settings_test` + 4
`reconcile_live_settings_test` cases + e2e), #264 (2 controller cases + e2e),
#274 (3 controller cases with the actual `LateInitializationError` + e2e), #265
(widget test + `widget_test.dart` + e2e), #266 (both new unit groups + e2e),
#273 (e2e round trip: author a rule → save → it prunes the very next
Synchroniseer).

The repo's full integration sweep was left to CI per the batch's bounded-scope
rule.

## Follow-ups filed during this batch

- **#275** — the Synchronisatie idle help paragraph never renders;
  `loadOverview()` flips the phase `idle → ready` before the operator's first
  frame. Translated by #265 but deliberately unasserted. Queued into the next
  chunk.
- **#276** — deferred decision on persisting apply-earned WISA rules.
- **#277** — deferred decision on retiring `MarkAsOurs`/`MarkAsVirtual`.

Closes #262
Closes #263
Closes #264
Closes #274
Closes #265
Closes #266
Closes #273
