### PR TITLE
Give each of a card's decisions its own block, verdicts included (#281 #283)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2342,26 +2342,35 @@ void main() {
     expect(harness.graph.createdGroups, isEmpty);
 
     // …and the card says exactly what happened to each half, with the reason
-    // Graph gave.
-    final verdict = find.byKey(const ValueKey('entry-outcomes-group-5WW1'));
-    await tester.ensureVisible(verdict);
+    // Graph gave. Since #283 each verdict sits with the decision it answers:
+    // the refusal under the create that is still offered, the Smartschool half
+    // — whose decision the write settled — at card level.
+    final refused = find.byKey(const ValueKey('entry-outcomes-group-5WW1-0'));
+    final settled = find.byKey(const ValueKey('entry-outcomes-group-5WW1'));
+    await tester.ensureVisible(settled);
     expect(
       find.descendant(
-          of: verdict, matching: find.text('Resultaat van de vorige poging')),
+          of: refused, matching: find.text('Resultaat van de vorige poging')),
       findsOneWidget,
     );
     expect(
       find.descendant(
-          of: verdict,
+          of: refused,
           matching: find.textContaining('Authorization_RequestDenied')),
       findsOneWidget,
     );
     expect(
       find.descendant(
-          of: verdict,
+          of: settled,
           matching: find.text('Voeg deze klas toe aan Smartschool')),
       findsOneWidget,
     );
+    // Both on the one card, on screen together — the whole point of #272, which
+    // #283 splits without losing.
+    for (final block in <Finder>[refused, settled]) {
+      expect(find.descendant(of: find.byKey(entry), matching: block),
+          findsOneWidget);
+    }
 
     // The create is still offered, and running it again against a tenant that
     // allows it lands the group.
@@ -2471,6 +2480,135 @@ void main() {
       findsNothing,
       reason: "the Office 365 group's fields belong to the other decision",
     );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'after a pass, a card raising two decisions still reads as two and loses '
+      'no verdict end-to-end (#283)', (WidgetTester tester) async {
+    // #281 gave each of `5WW1`'s two decisions a block of its own; the verdict
+    // lines went on pooling below both of them, saying what happened without
+    // saying to which question. Splitting them is not the mechanical move it
+    // looks like, and that is what this run is here for:
+    //
+    // - a **dry-run** settles nothing, so both decisions survive it and each
+    //   one must claim exactly its own verdict — never the other's;
+    // - an **apply** settles the half that lands, so that decision is gone from
+    //   the card the relink builds. Its verdict has no block left to sit in and
+    //   would silently vanish — losing exactly what #272 exists to show. The
+    //   reported run is that case: Smartschool lands, Graph refuses the group,
+    //   and both verdicts have to stay readable side by side.
+    //
+    // Only a full run puts it together: which decisions a card raises is
+    // decided by the dispatch, the alternative collapse and the relink after
+    // the write, and "the verdict went missing" is a claim about what survives
+    // that relink.
+    useTallWindow(tester);
+    final harness = newClassNeedingBothWritesHarness();
+    harness.graph.refuseGroupCreates = true;
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+
+    const entry = ValueKey('entry-group-5WW1');
+    await tester.ensureVisible(find.byKey(entry));
+    await tester.tap(find.byKey(entry));
+    await tester.pumpAndSettle();
+
+    // A dry-run first: two decisions, two verdicts, one under each heading.
+    final dryRun = find.byKey(const ValueKey('entry-dry-run-5WW1'));
+    await tester.ensureVisible(dryRun);
+    await tester.tap(dryRun);
+    await tester.pumpAndSettle();
+
+    final office365 = find.byKey(const ValueKey('entry-outcomes-group-5WW1-0'));
+    final smartschool =
+        find.byKey(const ValueKey('entry-outcomes-group-5WW1-1'));
+    await tester.ensureVisible(smartschool);
+    expect(
+      find.descendant(
+        of: office365,
+        matching: find.text('Maak de Office 365-groep GBS-5WW1 voor klas 5WW1'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: office365,
+          matching: find.text('Voeg deze klas toe aan Smartschool')),
+      findsNothing,
+      reason: "the Smartschool write is the other decision's verdict",
+    );
+    expect(
+      find.descendant(
+          of: smartschool,
+          matching: find.text('Voeg deze klas toe aan Smartschool')),
+      findsOneWidget,
+    );
+    expect(
+        find.byKey(const ValueKey('entry-outcomes-group-5WW1')), findsNothing,
+        reason: 'a dry-run settles no decision, so nothing is left over');
+
+    // Now the real pass. Graph refuses the group; Smartschool takes the class.
+    final apply = find.byKey(const ValueKey('entry-apply-5WW1'));
+    await tester.ensureVisible(apply);
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(harness.soap.soapActions.where((a) => a.endsWith('#saveClass')),
+        hasLength(1));
+    expect(harness.graph.createdGroups, isEmpty);
+
+    // The refusal stays with the decision that still asks the question…
+    final decision = find.byKey(const ValueKey('entry-choice-group-5WW1-0'));
+    await tester.ensureVisible(decision);
+    expect(
+      find.descendant(
+          of: decision,
+          matching: find.textContaining('Authorization_RequestDenied')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: decision,
+          matching: find.text('Voeg deze klas toe aan Smartschool')),
+      findsNothing,
+    );
+
+    // …and the half that landed keeps its verdict at card level, with the
+    // reason it has no decision above it. Nothing went missing.
+    final settled = find.byKey(const ValueKey('entry-outcomes-group-5WW1'));
+    await tester.ensureVisible(settled);
+    expect(
+      find.descendant(
+          of: settled,
+          matching: find.text('Overige resultaten van de vorige poging')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: settled,
+        matching: find.text('Deze acties staan niet meer open op deze kaart.'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: settled,
+          matching: find.text('Voeg deze klas toe aan Smartschool')),
+      findsOneWidget,
+    );
+    // One card, both halves of the story.
+    for (final block in <Finder>[decision, settled]) {
+      expect(find.descendant(of: find.byKey(entry), matching: block),
+          findsOneWidget);
+    }
     expect(tester.takeException(), isNull);
   });
 

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2381,6 +2381,100 @@ void main() {
   });
 
   testWidgets(
+      'a card raising two decisions groups each one\'s fields under its own '
+      'heading end-to-end (#281)', (WidgetTester tester) async {
+    // `5WW1` is new to Smartschool *and* has no Office 365 group, so one card
+    // asks the operator two independent questions. The body used to answer them
+    // in one interleaved run: both summaries pooled in the subtitle, then the
+    // Office 365 field diff, then "Kies één oplossing:" with its radios, then
+    // the Smartschool option's diff. Nothing said which diff belonged to which
+    // decision, or that "pick one of these two" covered only half the card.
+    //
+    // Asserted end-to-end rather than on the widget alone: what a decision
+    // block *is* is decided by `entryDetail`, but which decisions a card raises
+    // is decided by the dispatch, the alternative collapse and the inventory
+    // composing — and a heading that groups nothing is exactly the bug.
+    useTallWindow(tester);
+    final harness = newClassNeedingBothWritesHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+
+    const entry = ValueKey('entry-group-5WW1');
+    await tester.ensureVisible(find.byKey(entry));
+    await tester.tap(find.byKey(entry));
+    await tester.pumpAndSettle();
+
+    // Two decisions, two blocks — the Office 365 create first, because
+    // `collapseAlternatives` emits the lone actions ahead of the either/ors.
+    final office365 = find.byKey(const ValueKey('entry-choice-group-5WW1-0'));
+    final smartschool = find.byKey(const ValueKey('entry-choice-group-5WW1-1'));
+    expect(office365, findsOneWidget);
+    expect(smartschool, findsOneWidget);
+
+    // The lone action is headed by what it does, and the fields under that
+    // heading are the group it would create.
+    expect(
+      find.descendant(
+        of: office365,
+        matching: find.text('Maak de Office 365-groep GBS-5WW1 voor klas 5WW1'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: office365, matching: find.text('groupTypes: ∅ → Unified')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: office365,
+        matching: find.text('description: ∅ → 5e jaar Wetenschappen-Wiskunde'),
+      ),
+      findsNothing,
+      reason: "the Smartschool class's fields belong to the other decision",
+    );
+    expect(
+      find.descendant(
+          of: office365, matching: find.text('Kies één oplossing:')),
+      findsNothing,
+      reason: 'there is nothing to pick between here',
+    );
+
+    // The either/or is headed by its question, and the diff below the radios is
+    // the Smartschool class the selected half would create.
+    expect(
+      find.descendant(
+          of: smartschool, matching: find.text('Kies één oplossing:')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: smartschool,
+          matching: find.text('Negeer deze klas bij het importeren uit WISA')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: smartschool,
+        matching: find.text('description: ∅ → 5e jaar Wetenschappen-Wiskunde'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: smartschool, matching: find.text('groupTypes: ∅ → Unified')),
+      findsNothing,
+      reason: "the Office 365 group's fields belong to the other decision",
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'an Office 365 group Graph already holds under our address is adopted, '
       'and the create stops being offered end-to-end (#280)',
       (WidgetTester tester) async {

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -65,6 +65,7 @@ class ActionOutcomeEntry {
     this.error,
     this.family = '',
     this.targetId = '',
+    this.situationId = '',
   });
 
   /// Human label of the record the action targets.
@@ -89,6 +90,21 @@ class ActionOutcomeEntry {
   /// cannot do that: it is a display string, and a class and an account can
   /// read the same.
   final String targetId;
+
+  /// The [PendingChoice.situationId] of the decision this row is the verdict of
+  /// — the option's `group ?? kind` (#283).
+  ///
+  /// [family] + [targetId] name the *card*; a card can raise several
+  /// independent decisions at once (a class new to Smartschool **and** without
+  /// an Office 365 group raises two), so routing a verdict to the decision it
+  /// answers needs this third stamp. A chained follow-up (#230/#240/#245)
+  /// carries the situation of the option that unlocked it, because that is the
+  /// decision the operator took when they started it.
+  ///
+  /// Empty on a row recorded before the stamp existed; such a row belongs to no
+  /// decision and is reported at card level instead (see
+  /// [ReconcileController.unroutedApplyOutcomesFor]).
+  final String situationId;
 
   /// Whether this row is a key for [ReconcileController.applyOutcomesFor] at
   /// all — a row recorded before the entry identity existed carries neither
@@ -155,6 +171,12 @@ class PendingActionOption {
   /// has run and relinked. The confirmation dialog has to name that second
   /// system *before* the write.
   final Set<core.Origin> unlockedSystems;
+
+  /// The decision this option belongs to, by the same rule
+  /// [PendingChoice.situationId] uses (#283) — the alternative group when this
+  /// option is one of several mutually-exclusive resolutions, else its own
+  /// kind. What routes a pass's verdict back to the decision that raised it.
+  String get situationId => group ?? kind;
 }
 
 /// What a confirmed apply of a selection would write, for the confirmation
@@ -254,8 +276,9 @@ class PendingChoice {
 
   /// The situation this choice resolves — the alternative-group key for a real
   /// choice, else the single action kind. Drives the "same situation" grouping
-  /// so two departed students share one bulk-apply subset.
-  String get situationId => alternatives.first.group ?? alternatives.first.kind;
+  /// so two departed students share one bulk-apply subset, and — since #283 —
+  /// routes a pass's verdict back to the decision it is the verdict of.
+  String get situationId => alternatives.first.situationId;
 }
 
 /// The pending actions for **one** linked account, staff member, or class group
@@ -666,6 +689,11 @@ class ReconcileController extends ChangeNotifier {
   ///
   /// Empty when the entry took no part in the last pass — including after a
   /// sync, which clears both result lists.
+  ///
+  /// The whole of it, in dispatch order. The card splits it further:
+  /// [applyOutcomesForChoice] gives the part that answers one decision, and
+  /// [unroutedApplyOutcomesFor] the part no decision on the card can claim
+  /// (#283).
   List<ActionOutcomeEntry> applyOutcomesFor(PendingAccountEntry entry) {
     final results = _applyResults ?? _dryRunResults;
     if (results == null) return const <ActionOutcomeEntry>[];
@@ -676,6 +704,72 @@ class ReconcileController extends ChangeNotifier {
             r.targetId == entry.targetId)
           r,
     ];
+  }
+
+  /// The part of [entry]'s verdict that answers [choice] — the rows stamped
+  /// with that decision's [PendingChoice.situationId] (#283).
+  ///
+  /// A card can raise several independent decisions, so a verdict pooled at
+  /// card level says *what happened* without saying *to which question*. These
+  /// are the rows the decision's own block shows.
+  ///
+  /// Empty when [choice]'s situation does not name exactly one decision on this
+  /// card. An entry groups every action on one target, and two targets that
+  /// share a display label share an entry, so a kind is not guaranteed unique
+  /// within a card (the same reason #281 keys the blocks by position). A row
+  /// that two blocks could equally claim is shown in neither — it falls to
+  /// [unroutedApplyOutcomesFor], which is where it was already being read
+  /// before #283.
+  List<ActionOutcomeEntry> applyOutcomesForChoice(
+    PendingAccountEntry entry,
+    PendingChoice choice,
+  ) {
+    if (!_routableSituations(entry).contains(choice.situationId)) {
+      return const <ActionOutcomeEntry>[];
+    }
+    return <ActionOutcomeEntry>[
+      for (final r in applyOutcomesFor(entry))
+        if (r.situationId == choice.situationId) r,
+    ];
+  }
+
+  /// The part of [entry]'s verdict that no decision on the card can claim
+  /// (#283) — reported at card level, exactly where the whole verdict was
+  /// reported before.
+  ///
+  /// This is not a leftovers bin: it is the normal home of every verdict that
+  /// **succeeded**. A write that lands settles its decision, so the next relink
+  /// does not raise it again and the block it would have sat in no longer
+  /// exists. Dropping those rows would lose exactly what #272 exists to show —
+  /// the reported run has the Smartschool half landing and the Office 365 half
+  /// refused, and both have to stay readable side by side.
+  ///
+  /// Also catches a row from a decision that is no longer offered for any other
+  /// reason (the record changed under the write, so the dispatcher now proposes
+  /// a different kind), one whose situation is ambiguous within the card, and
+  /// one recorded before #283 stamped the situation at all.
+  ///
+  /// Together with [applyOutcomesForChoice] over every choice this partitions
+  /// [applyOutcomesFor] exactly: no row is shown twice, and none goes missing.
+  List<ActionOutcomeEntry> unroutedApplyOutcomesFor(PendingAccountEntry entry) {
+    final routable = _routableSituations(entry);
+    return <ActionOutcomeEntry>[
+      for (final r in applyOutcomesFor(entry))
+        if (!routable.contains(r.situationId)) r,
+    ];
+  }
+
+  /// The situations that name **exactly one** decision on [entry] — the only
+  /// ones a verdict row can be routed by (#283).
+  static Set<String> _routableSituations(PendingAccountEntry entry) {
+    final counts = <String, int>{};
+    for (final c in entry.choices) {
+      counts[c.situationId] = (counts[c.situationId] ?? 0) + 1;
+    }
+    return <String>{
+      for (final e in counts.entries)
+        if (e.value == 1) e.key,
+    };
   }
 
   /// All pending actions of the current linked view, student → staff → group.
@@ -2123,7 +2217,8 @@ class ReconcileController extends ChangeNotifier {
         _record(option, changes, result),
         // A chained follow-up is a write the same click performed on the same
         // target, so it is stamped with the same entry identity and lands on
-        // the same card (#272).
+        // the same card (#272) — and, since #283, with the same *decision*,
+        // because the operator started it by picking this option.
         for (final followUp in applied.followUps)
           _record(option, followUp.changes, followUp),
       ];
@@ -2136,6 +2231,7 @@ class ReconcileController extends ChangeNotifier {
           target: option.target,
           family: option.family,
           targetId: option.targetId,
+          situationId: option.situationId,
           changes: changes,
           outcome: actions.ActionOutcome.failed,
           error: e,
@@ -2146,7 +2242,8 @@ class ReconcileController extends ChangeNotifier {
 
   /// Logs one action's outcome and shapes it as a results-list row, stamped
   /// with the entry [option] came from so the card can show its own verdict
-  /// (#272).
+  /// (#272) and with the decision it answers so that verdict sits under the
+  /// question it belongs to (#283).
   ActionOutcomeEntry _record(
     PendingActionOption option,
     actions.ChangeSet changes,
@@ -2165,6 +2262,7 @@ class ReconcileController extends ChangeNotifier {
       target: target,
       family: option.family,
       targetId: option.targetId,
+      situationId: option.situationId,
       changes: changes,
       outcome: result.outcome,
       error: result.error,

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -705,9 +705,10 @@ class PendingEntryTile extends StatelessWidget {
   }
 }
 
-/// The expanded body of one pending entry: one block per decision (#281), the
-/// verdict of the last pass that touched this entry (#272), and the per-entry
-/// dry-run / apply pair.
+/// The expanded body of one pending entry: one block per decision, each with
+/// its own verdict (#281/#283), then the verdicts of the last pass that no
+/// decision on the card can claim (#272/#283), then the per-entry dry-run /
+/// apply pair.
 ///
 /// Split out of [PendingEntryTile] so the class inventory can put the very same
 /// controls under a row that carries its own presence columns (#227), rather
@@ -731,9 +732,13 @@ List<Widget> entryDetail(
           controller: controller,
           entry: entry,
           choice: choice,
-          leading: index == 0,
+          index: index,
         ),
-      EntryOutcomes(controller: controller, entry: entry),
+      EntryOutcomes(
+        keyValue: 'entry-outcomes-${entry.family}-${entry.targetId}',
+        outcomes: controller.unroutedApplyOutcomesFor(entry),
+        settled: true,
+      ),
       const SizedBox(height: PlinkSpacing.s3),
       Row(
         children: <Widget>[
@@ -780,7 +785,8 @@ String choiceHeading(PendingChoice choice) =>
 
 /// One decision of a card, as a block of its own (#281): the heading that names
 /// it, then the radios (for an either/or) and the field diff of the resolution
-/// that would actually run.
+/// that would actually run — and, since #283, what the last pass did about
+/// *this* decision.
 ///
 /// The reading this exists for: a class that is new to Smartschool **and** has
 /// no Office 365 group raises two independent decisions on one card. The body
@@ -791,22 +797,31 @@ String choiceHeading(PendingChoice choice) =>
 /// to which decision, or that "pick one of these two" covered only half of what
 /// was on the card. Under its own heading each diff belongs to something, and a
 /// card with two decisions reads as two.
+///
+/// The verdict lines pooled the same way and for the same reason (#283): one
+/// apply on that card produces two of them, and below both decisions they said
+/// what happened without saying to which question. So the block carries the part
+/// of the entry's verdict that answers its own decision, and the card keeps the
+/// entry-level block for the rest — chiefly the decisions that *succeeded*, and
+/// are therefore no longer on the card to be answered.
 class EntryChoiceBlock extends StatelessWidget {
   const EntryChoiceBlock({
     super.key,
     required this.controller,
     required this.entry,
     required this.choice,
-    required this.leading,
+    required this.index,
   });
 
   final ReconcileController controller;
   final PendingAccountEntry entry;
   final PendingChoice choice;
 
-  /// Whether this is the card's first decision — the one that needs no rule
-  /// above it, because the tile's own header already closes the body at the top.
-  final bool leading;
+  /// This decision's position on the card. The first needs no rule above it —
+  /// the tile's own header already closes the body at the top — and it names
+  /// the block's verdict, which is keyed by position for the reason
+  /// [entryDetail] keys the blocks themselves that way.
+  final int index;
 
   @override
   Widget build(BuildContext context) {
@@ -816,7 +831,7 @@ class EntryChoiceBlock extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        if (!leading) ...<Widget>[
+        if (index > 0) ...<Widget>[
           const SizedBox(height: PlinkSpacing.s3),
           Divider(height: 1, color: Theme.of(context).dividerColor),
           const SizedBox(height: PlinkSpacing.s3),
@@ -830,13 +845,18 @@ class EntryChoiceBlock extends StatelessWidget {
           ChoiceControl(controller: controller, entry: entry, choice: choice)
         else
           OptionDetail(option: choice.selected),
+        EntryOutcomes(
+          keyValue: 'entry-outcomes-${entry.family}-${entry.targetId}-$index',
+          outcomes: controller.applyOutcomesForChoice(entry, choice),
+        ),
       ],
     );
   }
 }
 
-/// What the last pass did for **this** entry (#272), rendered on the entry's own
-/// card and nowhere else.
+/// What the last pass did, rendered on the card that raised the work and
+/// nowhere else (#272) — since #283, one such block per decision, plus one at
+/// card level for the verdicts no decision can claim.
 ///
 /// The bug this exists for: applying a WISA-only class runs two writes — create
 /// the class in Smartschool, create its `<PREFIX>-<KLAS>` Office 365 group — and
@@ -853,22 +873,37 @@ class EntryChoiceBlock extends StatelessWidget {
 /// the same gap again. The page-level sections stay — they report the *pass*,
 /// which is what a bulk apply over hundreds of accounts needs.
 ///
-/// Renders nothing when this entry took no part in the last pass, which is the
-/// state after every sync.
+/// [settled] marks the card-level block: those rows answer decisions that are
+/// no longer on the card, which is the ordinary fate of a write that **landed**
+/// — it settles its decision, so the next relink does not raise it again. They
+/// are not leftovers and must not be dropped: the reported run has the
+/// Smartschool half landing and the Office 365 half refused, and the operator
+/// has to read both.
+///
+/// Renders nothing when there is nothing to report, which is the state of every
+/// card after a sync.
 class EntryOutcomes extends StatelessWidget {
   const EntryOutcomes({
     super.key,
-    required this.controller,
-    required this.entry,
+    required this.keyValue,
+    required this.outcomes,
+    this.settled = false,
   });
 
-  final ReconcileController controller;
-  final PendingAccountEntry entry;
+  /// Names this block on screen — the card-level one keeps the
+  /// `entry-outcomes-<family>-<targetId>` of #272, a decision's own appends its
+  /// position.
+  final String keyValue;
+
+  /// The verdict rows this block reports, already routed by the controller.
+  final List<ActionOutcomeEntry> outcomes;
+
+  /// Whether these rows answer decisions the card no longer raises (#283),
+  /// which changes both the heading and the sentence under it.
+  final bool settled;
 
   @override
   Widget build(BuildContext context) {
-    final List<ActionOutcomeEntry> outcomes =
-        controller.applyOutcomesFor(entry);
     if (outcomes.isEmpty) return const SizedBox.shrink();
 
     final TextTheme text = Theme.of(context).textTheme;
@@ -876,25 +911,43 @@ class EntryOutcomes extends StatelessWidget {
     // list before it starts, so the whole block is one or the other.
     final bool dry =
         outcomes.every((o) => o.outcome == actions.ActionOutcome.dryRun);
+    final String what = dry ? 'vorige dry-run' : 'vorige poging';
 
     return Padding(
-      key: ValueKey('entry-outcomes-${entry.family}-${entry.targetId}'),
+      key: ValueKey(keyValue),
       padding: const EdgeInsets.only(top: PlinkSpacing.s3),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
+          // Set off from the decisions above by the same rule that separates
+          // them from each other, so the card reads as one section per block.
+          if (settled) ...<Widget>[
+            Divider(height: 1, color: Theme.of(context).dividerColor),
+            const SizedBox(height: PlinkSpacing.s3),
+          ],
           Text(
             // Deliberately not the page-level section's wording ("Resultaat van
             // het toepassen"): that one reports the pass, this one reports this
             // record, and an operator who sees both must be able to tell which
             // is which. "Vorige poging" also says the thing the operator needs
             // next — a failed write can simply be run again.
-            dry
-                ? 'Resultaat van de vorige dry-run'
-                : 'Resultaat van de vorige poging',
-            style: text.titleSmall,
+            settled
+                ? 'Overige resultaten van de $what'
+                : 'Resultaat van de $what',
+            style: settled
+                ? text.titleSmall
+                : text.bodySmall?.copyWith(fontWeight: FontWeight.w600),
           ),
+          // Why a verdict appears here with no decision above it to answer:
+          // the write landed, so there is nothing left to pick.
+          if (settled) ...<Widget>[
+            const SizedBox(height: PlinkSpacing.s1),
+            Text(
+              'Deze acties staan niet meer open op deze kaart.',
+              style: text.bodySmall,
+            ),
+          ],
           const SizedBox(height: PlinkSpacing.s1),
           for (final outcome in outcomes) EntryOutcomeLine(outcome: outcome),
         ],

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -705,24 +705,34 @@ class PendingEntryTile extends StatelessWidget {
   }
 }
 
-/// The expanded body of one pending entry: the radios (or the lone option's
-/// diff), the verdict of the last pass that touched this entry (#272), and the
-/// per-entry dry-run / apply pair.
+/// The expanded body of one pending entry: one block per decision (#281), the
+/// verdict of the last pass that touched this entry (#272), and the per-entry
+/// dry-run / apply pair.
 ///
 /// Split out of [PendingEntryTile] so the class inventory can put the very same
 /// controls under a row that carries its own presence columns (#227), rather
 /// than nesting one expandable tile inside another.
+///
+/// The blocks are keyed by position rather than by
+/// [PendingChoice.situationId]: an entry groups every action on one target, and
+/// two targets that share a display label share an entry, so a kind is not
+/// guaranteed unique within one card — and a duplicate key among a [Column]'s
+/// children is a build-time crash, not a cosmetic clash.
 List<Widget> entryDetail(
   BuildContext context, {
   required ReconcileController controller,
   required PendingAccountEntry entry,
 }) =>
     <Widget>[
-      for (final choice in entry.choices)
-        if (choice.isChoice)
-          ChoiceControl(controller: controller, entry: entry, choice: choice)
-        else
-          OptionDetail(option: choice.selected),
+      for (final (index, choice) in entry.choices.indexed)
+        EntryChoiceBlock(
+          key:
+              ValueKey('entry-choice-${entry.family}-${entry.targetId}-$index'),
+          controller: controller,
+          entry: entry,
+          choice: choice,
+          leading: index == 0,
+        ),
       EntryOutcomes(controller: controller, entry: entry),
       const SizedBox(height: PlinkSpacing.s3),
       Row(
@@ -757,6 +767,73 @@ List<Widget> entryDetail(
         ],
       ),
     ];
+
+/// The heading one [PendingChoice] leads its block with (#281): the question an
+/// either/or asks the operator, or — for a lone action — what that action does.
+///
+/// Deliberately the bare summary rather than the collapsed [pendingChoiceLine]:
+/// the "(manueel)" marker exists to make an informational action scannable in a
+/// list of many, while inside the block [OptionDetail] already spells the same
+/// thing out in a full sentence.
+String choiceHeading(PendingChoice choice) =>
+    choice.isChoice ? 'Kies één oplossing:' : choice.selected.changes.summary;
+
+/// One decision of a card, as a block of its own (#281): the heading that names
+/// it, then the radios (for an either/or) and the field diff of the resolution
+/// that would actually run.
+///
+/// The reading this exists for: a class that is new to Smartschool **and** has
+/// no Office 365 group raises two independent decisions on one card. The body
+/// used to render every choice's control and diff one after another with nothing
+/// between them, under a subtitle that pooled both summaries at the top — so the
+/// operator read the Office 365 field diff, then "Kies één oplossing:" with its
+/// radios, then the Smartschool diff, and had no way to tell which diff belonged
+/// to which decision, or that "pick one of these two" covered only half of what
+/// was on the card. Under its own heading each diff belongs to something, and a
+/// card with two decisions reads as two.
+class EntryChoiceBlock extends StatelessWidget {
+  const EntryChoiceBlock({
+    super.key,
+    required this.controller,
+    required this.entry,
+    required this.choice,
+    required this.leading,
+  });
+
+  final ReconcileController controller;
+  final PendingAccountEntry entry;
+  final PendingChoice choice;
+
+  /// Whether this is the card's first decision — the one that needs no rule
+  /// above it, because the tile's own header already closes the body at the top.
+  final bool leading;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        if (!leading) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s3),
+          Divider(height: 1, color: Theme.of(context).dividerColor),
+          const SizedBox(height: PlinkSpacing.s3),
+        ],
+        Text(
+          choiceHeading(choice),
+          style: text.bodySmall?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: PlinkSpacing.s1),
+        if (choice.isChoice)
+          ChoiceControl(controller: controller, entry: entry, choice: choice)
+        else
+          OptionDetail(option: choice.selected),
+      ],
+    );
+  }
+}
 
 /// What the last pass did for **this** entry (#272), rendered on the entry's own
 /// card and nowhere else.
@@ -888,6 +965,10 @@ String applyResultsSubtitle(List<ActionOutcomeEntry> results) {
 
 /// The radio group for a mutually-exclusive choice (#110): the operator picks
 /// exactly one resolution; the selected one is what an apply runs.
+///
+/// The "Kies één oplossing:" heading above it belongs to the enclosing
+/// [EntryChoiceBlock] since #281, so that every decision on a card — either/or
+/// or lone action — is introduced by one and the same rule.
 class ChoiceControl extends StatelessWidget {
   const ChoiceControl({
     super.key,
@@ -908,10 +989,6 @@ class ChoiceControl extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text(
-          'Kies één oplossing:',
-          style: text.bodySmall?.copyWith(fontWeight: FontWeight.w600),
-        ),
         for (final option in choice.alternatives)
           InkWell(
             key: ValueKey('alt-${entry.targetId}-${option.kind}'),

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -2395,6 +2395,134 @@ void main() {
     });
   });
 
+  group("a verdict belongs to the decision it is the verdict of (#283)", () {
+    PendingAccountEntry entryOf(ReconcileHarness h) =>
+        h.controller.groupPendingEntries
+            .firstWhere((e) => e.targetId == '5WW1');
+
+    test('every row is stamped with the decision that produced it', () async {
+      final h = newClassNeedingBothWritesHarness();
+      await h.controller.sync();
+      // Before the apply, so both decisions are still there to be named.
+      expect(entryOf(h).choices.map((c) => c.situationId),
+          ['CreateAzureClassGroup', actions.classImportAlternative]);
+
+      await h.controller.applyEntry(entryOf(h));
+
+      // `family` + `targetId` name the card, never the decision — the whole
+      // reason the verdicts pooled. The situation is the third stamp.
+      expect(
+        h.controller.applyResults!.map((r) => r.situationId).toList(),
+        <String>[
+          // The Office 365 create…
+          'CreateAzureClassGroup',
+          // …and the roster write it chained (#245), which the operator
+          // started by picking that option, so it answers that decision.
+          'CreateAzureClassGroup',
+          actions.classImportAlternative,
+        ],
+      );
+    });
+
+    test('the refused half routes into the decision that is still offered',
+        () async {
+      final h = newClassNeedingBothWritesHarness();
+      h.graph.refuseGroupCreates = true;
+      await h.controller.sync();
+      await h.controller.applyEntry(entryOf(h));
+
+      final entry = entryOf(h);
+      final choice = entry.choices.single;
+      expect(choice.situationId, 'CreateAzureClassGroup',
+          reason:
+              'the failed write left the record alone, so it is re-offered');
+
+      final routed = h.controller.applyOutcomesForChoice(entry, choice);
+      expect(routed, hasLength(1));
+      expect(routed.single.outcome, actions.ActionOutcome.failed);
+      expect(routed.single.changes.summary,
+          'Maak de Office 365-groep GBS-5WW1 voor klas 5WW1');
+      expect('${routed.single.error}', contains('Authorization_RequestDenied'));
+    });
+
+    test('the half that succeeded is still reported, at card level', () async {
+      final h = newClassNeedingBothWritesHarness();
+      h.graph.refuseGroupCreates = true;
+      await h.controller.sync();
+      await h.controller.applyEntry(entryOf(h));
+
+      // The Smartschool create landed, so its decision is gone from the entry
+      // the relink built — and its verdict would silently vanish with it.
+      final entry = entryOf(h);
+      expect(entry.choices.map((c) => c.situationId),
+          isNot(contains(actions.classImportAlternative)));
+
+      final unrouted = h.controller.unroutedApplyOutcomesFor(entry);
+      expect(unrouted, hasLength(1));
+      expect(unrouted.single.outcome, actions.ActionOutcome.applied);
+      expect(unrouted.single.changes.summary,
+          'Voeg deze klas toe aan Smartschool');
+    });
+
+    test('the split partitions the verdict — nothing doubled, nothing lost',
+        () async {
+      final h = newClassNeedingBothWritesHarness();
+      h.graph.refuseGroupCreates = true;
+      await h.controller.sync();
+      await h.controller.applyEntry(entryOf(h));
+
+      final entry = entryOf(h);
+      final shown = <ActionOutcomeEntry>[
+        for (final c in entry.choices)
+          ...h.controller.applyOutcomesForChoice(entry, c),
+        ...h.controller.unroutedApplyOutcomesFor(entry),
+      ];
+      expect(
+        shown.map((r) => r.changes.summary).toList(),
+        h.controller
+            .applyOutcomesFor(entry)
+            .map((r) => r.changes.summary)
+            .toList(),
+      );
+    });
+
+    test("another decision's verdict never lands in this block", () async {
+      final h = newClassNeedingBothWritesHarness();
+      h.graph.refuseGroupCreates = true;
+      await h.controller.sync();
+      await h.controller.applyEntry(entryOf(h));
+
+      final entry = entryOf(h);
+      final routed = h.controller
+          .applyOutcomesForChoice(entry, entry.choices.single)
+          .map((r) => r.changes.summary);
+      expect(routed, isNot(contains('Voeg deze klas toe aan Smartschool')));
+    });
+
+    test('a dry-run verdict routes the same way as an apply', () async {
+      final h = newClassNeedingBothWritesHarness();
+      await h.controller.sync();
+      // A dry-run settles nothing, so both decisions are still on the card and
+      // each one claims its own row.
+      await h.controller.dryRunEntry(entryOf(h));
+
+      final entry = entryOf(h);
+      expect(
+        <String>[
+          for (final c in entry.choices)
+            ...h.controller
+                .applyOutcomesForChoice(entry, c)
+                .map((r) => r.changes.summary),
+        ],
+        <String>[
+          'Maak de Office 365-groep GBS-5WW1 voor klas 5WW1',
+          'Voeg deze klas toe aan Smartschool',
+        ],
+      );
+      expect(h.controller.unroutedApplyOutcomesFor(entry), isEmpty);
+    });
+  });
+
   group('LogBuffer', () {
     test('caps its entries and reports errors', () {
       final log = LogBuffer(capacity: 3, clock: () => kFixtureDate);

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -248,17 +248,18 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
-    // The row's own verdict, on the row, naming the reason Graph gave.
-    final verdict = find.byKey(const ValueKey('entry-outcomes-group-5WW1'));
-    expect(verdict, findsOneWidget);
+    // The row's own verdict, on the row, naming the reason Graph gave — under
+    // the decision it is the verdict of, since #283.
+    final refused = find.byKey(const ValueKey('entry-outcomes-group-5WW1-0'));
+    expect(refused, findsOneWidget);
     expect(
       find.descendant(
-          of: verdict, matching: find.text('Resultaat van de vorige poging')),
+          of: refused, matching: find.text('Resultaat van de vorige poging')),
       findsOneWidget,
     );
     expect(
       find.descendant(
-        of: verdict,
+        of: refused,
         matching: find.textContaining('Mislukt — Maak de Office 365-groep '
             'GBS-5WW1 voor klas 5WW1'),
       ),
@@ -266,18 +267,28 @@ void main() {
     );
     expect(
       find.descendant(
-          of: verdict,
+          of: refused,
           matching: find.textContaining('Authorization_RequestDenied')),
       findsOneWidget,
     );
     // …beside the half that did land, so the operator reads one card, not two
-    // halves of the story in two places.
+    // halves of the story in two places. That half settled its own decision, so
+    // the card no longer raises it and its verdict is reported at card level
+    // (#283) — on the same card, on screen at the same time.
+    final settled = find.byKey(const ValueKey('entry-outcomes-group-5WW1'));
     expect(
       find.descendant(
-          of: verdict,
+          of: settled,
           matching: find.text('Voeg deze klas toe aan Smartschool')),
       findsOneWidget,
     );
+    for (final block in <Finder>[refused, settled]) {
+      expect(
+        find.descendant(of: find.byKey(entry), matching: block),
+        findsOneWidget,
+        reason: 'both verdicts stay readable together on the one card',
+      );
+    }
 
     // The pass summary stops claiming everything was written.
     expect(
@@ -369,6 +380,144 @@ void main() {
       find.descendant(
           of: find.byKey(office365),
           matching: find.text('Kies één oplossing:')),
+      findsNothing,
+    );
+  });
+
+  testWidgets(
+      "a row with two decisions puts each one's verdict under its own heading "
+      '(#283)', (WidgetTester tester) async {
+    // A dry-run settles nothing, so both of `5WW1`'s decisions are still on the
+    // row afterwards and each one can be asked what happened to it. The verdict
+    // lines used to pool in one block below both decisions, exactly the way the
+    // field diffs did before #281.
+    _useTallWindow(tester);
+    final harness = newClassNeedingBothWritesHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('entry-group-5WW1')));
+    await tester.pumpAndSettle();
+    final dryRun = find.byKey(const ValueKey('entry-dry-run-5WW1'));
+    await tester.ensureVisible(dryRun);
+    await tester.tap(dryRun);
+    await tester.pumpAndSettle();
+
+    final office365 = find.byKey(const ValueKey('entry-outcomes-group-5WW1-0'));
+    final smartschool =
+        find.byKey(const ValueKey('entry-outcomes-group-5WW1-1'));
+
+    // Each decision reports its own write, and only its own.
+    expect(
+      find.descendant(
+          of: office365,
+          matching: find.text('Resultaat van de vorige dry-run')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: office365,
+        matching: find.text('Maak de Office 365-groep GBS-5WW1 voor klas 5WW1'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: office365,
+          matching: find.text('Voeg deze klas toe aan Smartschool')),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+          of: smartschool,
+          matching: find.text('Voeg deze klas toe aan Smartschool')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: smartschool,
+        matching: find.text('Maak de Office 365-groep GBS-5WW1 voor klas 5WW1'),
+      ),
+      findsNothing,
+    );
+
+    // Nothing is left over: both decisions are still on the row, so the
+    // card-level block has nothing to report and does not render at all.
+    expect(
+        find.byKey(const ValueKey('entry-outcomes-group-5WW1')), findsNothing,
+        reason: 'a dry-run settles no decision, so no verdict is orphaned');
+  });
+
+  testWidgets(
+      'a verdict whose decision succeeded is still reported on the row (#283)',
+      (WidgetTester tester) async {
+    // The reported run, read the way #283 asks for it. The Smartschool half
+    // lands — so its decision is gone from the row the relink builds and its
+    // verdict has no block left to sit in — while the Office 365 half is
+    // refused and keeps its decision. Both have to stay readable side by side.
+    _useTallWindow(tester);
+    final harness = newClassNeedingBothWritesHarness();
+    harness.graph.refuseGroupCreates = true;
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    const entry = ValueKey('entry-group-5WW1');
+    await tester.tap(find.byKey(entry));
+    await tester.pumpAndSettle();
+    final apply = find.byKey(const ValueKey('entry-apply-5WW1'));
+    await tester.ensureVisible(apply);
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    // The refusal sits under the decision that still asks the question…
+    final decision = find.byKey(const ValueKey('entry-choice-group-5WW1-0'));
+    expect(
+      find.descendant(
+          of: decision,
+          matching: find.textContaining('Authorization_RequestDenied')),
+      findsOneWidget,
+    );
+    // …and nothing else does. The half that landed is not this decision's
+    // verdict, so it does not appear under its heading.
+    expect(
+      find.descendant(
+          of: decision,
+          matching: find.text('Voeg deze klas toe aan Smartschool')),
+      findsNothing,
+    );
+
+    // The half that landed keeps its verdict at card level, and the card says
+    // why it has no decision above it.
+    final settled = find.byKey(const ValueKey('entry-outcomes-group-5WW1'));
+    expect(
+      find.descendant(
+          of: settled,
+          matching: find.text('Overige resultaten van de vorige poging')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: settled,
+        matching: find.text('Deze acties staan niet meer open op deze kaart.'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: settled,
+          matching: find.text('Voeg deze klas toe aan Smartschool')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: settled,
+          matching: find.textContaining('Authorization_RequestDenied')),
       findsNothing,
     );
   });

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -298,6 +298,82 @@ void main() {
   });
 
   testWidgets(
+      'a row with two decisions puts each one\'s fields under its own heading '
+      '(#281)', (WidgetTester tester) async {
+    // `5WW1` is new to Smartschool *and* has no Office 365 group, so its row
+    // raises two independent decisions. They used to interleave: both summaries
+    // pooled in the subtitle, then the Office 365 field diff, then "Kies één
+    // oplossing:" with its radios, then the Smartschool diff — so which diff
+    // belonged to which decision was anybody's guess.
+    _useTallWindow(tester);
+    final harness = newClassNeedingBothWritesHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('entry-group-5WW1')));
+    await tester.pumpAndSettle();
+
+    // Two decisions, two blocks — the Office 365 create first, because
+    // `collapseAlternatives` emits the lone actions ahead of the either/ors.
+    const office365 = ValueKey('entry-choice-group-5WW1-0');
+    const smartschool = ValueKey('entry-choice-group-5WW1-1');
+
+    // The either/or leads with its question, and the fields under it are the
+    // Smartschool class it would create — never the Office 365 group's.
+    expect(
+      find.descendant(
+          of: find.byKey(smartschool),
+          matching: find.text('Kies één oplossing:')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(smartschool),
+        matching: find.text('description: ∅ → 5e jaar Wetenschappen-Wiskunde'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: find.byKey(smartschool),
+          matching: find.text('groupTypes: ∅ → Unified')),
+      findsNothing,
+    );
+
+    // The lone action leads with what it does, and carries its own diff.
+    expect(
+      find.descendant(
+        of: find.byKey(office365),
+        matching: find.text('Maak de Office 365-groep GBS-5WW1 voor klas 5WW1'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: find.byKey(office365),
+          matching: find.text('groupTypes: ∅ → Unified')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(office365),
+        matching: find.text('description: ∅ → 5e jaar Wetenschappen-Wiskunde'),
+      ),
+      findsNothing,
+    );
+    // "Kies één oplossing:" covers half the card, and says so by sitting in
+    // that half only.
+    expect(
+      find.descendant(
+          of: find.byKey(office365),
+          matching: find.text('Kies één oplossing:')),
+      findsNothing,
+    );
+  });
+
+  testWidgets(
       'a passive session says it is read-only and renders static rows (#214)',
       (WidgetTester tester) async {
     _useTallWindow(tester);


### PR DESCRIPTION
Two issues, one commit each. Both are follow-ups filed during this batch — #281
was split out of #272, and #283 out of #281.

## What changed

- **#281** — a class that is new to Smartschool *and* has no Office 365 group
  raises two independent decisions on one card, but `entryDetail` rendered every
  choice's collapsed summary first and then the expanded bodies one after
  another, so an operator could not tell which field diff belonged to which
  decision. Each `PendingChoice` now renders as an `EntryChoiceBlock` — heading
  (`choiceHeading`: the lone action's summary, or "Kies één oplossing:" for an
  either/or), then that decision's radios and field diff, separated by a rule.
  `ChoiceControl` gave up its own heading so both kinds share one rule, and
  blocks are keyed by position so an entry whose targets share a label cannot
  crash on duplicate keys.
- **#283** — the verdict lines #272 added still pooled below *all* the decision
  blocks, so one apply on that same card produced two verdict lines sitting
  together exactly the way the field diffs used to. The routing was the hard
  part: `ActionOutcomeEntry` identified the entry (`family` + `targetId`), not
  the decision, and a decision that *succeeds* is gone from the entry the next
  relink builds — so a naive split would silently drop the very information
  #272 exists to show. `ActionOutcomeEntry` now also carries the decision's
  `situationId` (`group ?? kind`, inherited by chained follow-ups);
  `applyOutcomesForChoice` routes rows into their own block while
  `unroutedApplyOutcomesFor` keeps a card-level block for verdicts whose
  decision succeeded or is otherwise gone. The two partition the entry's
  verdicts exactly — nothing doubled, nothing lost.

#272's assertions that a succeeded Smartschool line and a refused Office 365
line stay readable side by side were **re-shaped, not weakened** — they now
prove both verdicts sit on the one card in their respective blocks.

## Test plan

Both commits passed format + analyzer + the full unit/widget suite on their own
before landing. Final state of the branch:

- `dart format --output=none --set-exit-if-changed .` — clean
- `dart analyze account_manager packages` — clean
- `dart test packages` — **1355 pass**, 11 skipped (live self-skips)
- `flutter test` (account_manager) — **469 pass** (461 after #281; #283 added 6
  controller cases and 2 Klasgroepen widget cases)
- `flutter test integration_test/app_launch_test.dart -d windows` — **101 pass**
  (99 at the branch point; one new e2e per issue)

Fail-without-fix proven for both by stashing `action_tiles.dart`: #281's new
widget case fails, and for #283 both new widget cases, the re-shaped #272 widget
case and the new e2e all fail.

The repo's full integration sweep was left to CI per the batch's bounded-scope
rule.

Closes #281
Closes #283
