### PR TITLE
WISA import rules: persist what an apply earns, stamp its provenance, retire the dead rules

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1387,8 +1387,8 @@ void main() {
       'Settings, re-bucketing its student to the leaver group (#178)',
       (WidgetTester tester) async {
     // A student enrolled in school 2, fully present in our Smartschool + Azure.
-    // The WISA schools carry no MarkAsOurs flag, so ownership comes solely from
-    // the Settings-derived managed set the applier is wired with — the exact
+    // A WISA snapshot carries no ownership at all (#286), so it comes solely
+    // from the Settings-derived managed set the applier is wired with — the
     // "persisted but never consumed" wiring #178 closes. Here only school 1 is
     // managed, so the school-2 student is groupOnly.
     useTallWindow(tester);
@@ -1428,8 +1428,8 @@ void main() {
       'the Actions drill-down end-to-end (#178)', (WidgetTester tester) async {
     // The very same school-2 student, but now school 2 is one of ours: their
     // class must be browsable instead of sitting in the leaver bucket. Proves
-    // the managed set from Settings — not the snapshot MarkAsOurs flags —
-    // drives which students show. The school itself is no longer a node (#210),
+    // the managed set from Settings drives which students show. The school
+    // itself is no longer a node (#210),
     // so the proof is that the student's own class is reachable.
     useTallWindow(tester);
     final harness = managedSchoolsHarness(ourSchoolIds: const {1, 2});
@@ -6038,7 +6038,7 @@ void main() {
     );
     final live = LiveSettings(stored);
     // One student, enrolled in school 2 and fully present in our Smartschool +
-    // Azure. The WISA schools carry no `MarkAsOurs` flag, so who is managed can
+    // Azure. A WISA snapshot carries no ownership (#286), so who is managed can
     // only come from the settings document — the #178 wiring, now live.
     final harness = ReconcileHarness(
       wisa: wisaSnap(
@@ -6423,6 +6423,90 @@ void main() {
   });
 
   testWidgets(
+      'a settings document carrying the retired MarkAsOurs rule still loads, '
+      'and the dead rule is gone from the view and the next save (#286)',
+      (WidgetTester tester) async {
+    // `MarkAsOurs` was a rule an operator could author and that then silently
+    // did nothing — ownership comes from the WISA-scholen list, which wins as
+    // soon as it holds one school. #286 deleted it. The shared settings document
+    // is what every operator and every older build writes into, so one that
+    // still carries the tag has to load rather than take the app down; the entry
+    // is ignored, and the rules that *do* something are untouched.
+    //
+    // The document can only be introduced as raw JSON now that the type is gone
+    // — which is exactly how it comes back from Cosmos.
+    useTallWindow(tester);
+    final stored = AppSettings.fromJson(<String, dynamic>{
+      'wisaRules': <dynamic>[
+        <String, dynamic>{'type': 'markAsOurs', 'schoolCode': 'ISMAA'},
+        <String, dynamic>{'type': 'dontImportClass', 'className': '3C'},
+      ],
+    }).copyWith(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9, 1)),
+      ),
+    );
+    final live = LiveSettings(stored);
+    final wire = RecordingWisaSoap();
+    final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+    final settings = SettingsHarness(initial: stored, liveSettings: live);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // The production WISA pull runs on the document as stored: the surviving
+    // rule still prunes 3C, and the retired one changes nothing (as it never
+    // did).
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining(
+        'WISA opgehaald: 1 leerling(en), 0 personeelsleden, 0 klassen.',
+      ),
+      findsOneWidget,
+    );
+
+    // Instellingen → Wisa lists the live rule and nothing about "beheerd" —
+    // there is no rule kind left to render, and no dead row to puzzle over.
+    await tester.tap(find.text('Instellingen'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    expect(find.text('Klas niet importeren uit WISA: 3C'), findsOneWidget);
+    expect(find.textContaining('Markeer als beheerd'), findsNothing);
+    // Toevoegen cannot author one either.
+    await tester
+        .ensureVisible(find.byKey(const ValueKey('settings-wisa-rule-add')));
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-add')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('settings-wisa-rule-add-markAsOurs')),
+        findsNothing);
+    await tester.tapAt(const Offset(5, 5));
+    await tester.pumpAndSettle();
+
+    // Saving rewrites the document without it, so the next operator to open it
+    // never sees the dead entry again.
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    final saved = await settings.store.load();
+    expect(saved.wisaRules.single, isA<DontImportClass>());
+    expect(
+      (saved.toJson()['wisaRules'] as List<dynamic>)
+          .map((dynamic r) => (r as Map<String, dynamic>)['type']),
+      <String>['dontImportClass'],
+    );
+  });
+
+  testWidgets(
       'a DontImportFromWisa apply writes its rule to the shared settings '
       'document, where it outlives the session and is removable (#276)',
       (WidgetTester tester) async {
@@ -6736,7 +6820,7 @@ void main() {
     final harness = ReconcileHarness(
       wisa: wisaSnap(
         students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
-        schools: [wisaSchool(1, ours: true)],
+        schools: [wisaSchool(1)],
       ),
       smartschool: ssSnap(
         groups: [ssGroup('3C', code: '3C_ss')],
@@ -7237,7 +7321,7 @@ void main() {
     final harness = ReconcileHarness(
       wisa: wisaSnap(
         students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
-        schools: [wisaSchool(1, ours: true)],
+        schools: [wisaSchool(1)],
       ),
       smartschool: ssSnap(
         groups: [ssGroup('3C', code: '3C_ss')],
@@ -7810,7 +7894,7 @@ void main() {
     final harness = ReconcileHarness(
       wisa: wisaSnap(
         students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
-        schools: [wisaSchool(1, ours: true)],
+        schools: [wisaSchool(1)],
       ),
       smartschool: ssSnap(
         groups: [ssGroup('3C', code: '3C_ss')],

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:account_core/account_core.dart' show Address, Origin;
+import 'package:account_core/account_core.dart' show Address, GroupType, Origin;
 import 'package:account_manager/main.dart' as app;
 import 'package:account_manager/src/app.dart';
 import 'package:account_manager/src/auth/auth.dart';
@@ -34,6 +34,7 @@ import 'package:account_state/account_state.dart'
         SignalRSocketConnector,
         SignalRSubscriber,
         SignalRTransport,
+        SmartschoolClassTree,
         StaticSignalRTokenProvider,
         WisaConnection,
         WisaSchoolProfile,
@@ -6414,6 +6415,149 @@ void main() {
     await tester.pumpAndSettle();
     await openSettingsTab(tester, 'settings-tab-wisa');
     expect(find.text('Klas niet importeren uit WISA: 3C'), findsOneWidget);
+  });
+
+  testWidgets(
+      'a DontImportFromWisa apply writes its rule to the shared settings '
+      'document, where it outlives the session and is removable (#276)',
+      (WidgetTester tester) async {
+    // The reported bug, driven end-to-end over the *production* WISA pull. A
+    // `DontImportFromWisa` apply only ever grew the process-lifetime
+    // `WisaImportRules` holder, so the exclusion it earned did not merely
+    // evaporate on relaunch — it oscillated. The apply drops the class (or the
+    // retired staff member) from this run's snapshot, the Office 365 side keeps
+    // surfacing (#269) so the operator deletes it, and the next launch rebuilds
+    // the holder empty: WISA still reports the record, nothing exists
+    // downstream, and the app proposes creating it. The rule was also invisible
+    // in Instellingen, so it could neither be seen nor undone.
+    //
+    // Every step here is the operator's own — Klasgroepen → the class → *Negeer
+    // deze klas* → **Toepassen**, then Instellingen → **Herladen** → Wisa —
+    // and the reload is what stands in for the relaunch: it is the stored
+    // document coming back, which is all any other operator or session ever
+    // sees.
+    useTallWindow(tester);
+    final stored = AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9, 1)),
+      ),
+    );
+    final live = LiveSettings(stored);
+    final settings = SettingsHarness(initial: stored, liveSettings: live);
+    final harness = ReconcileHarness(
+      wisaTransport: RecordingWisaSoap(),
+      liveSettings: live,
+      settingsStore: settings.store,
+      // Smartschool holds only the root a new class would hang under, so WISA's
+      // `3C` is genuinely absent downstream and raises the #244 either/or.
+      smartschool: ssSnap(
+        groups: [
+          ssGroup(
+            'Leerlingen',
+            code: 'SCHOOL',
+            official: false,
+            type: GroupType.group,
+          ),
+        ],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+      ourSchoolIds: const {1},
+      classTree: const SmartschoolClassTree(path: 'SCHOOL'),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // A first Synchroniseer: the whole roster comes in, class 3C included.
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining(
+        'WISA opgehaald: 1 leerling(en), 0 personeelsleden, 1 klassen.',
+      ),
+      findsOneWidget,
+    );
+
+    // Klasgroepen offers the class as one either/or; the operator switches it
+    // to the opt-out.
+    await openKlasgroepen(tester);
+    final entry = find.byKey(const ValueKey('entry-group-3C'));
+    await tester.ensureVisible(entry);
+    await tester.tap(entry);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('alt-3C-DoNotImportFromWisa')));
+    await tester.pumpAndSettle();
+
+    // The confirmation says outright that this is permanent and shared — the
+    // operator's one chance to know a standing, group-wide decision is what the
+    // button commits them to.
+    await tester.ensureVisible(find.byKey(const ValueKey('entry-apply-3C')));
+    await tester.tap(find.byKey(const ValueKey('entry-apply-3C')));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining('bewaart 1 importregel blijvend voor iedereen'),
+      findsOneWidget,
+    );
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    // It landed on the settings document, on the wire shape #263's pull reads.
+    final saved = await settings.store.load();
+    expect(saved.wisaRules.single, isA<DontImportClass>());
+    expect((saved.wisaRules.single as DontImportClass).className, '3C');
+    expect(harness.controller.error, isNull);
+
+    // The apply re-pulled WISA with the rule itself, so **Controleer op drift**
+    // must not now refuse over the document that apply just wrote (#238).
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('reconcile-drift-blocked')), findsNothing);
+
+    // The operator reads the rule back off the *stored* document — what a
+    // relaunch, and every other operator, gets.
+    await tester.tap(find.text('Instellingen'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-reload')));
+    await tester.tap(find.byKey(const ValueKey('settings-reload')));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    expect(find.text('Klas niet importeren uit WISA: 3C'), findsOneWidget);
+
+    // …and that document still prunes the pull it is read for.
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining(
+        'WISA opgehaald: 1 leerling(en), 0 personeelsleden, 0 klassen.',
+      ),
+      findsWidgets,
+    );
+
+    // A rule applied in error is undone where every other rule is: the #273
+    // editor, which now owns this one too.
+    await tester.tap(find.text('Instellingen'));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    final remove = find.byKey(const ValueKey('settings-wisa-rule-0-remove'));
+    await tester.ensureVisible(remove);
+    await tester.tap(remove);
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    expect((await settings.store.load()).wisaRules, isEmpty);
   });
 
   testWidgets(

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -46,7 +46,12 @@ import 'package:azure_api/azure_api.dart'
 import 'package:smartschool_api/smartschool_api.dart'
     show DiscardSmartschoolGroup, SmartschoolConnector;
 import 'package:wisa_api/wisa_api.dart'
-    show DontImportClass, WisaImportRule, WisaSchool, parseSchoolRow;
+    show
+        DontImportClass,
+        DontImportUserFromWisa,
+        WisaImportRule,
+        WisaSchool,
+        parseSchoolRow;
 import 'package:flutter/gestures.dart' show PointerDeviceKind, kSecondaryButton;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -6558,6 +6563,148 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('settings-save')));
     await tester.pumpAndSettle();
     expect((await settings.store.load()).wisaRules, isEmpty);
+  });
+
+  testWidgets(
+      'a persisted WISA import rule says who added it, when, and for whom '
+      '(#285)', (WidgetTester tester) async {
+    // The settings document is shared across operators on purpose (#276), and
+    // that only works if a rule somebody else added last month is legible to
+    // whoever opens the panel next. A `DontImportUserFromWisa` stores a bare
+    // WISA code and a `DontImportClass` a bare class name, so a colleague's rule
+    // used to appear as a string with no indication of who added it, when, or
+    // which human it refers to — mechanically removable (#273), but with no way
+    // to tell what you would be undoing. Worse, the people these rules are about
+    // eventually disappear from WISA entirely, so resolving the code against the
+    // current roster for display would give a blank exactly when the name is
+    // needed most.
+    //
+    // Driven end-to-end because the payoff is a rendering: the three fields have
+    // to survive an apply, a store round-trip, a **Herladen**, and the real
+    // Instellingen layout — and the same columns have to serve a rule that
+    // predates #285, which must read "onbekend" rather than blank.
+    useTallWindow(tester);
+    final stored = AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9, 1)),
+      ),
+      // A rule from before #285: on the document, with no provenance at all.
+      // It matches no staff member in the fixture, so it changes no pull.
+      wisaRules: const <WisaImportRule>[DontImportUserFromWisa('OUD')],
+    );
+    final live = LiveSettings(stored);
+    final settings = SettingsHarness(
+      initial: stored,
+      liveSettings: live,
+      operatorName: 'operator@school.example',
+    );
+    final harness = ReconcileHarness(
+      wisaTransport: RecordingWisaSoap(),
+      liveSettings: live,
+      settingsStore: settings.store,
+      smartschool: ssSnap(
+        groups: [
+          ssGroup(
+            'Leerlingen',
+            code: 'SCHOOL',
+            official: false,
+            type: GroupType.group,
+          ),
+        ],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+      ourSchoolIds: const {1},
+      classTree: const SmartschoolClassTree(path: 'SCHOOL'),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // The operator opts class 3C out of the import — the apply that earns a rule.
+    await openKlasgroepen(tester);
+    final entry = find.byKey(const ValueKey('entry-group-3C'));
+    await tester.ensureVisible(entry);
+    await tester.tap(entry);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('alt-3C-DoNotImportFromWisa')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('entry-apply-3C')));
+    await tester.tap(find.byKey(const ValueKey('entry-apply-3C')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // Read it back off the *stored* document — what a relaunch, and every other
+    // operator, gets.
+    await tester.tap(find.text('Instellingen'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-reload')));
+    await tester.tap(find.byKey(const ValueKey('settings-reload')));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-wisa');
+
+    String cell(int index, String field) => tester
+        .widget<Text>(find.byKey(ValueKey('settings-wisa-rule-$index-$field')))
+        .data!;
+
+    // The columns are named, with the timestamp getting one of its own rather
+    // than hiding in a tooltip: with no free-text reason on the record, *when*
+    // is what lets someone reconstruct the context later.
+    expect(
+      find.byKey(const ValueKey('settings-wisa-rules-header')),
+      findsOneWidget,
+    );
+    expect(find.text('Toegevoegd op'), findsOneWidget);
+
+    // Rule 1 is the one the apply just earned: the class it was about, the
+    // instant, and the operator who decided it.
+    expect(find.text('Klas niet importeren uit WISA: 3C'), findsOneWidget);
+    expect(cell(1, 'subject'), '3C');
+    expect(cell(1, 'added-by'), 'operator@school.example');
+    expect(cell(1, 'added-at'), contains('${DateTime.now().year}'));
+
+    // Rule 0 predates #285 and says so, in all three columns. A blank would read
+    // like nobody did it; "onbekend" says the record is missing.
+    expect(cell(0, 'subject'), 'onbekend');
+    expect(cell(0, 'added-at'), 'onbekend');
+    expect(cell(0, 'added-by'), 'onbekend');
+
+    // A rule typed by hand in #273's editor is stamped the same way. The name is
+    // the one field this surface cannot know — it holds no WISA snapshot to
+    // resolve a code against — so it records nothing rather than guessing.
+    await addWisaRule(tester, 'dontImportClass', <String>['OKAN']);
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    expect(cell(2, 'added-by'), 'operator@school.example');
+    expect(cell(2, 'added-at'), contains('${DateTime.now().year}'));
+    expect(cell(2, 'subject'), 'onbekend');
+
+    // …and all of it is on the shared document, not just on this screen.
+    final saved = await settings.store.load();
+    final earned = saved.provenanceOf(const DontImportClass('3C'))!;
+    expect(earned.subject, '3C');
+    expect(earned.addedBy, 'operator@school.example');
+    expect(earned.addedAt, isNotNull);
+    expect(saved.provenanceOf(const DontImportUserFromWisa('OUD')), isNull);
+    expect(
+      saved.provenanceOf(const DontImportClass('OKAN'))!.addedBy,
+      'operator@school.example',
+    );
   });
 
   testWidgets(

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -6507,6 +6507,120 @@ void main() {
   });
 
   testWidgets(
+      'a settings document carrying the retired MarkAsVirtual rule migrates its '
+      'mark to the WISA-scholen grid, and the virtuele werkdatum still reaches '
+      'the pull (#277)', (WidgetTester tester) async {
+    // The risk this issue names: the mark is live configuration, and losing it
+    // is seasonally invisible — the school simply pulls with the ordinary
+    // werkdatum and fails to produce next year's students months later. So the
+    // proof runs end-to-end over the *production* WISA pull: the migrated mark
+    // has to put the virtuele werkdatum on the wire for that school, show up as
+    // the grid's own (unlocked) checkbox, and survive the next save with no rule
+    // left behind.
+    //
+    // The document can only be introduced as raw JSON now that the type is gone
+    // — which is exactly how it comes back from Cosmos.
+    useTallWindow(tester);
+    final stored = AppSettings.fromJson(<String, dynamic>{
+      'wisaRules': <dynamic>[
+        <String, dynamic>{'type': 'markAsVirtual', 'schoolCode': 'V'},
+        <String, dynamic>{'type': 'dontImportClass', 'className': 'OKAN'},
+      ],
+      'wisaSchools': <dynamic>[
+        const WisaSchoolProfile(schoolId: 1, code: 'S1', name: 'School 1')
+            .toJson(),
+        const WisaSchoolProfile(
+          schoolId: 99,
+          code: 'V',
+          name: 'Virtuele school',
+          ours: true,
+        ).toJson(),
+      ],
+    }).copyWith(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9, 1)),
+        virtualWorkDate:
+            WorkDateSetting(isNow: false, date: DateTime(2025, 10, 1)),
+      ),
+    );
+    final live = LiveSettings(stored);
+    final wire = RecordingWisaSoap(schools: const <(int, String, String)>[
+      (1, 'School 1', 'S1'),
+      (99, 'Virtuele school', 'V'),
+    ]);
+    final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+    final settings = SettingsHarness(initial: stored, liveSettings: live);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      settingsBootstrap: settings.bootstrap,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // The capability is untouched: school 99 still went out on the virtuele
+    // werkdatum, the ordinary school on the ordinary one — and the Log panel
+    // names both, exactly as it did while the rule existed.
+    expect(wire.werkdatums, <String>['01/09/2025', '01/10/2025']);
+    expect(
+      find.textContaining(
+        'WISA ophalen met werkdatum 01/09/2025; virtuele werkdatum '
+        '01/10/2025 voor V.',
+      ),
+      findsOneWidget,
+    );
+
+    // Instellingen → Wisa: the mark now lives on the grid's own checkbox, and
+    // that checkbox is editable — the #273 lock existed only because a rule
+    // could contradict it.
+    await tester.tap(find.text('Instellingen'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsScreen), findsOneWidget);
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    final virtualBox =
+        find.byKey(const ValueKey('settings-wisa-school-99-virtual'));
+    await tester.ensureVisible(virtualBox);
+    await tester.pumpAndSettle();
+    expect(tester.widget<CheckboxListTile>(virtualBox).value, isTrue);
+    expect(tester.widget<CheckboxListTile>(virtualBox).onChanged, isNotNull);
+    expect(find.text('virtueel (importregel)'), findsNothing);
+
+    // The rules list keeps the rule that does something and says nothing about
+    // virtueel; Toevoegen cannot author one either.
+    expect(find.text('Klas niet importeren uit WISA: OKAN'), findsOneWidget);
+    expect(find.textContaining('Markeer als virtueel'), findsNothing);
+    await tester
+        .ensureVisible(find.byKey(const ValueKey('settings-wisa-rule-add')));
+    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-add')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('settings-wisa-rule-add-markAsVirtual')),
+        findsNothing);
+    await tester.tapAt(const Offset(5, 5));
+    await tester.pumpAndSettle();
+
+    // Saving writes the mark where the grid keeps it and drops the rule for
+    // good, so the migration runs once and the next operator sees one surface.
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-save')));
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    final saved = await settings.store.load();
+    expect(saved.virtualWisaSchoolIds, <int>{99});
+    expect(saved.wisaRules.single, isA<DontImportClass>());
+    expect(
+      (saved.toJson()['wisaRules'] as List<dynamic>)
+          .map((dynamic r) => (r as Map<String, dynamic>)['type']),
+      <String>['dontImportClass'],
+    );
+  });
+
+  testWidgets(
       'a DontImportFromWisa apply writes its rule to the shared settings '
       'document, where it outlives the session and is removable (#276)',
       (WidgetTester tester) async {

--- a/account_manager/lib/src/format/timestamps.dart
+++ b/account_manager/lib/src/format/timestamps.dart
@@ -40,3 +40,25 @@ String formatFreshnessStamp(DateTime at, {DateTime? now}) {
   final String date = t.year == n.year ? dm : '$dm/${t.year}';
   return '$date $hhmm';
 }
+
+/// Renders [at] as the stamp on a **standing decision** — when a persisted
+/// import rule was added (#285).
+///
+/// Absolute and complete, unlike [formatFreshnessStamp], because the two stamps
+/// answer different questions. A freshness stamp is read minutes after the event
+/// and optimizes for the common "today" case; a rule's stamp is read months or
+/// years later by whoever inherited the configuration, and with no free-text
+/// reason on the record the date is what lets them reconstruct the context
+/// ("that was the June retirement round"). "gisteren", or a date whose year is
+/// only implied, would be worth nothing by then — so the year is always there.
+///
+/// Converted to local time: the document stores UTC, and operators read their
+/// own clock.
+String formatRuleStamp(DateTime at) {
+  final DateTime t = at.toLocal();
+  return '${t.day.toString().padLeft(2, '0')}/'
+      '${t.month.toString().padLeft(2, '0')}/'
+      '${t.year} '
+      '${t.hour.toString().padLeft(2, '0')}:'
+      '${t.minute.toString().padLeft(2, '0')}';
+}

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -651,9 +651,9 @@ String smartschoolSiteFrom(String uri) {
 /// document holds what the operator persisted, and only reading both at call
 /// time lets either move under a running session.
 ///
-/// Schools are re-read per sync so a WISA-side school change is picked up;
-/// `MarkAsVirtual` rules and the operator's virtual marks are applied to them
-/// before the row pulls, the other rules at snapshot construction.
+/// Schools are re-read per sync so a WISA-side school change is picked up; the
+/// operator's virtual marks are stamped onto them before the row pulls (no rule
+/// touches a school since #277), the rest at snapshot construction.
 ///
 /// Because this is the one place a pass's work dates are resolved, it is also
 /// the one place that can say what they were: [log] gets a single
@@ -672,10 +672,7 @@ Syncer<wapi.WisaSnapshot> wisaSyncer(
       final current = settings.current;
       final importRules = rules.unionWith(current.wisaRules);
       final schools = markVirtualSchools(
-        wapi.WisaConnector.applySchoolRules(
-          await connector.loadSchools(),
-          importRules,
-        ),
+        await connector.loadSchools(),
         current.virtualWisaSchoolIds,
       );
       final at = clock();
@@ -740,24 +737,26 @@ String _schoolLabel(wapi.WisaSchool school) {
 /// Flags the operator's virtual WISA schools on a freshly loaded school list.
 ///
 /// The virtual marks live in the settings document keyed by school **id**
-/// ([AppSettings.virtualWisaSchoolIds], #203), while the snapshot-time
-/// `MarkAsVirtual` import rule matches by school **code**. Setting
-/// `WisaSchool.isVirtual` straight from settings is the same move ownership
-/// made: the operator-editable record is authoritative and no rule has to be
-/// synthesised for it — which for ownership went all the way, the rule being
-/// deleted outright in #286.
+/// ([AppSettings.virtualWisaSchoolIds], #203), and since #277 this is the only
+/// thing that ever sets `WisaSchool.isVirtual`: the snapshot-time `MarkAsVirtual`
+/// import rule matched by school **code** and fed the same flag, so the pull had
+/// to union two surfaces that could disagree. Ownership made the same move one
+/// issue earlier (#286) — the operator-editable record is authoritative and no
+/// rule has to be synthesised for it.
 ///
-/// The pass is additive — a school the rules already flagged stays flagged even
-/// when it is not in [virtualIds] — so wiring settings in can never silently
-/// un-virtualise a school an existing `MarkAsVirtual` rule covers. Returns a new
-/// list; the input is not mutated.
+/// [virtualIds] is therefore the whole answer, and this pass *sets* the flag
+/// rather than only adding to it: a school outside the set pulls with the
+/// ordinary werkdatum, full stop. Until #277 it was deliberately additive, so
+/// that wiring the grid in could not silently un-virtualise a school a rule
+/// covered; with no rule left to defer to, that additive step could only keep a
+/// stale flag alive against what the grid says. Returns a new list; the input is
+/// not mutated.
 List<wapi.WisaSchool> markVirtualSchools(
   Iterable<wapi.WisaSchool> schools,
   Set<int> virtualIds,
 ) =>
     <wapi.WisaSchool>[
-      for (final s in schools)
-        virtualIds.contains(s.id) ? s.copyWith(isVirtual: true) : s,
+      for (final s in schools) s.copyWith(isVirtual: virtualIds.contains(s.id)),
     ];
 
 String _firstNonEmpty(String preferred, String fallback) =>

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -393,14 +393,14 @@ Future<ReconcileServices> bootstrapReconcile({
 
   // The operator's managed-school set from Settings, shared by the linker
   // (#178) and by the Azure back-fill below (#224) so both scope to the same
-  // schools. Null when no school is flagged, so a not-yet-configured group
-  // falls back to the snapshot's own `MarkAsOurs` flags.
+  // schools. Empty when no school is flagged, which every reader treats as
+  // "ownership unconfigured" and counts every school.
   //
   // Read from the live document at every use (#246) — flipping a school's
   // **beheerd** mark in Instellingen must reach the next relink, not the next
   // launch. Both readers below call this, so the linker and the Azure back-fill
   // can never end up scoping to different school sets.
-  Set<int>? ourSchoolIdsNow() => managedSchoolIdsOf(live.current);
+  Set<int> ourSchoolIdsNow() => managedSchoolIdsOf(live.current);
 
   // Assigned immediately below; the Azure syncer closes over it so it can read
   // the WISA snapshot *this* pass just pulled (WISA always syncs first).
@@ -587,17 +587,22 @@ Future<ReconcileServices> bootstrapReconcile({
 }
 
 /// The WISA school ids the operator manages, as the linker and the Azure
-/// back-fill both want them: the `ours`-flagged ids of [settings], or `null`
-/// when the operator has curated no school at all.
+/// back-fill both want them: the `ours`-flagged ids of the WISA-scholen grid in
+/// Instellingen (#178/#246).
 ///
-/// The null is load-bearing and is why this is a named function rather than an
-/// inline read (#178/#246). An **empty set** means "ownership is configured and
-/// nothing is ours"; `null` means "not configured", which makes `link()` and
-/// [PlacementResolver] fall back to the snapshot's own `MarkAsOurs` flags. A
-/// group that has never filled the WISA-scholen grid in must get the second, not
-/// the first.
-Set<int>? managedSchoolIdsOf(AppSettings settings) =>
-    settings.wisaSchools.isEmpty ? null : settings.managedWisaSchoolIds;
+/// This is the whole of ownership since #286. It used to answer `null` for an
+/// install whose grid was empty, so `link()` and [PlacementResolver] would fall
+/// back to the snapshot's own `MarkAsOurs` flags — a fallback no install ever
+/// reached once **Scholen ophalen** had been pressed, and which the rule that
+/// fed it has now been deleted with.
+///
+/// An **empty** set is therefore the answer for a not-yet-configured install,
+/// and it is the right one: every reader treats an empty managed set as
+/// "ownership unconfigured" and counts every school, never as "no school is
+/// ours". It stays a named function so both readers below share one definition
+/// and can never scope to different school sets.
+Set<int> managedSchoolIdsOf(AppSettings settings) =>
+    settings.managedWisaSchoolIds;
 
 /// The Smartschool class-tree live-config, derived from the persisted
 /// connection profile: the year or grade group codes (whichever the school
@@ -736,10 +741,11 @@ String _schoolLabel(wapi.WisaSchool school) {
 ///
 /// The virtual marks live in the settings document keyed by school **id**
 /// ([AppSettings.virtualWisaSchoolIds], #203), while the snapshot-time
-/// `MarkAsVirtual` import rule matches by school **name**. Setting
-/// `WisaSchool.isVirtual` straight from settings mirrors how `ourSchoolIds`
-/// bypasses `MarkAsOurs`: the operator-editable record is authoritative and no
-/// rule has to be synthesised for it.
+/// `MarkAsVirtual` import rule matches by school **code**. Setting
+/// `WisaSchool.isVirtual` straight from settings is the same move ownership
+/// made: the operator-editable record is authoritative and no rule has to be
+/// synthesised for it — which for ownership went all the way, the rule being
+/// deleted outright in #286.
 ///
 /// The pass is additive — a school the rules already flagged stays flagged even
 /// when it is not in [virtualIds] — so wiring settings in can never silently

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:smartschool_api/smartschool_api.dart' as ss;
 import 'package:wisa_api/wisa_api.dart' as wapi;
 
+import '../settings/wisa_rule_labels.dart';
 import 'log_buffer.dart';
 
 /// What the reconcile screen is doing right now.
@@ -2117,6 +2118,10 @@ class ReconcileController extends ChangeNotifier {
     final options =
         dry ? actions.ApplyOptions.dry : const actions.ApplyOptions();
     final results = <ActionOutcomeEntry>[];
+    // The WISA import rules this pass earned (#276). Collected across the whole
+    // pass and written once at the end rather than per action, so blacklisting
+    // thirty departed teachers is one settings write, not thirty.
+    final earnedRules = <wapi.WisaImportRule>[];
     // "Dry-run" is the term the Acties buttons already use ("Dry-run alles"),
     // so it stays; its counterpart is the "Alles toepassen" of those same
     // buttons rather than a second word for the same thing.
@@ -2144,6 +2149,7 @@ class ReconcileController extends ChangeNotifier {
         results.addAll(await _applyOne(
           () => _applyAny(option.action, options),
           option,
+          earnedRules,
         ));
         // Advance once per action so a long apply/dry-run pass reads as busy
         // and visibly progressing rather than a motionless bar (#176).
@@ -2162,6 +2168,7 @@ class ReconcileController extends ChangeNotifier {
       } else {
         _applyResults = results;
         _dryRunResults = null;
+        await _persistEarnedWisaRules(earnedRules);
         await _shareApplied(_refreshRollups(), touched);
       }
       _applyStep = null;
@@ -2175,7 +2182,9 @@ class ReconcileController extends ChangeNotifier {
         _applyResults = results;
         // A pass that broke halfway still wrote whatever it got through, so the
         // overview owes the operator those counts too (#236) — and so do the
-        // other operators (#254).
+        // other operators (#254). The rules it earned before it broke are just
+        // as real, and just as permanent (#276).
+        await _persistEarnedWisaRules(earnedRules);
         await _shareApplied(_refreshRollups(), touched);
       }
       // Nothing is in flight any more, however the pass ended (#243).
@@ -2204,15 +2213,27 @@ class ReconcileController extends ChangeNotifier {
   /// relinked record — and the operator's one click therefore made two writes.
   /// Both are logged and both land in the results list; hiding the second would
   /// under-report what the app just did.
+  ///
+  /// Every WISA import rule a real write earned is appended to [earnedRules] on
+  /// the way past, for the pass to persist when it ends (#276) — the follow-ups
+  /// included, since a chained write is as much this click's doing as the option
+  /// the operator picked.
   Future<List<ActionOutcomeEntry>> _applyOne(
     Future<ApplyResult> Function() run,
     PendingActionOption option,
+    List<wapi.WisaImportRule> earnedRules,
   ) async {
     final changes = option.changes;
     try {
       final applied = await run();
       if (applied.refreshed) _linked = applied.linked;
       final result = applied.result;
+      for (final r in <actions.ActionResult>[result, ...applied.followUps]) {
+        final rule = r.wisaRule;
+        // A dry run projects the rule without earning it, and a failed action
+        // earned nothing at all — neither may reach the shared document.
+        if (rule != null && r.wrote) earnedRules.add(rule);
+      }
       return <ActionOutcomeEntry>[
         _record(option, changes, result),
         // A chained follow-up is a write the same click performed on the same
@@ -2686,6 +2707,75 @@ class ReconcileController extends ChangeNotifier {
       log.addError(
         core.Origin.wisa,
         'Kon de WISA-schoolnamen niet bijwerken in de instellingen: $e',
+      );
+    }
+  }
+
+  /// Writes the WISA import rules this apply pass earned to the shared settings
+  /// document (#276), so the exclusion outlives the session that decided it.
+  ///
+  /// Until this, a `DontImportFromWisa` apply only grew the process-lifetime
+  /// `WisaImportRules` holder, and that made the rule oscillate rather than
+  /// merely evaporate: the apply drops the person from this run's snapshot,
+  /// their Azure account keeps surfacing (#269) so the operator deletes it, and
+  /// the next launch rebuilds the holder empty — WISA still reports the person
+  /// active, no Azure account exists any more, and the linker proposes creating
+  /// them. Persisting the rule is what breaks that loop, and it is the same
+  /// document #263 reads at pull time and #273 edits, so the rule is visible and
+  /// removable in Instellingen → Wisa with no extra UI.
+  ///
+  /// The document is re-read immediately before the write, exactly as
+  /// [_backfillSchoolProfiles] does, so a change another operator saved during
+  /// this pass is not clobbered by this session's copy; nothing is written when
+  /// every earned rule is already on it.
+  ///
+  /// **The drift gate stays honest.** `wisaPullFingerprint` covers the persisted
+  /// rules (#238), so this write would otherwise arm it — falsely, because the
+  /// applier re-pulled WISA *with* these rules the moment each was earned, and
+  /// the snapshot in hand already reflects them. So the pull is re-credited to
+  /// the document it now matches, but only when the gate was closed to begin
+  /// with and the saved document differs from the one in hand by nothing but
+  /// these rules. Anything else another operator slipped in — a werkdatum, a
+  /// virtual-school mark — arms the gate as it should.
+  ///
+  /// A failing settings store must never fail the pass: the writes it performed
+  /// are done and reported, so the problem is logged and the operator can
+  /// re-apply (or type the rule in Instellingen) rather than lose the results.
+  Future<void> _persistEarnedWisaRules(
+    List<wapi.WisaImportRule> earned,
+  ) async {
+    final store = settingsStore;
+    if (store == null || earned.isEmpty) return;
+    final live = liveSettings;
+    // Sampled before the write: whether the WISA snapshot in hand is credited
+    // to the document this session holds, and what that document plus these
+    // rules would fingerprint as.
+    final held = live?.current;
+    final inSync = _wisaFingerprint() == _wisaPullFingerprint;
+    try {
+      final stored = await store.load();
+      final merged = mergeEarnedWisaRules(stored: stored, earned: earned);
+      if (merged == null) return;
+      await store.save(merged.settings);
+      live?.publish(merged.settings);
+      if (inSync && held != null) {
+        final credited = wisaPullFingerprint(
+          mergeEarnedWisaRules(stored: held, earned: earned)?.settings ?? held,
+        );
+        if (credited == _wisaFingerprint()) _stampWisaPull(credited);
+      }
+      for (final rule in merged.added) {
+        log.addMessage(
+          core.Origin.wisa,
+          'Importregel bewaard voor iedereen: ${describeWisaRule(rule)}. '
+          'Dit blijft gelden tot de regel in Instellingen → Wisa verwijderd '
+          'wordt.',
+        );
+      }
+    } on Object catch (e) {
+      log.addError(
+        core.Origin.wisa,
+        'Kon de WISA-importregel(s) niet opslaan in de instellingen: $e',
       );
     }
   }

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -2121,7 +2121,7 @@ class ReconcileController extends ChangeNotifier {
     // The WISA import rules this pass earned (#276). Collected across the whole
     // pass and written once at the end rather than per action, so blacklisting
     // thirty departed teachers is one settings write, not thirty.
-    final earnedRules = <wapi.WisaImportRule>[];
+    final earnedRules = <EarnedWisaRule>[];
     // "Dry-run" is the term the Acties buttons already use ("Dry-run alles"),
     // so it stays; its counterpart is the "Alles toepassen" of those same
     // buttons rather than a second word for the same thing.
@@ -2218,10 +2218,16 @@ class ReconcileController extends ChangeNotifier {
   /// the way past, for the pass to persist when it ends (#276) — the follow-ups
   /// included, since a chained write is as much this click's doing as the option
   /// the operator picked.
+  ///
+  /// Each rule is carried with [PendingActionOption.target] as its subject
+  /// (#285): the label this option is acting on *is* the name of the person or
+  /// class the rule is about, and here is the only moment the app still has it —
+  /// the rule itself keeps nothing but an opaque WISA code, and the staff these
+  /// rules concern are the ones who later disappear from WISA entirely.
   Future<List<ActionOutcomeEntry>> _applyOne(
     Future<ApplyResult> Function() run,
     PendingActionOption option,
-    List<wapi.WisaImportRule> earnedRules,
+    List<EarnedWisaRule> earnedRules,
   ) async {
     final changes = option.changes;
     try {
@@ -2232,7 +2238,9 @@ class ReconcileController extends ChangeNotifier {
         final rule = r.wisaRule;
         // A dry run projects the rule without earning it, and a failed action
         // earned nothing at all — neither may reach the shared document.
-        if (rule != null && r.wrote) earnedRules.add(rule);
+        if (rule != null && r.wrote) {
+          earnedRules.add(EarnedWisaRule(rule, subject: option.target));
+        }
       }
       return <ActionOutcomeEntry>[
         _record(option, changes, result),
@@ -2738,15 +2746,25 @@ class ReconcileController extends ChangeNotifier {
   /// these rules. Anything else another operator slipped in — a werkdatum, a
   /// virtual-school mark — arms the gate as it should.
   ///
+  /// **Each rule is stamped with its provenance** (#285): the operator running
+  /// the pass, the instant it ended, and the name of the record it was earned
+  /// about. The shared document is only legible if a rule someone else added
+  /// last month says who to ask about it — and a rule that collapses into one
+  /// the document already carries keeps the *first* operator's stamp, because
+  /// that is the decision the document has been standing on.
+  ///
   /// A failing settings store must never fail the pass: the writes it performed
   /// are done and reported, so the problem is logged and the operator can
   /// re-apply (or type the rule in Instellingen) rather than lose the results.
   Future<void> _persistEarnedWisaRules(
-    List<wapi.WisaImportRule> earned,
+    List<EarnedWisaRule> earned,
   ) async {
     final store = settingsStore;
     if (store == null || earned.isEmpty) return;
     final live = liveSettings;
+    // One instant for the whole pass, sampled once: thirty rules earned by one
+    // click are one decision and read as one.
+    final addedAt = _now();
     // Sampled before the write: whether the WISA snapshot in hand is credited
     // to the document this session holds, and what that document plus these
     // rules would fingerprint as.
@@ -2754,11 +2772,19 @@ class ReconcileController extends ChangeNotifier {
     final inSync = _wisaFingerprint() == _wisaPullFingerprint;
     try {
       final stored = await store.load();
-      final merged = mergeEarnedWisaRules(stored: stored, earned: earned);
+      final merged = mergeEarnedWisaRules(
+        stored: stored,
+        earned: earned,
+        addedBy: syncedBy,
+        addedAt: addedAt,
+      );
       if (merged == null) return;
       await store.save(merged.settings);
       live?.publish(merged.settings);
       if (inSync && held != null) {
+        // Provenance is deliberately absent from the fingerprint — who typed a
+        // rule changes nothing about what WISA returns — so this re-credit is
+        // unaffected by the stamps just written.
         final credited = wisaPullFingerprint(
           mergeEarnedWisaRules(stored: held, earned: earned)?.settings ?? held,
         );

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -144,9 +144,14 @@ String _followUpCount(int n) => n == 1 ? '1 vervolgactie' : '$n vervolgacties';
 ///
 /// Three things it is careful about:
 /// - **WISA is never written.** The `DontImportFromWisa` family's `ChangeSet`
-///   carries `Origin.wisa`, but what it produces is a local import rule — the
+///   carries `Origin.wisa`, but what it produces is an import rule — the
 ///   connector is read-only. So those are counted as import rules and the
-///   sentence says outright that nothing is written to WISA.
+///   sentence says outright that nothing is written to WISA. Since #276 the
+///   rule lands on the *shared* settings document rather than dying with the
+///   session, so the sentence says that too: this is a standing decision every
+///   operator inherits, not a one-run one, and the operator must know that
+///   before pressing the button (undoing it means finding the rule in
+///   Instellingen → Wisa).
 /// - **Chained follow-ups are named, not counted.** A new student's Office 365
 ///   create writes Smartschool too (#230/#240). Whether the follow-up runs is
 ///   decided by its own `evaluate` after the first write, so it gets its own
@@ -161,7 +166,8 @@ String applyConfirmationMessage(ApplyScope scope) {
     if (writes.isNotEmpty)
       'schrijft ${_changeCount(writes.length)} naar ${_joinSystems(writes)}',
     if (rules > 0)
-      'legt ${_ruleCount(rules)} vast (er wordt niets naar WISA geschreven)',
+      'bewaart ${_ruleCount(rules)} blijvend voor iedereen (er wordt niets '
+          'naar WISA geschreven)',
   ];
   final what =
       clauses.isEmpty ? 'Dit schrijft niets.' : 'Dit ${clauses.join(' en ')}.';

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -115,6 +115,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
   // so authoring one here reaches the very next Synchroniseer.
   List<WisaImportRule> _wisaRules = const <WisaImportRule>[];
 
+  // Who added each of those rules, when, and for whom (#285), keyed by
+  // `wisaRuleKey` exactly as the document keys it. Edited alongside `_wisaRules`
+  // and pruned to them on save, so removing a rule takes its provenance with it
+  // rather than leaving a stamp that a later, unrelated rule with the same key
+  // would inherit.
+  Map<String, RuleProvenance> _wisaRuleProvenance =
+      const <String, RuleProvenance>{};
+
   // Azure profile.
   final _azClientId = TextEditingController();
   final _azTenantId = TextEditingController();
@@ -243,6 +251,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     }
     _ssRules = List<SmartschoolImportRule>.of(s.smartschoolRules);
     _wisaRules = List<WisaImportRule>.of(s.wisaRules);
+    _wisaRuleProvenance = Map<String, RuleProvenance>.of(s.wisaRuleProvenance);
 
     _azClientId.text = s.azure.clientId;
     _azTenantId.text = s.azure.tenantId;
@@ -326,12 +335,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _addWisaRule(_WisaRuleKind kind) async {
     final values = await _promptWisaRule(kind: kind);
     if (values == null || !mounted) return;
-    toggle(() => _wisaRules = <WisaImportRule>[..._wisaRules, kind(values)]);
+    final rule = kind(values);
+    toggle(() {
+      _wisaRules = <WisaImportRule>[..._wisaRules, rule];
+      _stampWisaRule(rule);
+    });
   }
 
   /// Re-prompts for the field(s) of the rule at [index], keeping its kind. Every
   /// kind is editable, including the two school-marking ones **Toevoegen** does
   /// not offer — a document that already carries one must stay correctable.
+  ///
+  /// The edited rule is re-stamped (#285): changing what a rule matches makes it
+  /// a different standing decision, and attributing it to whoever wrote the
+  /// *previous* one would be a lie about a record whose whole purpose is saying
+  /// who to ask.
   Future<void> _editWisaRule(int index) async {
     final rule = _wisaRules[index];
     final kind = _WisaRuleKind.of(rule);
@@ -340,16 +358,53 @@ class _SettingsScreenState extends State<SettingsScreen> {
       initial: _wisaRuleValues(rule),
     );
     if (values == null || !mounted) return;
+    final edited = kind(values);
     toggle(() {
-      _wisaRules = List<WisaImportRule>.of(_wisaRules)..[index] = kind(values);
+      _wisaRules = List<WisaImportRule>.of(_wisaRules)..[index] = edited;
+      _pruneWisaProvenance();
+      _stampWisaRule(edited);
     });
   }
 
-  /// Drops the WISA rule at [index] from the working list.
+  /// Drops the WISA rule at [index] from the working list, and its provenance
+  /// with it (#285).
   void _removeWisaRule(int index) {
     toggle(() {
       _wisaRules = List<WisaImportRule>.of(_wisaRules)..removeAt(index);
+      _pruneWisaProvenance();
     });
+  }
+
+  /// Records this session as the author of [rule] (#285).
+  ///
+  /// No subject: this view holds no WISA snapshot to resolve a code against —
+  /// the same reason #273's prompts are free text — so the name genuinely is
+  /// unknown here and is recorded as such rather than guessed from the code the
+  /// operator typed. The two fields that *are* known are the two the issue calls
+  /// load-bearing: who, and when.
+  void _stampWisaRule(WisaImportRule rule) {
+    _wisaRuleProvenance = <String, RuleProvenance>{
+      ..._wisaRuleProvenance,
+      wisaRuleKey(rule): RuleProvenance(
+        addedBy: _services?.operatorName ?? '',
+        addedAt: DateTime.now(),
+      ),
+    };
+  }
+
+  /// Drops every provenance entry no rule in the working list claims any more.
+  void _pruneWisaProvenance() {
+    _wisaRuleProvenance = _prunedWisaProvenance(_wisaRules);
+  }
+
+  Map<String, RuleProvenance> _prunedWisaProvenance(
+    List<WisaImportRule> rules,
+  ) {
+    return <String, RuleProvenance>{
+      for (final rule in rules)
+        if (_wisaRuleProvenance[wisaRuleKey(rule)] case final RuleProvenance p)
+          wisaRuleKey(rule): p,
+    };
   }
 
   /// Asks for the one or two values a WISA rule matches on. Returns the trimmed
@@ -480,6 +535,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ),
       smartschoolRules: List<SmartschoolImportRule>.of(_ssRules),
       wisaRules: List<WisaImportRule>.of(_wisaRules),
+      wisaRuleProvenance: _prunedWisaProvenance(_wisaRules),
       wisaSchools: List<WisaSchoolProfile>.of(_wisaSchools),
     );
   }
@@ -1193,15 +1249,29 @@ class _WisaRulesEditor extends StatelessWidget {
             key: const ValueKey('settings-wisa-rules-empty'),
             style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
           )
-        else
+        else ...<Widget>[
+          const _WisaRuleColumnHeader(),
           for (var i = 0; i < rules.length; i++)
             _RuleRow(
               keyPrefix: 'settings-wisa-rule',
               index: i,
               description: describeWisaRule(rules[i]),
+              // Who decided this, when, and about whom (#285). The document is
+              // shared, so without these a colleague's rule reads as a bare
+              // WISA code nobody dares remove.
+              subject: describeRuleSubject(
+                state._wisaRuleProvenance[wisaRuleKey(rules[i])],
+              ),
+              addedAt: describeRuleAddedAt(
+                state._wisaRuleProvenance[wisaRuleKey(rules[i])],
+              ),
+              addedBy: describeRuleAddedBy(
+                state._wisaRuleProvenance[wisaRuleKey(rules[i])],
+              ),
               onEdit: () => state._editWisaRule(i),
               onRemove: () => state._removeWisaRule(i),
             ),
+        ],
         const SizedBox(height: PlinkSpacing.s4),
         MenuAnchor(
           menuChildren: <Widget>[
@@ -1439,6 +1509,9 @@ class _RuleRow extends StatelessWidget {
     required this.description,
     required this.onEdit,
     required this.onRemove,
+    this.subject,
+    this.addedAt,
+    this.addedBy,
   });
 
   final String keyPrefix;
@@ -1447,20 +1520,61 @@ class _RuleRow extends StatelessWidget {
   final VoidCallback onEdit;
   final VoidCallback onRemove;
 
+  /// The three provenance cells (#285), already resolved to display strings —
+  /// `onbekend` where the document records nothing. All three are null for the
+  /// Smartschool list, which carries no provenance and renders as it always did.
+  final String? subject;
+  final String? addedAt;
+  final String? addedBy;
+
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final TextStyle? meta =
+        text.bodySmall?.copyWith(color: colors.onSurfaceVariant);
     return Padding(
       padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
           Expanded(
+            flex: _RuleColumns.rule,
             child: Text(
               description,
               key: ValueKey('$keyPrefix-$index'),
               style: text.bodyMedium,
             ),
           ),
+          if (subject != null) ...<Widget>[
+            const SizedBox(width: PlinkSpacing.s2),
+            Expanded(
+              flex: _RuleColumns.subject,
+              child: Text(
+                subject!,
+                key: ValueKey('$keyPrefix-$index-subject'),
+                style: meta,
+              ),
+            ),
+            const SizedBox(width: PlinkSpacing.s2),
+            Expanded(
+              flex: _RuleColumns.addedAt,
+              child: Text(
+                addedAt!,
+                key: ValueKey('$keyPrefix-$index-added-at'),
+                style: meta,
+              ),
+            ),
+            const SizedBox(width: PlinkSpacing.s2),
+            Expanded(
+              flex: _RuleColumns.addedBy,
+              child: Text(
+                addedBy!,
+                key: ValueKey('$keyPrefix-$index-added-by'),
+                style: meta,
+              ),
+            ),
+          ],
           IconButton(
             key: ValueKey('$keyPrefix-$index-edit'),
             tooltip: 'Bewerken',
@@ -1473,6 +1587,63 @@ class _RuleRow extends StatelessWidget {
             icon: const Icon(Icons.delete_outline),
             onPressed: onRemove,
           ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The flexes the WISA rule list and its header share, so the two stay in one
+/// grid rather than drifting apart the first time either is edited.
+abstract final class _RuleColumns {
+  static const int rule = 5;
+  static const int subject = 3;
+  static const int addedAt = 3;
+  static const int addedBy = 3;
+
+  /// The width of the two trailing icon buttons, which the header has to leave
+  /// empty to line its labels up with the cells beneath them.
+  static const double actions = 96;
+}
+
+/// Names the provenance columns of the WISA rule list (#285).
+///
+/// The timestamp gets a column of its own rather than a tooltip on purpose:
+/// with no free-text reason on the record, *when* is what lets someone
+/// reconstruct why ("that was the June retirement round"), so it has to be
+/// readable at a glance beside the rule instead of hidden behind a hover.
+class _WisaRuleColumnHeader extends StatelessWidget {
+  const _WisaRuleColumnHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final TextStyle? style = text.labelSmall?.copyWith(
+      color: colors.onSurfaceVariant,
+    );
+    return Padding(
+      key: const ValueKey('settings-wisa-rules-header'),
+      padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
+      child: Row(
+        children: <Widget>[
+          Expanded(flex: _RuleColumns.rule, child: Text('Regel', style: style)),
+          const SizedBox(width: PlinkSpacing.s2),
+          Expanded(
+            flex: _RuleColumns.subject,
+            child: Text('Voor', style: style),
+          ),
+          const SizedBox(width: PlinkSpacing.s2),
+          Expanded(
+            flex: _RuleColumns.addedAt,
+            child: Text('Toegevoegd op', style: style),
+          ),
+          const SizedBox(width: PlinkSpacing.s2),
+          Expanded(
+            flex: _RuleColumns.addedBy,
+            child: Text('Door', style: style),
+          ),
+          const SizedBox(width: _RuleColumns.actions),
         ],
       ),
     );

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:smartschool_api/smartschool_api.dart';
 import 'package:wisa_api/wisa_api.dart';
 
 import '../settings/settings_bootstrap.dart';
+import '../settings/wisa_rule_labels.dart';
 
 /// The Settings view (#106): edit the full [AppSettings] config document and
 /// write the two credentials (WISA password, Smartschool passphrase) through the
@@ -45,9 +46,12 @@ import '../settings/settings_bootstrap.dart';
 ///
 /// The WISA list shows the **persisted** rules — the operator's standing
 /// configuration, which is what a pull unions with whatever this session earned.
-/// A rule a `DontImportFromWisa` apply accumulates lives in the reconcile
-/// stack's `WisaImportRules` holder for the life of the process and is on no
-/// settings document, so it does not appear here (#273).
+/// Since #276 that includes the rules a `DontImportFromWisa` apply earns: the
+/// apply writes its rule to this same document, so it shows up in this list
+/// (after a **Herladen**, or in the next session) and is removed here like any
+/// hand-typed one. The reconcile stack's `WisaImportRules` holder still carries
+/// its own copy for the life of the process — that is what re-syncs WISA the
+/// instant the rule is earned — but the document is now the record.
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key, required this.bootstrap});
 
@@ -1046,18 +1050,6 @@ class _WorkDateField extends StatelessWidget {
   }
 }
 
-/// How one WISA import rule reads in the settings list.
-String _describeWisaRule(WisaImportRule rule) => switch (rule) {
-      DontImportClass(:final className) =>
-        'Klas niet importeren uit WISA: $className',
-      DontImportUserFromWisa(:final userCode) =>
-        'Gebruiker niet importeren uit WISA: $userCode',
-      ReplaceInstitute(:final original, :final replacement) =>
-        'Vervang instituut: $original → $replacement',
-      MarkAsVirtual(:final schoolCode) => 'Markeer als virtueel: $schoolCode',
-      MarkAsOurs(:final schoolCode) => 'Markeer als beheerd: $schoolCode',
-    };
-
 /// The value(s) a WISA rule matches on, in the field order [_WisaRuleKind]
 /// declares — what the edit prompt opens on. The sealed base type carries no
 /// shared field, so a switch over the five cases is where they meet.
@@ -1206,7 +1198,7 @@ class _WisaRulesEditor extends StatelessWidget {
             _RuleRow(
               keyPrefix: 'settings-wisa-rule',
               index: i,
-              description: _describeWisaRule(rules[i]),
+              description: describeWisaRule(rules[i]),
               onEdit: () => state._editWisaRule(i),
               onRemove: () => state._removeWisaRule(i),
             ),

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -36,14 +36,12 @@ import '../settings/wisa_rule_labels.dart';
 /// - **Smartschool** (#202): the two rules the legacy app offers
 ///   (`DiscardSmartschoolGroup`, `NoSmartschoolSubgroups`).
 /// - **WISA** (#273): the three rules with no other surface —
-///   `DontImportClass`, `DontImportUserFromWisa` and `ReplaceInstitute`. The
-///   school-marking `MarkAsVirtual` stays editable and removable but is *not*
-///   offered under **Toevoegen**: the WISA-scholen grid above already marks a
-///   school virtueel per school **id**, so a rule authored here would duplicate
-///   a control that is already there. Its `beheerd` counterpart went further and
-///   was deleted (#286) — the grid was authoritative for ownership, so the rule
-///   could be saved and then silently do nothing; a document that still carries
-///   one is ignored when it loads.
+///   `DontImportClass`, `DontImportUserFromWisa` and `ReplaceInstitute`. Neither
+///   school-marking rule is left: `MarkAsOurs` was deleted in #286 and
+///   `MarkAsVirtual` in #277, both because the WISA-scholen grid above marks the
+///   same flag per school **id** and two surfaces for one flag could disagree.
+///   A document that still carries either loads fine — the entry is ignored, and
+///   a `markAsVirtual` mark is carried over to the grid's own checkbox first.
 ///
 /// The WISA list shows the **persisted** rules — the operator's standing
 /// configuration, which is what a pull unions with whatever this session earned.
@@ -1109,7 +1107,7 @@ class _WorkDateField extends StatelessWidget {
 
 /// The value(s) a WISA rule matches on, in the field order [_WisaRuleKind]
 /// declares — what the edit prompt opens on. The sealed base type carries no
-/// shared field, so a switch over the four cases is where they meet.
+/// shared field, so a switch over the three cases is where they meet.
 List<String> _wisaRuleValues(WisaImportRule rule) => switch (rule) {
       DontImportClass(:final className) => <String>[className],
       DontImportUserFromWisa(:final userCode) => <String>[userCode],
@@ -1117,18 +1115,16 @@ List<String> _wisaRuleValues(WisaImportRule rule) => switch (rule) {
           original,
           replacement,
         ],
-      MarkAsVirtual(:final schoolCode) => <String>[schoolCode],
     };
 
-/// The four WISA import rules, with the Dutch labels and the field prompts the
+/// The three WISA import rules, with the Dutch labels and the field prompts the
 /// editor authors them through (#273). Calling a kind builds its rule from the
 /// values the prompt collected, in [fields] order.
 ///
-/// [authorable] is what **Toevoegen** offers. `MarkAsVirtual` is deliberately
-/// not on that menu: the WISA-scholen grid above already marks a school virtueel
-/// per school **id**, so a rule authored here would duplicate it. It stays
-/// editable and removable, so a document that already carries one can be
-/// corrected or cleaned up.
+/// Every kind is on the **Toevoegen** menu. The two that were not — the
+/// school-marking `MarkAsVirtual` and `MarkAsOurs`, which duplicated the
+/// WISA-scholen grid above — are gone from the rule hierarchy entirely (#277,
+/// #286), so the grid is the only place either flag is set.
 enum _WisaRuleKind {
   dontImportClass(
     label: 'Klas niet importeren',
@@ -1148,14 +1144,6 @@ enum _WisaRuleKind {
         'ze bij het tweede horen.',
     fields: <String>['Oude instituutcode', 'Nieuwe instituutcode'],
     hints: <String>['Code zoals WISA ze levert', 'Code zoals wij ze willen'],
-  ),
-  markAsVirtual(
-    label: 'Markeer als virtueel',
-    explanation: 'De school met deze code wordt met de virtuele werkdatum '
-        'opgehaald.',
-    fields: <String>['Schoolcode'],
-    hints: <String>['De korte WISA-code van de school'],
-    authorable: false,
   );
 
   const _WisaRuleKind({
@@ -1163,7 +1151,6 @@ enum _WisaRuleKind {
     required this.explanation,
     required this.fields,
     required this.hints,
-    this.authorable = true,
   });
 
   /// The menu / dialog label.
@@ -1178,14 +1165,9 @@ enum _WisaRuleKind {
   /// Per-field placeholder text, parallel to [fields].
   final List<String> hints;
 
-  /// Whether **Toevoegen** offers this kind.
-  final bool authorable;
-
-  /// The kinds **Toevoegen** offers.
-  static List<_WisaRuleKind> get addable => <_WisaRuleKind>[
-        for (final kind in _WisaRuleKind.values)
-          if (kind.authorable) kind,
-      ];
+  /// The kinds **Toevoegen** offers — all of them, since the two the menu used
+  /// to hide were deleted rather than hidden (#277, #286).
+  static List<_WisaRuleKind> get addable => _WisaRuleKind.values;
 
   WisaImportRule call(List<String> values) => switch (this) {
         _WisaRuleKind.dontImportClass => DontImportClass(values[0]),
@@ -1194,14 +1176,12 @@ enum _WisaRuleKind {
             original: values[0],
             replacement: values[1],
           ),
-        _WisaRuleKind.markAsVirtual => MarkAsVirtual(values[0]),
       };
 
   static _WisaRuleKind of(WisaImportRule rule) => switch (rule) {
         DontImportClass() => _WisaRuleKind.dontImportClass,
         DontImportUserFromWisa() => _WisaRuleKind.dontImportUser,
         ReplaceInstitute() => _WisaRuleKind.replaceInstitute,
-        MarkAsVirtual() => _WisaRuleKind.markAsVirtual,
       };
 }
 
@@ -1790,20 +1770,6 @@ class _WisaSchoolsEditor extends StatelessWidget {
     );
   }
 
-  /// Whether a `MarkAsVirtual` import rule in the working list already flags the
-  /// school with [code] (#273).
-  ///
-  /// The two surfaces mark by different keys — the grid by school id, the rule by
-  /// the short WISA code — and `wisaSyncer` unions them, so a rule really does
-  /// make the school virtual whatever this grid's checkbox says. The cell has to
-  /// show that rather than contradict it.
-  bool _virtualByRule(String code) {
-    final trimmed = code.trim();
-    if (trimmed.isEmpty) return false;
-    return state._wisaRules
-        .any((r) => r is MarkAsVirtual && r.schoolCode == trimmed);
-  }
-
   /// Lays the known schools out as rows of [_columns] cells, padding the final
   /// row with empty slots so the grid columns stay aligned. Each cell toggles
   /// its school's managed (`ours`) and virtual flags inline.
@@ -1815,12 +1781,7 @@ class _WisaSchoolsEditor extends StatelessWidget {
         final i = start + col;
         cells.add(Expanded(
           child: i < schools.length
-              ? _SchoolCell(
-                  state: state,
-                  index: i,
-                  profile: schools[i],
-                  virtualByRule: _virtualByRule(schools[i].code),
-                )
+              ? _SchoolCell(state: state, index: i, profile: schools[i])
               : const SizedBox.shrink(),
         ));
       }
@@ -1845,6 +1806,13 @@ class _WisaSchoolsEditor extends StatelessWidget {
 /// mass leave. It therefore sits on its own indented, small-type line rather
 /// than as a second equal-looking checkbox.
 ///
+/// Both checkboxes answer for themselves. Until #277 the virtual one could be
+/// rendered ticked-and-locked, reading `virtueel (importregel)`, because a
+/// `MarkAsVirtual` rule set the same flag by school code and the pull unioned
+/// the two — so an unticked box would have been a lie and unticking it would not
+/// have stuck. With the rule retired this grid is the only virtual-school
+/// surface and the checkbox simply means what it shows.
+///
 /// The numeric id is strictly a fallback and never appears twice (#194): the
 /// title degrades name → code → `School <id>`, and the subtitle shows whichever
 /// of code / `id: <id>` the title has not already used — nothing at all when the
@@ -1854,18 +1822,11 @@ class _SchoolCell extends StatelessWidget {
     required this.state,
     required this.index,
     required this.profile,
-    this.virtualByRule = false,
   });
 
   final _SettingsScreenState state;
   final int index;
   final WisaSchoolProfile profile;
-
-  /// Whether a `MarkAsVirtual` import rule already flags this school by its code
-  /// (#273). The cell then renders the flag as set and locks the checkbox: the
-  /// pull unions both surfaces, so an unticked box would be a lie and unticking
-  /// it would not stick. Removing the rule under **Importregels** is the undo.
-  final bool virtualByRule;
 
   @override
   Widget build(BuildContext context) {
@@ -1913,15 +1874,13 @@ class _SchoolCell extends StatelessWidget {
             dense: true,
             visualDensity: VisualDensity.compact,
             title: Text(
-              virtualByRule ? 'virtueel (importregel)' : 'virtueel',
+              'virtueel',
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
             ),
-            value: profile.virtual || virtualByRule,
-            onChanged: virtualByRule
-                ? null
-                : (v) => state._toggleSchoolVirtual(index, v ?? false),
+            value: profile.virtual,
+            onChanged: (v) => state._toggleSchoolVirtual(index, v ?? false),
           ),
         ),
       ],

--- a/account_manager/lib/src/screens/settings_screen.dart
+++ b/account_manager/lib/src/screens/settings_screen.dart
@@ -36,13 +36,14 @@ import '../settings/wisa_rule_labels.dart';
 /// - **Smartschool** (#202): the two rules the legacy app offers
 ///   (`DiscardSmartschoolGroup`, `NoSmartschoolSubgroups`).
 /// - **WISA** (#273): the three rules with no other surface —
-///   `DontImportClass`, `DontImportUserFromWisa` and `ReplaceInstitute`. The two
-///   school-marking rules (`MarkAsVirtual`, `MarkAsOurs`) stay editable and
-///   removable but are *not* offered under **Toevoegen**: the WISA-scholen grid
-///   above already marks a school virtual/beheerd per school **id**, and for
-///   `beheerd` that grid is authoritative (`managedSchoolIdsOf` ignores the
-///   snapshot's `MarkAsOurs` flags as soon as the grid holds one school), so a
-///   rule authored here would be a control that silently does nothing.
+///   `DontImportClass`, `DontImportUserFromWisa` and `ReplaceInstitute`. The
+///   school-marking `MarkAsVirtual` stays editable and removable but is *not*
+///   offered under **Toevoegen**: the WISA-scholen grid above already marks a
+///   school virtueel per school **id**, so a rule authored here would duplicate
+///   a control that is already there. Its `beheerd` counterpart went further and
+///   was deleted (#286) — the grid was authoritative for ownership, so the rule
+///   could be saved and then silently do nothing; a document that still carries
+///   one is ignored when it loads.
 ///
 /// The WISA list shows the **persisted** rules — the operator's standing
 /// configuration, which is what a pull unions with whatever this session earned.
@@ -1108,7 +1109,7 @@ class _WorkDateField extends StatelessWidget {
 
 /// The value(s) a WISA rule matches on, in the field order [_WisaRuleKind]
 /// declares — what the edit prompt opens on. The sealed base type carries no
-/// shared field, so a switch over the five cases is where they meet.
+/// shared field, so a switch over the four cases is where they meet.
 List<String> _wisaRuleValues(WisaImportRule rule) => switch (rule) {
       DontImportClass(:final className) => <String>[className],
       DontImportUserFromWisa(:final userCode) => <String>[userCode],
@@ -1117,20 +1118,17 @@ List<String> _wisaRuleValues(WisaImportRule rule) => switch (rule) {
           replacement,
         ],
       MarkAsVirtual(:final schoolCode) => <String>[schoolCode],
-      MarkAsOurs(:final schoolCode) => <String>[schoolCode],
     };
 
-/// The five WISA import rules, with the Dutch labels and the field prompts the
+/// The four WISA import rules, with the Dutch labels and the field prompts the
 /// editor authors them through (#273). Calling a kind builds its rule from the
 /// values the prompt collected, in [fields] order.
 ///
-/// [authorable] is what **Toevoegen** offers. The two school-marking rules are
-/// deliberately not on that menu: the WISA-scholen grid above already marks a
-/// school virtueel/beheerd per school **id**, and for `beheerd` that grid wins
-/// outright — `managedSchoolIdsOf` stops consulting the snapshot's `MarkAsOurs`
-/// flags the moment the grid holds a single school, so a rule authored here
-/// would persist and then do nothing. They stay editable and removable, so a
-/// document that already carries one can be corrected or cleaned up.
+/// [authorable] is what **Toevoegen** offers. `MarkAsVirtual` is deliberately
+/// not on that menu: the WISA-scholen grid above already marks a school virtueel
+/// per school **id**, so a rule authored here would duplicate it. It stays
+/// editable and removable, so a document that already carries one can be
+/// corrected or cleaned up.
 enum _WisaRuleKind {
   dontImportClass(
     label: 'Klas niet importeren',
@@ -1155,13 +1153,6 @@ enum _WisaRuleKind {
     label: 'Markeer als virtueel',
     explanation: 'De school met deze code wordt met de virtuele werkdatum '
         'opgehaald.',
-    fields: <String>['Schoolcode'],
-    hints: <String>['De korte WISA-code van de school'],
-    authorable: false,
-  ),
-  markAsOurs(
-    label: 'Markeer als beheerd',
-    explanation: 'De school met deze code telt als een school die wij beheren.',
     fields: <String>['Schoolcode'],
     hints: <String>['De korte WISA-code van de school'],
     authorable: false,
@@ -1204,7 +1195,6 @@ enum _WisaRuleKind {
             replacement: values[1],
           ),
         _WisaRuleKind.markAsVirtual => MarkAsVirtual(values[0]),
-        _WisaRuleKind.markAsOurs => MarkAsOurs(values[0]),
       };
 
   static _WisaRuleKind of(WisaImportRule rule) => switch (rule) {
@@ -1212,7 +1202,6 @@ enum _WisaRuleKind {
         DontImportUserFromWisa() => _WisaRuleKind.dontImportUser,
         ReplaceInstitute() => _WisaRuleKind.replaceInstitute,
         MarkAsVirtual() => _WisaRuleKind.markAsVirtual,
-        MarkAsOurs() => _WisaRuleKind.markAsOurs,
       };
 }
 
@@ -1292,8 +1281,7 @@ class _WisaRulesEditor extends StatelessWidget {
         const SizedBox(height: PlinkSpacing.s3),
         Text(
           'Virtueel en beheerd markeer je per school hierboven bij '
-          '"WISA-scholen", niet met een regel: die lijst gaat per school en is '
-          'voor "beheerd" doorslaggevend.',
+          '"WISA-scholen", niet met een regel.',
           key: const ValueKey('settings-wisa-rules-school-note'),
           style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
         ),

--- a/account_manager/lib/src/settings/settings_bootstrap.dart
+++ b/account_manager/lib/src/settings/settings_bootstrap.dart
@@ -69,6 +69,7 @@ class SettingsServices {
     required this.secrets,
     this.fetchWisaSchools,
     this.liveSettings,
+    this.operatorName = '',
   });
 
   /// The persistence seam for the [AppSettings] document (#114: Cosmos-backed).
@@ -90,6 +91,18 @@ class SettingsServices {
   /// relaunch. Null when the build wires no reconcile stack (the settings-only
   /// harnesses), which simply skips the hand-off.
   final LiveSettings? liveSettings;
+
+  /// The signed-in operator, as the shared settings document should name them
+  /// (#285). Stamped onto every WISA import rule authored here, so a colleague
+  /// reading the rule next month knows whom to ask about it.
+  ///
+  /// This is the same string the rest of the app already shows as the operator
+  /// (`ReconcileController.syncedBy`, the "· door …" on the sync stamps) — the
+  /// broker's account, which is a UPN. #98's sign-in path is what would upgrade
+  /// it to a proper display name; until it does, one readable identifier used
+  /// consistently everywhere beats two half-known ones. Empty when the session
+  /// has no identity yet, which records as `onbekend` rather than as a blank.
+  final String operatorName;
 }
 
 /// Wires the Settings view's two seams for one signed-in session: a
@@ -131,5 +144,8 @@ Future<SettingsServices> bootstrapSettings({
     secrets: secrets,
     fetchWisaSchools: fetchWisaSchools ?? fetchWisaSchoolsLive,
     liveSettings: liveSettings,
+    // The same identity `bootstrapReconcile` syncs as, so a rule this operator
+    // types and a rule this operator's apply earns are attributed alike (#285).
+    operatorName: session.account ?? '',
   );
 }

--- a/account_manager/lib/src/settings/wisa_rule_labels.dart
+++ b/account_manager/lib/src/settings/wisa_rule_labels.dart
@@ -7,7 +7,10 @@
 /// thing on Synchronisatie and finds another under Instellingen.
 library;
 
+import 'package:account_state/account_state.dart';
 import 'package:wisa_api/wisa_api.dart';
+
+import '../format/timestamps.dart';
 
 /// How one WISA import rule reads in the settings list and the log.
 String describeWisaRule(WisaImportRule rule) => switch (rule) {
@@ -20,3 +23,33 @@ String describeWisaRule(WisaImportRule rule) => switch (rule) {
       MarkAsVirtual(:final schoolCode) => 'Markeer als virtueel: $schoolCode',
       MarkAsOurs(:final schoolCode) => 'Markeer als beheerd: $schoolCode',
     };
+
+/// What a provenance field reads as when the document records nothing for it
+/// (#285).
+///
+/// Named rather than blank on purpose. A rule persisted before #285 — or one an
+/// unsigned-in session added — genuinely has no answer, and an empty cell reads
+/// like nobody did it; "onbekend" says the record is missing, which is the true
+/// statement and the one that tells the reader to go and ask.
+const String unknownProvenance = 'onbekend';
+
+/// Whom a persisted rule was added *for*: the subject's name as it read when the
+/// rule was created, never re-resolved against a later WISA pull (#285).
+String describeRuleSubject(RuleProvenance? provenance) =>
+    (provenance?.subject.isNotEmpty ?? false)
+        ? provenance!.subject
+        : unknownProvenance;
+
+/// When a persisted rule was added, as its own readable stamp (#285).
+String describeRuleAddedAt(RuleProvenance? provenance) {
+  final at = provenance?.addedAt;
+  return at == null ? unknownProvenance : formatRuleStamp(at);
+}
+
+/// Which operator added a persisted rule (#285) — the load-bearing field, since
+/// the record is a pointer to the person who remembers rather than the
+/// explanation itself.
+String describeRuleAddedBy(RuleProvenance? provenance) =>
+    (provenance?.addedBy.isNotEmpty ?? false)
+        ? provenance!.addedBy
+        : unknownProvenance;

--- a/account_manager/lib/src/settings/wisa_rule_labels.dart
+++ b/account_manager/lib/src/settings/wisa_rule_labels.dart
@@ -21,7 +21,6 @@ String describeWisaRule(WisaImportRule rule) => switch (rule) {
       ReplaceInstitute(:final original, :final replacement) =>
         'Vervang instituut: $original → $replacement',
       MarkAsVirtual(:final schoolCode) => 'Markeer als virtueel: $schoolCode',
-      MarkAsOurs(:final schoolCode) => 'Markeer als beheerd: $schoolCode',
     };
 
 /// What a provenance field reads as when the document records nothing for it

--- a/account_manager/lib/src/settings/wisa_rule_labels.dart
+++ b/account_manager/lib/src/settings/wisa_rule_labels.dart
@@ -1,0 +1,22 @@
+/// How a WISA import rule reads to the operator.
+///
+/// Shared rather than private to the Settings view: since #276 a
+/// `DontImportFromWisa` apply writes its rule to the settings document, and the
+/// Log panel has to name the rule it just made permanent in exactly the words
+/// the Instellingen → Wisa list uses — otherwise the operator reads about one
+/// thing on Synchronisatie and finds another under Instellingen.
+library;
+
+import 'package:wisa_api/wisa_api.dart';
+
+/// How one WISA import rule reads in the settings list and the log.
+String describeWisaRule(WisaImportRule rule) => switch (rule) {
+      DontImportClass(:final className) =>
+        'Klas niet importeren uit WISA: $className',
+      DontImportUserFromWisa(:final userCode) =>
+        'Gebruiker niet importeren uit WISA: $userCode',
+      ReplaceInstitute(:final original, :final replacement) =>
+        'Vervang instituut: $original → $replacement',
+      MarkAsVirtual(:final schoolCode) => 'Markeer als virtueel: $schoolCode',
+      MarkAsOurs(:final schoolCode) => 'Markeer als beheerd: $schoolCode',
+    };

--- a/account_manager/lib/src/settings/wisa_rule_labels.dart
+++ b/account_manager/lib/src/settings/wisa_rule_labels.dart
@@ -20,7 +20,6 @@ String describeWisaRule(WisaImportRule rule) => switch (rule) {
         'Gebruiker niet importeren uit WISA: $userCode',
       ReplaceInstitute(:final original, :final replacement) =>
         'Vervang instituut: $original → $replacement',
-      MarkAsVirtual(:final schoolCode) => 'Markeer als virtueel: $schoolCode',
     };
 
 /// What a provenance field reads as when the document records nothing for it

--- a/account_manager/test/format/timestamps_test.dart
+++ b/account_manager/test/format/timestamps_test.dart
@@ -114,4 +114,30 @@ void main() {
       '15/08/${today.year - 1} 09:14',
     );
   });
+
+  group('formatRuleStamp — when a standing decision was made (#285)', () {
+    test('is absolute and carries the year, even for today', () {
+      // The counterpart of the freshness stamp, and deliberately not the same
+      // shape: a rule's stamp is read months later by whoever inherited the
+      // configuration, and with no reason field on the record the full date is
+      // what lets them reconstruct the context.
+      expect(formatRuleStamp(DateTime(2026, 6, 30, 14, 5)), '30/06/2026 14:05');
+    });
+
+    test('never says "gisteren"', () {
+      final DateTime yesterday =
+          DateTime.now().subtract(const Duration(days: 1));
+      expect(formatRuleStamp(yesterday), isNot(contains('gisteren')));
+    });
+
+    test('zero-pads day, month, hour and minute', () {
+      expect(formatRuleStamp(DateTime(2026, 1, 5, 9, 3)), '05/01/2026 09:03');
+    });
+
+    test('renders a UTC stamp on the operator\'s own clock', () {
+      // The document stores UTC; nobody reads their rules in UTC.
+      final DateTime local = DateTime(2026, 6, 30, 14, 5);
+      expect(formatRuleStamp(local.toUtc()), '30/06/2026 14:05');
+    });
+  });
 }

--- a/account_manager/test/reconcile/reconcile_bootstrap_test.dart
+++ b/account_manager/test/reconcile/reconcile_bootstrap_test.dart
@@ -424,19 +424,21 @@ void main() {
       expect(marked.every((s) => !s.isVirtual), isTrue);
     });
 
-    test('never un-flags a school an import rule already marked (#203)', () {
-      // MarkAsVirtual runs first and matches by code; settings marks by id.
-      // The settings pass is additive, so a legacy rule keeps working even
-      // when the school is not in the settings list.
-      const ruled = <WisaSchool>[
+    test('the grid decides outright, so a stale flag is cleared (#277)', () {
+      // The pass used to be additive: a `MarkAsVirtual` import rule flagged
+      // schools by code before this ran, and un-flagging one would have
+      // contradicted it. That rule is gone, and with it the reason to keep a
+      // flag the operator's list does not claim.
+      const preflagged = <WisaSchool>[
         WisaSchool(
             id: 25,
             name: 'Instituut Sancta Maria-A',
             code: 'ISMAA',
             isVirtual: true),
       ];
-      expect(markVirtualSchools(ruled, const <int>{}).single.isVirtual, isTrue);
-      expect(markVirtualSchools(ruled, {25}).single.isVirtual, isTrue);
+      expect(markVirtualSchools(preflagged, const <int>{}).single.isVirtual,
+          isFalse);
+      expect(markVirtualSchools(preflagged, {25}).single.isVirtual, isTrue);
     });
 
     test('does not mutate the input list (#203)', () {

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -1185,7 +1185,7 @@ void main() {
     ReconcileHarness newIntakeHarness() => ReconcileHarness(
           wisa: wisaSnap(
             students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
-            schools: [wisaSchool(1, ours: true)],
+            schools: [wisaSchool(1)],
           ),
           smartschool: ssSnap(
             groups: [ssGroup('3C', code: '3C_ss')],
@@ -1516,7 +1516,6 @@ void main() {
               id: 25,
               name: 'Instituut Sancta Maria-A',
               code: 'ISMAA',
-              isOurs: true,
             ),
           ],
         ),

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -631,6 +631,91 @@ void main() {
         'WISA-instellingen gewijzigd — synchroniseer eerst.',
       );
     });
+
+    group('the persisted rule records who, when, and for whom (#285)', () {
+      test('stamps the operator, the instant, and the subject\'s name',
+          () async {
+        // A `DontImportUserFromWisa` stores nothing but `SMIT`, and the staff
+        // these rules are about are precisely the ones who later disappear from
+        // WISA — so the name has to be captured here, at the decision, or it is
+        // gone. The operator is the load-bearing half: with no reason field on
+        // the record, it is the pointer to the person who remembers.
+        final settings = InMemorySettingsStore(const AppSettings());
+        final h = ignoreStaffHarness(
+          settingsStore: settings,
+          liveSettings: LiveSettings(const AppSettings()),
+        );
+        await h.controller.sync();
+
+        await ignoreTheStaffMember(h);
+
+        final saved = await settings.load();
+        final provenance =
+            saved.provenanceOf(const wapi.DontImportUserFromWisa('SMIT'))!;
+        expect(provenance.subject, 'Anna Smit');
+        expect(provenance.addedBy, 'operator@school.example');
+        // The pass's own clock, sampled once for the whole pass.
+        expect(provenance.addedAt, kFixtureDate);
+      });
+
+      test('re-applying keeps the first operator\'s stamp', () async {
+        // Two operators can reach the same conclusion; the union puts persisted
+        // rules first (#263), so the collapse keeps the decision the document
+        // has been standing on — and its author with it.
+        final settings = InMemorySettingsStore(AppSettings(
+          wisaRules: const <wapi.WisaImportRule>[
+            wapi.DontImportUserFromWisa('SMIT'),
+          ],
+          wisaRuleProvenance: <String, RuleProvenance>{
+            'user:SMIT': RuleProvenance(
+              subject: 'Anna Smit',
+              addedBy: 'ann@school.example',
+              addedAt: DateTime.utc(2026, 1, 15, 9),
+            ),
+          },
+        ));
+        final h = ignoreStaffHarness(
+          settingsStore: settings,
+          liveSettings: LiveSettings(const AppSettings()),
+        );
+        await h.controller.sync();
+
+        await ignoreTheStaffMember(h);
+
+        final provenance = (await settings.load())
+            .provenanceOf(const wapi.DontImportUserFromWisa('SMIT'))!;
+        expect(provenance.addedBy, 'ann@school.example');
+        expect(provenance.addedAt, DateTime.utc(2026, 1, 15, 9));
+      });
+
+      test('an unsigned-in session still records when, and for whom', () async {
+        // #98's sign-in is what supplies the operator; a session without one
+        // must not lose the other two fields — "onbekend" for the author is the
+        // honest degradation, a lost date is a real loss.
+        final settings = InMemorySettingsStore(const AppSettings());
+        final h = ReconcileHarness(
+          wisa: wisaSnap(students: const [], staff: [wisaStaff()]),
+          smartschool: ssSnap(
+            groups: const [],
+            accounts: const [],
+            memberships: const [],
+          ),
+          azure: azSnap(users: const []),
+          settingsStore: settings,
+          liveSettings: LiveSettings(const AppSettings()),
+          syncedBy: '',
+        );
+        await h.controller.sync();
+
+        await ignoreTheStaffMember(h);
+
+        final provenance = (await settings.load())
+            .provenanceOf(const wapi.DontImportUserFromWisa('SMIT'))!;
+        expect(provenance.addedBy, isEmpty);
+        expect(provenance.subject, 'Anna Smit');
+        expect(provenance.addedAt, isNotNull);
+      });
+    });
   });
 
   group('cross-session snapshot persistence (#107)', () {

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -44,6 +44,23 @@ class _RecordingSettingsStore extends InMemorySettingsStore {
   }
 }
 
+/// A settings store that hands back a document this session has never seen —
+/// what a re-read looks like when another operator saved a werkdatum while this
+/// pass was running (#276). Saves land normally on top of it.
+class _MovedWerkdatumStore extends InMemorySettingsStore {
+  _MovedWerkdatumStore(this.theirs) : super(const AppSettings());
+
+  final AppSettings theirs;
+  bool _handedOver = false;
+
+  @override
+  Future<AppSettings> load() async {
+    if (_handedOver) return super.load();
+    _handedOver = true;
+    return theirs;
+  }
+}
+
 /// A settings store whose every read throws — models the store being down while
 /// a sync tries to repair the school profiles (#207).
 class _ThrowingSettingsStore implements SettingsStore {
@@ -420,6 +437,198 @@ void main() {
           'Kon de WISA-schoolnamen niet bijwerken in de instellingen: '
           'Bad state: cosmos 503',
         ),
+      );
+    });
+  });
+
+  group('a DontImportFromWisa apply persists its rule (#276)', () {
+    // Two freshly hired teachers exist in WISA only, so each raises the #248
+    // either/or: provision them, or stop importing them. Picking the opt-out is
+    // what earns a `DontImportUserFromWisa` rule — and, until #276, that rule
+    // lived only in the process-lifetime `WisaImportRules` holder, so the next
+    // launch rebuilt it empty, WISA still reported the person active, and the
+    // account the operator had meanwhile deleted (#269) was proposed anew.
+    ReconcileHarness ignoreStaffHarness({
+      SettingsStore? settingsStore,
+      LiveSettings? liveSettings,
+    }) =>
+        ReconcileHarness(
+          wisa: wisaSnap(students: const [], staff: [wisaStaff()]),
+          smartschool: ssSnap(
+            groups: const [],
+            accounts: const [],
+            memberships: const [],
+          ),
+          azure: azSnap(users: const []),
+          settingsStore: settingsStore,
+          liveSettings: liveSettings,
+        );
+
+    /// Syncs, switches the staff either/or to the opt-out the way the screen
+    /// does, and applies that one row.
+    Future<void> ignoreTheStaffMember(ReconcileHarness h) async {
+      final entry =
+          h.controller.pendingEntries.firstWhere((e) => e.family == 'staff');
+      h.controller.chooseAlternative(
+        entry: entry,
+        group: actions.staffImportAlternative,
+        kind: 'DontImportStaffFromWisa',
+      );
+      // Re-read after the choice: the entry list is rebuilt.
+      final chosen = h.controller.pendingEntries
+          .firstWhere((e) => e.targetId == entry.targetId);
+      await h.controller.applyEntry(chosen);
+    }
+
+    test('writes the earned rule to the shared settings document', () async {
+      final settings = InMemorySettingsStore(const AppSettings());
+      final live = LiveSettings(const AppSettings());
+      final h = ignoreStaffHarness(settingsStore: settings, liveSettings: live);
+      await h.controller.sync();
+
+      await ignoreTheStaffMember(h);
+
+      final saved = await settings.load();
+      expect(saved.wisaRules.single, isA<wapi.DontImportUserFromWisa>());
+      expect(
+        (saved.wisaRules.single as wapi.DontImportUserFromWisa).userCode,
+        'SMIT',
+      );
+      // …and it is published, so this session's next pull unions it in without
+      // a reload (#263) and Instellingen shows what the store holds (#273).
+      expect(live.current.wisaRules, hasLength(1));
+      expect(h.controller.error, isNull);
+    });
+
+    test('tells the operator the exclusion is permanent and shared', () async {
+      // A rule every operator inherits, for as long as nobody removes it, must
+      // not land silently — the log is where the operator finds out what the
+      // click actually committed them to.
+      final settings = InMemorySettingsStore(const AppSettings());
+      final h = ignoreStaffHarness(
+        settingsStore: settings,
+        liveSettings: LiveSettings(const AppSettings()),
+      );
+      await h.controller.sync();
+
+      await ignoreTheStaffMember(h);
+
+      expect(
+        h.log.entries.map((e) => e.message),
+        contains('Importregel bewaard voor iedereen: Gebruiker niet importeren '
+            'uit WISA: SMIT. Dit blijft gelden tot de regel in Instellingen → '
+            'Wisa verwijderd wordt.'),
+      );
+    });
+
+    test('applying the same rule twice does not grow the persisted list',
+        () async {
+      // `WisaImportRules`' de-dup has to hold across the persist path too, or a
+      // September of re-applies would append the same rule until the settings
+      // document itself became the problem.
+      final settings = _RecordingSettingsStore(const AppSettings());
+      final h = ignoreStaffHarness(
+        settingsStore: settings,
+        liveSettings: LiveSettings(const AppSettings()),
+      );
+      await h.controller.sync();
+
+      await ignoreTheStaffMember(h);
+      await ignoreTheStaffMember(h);
+
+      expect((await settings.load()).wisaRules, hasLength(1));
+      expect(settings.saves, 1,
+          reason: 'the second apply had nothing new to write');
+    });
+
+    test('a dry run writes nothing', () async {
+      // A dry run projects the rule without earning it; a shared, permanent
+      // change must never come out of a preview.
+      final settings = _RecordingSettingsStore(const AppSettings());
+      final h = ignoreStaffHarness(
+        settingsStore: settings,
+        liveSettings: LiveSettings(const AppSettings()),
+      );
+      await h.controller.sync();
+      final entry =
+          h.controller.pendingEntries.firstWhere((e) => e.family == 'staff');
+      h.controller.chooseAlternative(
+        entry: entry,
+        group: actions.staffImportAlternative,
+        kind: 'DontImportStaffFromWisa',
+      );
+
+      await h.controller.dryRunEntry(h.controller.pendingEntries
+          .firstWhere((e) => e.targetId == entry.targetId));
+
+      expect(settings.saves, 0);
+      expect((await settings.load()).wisaRules, isEmpty);
+    });
+
+    test('a failing settings store is logged, never fails the pass', () async {
+      // The apply pass itself succeeded and its results are on screen; losing
+      // them to a wedged Cosmos would be the worse failure.
+      final h = ignoreStaffHarness(
+        settingsStore: const _ThrowingSettingsStore('cosmos 503'),
+        liveSettings: LiveSettings(const AppSettings()),
+      );
+      await h.controller.sync();
+
+      await ignoreTheStaffMember(h);
+
+      expect(h.controller.error, isNull);
+      expect(
+        h.controller.applyResults!.map((r) => r.outcome),
+        everyElement(actions.ActionOutcome.applied),
+      );
+      expect(
+        h.log.entries.where((e) => e.isError).map((e) => e.message),
+        contains('Kon de WISA-importregel(s) niet opslaan in de instellingen: '
+            'Bad state: cosmos 503'),
+      );
+    });
+
+    test('does not arm the drift gate it just satisfied (#238)', () async {
+      // `wisaPullFingerprint` covers the persisted rules, so this write would
+      // otherwise block **Controleer op drift** with "synchroniseer eerst" —
+      // over a rule the applier had already re-pulled WISA with.
+      final settings = InMemorySettingsStore(const AppSettings());
+      final live = LiveSettings(const AppSettings());
+      final h = ignoreStaffHarness(settingsStore: settings, liveSettings: live);
+      await h.controller.sync();
+      expect(h.controller.canCheckDrift, isTrue);
+
+      await ignoreTheStaffMember(h);
+
+      expect(h.controller.driftBlockedReason, isNull);
+      expect(h.controller.canCheckDrift, isTrue);
+    });
+
+    test('still arms it for a change another operator slipped in', () async {
+      // The re-credit is narrow on purpose: it claims only *these rules*. A
+      // werkdatum this session's snapshot was never pulled with comes back on
+      // the re-read and must keep blocking drift.
+      final live = LiveSettings(const AppSettings());
+      final h = ignoreStaffHarness(
+        settingsStore: _MovedWerkdatumStore(
+          AppSettings(
+            wisa: WisaConnection(
+              workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9)),
+            ),
+          ),
+        ),
+        liveSettings: live,
+      );
+      await h.controller.sync();
+      expect(h.controller.canCheckDrift, isTrue);
+
+      await ignoreTheStaffMember(h);
+
+      expect(live.current.wisaRules, hasLength(1),
+          reason: 'the rule still landed on the document that came back');
+      expect(
+        h.controller.driftBlockedReason,
+        'WISA-instellingen gewijzigd — synchroniseer eerst.',
       );
     });
   });

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -941,18 +941,30 @@ wapi.WisaStudent wisaStudent({
       schoolId: schoolId,
     );
 
-/// A WISA school, optionally flagged [ours] (the managed-school signal the
-/// linker joins student `schoolId` against, #133/#134) and/or [virtual] (the
-/// flag `markVirtualSchools` stamps before the pull, whose class groups the
-/// linker refuses to seed, #209).
-wapi.WisaSchool wisaSchool(int id, {bool ours = false, bool virtual = false}) =>
-    wapi.WisaSchool(
+/// A WISA school, optionally flagged [virtual] (the flag `markVirtualSchools`
+/// stamps before the pull, whose class groups the linker refuses to seed, #209).
+///
+/// A school carries no ownership flag (#286): which schools we manage is the
+/// harness's `ourSchoolIds` — the persisted Settings path, and the only one.
+wapi.WisaSchool wisaSchool(int id, {bool virtual = false}) => wapi.WisaSchool(
       id: id,
       name: 'School $id',
       code: '',
-      isOurs: ours,
       isVirtual: virtual,
     );
+
+/// The managed-school set a fixture's reconcile stack scopes by: the live
+/// settings document's WISA-scholen list when it configures one, otherwise the
+/// set the harness was constructed with.
+///
+/// Since #286 an unconfigured document answers with an **empty** set rather than
+/// null, so emptiness is what the fallback tests for — otherwise a fixture that
+/// pins `ourSchoolIds` directly, without curating school profiles, would silently
+/// lose its managed set.
+Set<int>? _managedSchoolsOr(AppSettings settings, Set<int>? pinned) {
+  final configured = managedSchoolIdsOf(settings);
+  return configured.isEmpty ? pinned : configured;
+}
 
 /// A WISA class group. [name] is the `fullName` the linker matches on;
 /// [schoolId] decides whether the class belongs to a school we manage — a
@@ -1288,13 +1300,14 @@ ReconcileHarness manyDepartedHarness({
 
 /// A reconcile harness for the group-wide-leave keep-Azure case (#134): one
 /// student still in *our* Smartschool and Azure, but whose WISA record now sits
-/// only in a sibling group school (id 2) we don't manage — school 1 is flagged
-/// ours. The dispatcher must raise the Smartschool departure (unregister/delete)
-/// while **keeping** Azure (no `RemoveStudentFromAzure`).
+/// only in a sibling group school (id 2) we don't manage — only school 1 is in
+/// the managed set. The dispatcher must raise the Smartschool departure
+/// (unregister/delete) while **keeping** Azure (no `RemoveStudentFromAzure`).
 ReconcileHarness movedToSiblingHarness() => ReconcileHarness(
+      ourSchoolIds: const {1},
       wisa: wisaSnap(
         students: [wisaStudent(schoolId: 2)],
-        schools: [wisaSchool(1, ours: true), wisaSchool(2)],
+        schools: [wisaSchool(1), wisaSchool(2)],
       ),
       smartschool: ssSnap(
         groups: const [],
@@ -1305,9 +1318,9 @@ ReconcileHarness movedToSiblingHarness() => ReconcileHarness(
     );
 
 /// A harness for the managed-schools-only Actions filter (#178). One student is
-/// enrolled in school 2 and fully present in *our* Smartschool + Azure. The WISA
-/// schools carry **no** `MarkAsOurs` flag, so the managed set comes solely from
-/// [ourSchoolIds] (the persisted Settings path). Managing only school 1 leaves
+/// enrolled in school 2 and fully present in *our* Smartschool + Azure. The
+/// managed set comes solely from [ourSchoolIds] (the persisted Settings path —
+/// the only one since #286). Managing only school 1 leaves
 /// the student `groupOnly` — kept out of the school tree (re-bucketed to "Niet
 /// toegewezen"); adding school 2 to the managed set surfaces it under School 2.
 ReconcileHarness managedSchoolsHarness({required Set<int> ourSchoolIds}) =>
@@ -1837,8 +1850,8 @@ ReconcileHarness virtualClassGroupHarness() => ReconcileHarness(
           wisaStudent(wisaId: '2', classGroup: '1V', schoolId: 99),
         ],
         schools: [
-          wisaSchool(1, ours: true),
-          wisaSchool(99, ours: true, virtual: true),
+          wisaSchool(1),
+          wisaSchool(99, virtual: true),
         ],
         classGroups: [
           wisaClassGroup(
@@ -3149,7 +3162,7 @@ class ReconcileHarness {
           ...managedStudentEmployeeIds(
             app.wisa.snapshot,
             ourSchoolIds:
-                managedSchoolIdsOf(this.liveSettings.current) ?? ourSchoolIds,
+                _managedSchoolsOr(this.liveSettings.current, ourSchoolIds),
           ),
           ...managedStaffEmployeeIds(app.wisa.snapshot),
         },
@@ -3159,7 +3172,7 @@ class ReconcileHarness {
           app.wisa.snapshot,
           schoolPrefix: prefix,
           ourSchoolIds:
-              managedSchoolIdsOf(this.liveSettings.current) ?? ourSchoolIds,
+              _managedSchoolsOr(this.liveSettings.current, ourSchoolIds),
         ),
         // The prefix the pull scopes by, read live (#246) — the fixture's 'GBS'
         // until a test saves one in Instellingen.
@@ -3279,10 +3292,10 @@ class ReconcileHarness {
           // tenant); a fixture that applies `AddToSmartschool` for real names
           // the root here, and a test that saves one in Instellingen wins.
           classTree: _liveClassTree(s.smartschool) ?? classTree,
-          // The operator's managed-school set from Settings (#178). When unset,
-          // the linker falls back to the WISA snapshot's MarkAsOurs flags, as
-          // bootstrap does for a not-yet-configured group.
-          ourSchoolIds: managedSchoolIdsOf(s) ?? ourSchoolIds,
+          // The operator's managed-school set from Settings (#178), falling back
+          // to whatever set this fixture was pinned with when the document
+          // configures none.
+          ourSchoolIds: _managedSchoolsOr(s, ourSchoolIds),
         );
       },
     );

--- a/account_manager/test/reconcile/reconcile_live_settings_test.dart
+++ b/account_manager/test/reconcile/reconcile_live_settings_test.dart
@@ -453,10 +453,12 @@ void main() {
     });
 
     test("unions the persisted rules with the session's own (#263)", () async {
-      // Both halves reach one pull: the `MarkAsVirtual` this session earned and
-      // the `DontImportClass` the operator saved a moment ago.
+      // Both halves reach one pull, and in the documented order: the operator's
+      // persisted rule rewrites institute 111 → 888, and the one this session
+      // holds then rewrites 888 → 999. Only a real union produces 999.
       final wire = RecordingWisaSoap();
-      final rules = WisaImportRules()..add(const wapi.MarkAsVirtual('S1'));
+      final rules = WisaImportRules()
+        ..add(const wapi.ReplaceInstitute(original: '888', replacement: '999'));
       final live = LiveSettings(_settings());
       final syncer = wisaSyncer(
         wapi.WisaConnector.fromParts(
@@ -472,19 +474,18 @@ void main() {
       );
 
       final first = await syncer(null);
-      expect(first.schools.single.isVirtual, isTrue,
-          reason: 'the session rule already marks the school virtual');
-      expect(first.classGroups, hasLength(1));
+      expect(first.classGroups.single.schoolCode, '111',
+          reason: 'nothing matches yet — the session rule keys off 888');
 
       live.publish(_settings().copyWith(
-        wisaRules: const <wapi.WisaImportRule>[wapi.DontImportClass('3C')],
+        wisaRules: const <wapi.WisaImportRule>[
+          wapi.ReplaceInstitute(original: '111', replacement: '888'),
+        ],
       ));
 
-      final pruned = await syncer(null);
-      expect(pruned.classGroups, isEmpty,
-          reason: 'the saved rule reached the pull');
-      expect(pruned.schools.single.isVirtual, isTrue,
-          reason: 'and the session rule was not lost composing it');
+      final merged = await syncer(null);
+      expect(merged.classGroups.single.schoolCode, '999',
+          reason: 'the saved rule ran first and the session rule after it');
     });
   });
 

--- a/account_manager/test/reconcile/reconcile_live_settings_test.dart
+++ b/account_manager/test/reconcile/reconcile_live_settings_test.dart
@@ -570,8 +570,12 @@ void main() {
     });
 
     test('a rule an apply earned never arms the drift gate', () async {
-      // Session rules are not on any settings document, and the apply that
-      // earns one re-syncs WISA itself — so the gate must stay open.
+      // The apply that earns a rule re-syncs WISA itself, so the snapshot in
+      // hand already reflects it and the gate must stay open. The session
+      // holder is on no settings document, so nothing here can move the
+      // fingerprint; since #276 the apply *also* writes the rule to the
+      // document, and re-credits its own pull to it for exactly this reason
+      // (see `ReconcileController._persistEarnedWisaRules` and its test).
       final live = LiveSettings(_settings());
       final harness = ReconcileHarness(
         wisaTransport: RecordingWisaSoap(),

--- a/account_manager/test/reconcile/reconcile_live_settings_test.dart
+++ b/account_manager/test/reconcile/reconcile_live_settings_test.dart
@@ -593,8 +593,8 @@ void main() {
   group('the rest of the reconcile stack reads settings live too (#246)', () {
     /// The #178 fixture, but with ownership coming from the settings document
     /// rather than a constructor argument: one student enrolled in school 2 and
-    /// fully present in our Smartschool + Azure, and no `MarkAsOurs` flag on the
-    /// WISA schools — so who is managed is decided solely by [live].
+    /// fully present in our Smartschool + Azure, and no ownership anywhere on
+    /// the WISA snapshot — so who is managed is decided solely by [live].
     ReconcileHarness managedFrom(LiveSettings live) => ReconcileHarness(
           wisa: wisaSnap(
             students: [wisaStudent(schoolId: 2)],
@@ -925,7 +925,7 @@ void main() {
     ReconcileHarness intakeFrom(LiveSettings live) => ReconcileHarness(
           wisa: wisaSnap(
             students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
-            schools: [wisaSchool(1, ours: true)],
+            schools: [wisaSchool(1)],
           ),
           smartschool: ssSnap(
             groups: [ssGroup('3C', code: '3C_ss')],
@@ -1000,7 +1000,7 @@ void main() {
       final harness = ReconcileHarness(
         wisa: wisaSnap(
           students: [wisaStudent(classGroup: '3C')],
-          schools: [wisaSchool(1, ours: true)],
+          schools: [wisaSchool(1)],
           classGroups: [wisaClassGroup('3C')],
         ),
         smartschool: ssSnap(
@@ -1112,7 +1112,7 @@ void main() {
       final harness = ReconcileHarness(
         wisa: wisaSnap(
           students: [wisaStudent(wisaId: 'W7', classGroup: '3C')],
-          schools: [wisaSchool(1, ours: true)],
+          schools: [wisaSchool(1)],
         ),
         smartschool: ssSnap(
           groups: [ssGroup('3C', code: '3C_ss')],

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -184,21 +184,32 @@ void main() {
 
     test('the WISA opt-out family claims no write at all', () {
       // DontImportStaffFromWisa & co carry Origin.wisa on their ChangeSet, but
-      // WISA is read-only here: what they produce is a local import rule.
+      // WISA is read-only here: what they produce is an import rule.
       final message = applyConfirmationMessage(scope(<Origin>[Origin.wisa]));
       expect(
         message,
-        startsWith('Dit legt 1 importregel vast (er wordt niets naar WISA '
-            'geschreven).'),
+        startsWith('Dit bewaart 1 importregel blijvend voor iedereen (er wordt '
+            'niets naar WISA geschreven).'),
       );
       expect(message, isNot(contains('schrijft 1 wijziging')));
+    });
+
+    test('the rule is announced as permanent and shared (#276)', () {
+      // The rule is written to the shared settings document, so it outlives the
+      // session and every other operator inherits it. A sentence that read like
+      // a one-run decision would be the operator's only warning before an
+      // irreversible-looking click.
+      final message = applyConfirmationMessage(scope(<Origin>[Origin.wisa]));
+      expect(message, contains('blijvend'));
+      expect(message, contains('voor iedereen'));
     });
 
     test('a rule beside a real write is counted apart from it', () {
       expect(
         applyConfirmationMessage(scope(<Origin>[Origin.azure, Origin.wisa])),
-        startsWith('Dit schrijft 1 wijziging naar Office 365 en legt 1 '
-            'importregel vast (er wordt niets naar WISA geschreven).'),
+        startsWith('Dit schrijft 1 wijziging naar Office 365 en bewaart 1 '
+            'importregel blijvend voor iedereen (er wordt niets naar WISA '
+            'geschreven).'),
       );
     });
 

--- a/account_manager/test/screens/settings_fakes.dart
+++ b/account_manager/test/screens/settings_fakes.dart
@@ -16,6 +16,7 @@ class SettingsHarness {
     Map<SecretRef, String> secrets = const {},
     this.fetchWisaSchools,
     this.liveSettings,
+    this.operatorName = '',
   })  : store = InMemorySettingsStore(initial),
         secrets = InMemorySecretProvider(secrets);
 
@@ -33,11 +34,16 @@ class SettingsHarness {
   /// Instellingen reaches the running reconcile stack.
   final LiveSettings? liveSettings;
 
+  /// The signed-in operator a rule authored here is attributed to (#285).
+  /// Defaults to empty — the unsigned-in session, which records as `onbekend`.
+  final String operatorName;
+
   SettingsServices get services => SettingsServices(
         store: store,
         secrets: secrets,
         fetchWisaSchools: fetchWisaSchools,
         liveSettings: liveSettings,
+        operatorName: operatorName,
       );
 
   /// A ready-made bootstrap closure for [SettingsScreen]/[AccountManagerApp].

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -1173,8 +1173,19 @@ void main() {
 
     final saved = await harness.store.load();
     expect(saved.wisaRules, hasLength(3));
-    // …on the wire shape the codec already defined — no new tags (#273).
-    expect(saved.toJson()['wisaRules'], <Map<String, dynamic>>[
+    // …on the rule tags the codec already defined — no new ones (#273). The
+    // provenance keys #285 writes beside them are asserted separately below;
+    // stripping them here keeps this test about the rule half of the object.
+    final encoded = (saved.toJson()['wisaRules'] as List<dynamic>)
+        .cast<Map<String, dynamic>>()
+        .map((Map<String, dynamic> rule) => <String, dynamic>{
+              for (final MapEntry<String, dynamic> e in rule.entries)
+                if (!const <String>{'subject', 'addedBy', 'addedAt'}
+                    .contains(e.key))
+                  e.key: e.value,
+            })
+        .toList();
+    expect(encoded, <Map<String, dynamic>>[
       {'type': 'dontImportClass', 'className': 'OKAN'},
       {'type': 'dontImportUserFromWisa', 'userCode': 'ABC'},
       {
@@ -1390,5 +1401,220 @@ void main() {
     // is what blocks a stale drift pass.
     expect(live.current.wisaRules, hasLength(1));
     expect(wisaPullFingerprint(live.current), isNot(before));
+  });
+
+  group('a persisted WISA rule says who added it, when, and for whom (#285)',
+      () {
+    testWidgets('renders the three fields, each in its own column',
+        (WidgetTester tester) async {
+      // The shared settings document is the point (#276), and it only works if a
+      // rule a colleague added last month is legible to whoever opens the panel
+      // next: a bare `DontImportUserFromWisa` shows an opaque WISA code, and the
+      // staff these rules are about eventually vanish from WISA altogether, so
+      // the name cannot be resolved later.
+      _useTallWindow(tester);
+      final harness = SettingsHarness(
+        initial: AppSettings(
+          wisaRules: const <WisaImportRule>[DontImportUserFromWisa('SMIT')],
+          wisaRuleProvenance: <String, RuleProvenance>{
+            'user:SMIT': RuleProvenance(
+              subject: 'Jan Smit',
+              addedBy: 'ann@school.example',
+              addedAt: DateTime.utc(2026, 6, 30, 14, 5),
+            ),
+          },
+        ),
+      );
+      await tester
+          .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+      await _openTab(tester, 'settings-tab-wisa');
+
+      expect(
+        find.byKey(const ValueKey('settings-wisa-rules-header')),
+        findsOneWidget,
+      );
+      expect(find.text('Toegevoegd op'), findsOneWidget);
+      expect(
+        tester
+            .widget<Text>(
+                find.byKey(const ValueKey('settings-wisa-rule-0-subject')))
+            .data,
+        'Jan Smit',
+      );
+      expect(
+        tester
+            .widget<Text>(
+                find.byKey(const ValueKey('settings-wisa-rule-0-added-by')))
+            .data,
+        'ann@school.example',
+      );
+      // A full, absolute stamp: read months later, "gisteren" or a year-less
+      // date would tell the reader nothing.
+      final stamp = tester
+          .widget<Text>(
+              find.byKey(const ValueKey('settings-wisa-rule-0-added-at')))
+          .data!;
+      expect(stamp, contains('30/06/2026'));
+    });
+
+    testWidgets('a rule stored before #285 reads as onbekend, not as a blank',
+        (WidgetTester tester) async {
+      // An empty cell reads like nobody did it. "onbekend" says the record is
+      // missing — the true statement, and the one that tells the reader to ask.
+      _useTallWindow(tester);
+      final harness = SettingsHarness(
+        initial: AppSettings(
+          wisaRules: <WisaImportRule>[const DontImportClass('OKAN')],
+        ),
+      );
+      await tester
+          .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+      await _openTab(tester, 'settings-tab-wisa');
+
+      for (final String cell in <String>['subject', 'added-at', 'added-by']) {
+        expect(
+          tester
+              .widget<Text>(find.byKey(ValueKey('settings-wisa-rule-0-$cell')))
+              .data,
+          'onbekend',
+          reason: 'the $cell cell of a pre-#285 rule',
+        );
+      }
+    });
+
+    testWidgets('a rule typed by hand is stamped the same way an apply is',
+        (WidgetTester tester) async {
+      // #273's editor is the other authoring surface, and a rule typed there is
+      // just as much a standing decision the rest of the group inherits.
+      _useTallWindow(tester);
+      final harness = SettingsHarness(operatorName: 'ann@school.example');
+      await tester
+          .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+      await _openTab(tester, 'settings-tab-wisa');
+      await _addWisaRule(tester, 'dontImportClass', <String>['OKAN']);
+      await tester.tap(find.byKey(const ValueKey('settings-save')));
+      await tester.pumpAndSettle();
+
+      final saved = await harness.store.load();
+      final provenance = saved.provenanceOf(const DontImportClass('OKAN'))!;
+      expect(provenance.addedBy, 'ann@school.example');
+      expect(provenance.addedAt, isNotNull);
+      // No subject: this view holds no WISA snapshot to resolve a name against
+      // (the same reason #273's prompts are free text), so it records nothing
+      // rather than passing the typed code off as a name.
+      expect(provenance.subject, isEmpty);
+    });
+
+    testWidgets('removing a rule takes its provenance with it',
+        (WidgetTester tester) async {
+      // Otherwise a later, unrelated rule keying the same way would inherit a
+      // stamp naming an operator who never decided it.
+      _useTallWindow(tester);
+      final harness = SettingsHarness(
+        initial: AppSettings(
+          wisaRules: const <WisaImportRule>[DontImportClass('OKAN')],
+          wisaRuleProvenance: <String, RuleProvenance>{
+            'class:OKAN': RuleProvenance(
+              addedBy: 'ann@school.example',
+              addedAt: DateTime.utc(2026, 1, 1),
+            ),
+          },
+        ),
+      );
+      await tester
+          .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+      await _openTab(tester, 'settings-tab-wisa');
+      await tester
+          .tap(find.byKey(const ValueKey('settings-wisa-rule-0-remove')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('settings-save')));
+      await tester.pumpAndSettle();
+
+      final saved = await harness.store.load();
+      expect(saved.wisaRules, isEmpty);
+      expect(saved.wisaRuleProvenance, isEmpty);
+    });
+
+    testWidgets('editing a rule re-attributes it to whoever edited it',
+        (WidgetTester tester) async {
+      // Changing what a rule matches makes it a different standing decision;
+      // leaving the previous operator's name on it would be a lie about a record
+      // whose whole purpose is saying who to ask.
+      _useTallWindow(tester);
+      final harness = SettingsHarness(
+        operatorName: 'bob@school.example',
+        initial: AppSettings(
+          wisaRules: const <WisaImportRule>[DontImportClass('OKAN')],
+          wisaRuleProvenance: <String, RuleProvenance>{
+            'class:OKAN': RuleProvenance(
+              addedBy: 'ann@school.example',
+              addedAt: DateTime.utc(2026, 1, 1),
+            ),
+          },
+        ),
+      );
+      await tester
+          .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+      await _openTab(tester, 'settings-tab-wisa');
+      await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-0-edit')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('settings-wisa-rule-value-0')),
+        'ONTHAAL',
+      );
+      await tester.pump();
+      await tester
+          .tap(find.byKey(const ValueKey('settings-wisa-rule-confirm')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('settings-save')));
+      await tester.pumpAndSettle();
+
+      final saved = await harness.store.load();
+      expect(saved.wisaRuleProvenance.keys, <String>['class:ONTHAAL']);
+      expect(
+        saved.provenanceOf(const DontImportClass('ONTHAAL'))!.addedBy,
+        'bob@school.example',
+      );
+    });
+
+    testWidgets('a stamp on its own does not arm the drift gate',
+        (WidgetTester tester) async {
+      // `wisaPullFingerprint` covers the persisted rules (#238/#263), and
+      // provenance must stay out of it: who typed a rule changes nothing about
+      // what WISA returns, and #276's post-apply re-credit depends on that.
+      _useTallWindow(tester);
+      const rules = <WisaImportRule>[DontImportClass('OKAN')];
+      final live = LiveSettings(const AppSettings(wisaRules: rules));
+      final harness = SettingsHarness(
+        operatorName: 'ann@school.example',
+        initial: const AppSettings(wisaRules: rules),
+        liveSettings: live,
+      );
+      await tester
+          .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+
+      final before = wisaPullFingerprint(live.current);
+      await _openTab(tester, 'settings-tab-wisa');
+      await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-0-edit')));
+      await tester.pumpAndSettle();
+      await tester
+          .tap(find.byKey(const ValueKey('settings-wisa-rule-confirm')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('settings-save')));
+      await tester.pumpAndSettle();
+
+      // Re-confirming the same values re-stamps the rule but changes no match.
+      expect(
+        live.current.provenanceOf(const DontImportClass('OKAN'))!.addedBy,
+        'ann@school.example',
+      );
+      expect(wisaPullFingerprint(live.current), before);
+    });
   });
 }

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -1109,7 +1109,7 @@ void main() {
   });
 
   testWidgets(
-      'Toevoegen offers the three rules with no other surface, and not the two '
+      'Toevoegen offers the three rules with no other surface, and not the one '
       'the WISA-scholen grid already marks (#273)',
       (WidgetTester tester) async {
     _useTallWindow(tester);
@@ -1130,14 +1130,14 @@ void main() {
       expect(
           find.byKey(ValueKey('settings-wisa-rule-add-$kind')), findsOneWidget);
     }
-    // `MarkAsOurs` is dead once the grid holds a school (managedSchoolIdsOf
-    // stops reading the snapshot's flags), and `MarkAsVirtual` duplicates the
-    // grid's per-school mark — neither is offered as a new rule.
+    // `MarkAsVirtual` duplicates the grid's per-school mark, so it is not
+    // offered as a new rule. Its `beheerd` counterpart is not a rule kind at all
+    // any more (#286), so there is nothing to offer.
     expect(find.byKey(const ValueKey('settings-wisa-rule-add-markAsVirtual')),
         findsNothing);
     expect(find.byKey(const ValueKey('settings-wisa-rule-add-markAsOurs')),
         findsNothing);
-    // …and the section says where those two live instead.
+    // …and the section says where the school marks live instead.
     expect(find.byKey(const ValueKey('settings-wisa-rules-school-note')),
         findsOneWidget);
   });
@@ -1319,7 +1319,7 @@ void main() {
     _useTallWindow(tester);
     final harness = SettingsHarness(
       initial: AppSettings(
-        wisaRules: <WisaImportRule>[const MarkAsOurs('ISMAA')],
+        wisaRules: <WisaImportRule>[const MarkAsVirtual('ISMAA')],
       ),
     );
     await tester
@@ -1330,7 +1330,7 @@ void main() {
     // Editable: the prompt opens on the rule's own kind and value.
     await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-0-edit')));
     await tester.pumpAndSettle();
-    expect(find.text('Markeer als beheerd'), findsOneWidget);
+    expect(find.text('Markeer als virtueel'), findsOneWidget);
     expect(find.text('ISMAA'), findsOneWidget);
     await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-cancel')));
     await tester.pumpAndSettle();
@@ -1341,6 +1341,41 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('settings-save')));
     await tester.pumpAndSettle();
     expect((await harness.store.load()).wisaRules, isEmpty);
+  });
+
+  testWidgets(
+      'a persisted MarkAsOurs is ignored, so the list shows only live rules '
+      '(#286)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // A document another operator (or an older build) wrote. The rule kind is
+    // gone, so it can only be introduced as raw JSON — which is exactly the
+    // shape Cosmos hands back.
+    final harness = SettingsHarness(
+      initial: AppSettings.fromJson(<String, dynamic>{
+        'wisaRules': <dynamic>[
+          <String, dynamic>{'type': 'markAsOurs', 'schoolCode': 'ISMAA'},
+          <String, dynamic>{'type': 'dontImportClass', 'className': 'OKAN'},
+        ],
+      }),
+    );
+    await tester
+        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await _openTab(tester, 'settings-tab-wisa');
+    expect(find.text('Klas niet importeren uit WISA: OKAN'), findsOneWidget);
+    expect(find.textContaining('Markeer als beheerd'), findsNothing);
+
+    // …and saving drops it from the document for good.
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    final saved = await harness.store.load();
+    expect(saved.wisaRules, hasLength(1));
+    expect(
+      (saved.toJson()['wisaRules'] as List<dynamic>)
+          .map((dynamic r) => (r as Map<String, dynamic>)['type']),
+      <String>['dontImportClass'],
+    );
   });
 
   testWidgets(

--- a/account_manager/test/screens/settings_screen_test.dart
+++ b/account_manager/test/screens/settings_screen_test.dart
@@ -808,7 +808,7 @@ void main() {
       initial: AppSettings(
         wisaRules: <WisaImportRule>[
           const DontImportClass('OKAN'),
-          const MarkAsVirtual('VIRT'),
+          const DontImportUserFromWisa('VIRT'),
         ],
       ),
     );
@@ -1109,9 +1109,8 @@ void main() {
   });
 
   testWidgets(
-      'Toevoegen offers the three rules with no other surface, and not the one '
-      'the WISA-scholen grid already marks (#273)',
-      (WidgetTester tester) async {
+      'Toevoegen offers the three rules with no other surface, and neither '
+      'school-marking rule (#273)', (WidgetTester tester) async {
     _useTallWindow(tester);
     final harness = SettingsHarness();
     await tester
@@ -1130,9 +1129,9 @@ void main() {
       expect(
           find.byKey(ValueKey('settings-wisa-rule-add-$kind')), findsOneWidget);
     }
-    // `MarkAsVirtual` duplicates the grid's per-school mark, so it is not
-    // offered as a new rule. Its `beheerd` counterpart is not a rule kind at all
-    // any more (#286), so there is nothing to offer.
+    // Neither school-marking rule is a rule kind any more — `MarkAsOurs` went
+    // in #286 and `MarkAsVirtual` in #277 — so there is nothing to offer and
+    // nothing that could be authored to contradict the grid.
     expect(find.byKey(const ValueKey('settings-wisa-rule-add-markAsVirtual')),
         findsNothing);
     expect(find.byKey(const ValueKey('settings-wisa-rule-add-markAsOurs')),
@@ -1314,36 +1313,6 @@ void main() {
   });
 
   testWidgets(
-      'a school-marking rule stays editable and removable even though '
-      'Toevoegen does not offer it (#273)', (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final harness = SettingsHarness(
-      initial: AppSettings(
-        wisaRules: <WisaImportRule>[const MarkAsVirtual('ISMAA')],
-      ),
-    );
-    await tester
-        .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    await _openTab(tester, 'settings-tab-wisa');
-    // Editable: the prompt opens on the rule's own kind and value.
-    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-0-edit')));
-    await tester.pumpAndSettle();
-    expect(find.text('Markeer als virtueel'), findsOneWidget);
-    expect(find.text('ISMAA'), findsOneWidget);
-    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-cancel')));
-    await tester.pumpAndSettle();
-
-    // …and removable, so a legacy rule that contradicts the grid can go.
-    await tester.tap(find.byKey(const ValueKey('settings-wisa-rule-0-remove')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('settings-save')));
-    await tester.pumpAndSettle();
-    expect((await harness.store.load()).wisaRules, isEmpty);
-  });
-
-  testWidgets(
       'a persisted MarkAsOurs is ignored, so the list shows only live rules '
       '(#286)', (WidgetTester tester) async {
     _useTallWindow(tester);
@@ -1379,17 +1348,29 @@ void main() {
   });
 
   testWidgets(
-      'a MarkAsVirtual rule shows on the school it marks instead of '
-      'contradicting the grid (#273)', (WidgetTester tester) async {
+      'a persisted MarkAsVirtual becomes the grid\'s own checkbox, unlocked '
+      '(#277)', (WidgetTester tester) async {
     _useTallWindow(tester);
+    // A document another operator (or an older build) wrote. The rule kind is
+    // gone, so it can only be introduced as raw JSON — which is exactly the
+    // shape Cosmos hands back.
     final harness = SettingsHarness(
-      initial: AppSettings(
-        wisaRules: <WisaImportRule>[const MarkAsVirtual('ISMV')],
-        wisaSchools: const <WisaSchoolProfile>[
-          WisaSchoolProfile(schoolId: 1, code: 'ISMV', name: 'Virtuele school'),
-          WisaSchoolProfile(schoolId: 2, code: 'ISMAA', name: 'Sint-Maarten'),
+      initial: AppSettings.fromJson(<String, dynamic>{
+        'wisaRules': <dynamic>[
+          <String, dynamic>{'type': 'markAsVirtual', 'schoolCode': 'ISMV'},
         ],
-      ),
+        'wisaSchools': <dynamic>[
+          const WisaSchoolProfile(
+                  schoolId: 1,
+                  code: 'ISMV',
+                  name: 'Virtuele school',
+                  ours: true)
+              .toJson(),
+          const WisaSchoolProfile(
+                  schoolId: 2, code: 'ISMAA', name: 'Sint-Maarten', ours: true)
+              .toJson(),
+        ],
+      }),
     );
     await tester
         .pumpWidget(_wrap(SettingsScreen(bootstrap: harness.bootstrap)));
@@ -1397,22 +1378,33 @@ void main() {
 
     await _openTab(tester, 'settings-tab-wisa');
 
-    // The rule-marked school reads as virtual and says where that came from;
-    // its checkbox is locked, because the pull unions both surfaces and
-    // unticking it would not stick.
+    // The mark survived, on the grid this time: ticked and editable, with no
+    // "(importregel)" caveat, because nothing can contradict the checkbox now.
     final marked = tester.widget<CheckboxListTile>(
       find.byKey(const ValueKey('settings-wisa-school-1-virtual')),
     );
     expect(marked.value, isTrue);
-    expect(marked.onChanged, isNull);
-    expect(find.text('virtueel (importregel)'), findsOneWidget);
+    expect(marked.onChanged, isNotNull);
+    expect(find.text('virtueel (importregel)'), findsNothing);
 
-    // The school no rule names is untouched: unticked and still editable.
+    // The school the rule never named is untouched.
     final plain = tester.widget<CheckboxListTile>(
       find.byKey(const ValueKey('settings-wisa-school-2-virtual')),
     );
     expect(plain.value, isFalse);
     expect(plain.onChanged, isNotNull);
+
+    // The rules list has nothing left to show, and unticking now sticks.
+    expect(find.byKey(const ValueKey('settings-wisa-rules-empty')),
+        findsOneWidget);
+    await tester
+        .tap(find.byKey(const ValueKey('settings-wisa-school-1-virtual')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('settings-save')));
+    await tester.pumpAndSettle();
+    final saved = await harness.store.load();
+    expect(saved.virtualWisaSchoolIds, isEmpty);
+    expect(saved.wisaRules, isEmpty);
   });
 
   testWidgets(

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -270,9 +270,10 @@ See INV-40, INV-41, INV-42. `ApplyOptions` carries `dryRun: bool` (PAIN-3).
 | `DontImportClass` | WISA | Discard | className |
 | `DontImportUserFromWisa` | WISA | Discard | userCode |
 | `ReplaceInstitute` | WISA | Modify | from → to |
-| `MarkAsVirtual` | WISA | WorkDate | schoolCode |
 
 Rules are applied **at snapshot construction time** (inside the connector or just after), not at link time. The legacy code interleaves them; we don't.
+
+The legacy school-marking rules `MarkAsVirtual` (WorkDate, schoolCode) and `MarkAsOurs` are **not** ported. Both flagged a `WisaSchool` by its short code, and both flags are the operator's WISA-scholen list in Instellingen instead, keyed by school **id**: `AppSettings.virtualWisaSchoolIds` decides which schools pull with the virtual werkdatum (#277) and `AppSettings.managedWisaSchoolIds` which schools we manage (#286). A settings document that still carries either rule loads; a persisted `MarkAsVirtual` is migrated onto the matching school's `virtual` flag on the way in.
 
 ## 4. Identity scheme
 

--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -78,9 +78,11 @@ one immutable value:
     **label vocabulary**.
   - `AzureConnection` — clientId / tenantId / domain.
 - **Import-rule sets** — the WISA (`ReplaceInstitute`, `DontImportClass`,
-  `MarkAsVirtual`, `DontImportUserFromWisa`) and Smartschool
-  (`DiscardSmartschoolGroup`, `NoSmartschoolSubgroups`) rules, round-tripped
-  through `SettingsStore` via the tagged-JSON codecs.
+  `DontImportUserFromWisa`) and Smartschool (`DiscardSmartschoolGroup`,
+  `NoSmartschoolSubgroups`) rules, round-tripped through `SettingsStore` via the
+  tagged-JSON codecs. The legacy school-marking rules are not among them:
+  `MarkAsVirtual` (#277) and `MarkAsOurs` (#286) are the per-school
+  `WisaSchoolProfile` flags in the same document, keyed by school id.
 
 Two seams keep the model clean:
 

--- a/packages/account_core/lib/src/enums.dart
+++ b/packages/account_core/lib/src/enums.dart
@@ -107,6 +107,10 @@ enum Origin {
 
 /// Import rules applied at snapshot construction time
 /// (`docs/domain-model.md` §3.11).
+///
+/// Neither legacy school-marking rule is here. Both flagged a WISA school by its
+/// short code, and both flags are the operator's WISA-scholen list keyed by
+/// school **id** instead — `MarkAsOurs` since #286, `MarkAsVirtual` since #277.
 enum Rule {
   // Smartschool import rules.
   ssDiscardGroup,
@@ -114,7 +118,6 @@ enum Rule {
   // WISA import rules.
   wiReplaceInstitution,
   wiDontImportClass,
-  wiMarkAsVirtual,
   wiDontImportUser,
   ;
 

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -54,10 +54,10 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 /// [ourSchoolIds] is the set of WISA school ids we actually **manage** (#133).
 /// The shared credentials pull every group school, so this set is what tells a
 /// student who left *our* school (but is still in a sibling group school) from
-/// one who is genuinely present here. When null, it is derived from the
-/// snapshot's own `WisaSchool.isOurs` flags (the `MarkAsOurs` import rule). When
-/// that derived set is also empty — ownership unconfigured — every WISA-present
-/// student is treated as ours, preserving the pre-#134 behaviour. For students
+/// one who is genuinely present here. It comes from Settings and nowhere else
+/// (#286): null and empty both mean ownership is unconfigured, in which case
+/// every WISA-present student is treated as ours, preserving the pre-#134
+/// behaviour. For students
 /// and staff, membership never changes which records exist or their identity
 /// keys, only how each is classified ([WisaPresence]); for **groups** it is a
 /// filter (#205), because a class of a school we do not manage has no business
@@ -78,11 +78,7 @@ LinkedSnapshot link(
   required String schoolPrefix,
   Set<int>? ourSchoolIds,
 }) {
-  final effectiveOurSchoolIds = ourSchoolIds ??
-      <int>{
-        for (final school in wisaSnapshot.schools)
-          if (school.isOurs) school.id,
-      };
+  final effectiveOurSchoolIds = ourSchoolIds ?? const <int>{};
 
   // The virtual schools (#209). Unlike ownership there is no caller override:
   // the flag is stamped onto the school list before the pull, and `sync()`

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -767,7 +767,7 @@ void main() {
 
   group('link — class groups are scoped to the schools we manage (#205)', () {
     /// Links [classGroups] alone (no people), with the managed-school set
-    /// pinned by [ourSchoolIds] (the Settings path) or derived from [schools].
+    /// pinned by [ourSchoolIds] (the Settings path, and the only one).
     LinkedSnapshot linkClasses(
       List<wapi.WisaClassGroup> classGroups, {
       Set<int>? ourSchoolIds,
@@ -822,25 +822,30 @@ void main() {
       expect(snapshot.groups.single.wisa!.instituteNumber, '111');
     });
 
-    test('the managed set falls back to WisaSchool.isOurs when unset', () {
+    test('ownership unconfigured → every class still links', () {
+      // No explicit set: the pre-#205 behaviour is preserved for a group that
+      // has not marked its schools yet. Since #286 the snapshot has no say in
+      // this — a school list carrying both schools changes nothing.
       final snapshot = linkClasses(
         [
           wisaClassGroup('5A', schoolId: 1),
           wisaClassGroup('9Z', schoolId: 2),
         ],
-        schools: [wisaSchool(1, ours: true), wisaSchool(2)],
+        schools: [wisaSchool(1), wisaSchool(2)],
       );
 
-      expect([for (final g in snapshot.groups) g.wisa!.name], ['5A']);
+      expect([for (final g in snapshot.groups) g.wisa!.name], ['5A', '9Z']);
     });
 
-    test('ownership unconfigured → every class still links', () {
-      // No explicit set and no isOurs flags anywhere: the pre-#205 behaviour is
-      // preserved for a group that has not marked its schools yet.
-      final snapshot = linkClasses([
-        wisaClassGroup('5A', schoolId: 1),
-        wisaClassGroup('9Z', schoolId: 2),
-      ]);
+    test('an empty managed set reads as unconfigured, not as "none is ours"',
+        () {
+      final snapshot = linkClasses(
+        [
+          wisaClassGroup('5A', schoolId: 1),
+          wisaClassGroup('9Z', schoolId: 2),
+        ],
+        ourSchoolIds: const <int>{},
+      );
 
       expect([for (final g in snapshot.groups) g.wisa!.name], ['5A', '9Z']);
     });
@@ -865,8 +870,8 @@ void main() {
   group('link — class groups of a virtual school are never imported (#209)',
       () {
     /// Links [classGroups] (and optionally [students]) with the schools list
-    /// carrying the virtual/ours flags the linker derives its two group filters
-    /// from. [ourSchoolIds] pins the managed set the Settings path supplies.
+    /// carrying the virtual flags one of the linker's two group filters reads.
+    /// [ourSchoolIds] pins the managed set the Settings path supplies.
     LinkedSnapshot linkVirtual(
       List<wapi.WisaClassGroup> classGroups, {
       List<wapi.WisaSchool> schools = const [],
@@ -889,7 +894,7 @@ void main() {
       // exclusion keeps its classes out.
       final snapshot = linkVirtual(
         [wisaClassGroup('1V', schoolId: 99)],
-        schools: [wisaSchool(99, ours: true, virtual: true)],
+        schools: [wisaSchool(99, virtual: true)],
         ourSchoolIds: const {1, 99},
       );
 
@@ -902,7 +907,7 @@ void main() {
           wisaClassGroup('3B', schoolCode: '111', schoolId: 1),
           wisaClassGroup('1V', schoolId: 99),
         ],
-        schools: [wisaSchool(1, ours: true), wisaSchool(99, virtual: true)],
+        schools: [wisaSchool(1), wisaSchool(99, virtual: true)],
         ourSchoolIds: const {1, 99},
       );
 
@@ -932,10 +937,7 @@ void main() {
           wisaClassGroup('1A', schoolCode: '999', schoolId: 99),
           wisaClassGroup('1A', schoolCode: '111', schoolId: 1),
         ],
-        schools: [
-          wisaSchool(1, ours: true),
-          wisaSchool(99, ours: true, virtual: true)
-        ],
+        schools: [wisaSchool(1), wisaSchool(99, virtual: true)],
         ourSchoolIds: const {1, 99},
       );
 
@@ -949,10 +951,7 @@ void main() {
       // `classGroup` string, so dropping the records moves nobody.
       final snapshot = linkVirtual(
         [wisaClassGroup('1V', schoolId: 99)],
-        schools: [
-          wisaSchool(1, ours: true),
-          wisaSchool(99, ours: true, virtual: true)
-        ],
+        schools: [wisaSchool(1), wisaSchool(99, virtual: true)],
         ourSchoolIds: const {1, 99},
         students: [wisaStudent('W9', schoolId: 99)],
       );
@@ -969,7 +968,7 @@ void main() {
         'orphan', () {
       final snapshot = linkVirtual(
         [wisaClassGroup('1V', schoolId: 99)],
-        schools: [wisaSchool(99, ours: true, virtual: true)],
+        schools: [wisaSchool(99, virtual: true)],
         ourSchoolIds: const {99},
         ssGroups: [ssGroup('1V')],
       );
@@ -1254,8 +1253,8 @@ void main() {
 
   group('link — WISA-school membership + ours-vs-group (#134)', () {
     /// A student fully linked across the three systems whose WISA row sits in
-    /// [schoolId]. [schools] carries the managed-school flags the linker derives
-    /// its ownership set from; [ourSchoolIds] overrides that derivation.
+    /// [schoolId]. [schools] is the snapshot's school list (no ownership in it
+    /// since #286); [ourSchoolIds] is the managed set, from Settings.
     LinkedSnapshot linkStudentIn(
       int schoolId, {
       List<wapi.WisaSchool> schools = const [],
@@ -1307,25 +1306,28 @@ void main() {
       expect(a.hasLeftGroup, isFalse);
     });
 
-    test('the managed-school set is derived from WisaSchool.isOurs by default',
-        () {
-      // No explicit ourSchoolIds: the snapshot's own isOurs flags decide.
-      final ours = linkStudentIn(
-        1,
-        schools: [wisaSchool(1, ours: true), wisaSchool(2)],
-      ).accounts.single;
-      expect(ours.wisaPresence, WisaPresence.ours);
-
+    test('the snapshot never decides ownership on its own (#286)', () {
+      // The school list is not a source of ownership — only the Settings-derived
+      // `ourSchoolIds` is. Without one, a sibling school's student is ours, the
+      // same as any other, rather than being classified by a snapshot flag.
       final sibling = linkStudentIn(
         2,
-        schools: [wisaSchool(1, ours: true), wisaSchool(2)],
+        schools: [wisaSchool(1), wisaSchool(2)],
       ).accounts.single;
-      expect(sibling.wisaPresence, WisaPresence.groupOnly);
+      expect(sibling.wisaPresence, WisaPresence.ours);
+
+      // Naming the managed set is what separates the two.
+      final pinned = linkStudentIn(
+        2,
+        schools: [wisaSchool(1), wisaSchool(2)],
+        ourSchoolIds: {1},
+      ).accounts.single;
+      expect(pinned.wisaPresence, WisaPresence.groupOnly);
     });
 
     test('a WISA-absent (Azure-only) record is classified absent', () {
       final snapshot = link(
-        wisaSnap(const [], schools: [wisaSchool(1, ours: true)]),
+        wisaSnap(const [], schools: [wisaSchool(1)]),
         ssSnap(const []),
         azSnap([azureUser(id: 'az-9', upn: 'gone@s.be', companyName: _prefix)]),
         SeqResolver(),

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -40,8 +40,9 @@ wapi.WisaStudent wisaStudent(String wisaId, {int schoolId = 1}) =>
       schoolId: schoolId,
     );
 
-/// A WISA school, optionally flagged [virtual] (the `MarkAsVirtual` / settings
-/// flag whose class groups the linker refuses to seed, #209).
+/// A WISA school, optionally flagged [virtual] (the operator's per-school mark,
+/// stamped on before the pull, whose class groups the linker refuses to seed —
+/// #209; the rule that once set the same flag went in #277).
 ///
 /// Ownership is not a snapshot flag (#286): the managed set reaches `link()`
 /// only as its `ourSchoolIds` argument.

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -40,16 +40,15 @@ wapi.WisaStudent wisaStudent(String wisaId, {int schoolId = 1}) =>
       schoolId: schoolId,
     );
 
-/// A WISA school, optionally flagged [ours] (the `MarkAsOurs` import-rule
-/// outcome the linker derives the managed-school set from, #133/#134) and/or
-/// [virtual] (the `MarkAsVirtual` / settings flag whose class groups the linker
-/// refuses to seed, #209).
-wapi.WisaSchool wisaSchool(int id, {bool ours = false, bool virtual = false}) =>
-    wapi.WisaSchool(
+/// A WISA school, optionally flagged [virtual] (the `MarkAsVirtual` / settings
+/// flag whose class groups the linker refuses to seed, #209).
+///
+/// Ownership is not a snapshot flag (#286): the managed set reaches `link()`
+/// only as its `ourSchoolIds` argument.
+wapi.WisaSchool wisaSchool(int id, {bool virtual = false}) => wapi.WisaSchool(
       id: id,
       name: 'S$id',
       code: '',
-      isOurs: ours,
       isVirtual: virtual,
     );
 

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -100,6 +100,7 @@ export 'src/settings/import_rule_codec.dart';
 export 'src/settings/live_settings.dart';
 export 'src/settings/secret_provider.dart';
 export 'src/settings/settings_store.dart';
+export 'src/settings/wisa_rule_merge.dart';
 export 'src/settings/wisa_school_label.dart';
 export 'src/settings/wisa_school_merge.dart';
 export 'src/settings/wisa_school_profile.dart';

--- a/packages/account_state/lib/account_state.dart
+++ b/packages/account_state/lib/account_state.dart
@@ -98,6 +98,7 @@ export 'src/settings/app_settings.dart';
 export 'src/settings/connection.dart';
 export 'src/settings/import_rule_codec.dart';
 export 'src/settings/live_settings.dart';
+export 'src/settings/rule_provenance.dart';
 export 'src/settings/secret_provider.dart';
 export 'src/settings/settings_store.dart';
 export 'src/settings/wisa_rule_merge.dart';

--- a/packages/account_state/lib/src/apply/state_applier.dart
+++ b/packages/account_state/lib/src/apply/state_applier.dart
@@ -94,7 +94,10 @@ class ApplierSettings {
 /// 3. for a `DontImportFromWisa` action (which writes nothing and returns a
 ///    [ActionResult.wisaRule]), accumulates the rule in [wisaRules] and
 ///    **re-syncs WISA** so the ignored record drops from the next snapshot —
-///    the one path that does hit the network again.
+///    the one path that does hit the network again. Making that rule permanent
+///    is the caller's job, not this layer's: since #276 the reconcile controller
+///    writes it to the shared settings document once the pass ends, where the
+///    store (and, for #285, the operator's identity) lives.
 ///
 /// **Smartschool uid uniqueness (#72).** Because State holds the account set,
 /// this applier wraps the injected [StudentActionConfig] / [StaffActionConfig]

--- a/packages/account_state/lib/src/apply/state_applier.dart
+++ b/packages/account_state/lib/src/apply/state_applier.dart
@@ -75,8 +75,8 @@ class ApplierSettings {
   final SmartschoolClassTree classTree;
 
   /// The `ours`-flagged WISA school ids (#178), or null when no school is
-  /// flagged — which falls back to the snapshot's own `MarkAsOurs` flags rather
-  /// than treating an empty managed set as "none".
+  /// flagged — which, like an empty set, reads as "ownership unconfigured" and
+  /// counts every school, never as "no school is ours".
   final Set<int>? ourSchoolIds;
 }
 
@@ -187,7 +187,7 @@ class StateApplier {
   /// `AppSettings.wisaSchools` ownership flags, #178). Threaded into `link()` so
   /// a student present only in a non-managed sibling school is classified
   /// [core.WisaPresence.groupOnly] and kept out of the managed-school Actions
-  /// view. Null falls back to the snapshot's `MarkAsOurs` flags (see `link()`).
+  /// view. Null reads as unconfigured — every school counts (see `link()`).
   Set<int>? get ourSchoolIds => settings.ourSchoolIds;
 
   /// Smartschool class-tree live-config the placement resolver needs.

--- a/packages/account_state/lib/src/apply/wisa_import_rules.dart
+++ b/packages/account_state/lib/src/apply/wisa_import_rules.dart
@@ -45,6 +45,18 @@ import 'package:wisa_api/wisa_api.dart';
 /// all. So the two sources stay distinct — persisted rules on the settings
 /// document, read live at pull time through [unionWith]; session-earned rules
 /// here — and the pull unions them.
+///
+/// ## An earned rule is persisted too (#276)
+///
+/// This holder is no longer the *record* of a `DontImportFromWisa` apply, only
+/// its immediate effect: it is what lets the applier re-sync WISA at once,
+/// without waiting for a settings round-trip. The app layer writes the same rule
+/// to the settings document (`mergeEarnedWisaRules`) when the apply pass ends,
+/// because the exclusion is a standing decision — WISA keeps reporting a retired
+/// staff member active indefinitely — and a rule that died with the process made
+/// the app propose re-creating the very account it had just been told to stop
+/// importing. The two copies collapse to one at the next pull, exactly as
+/// [unionWith] collapses any other overlap.
 class WisaImportRules {
   WisaImportRules({Iterable<WisaImportRule> initial = const []}) {
     for (final rule in initial) {

--- a/packages/account_state/lib/src/apply/wisa_import_rules.dart
+++ b/packages/account_state/lib/src/apply/wisa_import_rules.dart
@@ -121,5 +121,4 @@ String wisaRuleKey(WisaImportRule rule) => switch (rule) {
       DontImportUserFromWisa(:final userCode) => 'user:$userCode',
       ReplaceInstitute(:final original) => 'institute:$original',
       MarkAsVirtual(:final schoolCode) => 'virtual:$schoolCode',
-      MarkAsOurs(:final schoolCode) => 'ours:$schoolCode',
     };

--- a/packages/account_state/lib/src/apply/wisa_import_rules.dart
+++ b/packages/account_state/lib/src/apply/wisa_import_rules.dart
@@ -120,5 +120,4 @@ String wisaRuleKey(WisaImportRule rule) => switch (rule) {
       DontImportClass(:final className) => 'class:$className',
       DontImportUserFromWisa(:final userCode) => 'user:$userCode',
       ReplaceInstitute(:final original) => 'institute:$original',
-      MarkAsVirtual(:final schoolCode) => 'virtual:$schoolCode',
     };

--- a/packages/account_state/lib/src/apply/wisa_import_rules.dart
+++ b/packages/account_state/lib/src/apply/wisa_import_rules.dart
@@ -99,11 +99,27 @@ class WisaImportRules {
     return true;
   }
 
-  static String _keyOf(WisaImportRule rule) => switch (rule) {
-        DontImportClass(:final className) => 'class:$className',
-        DontImportUserFromWisa(:final userCode) => 'user:$userCode',
-        ReplaceInstitute(:final original) => 'institute:$original',
-        MarkAsVirtual(:final schoolCode) => 'virtual:$schoolCode',
-        MarkAsOurs(:final schoolCode) => 'ours:$schoolCode',
-      };
+  static String _keyOf(WisaImportRule rule) => wisaRuleKey(rule);
 }
+
+/// The identity two WISA import rules are the *same rule* by: the fields that
+/// decide what the rule matches, and nothing else.
+///
+/// [WisaImportRules] de-duplicates on this, and so does everything that has to
+/// agree with it about what a duplicate is — the settings document's per-rule
+/// provenance is keyed by it (#285), so metadata attaches to the decision rather
+/// than to one particular object, and a rule the document already carries keeps
+/// the provenance of whoever decided it first.
+///
+/// Derived from the identifying fields rather than the whole record on purpose:
+/// that is what lets provenance ride along without changing what a duplicate is.
+/// Note [ReplaceInstitute] keys on [ReplaceInstitute.original] alone — two rules
+/// rewriting the same institute to different targets are one decision, correctly
+/// stated once.
+String wisaRuleKey(WisaImportRule rule) => switch (rule) {
+      DontImportClass(:final className) => 'class:$className',
+      DontImportUserFromWisa(:final userCode) => 'user:$userCode',
+      ReplaceInstitute(:final original) => 'institute:$original',
+      MarkAsVirtual(:final schoolCode) => 'virtual:$schoolCode',
+      MarkAsOurs(:final schoolCode) => 'ours:$schoolCode',
+    };

--- a/packages/account_state/lib/src/link/linked_state.dart
+++ b/packages/account_state/lib/src/link/linked_state.dart
@@ -63,12 +63,12 @@ class LinkedState {
   ///
   /// [ourSchoolIds] is the set of WISA school ids the operator actually manages
   /// (from the persisted `AppSettings.wisaSchools` ownership flags, #178). It is
-  /// threaded into `link()` so `wisaPresence` is authoritative from Settings
-  /// rather than only the snapshot's `MarkAsOurs` flags, **and** into the
+  /// threaded into `link()` so `wisaPresence` is authoritative from Settings —
+  /// the only place ownership lives since #286 — **and** into the
   /// [PlacementResolver] so "does this class hold students?" counts only the
   /// students of a school we manage (#222) — the two must agree, since the
   /// linker seeds a class group only for a managed school (#205). When null,
-  /// both fall back to those snapshot flags (see their doc-comments).
+  /// both read ownership as unconfigured and count every school.
   factory LinkedState.recompute({
     required wapi.WisaSnapshot wisa,
     required ss.SmartschoolSnapshot smartschool,

--- a/packages/account_state/lib/src/link/placement.dart
+++ b/packages/account_state/lib/src/link/placement.dart
@@ -88,19 +88,15 @@ class SmartschoolClassTree {
 /// Settings-derived set `LinkedState` threads into `link()` (#178/#205). The
 /// snapshots pool every school the shared WISA credentials reach, so the
 /// resolver needs it to keep a sibling school's rows from answering questions
-/// about *our* classes (#221/#222). When omitted it falls back to the
-/// snapshot's own `WisaSchool.isOurs` flags, exactly like `link()`.
+/// about *our* classes (#221/#222). When omitted, ownership counts as
+/// unconfigured and every school answers — exactly like `link()`.
 class PlacementResolver {
   PlacementResolver({
     required wapi.WisaSnapshot wisa,
     required ss.SmartschoolSnapshot smartschool,
     this.classTree = const SmartschoolClassTree(),
     Set<int>? ourSchoolIds,
-  }) : _ourSchoolIds = ourSchoolIds ??
-            <int>{
-              for (final school in wisa.schools)
-                if (school.isOurs) school.id,
-            } {
+  }) : _ourSchoolIds = ourSchoolIds ?? const <int>{} {
     // Index the Smartschool tree by name (for resolveClass) and by code (for
     // the current-class and logical-parent lookups). First wins on a
     // collision, keeping the result a deterministic function of snapshot order.
@@ -189,9 +185,9 @@ class PlacementResolver {
   /// The WISA school ids the operator actually manages (#222), from the
   /// persisted Settings ownership flags the State layer threads in — the same
   /// set the linker scopes group seeding by (#205). When the caller passes
-  /// none it is derived from the snapshot's own `WisaSchool.isOurs` flags,
-  /// exactly as `link()` derives its own fallback, so the two layers always
-  /// agree on which classes exist and which students populate them.
+  /// none it is empty, exactly as `link()` treats its own omitted set, so the
+  /// two layers always agree on which classes exist and which students
+  /// populate them.
   ///
   /// An **empty** set means ownership is unconfigured, in which case every
   /// school counts as ours — mirroring the linker's `_isOurWisaSchool` and

--- a/packages/account_state/lib/src/settings/app_settings.dart
+++ b/packages/account_state/lib/src/settings/app_settings.dart
@@ -90,16 +90,18 @@ class AppSettings {
   /// Smartschool import rules applied at snapshot construction (spec §3.11).
   final List<SmartschoolImportRule> smartschoolRules;
 
-  /// Per-WISA-school ownership entries (the `MarkAsOurs` counterpart persisted
-  /// by school id). Empty means no school has been marked managed yet — the
-  /// group-membership plumbing #113 slice 2 reads, but no action fires here.
+  /// Per-WISA-school ownership entries, keyed by school id. Empty means no
+  /// school has been marked managed yet — the group-membership plumbing #113
+  /// slice 2 reads, but no action fires here.
   final List<WisaSchoolProfile> wisaSchools;
 
   /// The set of WISA school ids the operator manages — the `ours`-flagged
   /// entries of [wisaSchools] (#178). This is what the linker joins student
-  /// membership against so `wisaPresence` is authoritative from Settings; empty
-  /// when no school is flagged (the caller then falls back to the snapshot's
-  /// `MarkAsOurs` flags rather than passing an empty managed set).
+  /// membership against so `wisaPresence` is authoritative from Settings, and
+  /// since #286 it is the *only* source of ownership. Empty means ownership is
+  /// unconfigured, which every reader treats as "every school counts" rather
+  /// than "no school is ours" — the honest answer for an install that has not
+  /// filled the WISA-scholen list in yet.
   Set<int> get managedWisaSchoolIds => <int>{
         for (final p in wisaSchools)
           if (p.ours) p.schoolId,
@@ -177,15 +179,20 @@ class AppSettings {
     // The rule and its provenance share one object on the wire (#285) and are
     // two values in memory, so they are split in one pass rather than by
     // decoding the list twice.
+    //
+    // A retired rule kind decodes as null and is dropped, provenance and all
+    // (#286): the document loads, and the entry is gone from the next save.
     final wisaRules = <WisaImportRule>[];
     final wisaRuleProvenance = <String, RuleProvenance>{};
     for (final r in wisa) {
       final encoded = r as Map<String, dynamic>;
       final rule = decodeWisaRule(encoded);
+      if (rule == null) continue;
       wisaRules.add(rule);
       final provenance = decodeWisaRuleProvenance(encoded);
-      if (provenance != null)
+      if (provenance != null) {
         wisaRuleProvenance[wisaRuleKey(rule)] = provenance;
+      }
     }
     return AppSettings(
       schoolPrefix: (json['schoolPrefix'] as String?) ?? '',

--- a/packages/account_state/lib/src/settings/app_settings.dart
+++ b/packages/account_state/lib/src/settings/app_settings.dart
@@ -168,6 +168,15 @@ class AppSettings {
   /// Missing keys fall back to the constructor defaults so an older or
   /// partial config still loads. Throws [FormatException] (via the rule
   /// codecs) if a rule carries an unknown `type` tag.
+  ///
+  /// This is also where the one-shot #277 migration runs: a persisted
+  /// `markAsVirtual` rule becomes the matching school's
+  /// [WisaSchoolProfile.virtual] flag. It lives here rather than in the app
+  /// because both halves — the rules and the school rows — are in this one
+  /// document, so no fetch has to complete first and every operator's session
+  /// reaches the same answer. It rewrites nothing by itself: the migrated flag
+  /// is simply what the document means from now on, and the next ordinary save
+  /// writes it back without the rule.
   factory AppSettings.fromJson(Map<String, dynamic> json) {
     final wisa = (json['wisaRules'] as List<dynamic>?) ?? const [];
     final smartschool =
@@ -182,10 +191,19 @@ class AppSettings {
     //
     // A retired rule kind decodes as null and is dropped, provenance and all
     // (#286): the document loads, and the entry is gone from the next save.
+    //
+    // `markAsVirtual` (#277) is retired the same way but not merely dropped —
+    // it was live configuration. Its school code is collected here and handed to
+    // `adoptRetiredVirtualMarks` below, which sets the WISA-scholen grid's own
+    // per-school `virtual` flag instead. Provenance goes with the rule: the mark
+    // now belongs to a school row, which records none.
     final wisaRules = <WisaImportRule>[];
     final wisaRuleProvenance = <String, RuleProvenance>{};
+    final retiredVirtualCodes = <String>{};
     for (final r in wisa) {
       final encoded = r as Map<String, dynamic>;
+      final retiredVirtual = retiredVirtualCodeOf(encoded);
+      if (retiredVirtual != null) retiredVirtualCodes.add(retiredVirtual);
       final rule = decodeWisaRule(encoded);
       if (rule == null) continue;
       wisaRules.add(rule);
@@ -212,10 +230,13 @@ class AppSettings {
         for (final r in smartschool)
           decodeSmartschoolRule(r as Map<String, dynamic>),
       ],
-      wisaSchools: [
-        for (final p in wisaSchools)
-          WisaSchoolProfile.fromJson(p as Map<String, dynamic>),
-      ],
+      wisaSchools: adoptRetiredVirtualMarks(
+        <WisaSchoolProfile>[
+          for (final p in wisaSchools)
+            WisaSchoolProfile.fromJson(p as Map<String, dynamic>),
+        ],
+        retiredVirtualCodes,
+      ),
     );
   }
 }

--- a/packages/account_state/lib/src/settings/app_settings.dart
+++ b/packages/account_state/lib/src/settings/app_settings.dart
@@ -1,8 +1,10 @@
 import 'package:smartschool_api/smartschool_api.dart';
 import 'package:wisa_api/wisa_api.dart';
 
+import '../apply/wisa_import_rules.dart';
 import 'connection.dart';
 import 'import_rule_codec.dart';
+import 'rule_provenance.dart';
 import 'wisa_school_profile.dart';
 
 /// The persisted configuration model for the Arcadia Account Manager.
@@ -35,6 +37,7 @@ class AppSettings {
     this.azure = const AzureConnection(),
     SmartschoolConnection? smartschool,
     this.wisaRules = const [],
+    this.wisaRuleProvenance = const <String, RuleProvenance>{},
     this.smartschoolRules = const [],
     this.wisaSchools = const [],
   }) : _smartschool = smartschool;
@@ -63,6 +66,26 @@ class AppSettings {
 
   /// WISA import rules applied at snapshot construction (spec §3.11).
   final List<WisaImportRule> wisaRules;
+
+  /// Provenance for the persisted [wisaRules], keyed by [wisaRuleKey] (#285).
+  ///
+  /// Keyed rather than positional, and separate from the rules themselves,
+  /// because the rule types belong to `wisa_api` and know nothing about
+  /// operators — on the wire the two travel in one object (see
+  /// [encodeWisaRule]), and only here are they two values. A rule with no entry
+  /// is one persisted before #285; [provenanceOf] answers `null` for it and the
+  /// view says `onbekend`.
+  ///
+  /// The key is the same identity [WisaImportRules] de-duplicates on, so two
+  /// operators earning the same rule collapse to one decision carrying the
+  /// **first** one's provenance — deliberately, since that is the decision the
+  /// document has been standing on.
+  final Map<String, RuleProvenance> wisaRuleProvenance;
+
+  /// Who added [rule], when, and for whom — or `null` when the document records
+  /// nothing about it (#285).
+  RuleProvenance? provenanceOf(WisaImportRule rule) =>
+      wisaRuleProvenance[wisaRuleKey(rule)];
 
   /// Smartschool import rules applied at snapshot construction (spec §3.11).
   final List<SmartschoolImportRule> smartschoolRules;
@@ -100,6 +123,7 @@ class AppSettings {
     AzureConnection? azure,
     SmartschoolConnection? smartschool,
     List<WisaImportRule>? wisaRules,
+    Map<String, RuleProvenance>? wisaRuleProvenance,
     List<SmartschoolImportRule>? smartschoolRules,
     List<WisaSchoolProfile>? wisaSchools,
   }) {
@@ -110,6 +134,7 @@ class AppSettings {
       azure: azure ?? this.azure,
       smartschool: smartschool ?? this.smartschool,
       wisaRules: wisaRules ?? this.wisaRules,
+      wisaRuleProvenance: wisaRuleProvenance ?? this.wisaRuleProvenance,
       smartschoolRules: smartschoolRules ?? this.smartschoolRules,
       wisaSchools: wisaSchools ?? this.wisaSchools,
     );
@@ -124,7 +149,13 @@ class AppSettings {
       'wisa': wisa.toJson(),
       'smartschool': smartschool.toJson(),
       'azure': azure.toJson(),
-      'wisaRules': wisaRules.map(encodeWisaRule).toList(),
+      // Each rule's provenance rides inside its own object (#285), so a stored
+      // rule and the record of who decided it can never come apart. A rule the
+      // document knows nothing about encodes exactly as it did before #285.
+      'wisaRules': <Map<String, dynamic>>[
+        for (final rule in wisaRules)
+          encodeWisaRule(rule, provenance: provenanceOf(rule)),
+      ],
       'smartschoolRules': smartschoolRules.map(encodeSmartschoolRule).toList(),
       'wisaSchools': wisaSchools.map((p) => p.toJson()).toList(),
     };
@@ -143,6 +174,19 @@ class AppSettings {
     final smartschoolConn = json['smartschool'] as Map<String, dynamic>?;
     final azureConn = json['azure'] as Map<String, dynamic>?;
     final wisaSchools = (json['wisaSchools'] as List<dynamic>?) ?? const [];
+    // The rule and its provenance share one object on the wire (#285) and are
+    // two values in memory, so they are split in one pass rather than by
+    // decoding the list twice.
+    final wisaRules = <WisaImportRule>[];
+    final wisaRuleProvenance = <String, RuleProvenance>{};
+    for (final r in wisa) {
+      final encoded = r as Map<String, dynamic>;
+      final rule = decodeWisaRule(encoded);
+      wisaRules.add(rule);
+      final provenance = decodeWisaRuleProvenance(encoded);
+      if (provenance != null)
+        wisaRuleProvenance[wisaRuleKey(rule)] = provenance;
+    }
     return AppSettings(
       schoolPrefix: (json['schoolPrefix'] as String?) ?? '',
       debugMode: (json['debugMode'] as bool?) ?? false,
@@ -155,9 +199,8 @@ class AppSettings {
       azure: azureConn == null
           ? const AzureConnection()
           : AzureConnection.fromJson(azureConn),
-      wisaRules: [
-        for (final r in wisa) decodeWisaRule(r as Map<String, dynamic>),
-      ],
+      wisaRules: wisaRules,
+      wisaRuleProvenance: wisaRuleProvenance,
       smartschoolRules: [
         for (final r in smartschool)
           decodeSmartschoolRule(r as Map<String, dynamic>),

--- a/packages/account_state/lib/src/settings/import_rule_codec.dart
+++ b/packages/account_state/lib/src/settings/import_rule_codec.dart
@@ -47,7 +47,6 @@ Map<String, dynamic> encodeWisaRule(
         'original': rule.original,
         'replacement': rule.replacement,
       },
-    MarkAsVirtual() => {'type': 'markAsVirtual', 'schoolCode': rule.schoolCode},
   };
   final Map<String, dynamic> extra = provenance?.toJson() ?? const {};
   if (extra.isEmpty) return encoded;
@@ -65,12 +64,17 @@ RuleProvenance? decodeWisaRuleProvenance(Map<String, dynamic> json) =>
 
 /// Decodes a tagged-JSON map produced by [encodeWisaRule].
 ///
-/// Returns `null` for a **retired** tag — a rule kind this app no longer has, so
-/// far the `markAsOurs` dropped by #286. A document another operator (or an
-/// older build) wrote still loads; the entry is simply ignored and disappears
-/// from the document the next time it is saved. That is safe precisely because
-/// the rule already did nothing: ownership comes from the WISA-scholen list in
-/// Settings, which wins over any snapshot flag.
+/// Returns `null` for a **retired** tag — a rule kind this app no longer has:
+/// the `markAsOurs` dropped by #286 and the `markAsVirtual` dropped by #277. A
+/// document another operator (or an older build) wrote still loads; the entry is
+/// simply ignored and disappears from the document the next time it is saved.
+/// Both school-marking rules duplicated the WISA-scholen grid in Settings, which
+/// marks by school **id** and is now the only surface for either flag.
+///
+/// `markAsOurs` can be dropped outright, the rule having done nothing for years.
+/// `markAsVirtual` was live, so it is not merely dropped: [retiredVirtualCodeOf]
+/// reads its school code back out of the same object, and `AppSettings.fromJson`
+/// carries the mark over to the grid's per-school flag (#277).
 ///
 /// Throws [FormatException] on an unknown or missing `type` tag so a corrupt
 /// config surfaces loudly rather than silently dropping rules.
@@ -87,12 +91,30 @@ WisaImportRule? decodeWisaRule(Map<String, dynamic> json) {
         replacement: json['replacement'] as String,
       );
     case 'markAsVirtual':
-      return MarkAsVirtual(json['schoolCode'] as String);
     case 'markAsOurs':
       return null;
     default:
       throw FormatException('Unknown WisaImportRule type: $type');
   }
+}
+
+/// The school code a persisted, now-retired `markAsVirtual` entry marked — or
+/// `null` for every other entry, retired or live (#277).
+///
+/// Exists because [decodeWisaRule] deliberately answers `null` for the retired
+/// tag and so cannot hand the code back: the mark is real configuration, not
+/// dead weight, and it has to reach the WISA-scholen grid's per-school `virtual`
+/// flag before the entry is dropped. Kept here with the rest of the wire shape
+/// so no reader outside this file has to know the tag's spelling.
+///
+/// A malformed entry (no `schoolCode`, or a non-string one) answers `null`
+/// rather than throwing: it marked no school when it was live either, and a
+/// settings document must not fail to load over a rule kind that no longer
+/// exists.
+String? retiredVirtualCodeOf(Map<String, dynamic> json) {
+  if (json['type'] != 'markAsVirtual') return null;
+  final code = json['schoolCode'];
+  return code is String ? code : null;
 }
 
 /// Encodes a [SmartschoolImportRule] to its tagged-JSON map.

--- a/packages/account_state/lib/src/settings/import_rule_codec.dart
+++ b/packages/account_state/lib/src/settings/import_rule_codec.dart
@@ -9,30 +9,60 @@
 /// The wire shape is a tagged object: `{ "type": "<tag>", ... }`. Tags are
 /// stable strings (not enum indices) so reordering the sealed hierarchy never
 /// changes a persisted config.
+///
+/// A WISA rule's object also carries its [RuleProvenance] — who added it, when,
+/// and for whom (#285) — beside the rule's own fields rather than in a parallel
+/// structure, so the two can never come apart on the wire.
 library;
 
 import 'package:smartschool_api/smartschool_api.dart';
 import 'package:wisa_api/wisa_api.dart';
 
-/// Encodes a [WisaImportRule] to its tagged-JSON map.
-Map<String, dynamic> encodeWisaRule(WisaImportRule rule) {
-  switch (rule) {
-    case DontImportClass():
-      return {'type': 'dontImportClass', 'className': rule.className};
-    case DontImportUserFromWisa():
-      return {'type': 'dontImportUserFromWisa', 'userCode': rule.userCode};
-    case ReplaceInstitute():
-      return {
+import 'rule_provenance.dart';
+
+/// Encodes a [WisaImportRule] to its tagged-JSON map, with [provenance] — when
+/// known — merged in beside the rule's own fields (#285).
+///
+/// The provenance keys (`subject`, `addedBy`, `addedAt`) are disjoint from every
+/// rule's own, and omitting them yields exactly the object every version before
+/// #285 wrote. That matters beyond backward compatibility: `wisaPullFingerprint`
+/// encodes the rules **without** provenance, because who typed a rule changes
+/// nothing about what the pull returns, and a re-stamped rule must not arm
+/// #238's drift gate.
+Map<String, dynamic> encodeWisaRule(
+  WisaImportRule rule, {
+  RuleProvenance? provenance,
+}) {
+  final Map<String, dynamic> encoded = switch (rule) {
+    DontImportClass() => {
+        'type': 'dontImportClass',
+        'className': rule.className
+      },
+    DontImportUserFromWisa() => {
+        'type': 'dontImportUserFromWisa',
+        'userCode': rule.userCode,
+      },
+    ReplaceInstitute() => {
         'type': 'replaceInstitute',
         'original': rule.original,
         'replacement': rule.replacement,
-      };
-    case MarkAsVirtual():
-      return {'type': 'markAsVirtual', 'schoolCode': rule.schoolCode};
-    case MarkAsOurs():
-      return {'type': 'markAsOurs', 'schoolCode': rule.schoolCode};
-  }
+      },
+    MarkAsVirtual() => {'type': 'markAsVirtual', 'schoolCode': rule.schoolCode},
+    MarkAsOurs() => {'type': 'markAsOurs', 'schoolCode': rule.schoolCode},
+  };
+  final Map<String, dynamic> extra = provenance?.toJson() ?? const {};
+  if (extra.isEmpty) return encoded;
+  return <String, dynamic>{...encoded, ...extra};
 }
+
+/// Reads the [RuleProvenance] out of a map produced by [encodeWisaRule], or
+/// `null` when it carries none — which is every rule persisted before #285.
+///
+/// Split from [decodeWisaRule] rather than folded into it because the rule types
+/// are `wisa_api`'s and must stay free of it: the rule and its provenance travel
+/// in one object but are two values, and only this package holds both.
+RuleProvenance? decodeWisaRuleProvenance(Map<String, dynamic> json) =>
+    RuleProvenance.fromJson(json);
 
 /// Decodes a tagged-JSON map produced by [encodeWisaRule].
 ///

--- a/packages/account_state/lib/src/settings/import_rule_codec.dart
+++ b/packages/account_state/lib/src/settings/import_rule_codec.dart
@@ -48,7 +48,6 @@ Map<String, dynamic> encodeWisaRule(
         'replacement': rule.replacement,
       },
     MarkAsVirtual() => {'type': 'markAsVirtual', 'schoolCode': rule.schoolCode},
-    MarkAsOurs() => {'type': 'markAsOurs', 'schoolCode': rule.schoolCode},
   };
   final Map<String, dynamic> extra = provenance?.toJson() ?? const {};
   if (extra.isEmpty) return encoded;
@@ -66,9 +65,16 @@ RuleProvenance? decodeWisaRuleProvenance(Map<String, dynamic> json) =>
 
 /// Decodes a tagged-JSON map produced by [encodeWisaRule].
 ///
+/// Returns `null` for a **retired** tag — a rule kind this app no longer has, so
+/// far the `markAsOurs` dropped by #286. A document another operator (or an
+/// older build) wrote still loads; the entry is simply ignored and disappears
+/// from the document the next time it is saved. That is safe precisely because
+/// the rule already did nothing: ownership comes from the WISA-scholen list in
+/// Settings, which wins over any snapshot flag.
+///
 /// Throws [FormatException] on an unknown or missing `type` tag so a corrupt
 /// config surfaces loudly rather than silently dropping rules.
-WisaImportRule decodeWisaRule(Map<String, dynamic> json) {
+WisaImportRule? decodeWisaRule(Map<String, dynamic> json) {
   final type = json['type'];
   switch (type) {
     case 'dontImportClass':
@@ -83,7 +89,7 @@ WisaImportRule decodeWisaRule(Map<String, dynamic> json) {
     case 'markAsVirtual':
       return MarkAsVirtual(json['schoolCode'] as String);
     case 'markAsOurs':
-      return MarkAsOurs(json['schoolCode'] as String);
+      return null;
     default:
       throw FormatException('Unknown WisaImportRule type: $type');
   }

--- a/packages/account_state/lib/src/settings/live_settings.dart
+++ b/packages/account_state/lib/src/settings/live_settings.dart
@@ -71,9 +71,14 @@ class LiveSettings {
 /// #263 the pull reads them from the live document, so a saved rule changes
 /// what the roster contains — and a drift pass, which never re-pulls WISA,
 /// would otherwise relink against the roster the rule never reached. Only the
-/// *persisted* rules count; the ones a `DontImportFromWisa` apply accumulates
-/// in the session's `WisaImportRules` holder trigger their own re-sync and are
-/// not part of any settings document.
+/// *persisted* rules count; the ones a `DontImportFromWisa` apply accumulates in
+/// the session's `WisaImportRules` holder trigger their own re-sync.
+///
+/// Since #276 an earned rule reaches this document too, which would make every
+/// such apply arm the gate — falsely, because the applier already re-pulled WISA
+/// with the rule. The apply path therefore re-credits its own pull to the
+/// document it just wrote (`ReconcileController._persistEarnedWisaRules`); the
+/// fingerprint itself stays a plain function of the document.
 ///
 /// Order-sensitive, like [smartschoolPullFingerprint]: the connector applies
 /// the rules in sequence.

--- a/packages/account_state/lib/src/settings/rule_provenance.dart
+++ b/packages/account_state/lib/src/settings/rule_provenance.dart
@@ -1,0 +1,101 @@
+/// Provenance for a persisted import rule: who added it, when, and for whom
+/// (#285).
+///
+/// This is metadata *about* a rule, never part of one. The rule types live in
+/// the connector packages and exist to be applied at snapshot construction;
+/// which operator typed one and when has no bearing on that, and `wisa_api` has
+/// no business knowing the tenant has operators at all. So the rule classes stay
+/// untouched and this rides beside the encoded rule in the settings document
+/// (`import_rule_codec`).
+///
+/// ## Why the record has exactly these three fields
+///
+/// The settings document is shared across operators on purpose — otherwise every
+/// staff member would have to recreate the same rule set — so a colleague's rule
+/// shows up in your panel as a bare WISA code with no indication of what it is.
+/// Deliberately **no free-text reason field**: an optional reason in a tool
+/// people use quickly either gets skipped or gets "n/a", and a half-filled
+/// reason column is worse than no column, because the blanks start implying
+/// those rules had no reason.
+///
+/// That shifts the weight onto the three fields that are here:
+///
+/// - [addedBy] is load-bearing — the record is a *pointer to the person who
+///   remembers*, not the explanation itself, so it holds a readable name rather
+///   than an object id;
+/// - [addedAt] does more work than it looks like: with no "why", the date is
+///   what lets someone reconstruct the context ("that was the June retirement
+///   round");
+/// - [subject] is a **snapshot**, never refreshed against a later pull. The
+///   people these rules are about are exactly the ones who eventually disappear
+///   from WISA, so resolving the code against the current staff list would give
+///   a blank precisely when the name is needed most.
+///
+/// Every field is optional. A rule persisted before #285 carries none of them at
+/// all — [decodeWisaRuleProvenance] answers `null` for it — and the view says so
+/// (`onbekend`) rather than rendering a blank that reads like nobody did it.
+class RuleProvenance {
+  /// [addedAt] is normalized to UTC: the document is read by operators who may
+  /// not share a timezone, and the view converts back to local for display.
+  RuleProvenance({this.subject = '', this.addedBy = '', DateTime? addedAt})
+      : addedAt = addedAt?.toUtc();
+
+  /// The subject's name as it read when the rule was created — the staff member
+  /// or class the rule is about. Empty when the authoring surface knew no name
+  /// (the Instellingen editor holds no WISA snapshot to resolve a code against).
+  final String subject;
+
+  /// The operator who added the rule, as a readable display name. Empty when the
+  /// session had no signed-in identity to attribute it to.
+  final String addedBy;
+
+  /// When the rule was added, in UTC. Null on a rule persisted before #285.
+  final DateTime? addedAt;
+
+  /// Whether this record says nothing at all — the case that is stored as *no*
+  /// provenance rather than as an empty object.
+  bool get isEmpty => subject.isEmpty && addedBy.isEmpty && addedAt == null;
+
+  /// Whether this record carries at least one field.
+  bool get isNotEmpty => !isEmpty;
+
+  /// The fields that are actually known, for merging into the rule's own JSON
+  /// object. An unknown field is **absent** rather than empty-stringed, so a
+  /// document never claims to record something it does not.
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        if (subject.isNotEmpty) 'subject': subject,
+        if (addedBy.isNotEmpty) 'addedBy': addedBy,
+        if (addedAt != null) 'addedAt': addedAt!.toIso8601String(),
+      };
+
+  /// Reads provenance out of a rule's JSON object, or `null` when the object
+  /// carries none — which is every rule written before #285.
+  ///
+  /// An unparseable `addedAt` degrades to "no timestamp" rather than throwing:
+  /// the rule itself is still perfectly applicable, and refusing to load the
+  /// whole settings document over a bad metadata string would take the tenant's
+  /// configuration down for a cosmetic field.
+  static RuleProvenance? fromJson(Map<String, dynamic> json) {
+    final raw = json['addedAt'];
+    final record = RuleProvenance(
+      subject: (json['subject'] as String?) ?? '',
+      addedBy: (json['addedBy'] as String?) ?? '',
+      addedAt: raw is String ? DateTime.tryParse(raw) : null,
+    );
+    return record.isEmpty ? null : record;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is RuleProvenance &&
+      other.subject == subject &&
+      other.addedBy == addedBy &&
+      other.addedAt == addedAt;
+
+  @override
+  int get hashCode => Object.hash(subject, addedBy, addedAt);
+
+  @override
+  String toString() =>
+      'RuleProvenance(subject: $subject, addedBy: $addedBy, addedAt: $addedAt)';
+}

--- a/packages/account_state/lib/src/settings/wisa_rule_merge.dart
+++ b/packages/account_state/lib/src/settings/wisa_rule_merge.dart
@@ -19,6 +19,29 @@ import 'package:wisa_api/wisa_api.dart';
 
 import '../apply/wisa_import_rules.dart';
 import 'app_settings.dart';
+import 'rule_provenance.dart';
+
+/// One rule an apply pass earned, with the name of whoever (or whatever) it was
+/// earned *about* (#285).
+///
+/// The subject travels per rule while the operator and the timestamp are
+/// arguments to the whole merge, because that is how a pass actually works: one
+/// operator, one instant, thirty departed teachers. The name is the label the
+/// apply already had in hand for the record it acted on — captured here, at the
+/// moment of the decision, and never refreshed afterwards. That is the point:
+/// the staff a `DontImportFromWisa` is about are exactly the ones who later
+/// vanish from WISA, so a name resolved lazily at render time would be blank
+/// precisely when it is needed.
+class EarnedWisaRule {
+  const EarnedWisaRule(this.rule, {this.subject = ''});
+
+  /// The rule the apply produced.
+  final WisaImportRule rule;
+
+  /// The subject's name as it read at the time — empty when the caller knows
+  /// none, which records honestly as "onbekend" rather than as a blank.
+  final String subject;
+}
 
 /// What [mergeEarnedWisaRules] produced: the document to save, and the rules
 /// that were genuinely new to it.
@@ -50,18 +73,41 @@ class MergedWisaRules {
 /// Nothing else on the document is touched, and the existing rules keep their
 /// order: the operator's standing configuration is theirs, and an apply only
 /// adds to it.
+///
+/// ## Provenance (#285)
+///
+/// Every rule this merge genuinely appends is stamped with [addedBy], [addedAt]
+/// and its own [EarnedWisaRule.subject], so a colleague opening Instellingen
+/// next month reads who decided it, when, and about whom instead of a bare WISA
+/// code. A rule the document **already** carries is not re-stamped: it collapses
+/// into the standing decision, which keeps the provenance of whoever made it
+/// first. That is the desired outcome of the collapse rather than an incidental
+/// one — the earlier decision is the one the document has been standing on.
 MergedWisaRules? mergeEarnedWisaRules({
   required AppSettings stored,
-  required Iterable<WisaImportRule> earned,
+  required Iterable<EarnedWisaRule> earned,
+  String addedBy = '',
+  DateTime? addedAt,
 }) {
   final merged = WisaImportRules(initial: stored.wisaRules);
-  final added = <WisaImportRule>[
-    for (final rule in earned)
-      if (merged.add(rule)) rule,
-  ];
+  final added = <WisaImportRule>[];
+  final provenance = Map<String, RuleProvenance>.of(stored.wisaRuleProvenance);
+  for (final entry in earned) {
+    if (!merged.add(entry.rule)) continue;
+    added.add(entry.rule);
+    final record = RuleProvenance(
+      subject: entry.subject,
+      addedBy: addedBy,
+      addedAt: addedAt,
+    );
+    if (record.isNotEmpty) provenance[wisaRuleKey(entry.rule)] = record;
+  }
   if (added.isEmpty) return null;
   return MergedWisaRules(
-    settings: stored.copyWith(wisaRules: merged.rules),
+    settings: stored.copyWith(
+      wisaRules: merged.rules,
+      wisaRuleProvenance: provenance,
+    ),
     added: added,
   );
 }

--- a/packages/account_state/lib/src/settings/wisa_rule_merge.dart
+++ b/packages/account_state/lib/src/settings/wisa_rule_merge.dart
@@ -1,0 +1,67 @@
+/// Folding session-earned WISA import rules into the settings document (#276).
+///
+/// A `DontImportFromWisa` apply produces a [WisaImportRule] rather than a write
+/// — WISA is read-only — and the State layer accumulates it in the session's
+/// [WisaImportRules] holder. That holder is rebuilt empty on every launch, so
+/// on its own the exclusion is a one-run decision. It is not: the rules exist
+/// for staff who retired or left while WISA still reports an *actief
+/// dienstverband*, which it will keep doing indefinitely. Persisting the rule is
+/// what makes the exclusion the standing decision it is meant to be, and what
+/// keeps the app from proposing to re-create an account it was just told to
+/// delete.
+///
+/// The merge lives here — beside the document it writes — rather than in the
+/// applier, because the store and the operator identity are an app-layer
+/// concern; the applier only earns the rule.
+library;
+
+import 'package:wisa_api/wisa_api.dart';
+
+import '../apply/wisa_import_rules.dart';
+import 'app_settings.dart';
+
+/// What [mergeEarnedWisaRules] produced: the document to save, and the rules
+/// that were genuinely new to it.
+///
+/// [added] is what the caller reports to the operator — a permanent, shared
+/// change owes them a line naming it — and is never empty (a merge that adds
+/// nothing returns `null` instead of an empty result).
+class MergedWisaRules {
+  const MergedWisaRules({required this.settings, required this.added});
+
+  /// [AppSettings] with [added] appended to its persisted WISA import rules.
+  final AppSettings settings;
+
+  /// The rules this merge appended, in the order they were earned.
+  final List<WisaImportRule> added;
+}
+
+/// Appends the session-[earned] WISA import rules to [stored]'s persisted rule
+/// list, or returns `null` when the document already carries every one of them
+/// and there is nothing to write.
+///
+/// De-duplication is [WisaImportRules]' own: the merge runs the persisted rules
+/// and the earned ones through a single holder, so "already persisted" means
+/// exactly what "already earned this session" means — same key per rule kind,
+/// same collapse. Applying the same `DontImportFromWisa` twice therefore cannot
+/// grow the document, whether the first apply happened in this session or in
+/// another operator's.
+///
+/// Nothing else on the document is touched, and the existing rules keep their
+/// order: the operator's standing configuration is theirs, and an apply only
+/// adds to it.
+MergedWisaRules? mergeEarnedWisaRules({
+  required AppSettings stored,
+  required Iterable<WisaImportRule> earned,
+}) {
+  final merged = WisaImportRules(initial: stored.wisaRules);
+  final added = <WisaImportRule>[
+    for (final rule in earned)
+      if (merged.add(rule)) rule,
+  ];
+  if (added.isEmpty) return null;
+  return MergedWisaRules(
+    settings: stored.copyWith(wisaRules: merged.rules),
+    added: added,
+  );
+}

--- a/packages/account_state/lib/src/settings/wisa_school_profile.dart
+++ b/packages/account_state/lib/src/settings/wisa_school_profile.dart
@@ -46,9 +46,11 @@ class WisaSchoolProfile {
 
   /// Whether this school is a *virtual* school, i.e. one WISA must be queried
   /// with [AppSettings.wisa]'s separate virtual workdate instead of the ordinary
-  /// one (#203). The persistent, id-keyed counterpart of the snapshot-time
-  /// `MarkAsVirtual` import rule, which still exists — the pull unions both
-  /// surfaces, unlike [ours], whose rule was dropped in #286.
+  /// one (#203). Since #277 this is the **only** virtual-school surface: the
+  /// snapshot-time `MarkAsVirtual` import rule set the same flag by short code,
+  /// the pull unioned both, and the two could disagree — so the rule went the
+  /// way [ours]'s did in #286, its persisted marks migrated onto this flag by
+  /// [adoptRetiredVirtualMarks].
   /// Defaults to `false`, so a settings document written before this field
   /// existed loads with every school non-virtual.
   final bool virtual;
@@ -134,4 +136,46 @@ class WisaSchoolProfile {
   String toString() =>
       'WisaSchoolProfile(schoolId: $schoolId, code: $code, name: $name, '
       'ours: $ours, virtual: $virtual, prefix: $prefix)';
+}
+
+/// Carries the school codes of retired `MarkAsVirtual` import rules onto the
+/// matching profiles' [WisaSchoolProfile.virtual] flag (#277).
+///
+/// The rule marked a school by its short **code**, the grid marks by school
+/// **id**, and both fed one flag; retiring the rule therefore has to move its
+/// marks rather than drop them, or a school pulled with the virtual werkdatum
+/// would quietly start pulling with the ordinary one. Runs against the profiles
+/// in the very document the rules came out of — no fetch is needed, because a
+/// school can only be marked `ours` after **Scholen ophalen** put a row here, so
+/// every school that can matter already has one.
+///
+/// Two kinds of mark are deliberately **dropped** rather than migrated:
+///
+/// - one on a school that is not [WisaSchoolProfile.ours]. A virtual school
+///   exists to create next-schoolyear accounts for our own students a few months
+///   early; for a sibling school's students the delay is irrelevant, since they
+///   turn up in an ordinary school anyway.
+/// - one whose code matches no profile at all. It marked nothing the operator
+///   could see before either, the grid being the list of schools this install
+///   knows about.
+///
+/// Idempotent, and safe to run on every load: a document that has since been
+/// saved carries no retired entries, so [codes] is empty and the profiles come
+/// back untouched. Codes are compared trimmed, as the rule editor stored them.
+List<WisaSchoolProfile> adoptRetiredVirtualMarks(
+  List<WisaSchoolProfile> profiles,
+  Set<String> codes,
+) {
+  if (codes.isEmpty) return profiles;
+  final wanted = <String>{
+    for (final code in codes)
+      if (code.trim().isNotEmpty) code.trim(),
+  };
+  if (wanted.isEmpty) return profiles;
+  return <WisaSchoolProfile>[
+    for (final p in profiles)
+      p.ours && !p.virtual && wanted.contains(p.code.trim())
+          ? p.copyWith(virtual: true)
+          : p,
+  ];
 }

--- a/packages/account_state/lib/src/settings/wisa_school_profile.dart
+++ b/packages/account_state/lib/src/settings/wisa_school_profile.dart
@@ -3,11 +3,11 @@
 /// The shared credentials pull *every* WISA school the group can see, but we
 /// only **manage** some of them. This profile records, per school id, whether
 /// it is [ours] (managed) and an optional per-school [prefix] override for the
-/// Azure-orphan scoping the linker does (INV-22). It is the persistent, keyed
-/// counterpart of the snapshot-time `MarkAsOurs` import rule: the rule flips
-/// `WisaSchool.isOurs` at pull time by school *name*, while this list is the
-/// operator-editable ownership record keyed by school *id* that survives in the
-/// settings blob.
+/// Azure-orphan scoping the linker does (INV-22). Since #286 this list is the
+/// **only** ownership record: the snapshot-time `MarkAsOurs` import rule that
+/// once flagged a school by code is gone, because this operator-editable list —
+/// keyed by school *id* and persisted in the settings document — won over it
+/// everywhere it was read.
 ///
 /// The shape (`{ schemaVersion, schoolId, code, name, ours, virtual, prefix }`)
 /// is the
@@ -47,7 +47,8 @@ class WisaSchoolProfile {
   /// Whether this school is a *virtual* school, i.e. one WISA must be queried
   /// with [AppSettings.wisa]'s separate virtual workdate instead of the ordinary
   /// one (#203). The persistent, id-keyed counterpart of the snapshot-time
-  /// `MarkAsVirtual` import rule, exactly as [ours] is for `MarkAsOurs`.
+  /// `MarkAsVirtual` import rule, which still exists — the pull unions both
+  /// surfaces, unlike [ours], whose rule was dropped in #286.
   /// Defaults to `false`, so a settings document written before this field
   /// existed loads with every school non-virtual.
   final bool virtual;

--- a/packages/account_state/lib/src/sync/application_state.dart
+++ b/packages/account_state/lib/src/sync/application_state.dart
@@ -145,9 +145,8 @@ Syncer<AzureSnapshot> azureSyncer(
 /// expects to find in Azure (#224).
 ///
 /// [ourSchoolIds] is the operator's managed-school set from Settings, exactly as
-/// handed to `link()`. `null` falls back to the snapshot's own
-/// `WisaSchool.isOurs` flags, and an empty effective set means ownership is
-/// unconfigured — in which case every WISA student counts, mirroring the
+/// handed to `link()`. `null` — like an empty set — means ownership is
+/// unconfigured, in which case every WISA student counts, mirroring the
 /// linker's own `_isOurWisaSchool` fallback. Scoping matters: a sibling school's
 /// student is none of our business, and looking their account up would grow the
 /// bounded pull for nothing.
@@ -156,11 +155,7 @@ Set<String> managedStudentEmployeeIds(
   Set<int>? ourSchoolIds,
 }) {
   if (snapshot == null) return const <String>{};
-  final effective = ourSchoolIds ??
-      <int>{
-        for (final school in snapshot.schools)
-          if (school.isOurs) school.id,
-      };
+  final effective = ourSchoolIds ?? const <int>{};
   return <String>{
     for (final student in snapshot.students)
       if (effective.isEmpty || effective.contains(student.schoolId))
@@ -181,8 +176,8 @@ Set<String> managedStudentEmployeeIds(
 /// `2F ECO`, since sub-groups share the parent class's one group.
 ///
 /// [ourSchoolIds] scopes the students exactly as [managedStudentEmployeeIds]
-/// does, with the same `null`-means-unconfigured fallback to the snapshot's own
-/// `MarkAsOurs` flags. A name that would not survive as a Graph `mailNickname`
+/// does, with the same `null`-means-unconfigured reading. A name that would not
+/// survive as a Graph `mailNickname`
 /// is dropped, mirroring the plan that would refuse to propose it.
 ///
 /// Names collapse case-insensitively (INV-12) but are asked about as WISA writes
@@ -193,11 +188,7 @@ Set<String> managedClassGroupMailNicknames(
   Set<int>? ourSchoolIds,
 }) {
   if (snapshot == null || schoolPrefix.trim().isEmpty) return const <String>{};
-  final effective = ourSchoolIds ??
-      <int>{
-        for (final school in snapshot.schools)
-          if (school.isOurs) school.id,
-      };
+  final effective = ourSchoolIds ?? const <int>{};
   final byKey = <String, String>{};
   for (final student in snapshot.students) {
     if (effective.isNotEmpty && !effective.contains(student.schoolId)) continue;

--- a/packages/account_state/test/application_state_test.dart
+++ b/packages/account_state/test/application_state_test.dart
@@ -561,17 +561,20 @@ void main() {
       expect(ids, {'W1'});
     });
 
-    test('falls back to the snapshot\'s own isOurs flags', () {
+    test('the snapshot\'s school list never narrows the scope (#286)', () {
+      // Ownership lives in Settings alone; a school list on the snapshot says
+      // nothing about which schools are ours, so an unnamed managed set still
+      // means every student counts.
       final ids = managedStudentEmployeeIds(
         snap(
           [student('W1'), student('W2', schoolId: 2)],
-          schools: [
-            const WisaSchool(id: 1, name: '', code: '', isOurs: false),
-            const WisaSchool(id: 2, name: '', code: '', isOurs: true),
+          schools: const [
+            WisaSchool(id: 1, name: '', code: ''),
+            WisaSchool(id: 2, name: '', code: ''),
           ],
         ),
       );
-      expect(ids, {'W2'});
+      expect(ids, {'W1', 'W2'});
     });
 
     test('an unconfigured ownership set means every student counts', () {
@@ -657,19 +660,19 @@ void main() {
       );
     });
 
-    test('falls back to the snapshot\'s own isOurs flags', () {
+    test('the snapshot\'s school list never narrows the scope (#286)', () {
       expect(
         managedClassGroupMailNicknames(
           snap(
             [student('W1'), student('W2', classGroup: '9Z', schoolId: 2)],
-            schools: [
-              const WisaSchool(id: 1, name: '', code: '', isOurs: false),
-              const WisaSchool(id: 2, name: '', code: '', isOurs: true),
+            schools: const [
+              WisaSchool(id: 1, name: '', code: ''),
+              WisaSchool(id: 2, name: '', code: ''),
             ],
           ),
           schoolPrefix: 'GBS',
         ),
-        {'GBS-9Z'},
+        {'GBS-1A', 'GBS-9Z'},
       );
     });
 

--- a/packages/account_state/test/linked_state_test.dart
+++ b/packages/account_state/test/linked_state_test.dart
@@ -530,8 +530,8 @@ void main() {
     });
 
     test('with ownership unconfigured every school still counts', () {
-      // Mirrors the linker's `_isOurWisaSchool` fallback: no managed set and no
-      // `isOurs` flags means ownership is unconfigured, not "nothing is ours".
+      // Mirrors the linker's `_isOurWisaSchool` fallback: no managed set means
+      // ownership is unconfigured, not "nothing is ours".
       final resolver = PlacementResolver(
         wisa: _wSnap(
           students: [_wStudent(wisaId: '1', classGroup: '1A', schoolId: 2)],
@@ -546,16 +546,16 @@ void main() {
       );
     });
 
-    test('the managed set falls back to the snapshot\'s isOurs flags', () {
-      // No caller-supplied set, but the snapshot says which school is ours —
-      // the same derivation `link()` applies, so the two layers agree.
+    test('the snapshot\'s school list never decides ownership (#286)', () {
+      // A school list on the snapshot carries no ownership, so it cannot narrow
+      // the tally on its own — exactly as `link()` no longer derives one, which
+      // is what keeps the two layers agreeing.
       final resolver = PlacementResolver(
         wisa: _wSnap(
           students: [_wStudent(wisaId: '1', classGroup: '1A', schoolId: 2)],
           classGroups: [_wClass('1A', adminCode: 'a1', schoolId: 1)],
           schools: const [
-            wapi.WisaSchool(
-                id: 1, name: 'Onze school', code: 'ISM', isOurs: true),
+            wapi.WisaSchool(id: 1, name: 'Onze school', code: 'ISM'),
             wapi.WisaSchool(id: 2, name: 'Andere school', code: 'AND'),
           ],
         ),
@@ -564,6 +564,21 @@ void main() {
 
       expect(
         resolver.groupPlacementFor(_linkedWisaGroup('1A')).containsStudents,
+        isTrue,
+      );
+
+      // Naming the managed set is what scopes it.
+      final scoped = PlacementResolver(
+        wisa: _wSnap(
+          students: [_wStudent(wisaId: '1', classGroup: '1A', schoolId: 2)],
+          classGroups: [_wClass('1A', adminCode: 'a1', schoolId: 1)],
+        ),
+        smartschool: _sSnap(),
+        ourSchoolIds: const {1},
+      );
+
+      expect(
+        scoped.groupPlacementFor(_linkedWisaGroup('1A')).containsStudents,
         isFalse,
       );
     });
@@ -855,7 +870,6 @@ void main() {
             id: 99,
             name: 'Virtuele school',
             code: 'ISMV',
-            isOurs: true,
             isVirtual: true,
           ),
         ],
@@ -879,7 +893,6 @@ void main() {
             id: 99,
             name: 'Virtuele school',
             code: 'ISMV',
-            isOurs: true,
             isVirtual: true,
           ),
         ],

--- a/packages/account_state/test/live_settings_test.dart
+++ b/packages/account_state/test/live_settings_test.dart
@@ -173,7 +173,7 @@ void main() {
       final settings = _settings().copyWith(
         wisaRules: const <WisaImportRule>[
           DontImportClass('3C'),
-          MarkAsOurs('S1'),
+          MarkAsVirtual('S1'),
         ],
       );
       expect(wisaPullFingerprint(settings), wisaPullFingerprint(settings));

--- a/packages/account_state/test/live_settings_test.dart
+++ b/packages/account_state/test/live_settings_test.dart
@@ -157,12 +157,12 @@ void main() {
         wisaPullFingerprint(base.copyWith(
           wisaRules: const <WisaImportRule>[
             DontImportClass('3C'),
-            MarkAsVirtual('V'),
+            DontImportUserFromWisa('SMIT'),
           ],
         )),
         isNot(wisaPullFingerprint(base.copyWith(
           wisaRules: const <WisaImportRule>[
-            MarkAsVirtual('V'),
+            DontImportUserFromWisa('SMIT'),
             DontImportClass('3C'),
           ],
         ))),
@@ -173,7 +173,7 @@ void main() {
       final settings = _settings().copyWith(
         wisaRules: const <WisaImportRule>[
           DontImportClass('3C'),
-          MarkAsVirtual('S1'),
+          DontImportUserFromWisa('SMIT'),
         ],
       );
       expect(wisaPullFingerprint(settings), wisaPullFingerprint(settings));

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -645,11 +645,10 @@ void main() {
       expect(managed.rollups.any((r) => r.school == '2'), isTrue);
     });
 
-    test(
-        'with no managed set the snapshot MarkAsOurs flags still classify '
-        '(fallback preserved)', () {
-      // ourSchoolIds null → link() derives ownership from the snapshot schools.
-      // Here school 1 is flagged ours, so a school-1 student is placed normally.
+    test('with no managed set every school is ours, so nobody is re-bucketed',
+        () {
+      // ourSchoolIds null → ownership is unconfigured (#286), which counts every
+      // school, so a school-1 student is placed normally.
       final linked = LinkedState.recompute(
         wisa: wapi.WisaSnapshot(
           fetchedAt: _d,
@@ -657,7 +656,7 @@ void main() {
           staff: const [],
           classGroups: const [],
           schools: const [
-            wapi.WisaSchool(id: 1, name: 'One', code: '', isOurs: true),
+            wapi.WisaSchool(id: 1, name: 'One', code: ''),
           ],
         ),
         smartschool: ss.SmartschoolSnapshot(

--- a/packages/account_state/test/rule_provenance_test.dart
+++ b/packages/account_state/test/rule_provenance_test.dart
@@ -1,0 +1,169 @@
+import 'dart:convert';
+
+import 'package:account_state/account_state.dart';
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+void main() {
+  group('RuleProvenance (#285)', () {
+    test('normalizes its timestamp to UTC', () {
+      // The settings document is shared; two operators must not read the same
+      // rule as added at two different times because one of them saved it with
+      // a local stamp.
+      final local = DateTime(2026, 6, 30, 14, 5);
+      final provenance = RuleProvenance(addedAt: local);
+
+      expect(provenance.addedAt!.isUtc, isTrue);
+      expect(provenance.addedAt!.isAtSameMomentAs(local), isTrue);
+    });
+
+    test('omits the fields it does not know', () {
+      // An absent field and an empty one are different claims: absent means
+      // "not recorded", which the view renders as "onbekend".
+      final json = RuleProvenance(addedBy: 'ann@school.example').toJson();
+
+      expect(json.keys, <String>['addedBy']);
+    });
+
+    test('an all-empty record is no record', () {
+      expect(RuleProvenance().isEmpty, isTrue);
+      expect(RuleProvenance.fromJson(<String, dynamic>{}), isNull);
+    });
+
+    test('an unparseable timestamp degrades instead of throwing', () {
+      // The rule itself still applies perfectly; refusing to load the whole
+      // tenant configuration over a cosmetic metadata string would be worse than
+      // the missing stamp.
+      final provenance = RuleProvenance.fromJson(<String, dynamic>{
+        'addedBy': 'ann@school.example',
+        'addedAt': 'niet-een-datum',
+      });
+
+      expect(provenance!.addedBy, 'ann@school.example');
+      expect(provenance.addedAt, isNull);
+    });
+  });
+
+  group('the persisted rule carries its provenance (#285)', () {
+    final at = DateTime.utc(2026, 6, 30, 14, 5);
+
+    test('encodes beside the rule, in the same object', () {
+      // Rule and provenance travel together on the wire so they can never come
+      // apart — a parallel array keyed by position is exactly what a hand-edited
+      // Cosmos document would desynchronize.
+      final json = encodeWisaRule(
+        const DontImportUserFromWisa('SMIT'),
+        provenance: RuleProvenance(
+          subject: 'Jan Smit',
+          addedBy: 'ann@school.example',
+          addedAt: at,
+        ),
+      );
+
+      expect(json, <String, dynamic>{
+        'type': 'dontImportUserFromWisa',
+        'userCode': 'SMIT',
+        'subject': 'Jan Smit',
+        'addedBy': 'ann@school.example',
+        'addedAt': at.toIso8601String(),
+      });
+    });
+
+    test('encodes exactly as before when there is none', () {
+      // The shape every version before #285 wrote, byte for byte — which is what
+      // keeps `wisaPullFingerprint` stable across the upgrade.
+      expect(
+        encodeWisaRule(const DontImportClass('3C')),
+        <String, dynamic>{'type': 'dontImportClass', 'className': '3C'},
+      );
+    });
+
+    test('the rule decodes unchanged from an object carrying provenance', () {
+      // `wisa_api`'s rule classes are untouched by this feature: the extra keys
+      // are simply not theirs to know about.
+      final json = encodeWisaRule(
+        const DontImportClass('3C'),
+        provenance: RuleProvenance(addedBy: 'ann@school.example', addedAt: at),
+      );
+
+      expect((decodeWisaRule(json) as DontImportClass).className, '3C');
+    });
+
+    test('a document written before #285 reads as no provenance', () {
+      // The acceptance criterion: those rules must render honestly as
+      // "onbekend", which means the decode has to answer null rather than an
+      // empty record that looks like a real one.
+      final legacy = jsonDecode(jsonEncode(<String, dynamic>{
+        'wisaRules': <Map<String, dynamic>>[
+          <String, dynamic>{'type': 'dontImportClass', 'className': '3C'},
+        ],
+      })) as Map<String, dynamic>;
+
+      final settings = AppSettings.fromJson(legacy);
+
+      expect(settings.wisaRules, hasLength(1));
+      expect(settings.wisaRuleProvenance, isEmpty);
+      expect(settings.provenanceOf(const DontImportClass('3C')), isNull);
+    });
+
+    test('the document round-trips provenance for every rule that has it', () {
+      final settings = AppSettings(
+        wisaRules: const <WisaImportRule>[
+          DontImportClass('3C'),
+          DontImportUserFromWisa('SMIT'),
+        ],
+        wisaRuleProvenance: <String, RuleProvenance>{
+          'user:SMIT': RuleProvenance(
+            subject: 'Jan Smit',
+            addedBy: 'ann@school.example',
+            addedAt: at,
+          ),
+        },
+      );
+
+      final restored = AppSettings.fromJson(
+        jsonDecode(jsonEncode(settings.toJson())) as Map<String, dynamic>,
+      );
+
+      expect(restored.provenanceOf(const DontImportClass('3C')), isNull);
+      expect(
+        restored.provenanceOf(const DontImportUserFromWisa('SMIT'))!.subject,
+        'Jan Smit',
+      );
+      expect(
+        restored.provenanceOf(const DontImportUserFromWisa('SMIT'))!.addedAt,
+        at,
+      );
+    });
+
+    test('provenance for a rule no longer on the document is not written', () {
+      // The map is keyed, not positional, so a stale entry cannot resurface
+      // attached to some later rule: nothing writes what no rule claims.
+      final settings = AppSettings(
+        wisaRules: const <WisaImportRule>[DontImportClass('3C')],
+        wisaRuleProvenance: <String, RuleProvenance>{
+          'user:SMIT': RuleProvenance(addedBy: 'ann@school.example'),
+        },
+      );
+
+      final encoded = settings.toJson()['wisaRules'] as List<dynamic>;
+
+      expect(encoded.single, <String, dynamic>{
+        'type': 'dontImportClass',
+        'className': '3C',
+      });
+    });
+
+    test('wisaRuleKey is the key WisaImportRules de-duplicates on', () {
+      // Provenance keys on it, so the two must not be allowed to drift: a
+      // duplicate for the holder has to be the same decision for the document.
+      final holder = WisaImportRules();
+      expect(holder.add(const DontImportClass('3C')), isTrue);
+      expect(holder.add(DontImportClass(<String>['3', 'C'].join())), isFalse);
+      expect(
+        wisaRuleKey(const DontImportClass('3C')),
+        wisaRuleKey(DontImportClass(<String>['3', 'C'].join())),
+      );
+    });
+  });
+}

--- a/packages/account_state/test/settings_store_test.dart
+++ b/packages/account_state/test/settings_store_test.dart
@@ -40,7 +40,6 @@ AppSettings _sampleSettings() => AppSettings(
         DontImportClass('1A'),
         DontImportUserFromWisa('U42'),
         ReplaceInstitute(original: '001', replacement: '002'),
-        MarkAsVirtual('VIRT'),
       ],
       smartschoolRules: const [
         DiscardSmartschoolGroup('Archief'),
@@ -125,6 +124,110 @@ void main() {
         }),
         throwsFormatException,
       );
+    });
+
+    group('a persisted markAsVirtual rule migrates to the grid (#277)', () {
+      Map<String, dynamic> document({
+        required String ruleCode,
+        required List<WisaSchoolProfile> schools,
+      }) =>
+          <String, dynamic>{
+            'wisaRules': <dynamic>[
+              <String, dynamic>{
+                'type': 'markAsVirtual',
+                'schoolCode': ruleCode,
+                'addedBy': 'jan@school.example',
+              },
+              <String, dynamic>{'type': 'dontImportClass', 'className': '3C'},
+            ],
+            'wisaSchools': <dynamic>[for (final s in schools) s.toJson()],
+          };
+
+      test('onto the matching school we manage, keyed code → id', () {
+        // The rule marked by short code, the grid marks by id — the migration
+        // is the join between them. Losing it would be seasonally invisible:
+        // the school pulls with the ordinary werkdatum and simply fails to
+        // produce next year's students in spring.
+        final settings = AppSettings.fromJson(document(
+          ruleCode: 'ISMV',
+          schools: const <WisaSchoolProfile>[
+            WisaSchoolProfile(schoolId: 25, code: 'ISMAA', ours: true),
+            WisaSchoolProfile(schoolId: 99, code: 'ISMV', ours: true),
+          ],
+        ));
+
+        expect(settings.virtualWisaSchoolIds, <int>{99});
+        // The rule itself is gone — from the model and from the next save.
+        expect(settings.wisaRules.single, isA<DontImportClass>());
+        expect(settings.wisaRuleProvenance.keys, isEmpty);
+        expect(
+          (settings.toJson()['wisaRules'] as List<dynamic>)
+              .map((dynamic r) => (r as Map<String, dynamic>)['type']),
+          <String>['dontImportClass'],
+        );
+        // …and the migrated flag is what the next save writes instead.
+        final saved = AppSettings.fromJson(settings.toJson());
+        expect(saved.virtualWisaSchoolIds, <int>{99});
+      });
+
+      test('but is dropped on a school that is not ours', () {
+        // Per the operator: a virtual school exists to create *our* next-year
+        // students early. A sibling school's students turn up in an ordinary
+        // school anyway, just later, so the delay does not matter.
+        final settings = AppSettings.fromJson(document(
+          ruleCode: 'ISMV',
+          schools: const <WisaSchoolProfile>[
+            WisaSchoolProfile(schoolId: 99, code: 'ISMV'),
+          ],
+        ));
+
+        expect(settings.virtualWisaSchoolIds, isEmpty);
+        expect(settings.wisaSchools.single.virtual, isFalse);
+        expect(settings.wisaRules.single, isA<DontImportClass>());
+      });
+
+      test('and dropped when its code matches no school at all', () {
+        // It flagged nothing before either: a school can only be marked
+        // beheerd after **Scholen ophalen** gave it a row here.
+        final settings = AppSettings.fromJson(document(
+          ruleCode: 'GONE',
+          schools: const <WisaSchoolProfile>[
+            WisaSchoolProfile(schoolId: 25, code: 'ISMAA', ours: true),
+          ],
+        ));
+
+        expect(settings.virtualWisaSchoolIds, isEmpty);
+        expect(settings.wisaRules.single, isA<DontImportClass>());
+      });
+
+      test('leaves a school the grid already marks virtual alone', () {
+        final settings = AppSettings.fromJson(document(
+          ruleCode: 'ISMV',
+          schools: const <WisaSchoolProfile>[
+            WisaSchoolProfile(
+                schoolId: 99, code: 'ISMV', ours: true, virtual: true),
+          ],
+        ));
+
+        expect(settings.virtualWisaSchoolIds, <int>{99});
+      });
+
+      test('a document with no retired rule is untouched', () {
+        // The migration runs on every load, so it has to be a no-op once the
+        // document has been saved back without the rule.
+        const original = AppSettings(
+          wisaRules: <WisaImportRule>[DontImportClass('3C')],
+          wisaSchools: <WisaSchoolProfile>[
+            WisaSchoolProfile(schoolId: 25, code: 'ISMAA', ours: true),
+            WisaSchoolProfile(schoolId: 99, code: 'ISMV', ours: true),
+          ],
+        );
+
+        final restored = AppSettings.fromJson(original.toJson());
+
+        expect(restored.wisaSchools, original.wisaSchools);
+        expect(restored.virtualWisaSchoolIds, isEmpty);
+      });
     });
 
     test('models secrets as refs, never as values in the blob', () {

--- a/packages/account_state/test/settings_store_test.dart
+++ b/packages/account_state/test/settings_store_test.dart
@@ -41,7 +41,6 @@ AppSettings _sampleSettings() => AppSettings(
         DontImportUserFromWisa('U42'),
         ReplaceInstitute(original: '001', replacement: '002'),
         MarkAsVirtual('VIRT'),
-        MarkAsOurs('SMA'),
       ],
       smartschoolRules: const [
         DiscardSmartschoolGroup('Archief'),
@@ -88,6 +87,44 @@ void main() {
       expect(settings.wisa, const WisaConnection());
       expect(settings.smartschool, SmartschoolConnection());
       expect(settings.azure, const AzureConnection());
+    });
+
+    test('a persisted markAsOurs rule loads and is dropped (#286)', () {
+      // The rule kind is gone, and a document that still carries one has to keep
+      // loading — it is shared, and an older build (or another operator) may
+      // have written it. It already did nothing, so there is nothing to migrate.
+      final settings = AppSettings.fromJson(<String, dynamic>{
+        'wisaRules': <dynamic>[
+          <String, dynamic>{
+            'type': 'markAsOurs',
+            'schoolCode': 'SMA',
+            'addedBy': 'jan@school.example',
+          },
+          <String, dynamic>{'type': 'dontImportClass', 'className': '3C'},
+        ],
+      });
+
+      expect(settings.wisaRules, hasLength(1));
+      expect(settings.wisaRules.single, isA<DontImportClass>());
+      // Its provenance goes with it rather than lingering as an orphan key.
+      expect(settings.wisaRuleProvenance.keys, isEmpty);
+      // …and the next save writes the document without it.
+      expect(
+        (settings.toJson()['wisaRules'] as List<dynamic>)
+            .map((dynamic r) => (r as Map<String, dynamic>)['type']),
+        <String>['dontImportClass'],
+      );
+    });
+
+    test('an unknown rule tag still throws, unlike a retired one (#286)', () {
+      expect(
+        () => AppSettings.fromJson(<String, dynamic>{
+          'wisaRules': <dynamic>[
+            <String, dynamic>{'type': 'markAsPurple', 'schoolCode': 'SMA'},
+          ],
+        }),
+        throwsFormatException,
+      );
     });
 
     test('models secrets as refs, never as values in the blob', () {

--- a/packages/account_state/test/wisa_import_rules_test.dart
+++ b/packages/account_state/test/wisa_import_rules_test.dart
@@ -7,12 +7,12 @@ void main() {
     test('keeps insertion order and drops structural duplicates', () {
       final rules = WisaImportRules();
       expect(rules.add(const DontImportClass('3C')), isTrue);
-      expect(rules.add(const MarkAsVirtual('S1')), isTrue);
+      expect(rules.add(const DontImportUserFromWisa('AAAAA')), isTrue);
       expect(rules.add(const DontImportClass('3C')), isFalse);
 
       expect(rules.rules, hasLength(2));
       expect(rules.rules.first, isA<DontImportClass>());
-      expect(rules.rules.last, isA<MarkAsVirtual>());
+      expect(rules.rules.last, isA<DontImportUserFromWisa>());
     });
   });
 
@@ -24,12 +24,12 @@ void main() {
 
       final merged = rules.unionWith(const <WisaImportRule>[
         DontImportClass('3C'),
-        MarkAsVirtual('V'),
+        ReplaceInstitute(original: '111', replacement: '222'),
       ]);
 
       expect(merged.map((r) => r.runtimeType).toList(), <Type>[
         DontImportClass,
-        MarkAsVirtual,
+        ReplaceInstitute,
         DontImportUserFromWisa,
       ]);
     });
@@ -66,7 +66,7 @@ void main() {
 
       rules.add(const DontImportClass('3C'));
       expect(
-        rules.unionWith(const <WisaImportRule>[MarkAsVirtual('S1')]),
+        rules.unionWith(const <WisaImportRule>[DontImportUserFromWisa('u1')]),
         hasLength(2),
       );
     });

--- a/packages/account_state/test/wisa_import_rules_test.dart
+++ b/packages/account_state/test/wisa_import_rules_test.dart
@@ -7,12 +7,12 @@ void main() {
     test('keeps insertion order and drops structural duplicates', () {
       final rules = WisaImportRules();
       expect(rules.add(const DontImportClass('3C')), isTrue);
-      expect(rules.add(const MarkAsOurs('S1')), isTrue);
+      expect(rules.add(const MarkAsVirtual('S1')), isTrue);
       expect(rules.add(const DontImportClass('3C')), isFalse);
 
       expect(rules.rules, hasLength(2));
       expect(rules.rules.first, isA<DontImportClass>());
-      expect(rules.rules.last, isA<MarkAsOurs>());
+      expect(rules.rules.last, isA<MarkAsVirtual>());
     });
   });
 
@@ -66,7 +66,7 @@ void main() {
 
       rules.add(const DontImportClass('3C'));
       expect(
-        rules.unionWith(const <WisaImportRule>[MarkAsOurs('S1')]),
+        rules.unionWith(const <WisaImportRule>[MarkAsVirtual('S1')]),
         hasLength(2),
       );
     });

--- a/packages/account_state/test/wisa_rule_merge_test.dart
+++ b/packages/account_state/test/wisa_rule_merge_test.dart
@@ -1,0 +1,143 @@
+import 'package:account_state/account_state.dart';
+import 'package:smartschool_api/smartschool_api.dart' as ss;
+import 'package:test/test.dart';
+import 'package:wisa_api/wisa_api.dart';
+
+void main() {
+  group('mergeEarnedWisaRules (#276)', () {
+    test('appends an earned rule to an empty document', () {
+      // The plain case: the first `DontImportFromWisa` apply of a fresh
+      // installation. Before #276 nothing ever wrote here, so the rule lived
+      // only in the process-lifetime holder and vanished on relaunch.
+      final merged = mergeEarnedWisaRules(
+        stored: const AppSettings(),
+        earned: const <WisaImportRule>[DontImportUserFromWisa('SMIT')],
+      );
+
+      expect(merged, isNotNull);
+      expect(merged!.settings.wisaRules.single, isA<DontImportUserFromWisa>());
+      expect(
+        (merged.settings.wisaRules.single as DontImportUserFromWisa).userCode,
+        'SMIT',
+      );
+      expect(merged.added, hasLength(1));
+    });
+
+    test("keeps the operator's standing rules, and their order", () {
+      // The document is shared configuration somebody curated by hand (#273);
+      // an apply may only add to it.
+      final merged = mergeEarnedWisaRules(
+        stored: const AppSettings(wisaRules: <WisaImportRule>[
+          ReplaceInstitute(original: '111', replacement: '222'),
+          MarkAsVirtual('V1'),
+        ]),
+        earned: const <WisaImportRule>[DontImportClass('3C')],
+      );
+
+      expect(merged!.settings.wisaRules.map((r) => r.runtimeType).toList(),
+          <Type>[ReplaceInstitute, MarkAsVirtual, DontImportClass]);
+    });
+
+    test('leaves every other field of the document untouched', () {
+      // The store replaces the whole config document, so a merge that dropped a
+      // field would silently un-configure the whole team.
+      const stored = AppSettings(
+        schoolPrefix: 'SMA',
+        debugMode: true,
+        wisa: WisaConnection(server: 'wisa.example', port: '9000'),
+        smartschoolRules: <ss.SmartschoolImportRule>[
+          ss.DiscardSmartschoolGroup('Oud'),
+        ],
+        wisaSchools: <WisaSchoolProfile>[
+          WisaSchoolProfile(schoolId: 25, ours: true),
+        ],
+      );
+
+      final merged = mergeEarnedWisaRules(
+        stored: stored,
+        earned: const <WisaImportRule>[DontImportClass('3C')],
+      )!;
+
+      expect(merged.settings.schoolPrefix, 'SMA');
+      expect(merged.settings.debugMode, isTrue);
+      expect(merged.settings.wisa.server, 'wisa.example');
+      expect(merged.settings.smartschoolRules, hasLength(1));
+      expect(merged.settings.wisaSchools.single.ours, isTrue);
+    });
+
+    test('returns null when the document already carries the rule', () {
+      // Applying the same opt-out twice — this session or another operator's —
+      // must not grow the persisted list, and must not spend a settings write.
+      expect(
+        mergeEarnedWisaRules(
+          stored: const AppSettings(
+            wisaRules: <WisaImportRule>[DontImportClass('3C')],
+          ),
+          earned: const <WisaImportRule>[DontImportClass('3C')],
+        ),
+        isNull,
+      );
+    });
+
+    test('de-duplicates on WisaImportRules\' own keys, not on identity', () {
+      // "Already persisted" has to mean exactly what "already earned this
+      // session" means, or the two halves the pull unions would disagree about
+      // what a duplicate is.
+      // Built at runtime, so this is a different object carrying the same key.
+      final sameClass = <String>['3', 'C'].join();
+      final merged = mergeEarnedWisaRules(
+        stored: const AppSettings(
+          wisaRules: <WisaImportRule>[DontImportClass('3C')],
+        ),
+        earned: <WisaImportRule>[
+          DontImportClass(sameClass),
+          const DontImportUserFromWisa('SMIT'),
+        ],
+      );
+
+      expect(merged!.settings.wisaRules, hasLength(2));
+      expect(merged.added.single, isA<DontImportUserFromWisa>());
+    });
+
+    test('collapses a rule the same pass earned twice', () {
+      // One bulk pass can blacklist the same class through two entries; the
+      // document must still grow by one.
+      final merged = mergeEarnedWisaRules(
+        stored: const AppSettings(),
+        earned: const <WisaImportRule>[
+          DontImportClass('3C'),
+          DontImportClass('3C'),
+        ],
+      );
+
+      expect(merged!.settings.wisaRules, hasLength(1));
+      expect(merged.added, hasLength(1));
+    });
+
+    test('returns null for an empty earned set', () {
+      expect(
+        mergeEarnedWisaRules(
+          stored: const AppSettings(),
+          earned: const <WisaImportRule>[],
+        ),
+        isNull,
+      );
+    });
+
+    test('round-trips through the settings codec', () {
+      // The merged document is what the store writes, so the appended rule has
+      // to survive the wire shape #263's pull reads back.
+      final merged = mergeEarnedWisaRules(
+        stored: const AppSettings(),
+        earned: const <WisaImportRule>[DontImportUserFromWisa('SMIT')],
+      )!;
+
+      final restored = AppSettings.fromJson(merged.settings.toJson());
+
+      expect(
+        (restored.wisaRules.single as DontImportUserFromWisa).userCode,
+        'SMIT',
+      );
+    });
+  });
+}

--- a/packages/account_state/test/wisa_rule_merge_test.dart
+++ b/packages/account_state/test/wisa_rule_merge_test.dart
@@ -11,7 +11,9 @@ void main() {
       // only in the process-lifetime holder and vanished on relaunch.
       final merged = mergeEarnedWisaRules(
         stored: const AppSettings(),
-        earned: const <WisaImportRule>[DontImportUserFromWisa('SMIT')],
+        earned: const <EarnedWisaRule>[
+          EarnedWisaRule(DontImportUserFromWisa('SMIT')),
+        ],
       );
 
       expect(merged, isNotNull);
@@ -31,7 +33,7 @@ void main() {
           ReplaceInstitute(original: '111', replacement: '222'),
           MarkAsVirtual('V1'),
         ]),
-        earned: const <WisaImportRule>[DontImportClass('3C')],
+        earned: const <EarnedWisaRule>[EarnedWisaRule(DontImportClass('3C'))],
       );
 
       expect(merged!.settings.wisaRules.map((r) => r.runtimeType).toList(),
@@ -55,7 +57,7 @@ void main() {
 
       final merged = mergeEarnedWisaRules(
         stored: stored,
-        earned: const <WisaImportRule>[DontImportClass('3C')],
+        earned: const <EarnedWisaRule>[EarnedWisaRule(DontImportClass('3C'))],
       )!;
 
       expect(merged.settings.schoolPrefix, 'SMA');
@@ -73,7 +75,7 @@ void main() {
           stored: const AppSettings(
             wisaRules: <WisaImportRule>[DontImportClass('3C')],
           ),
-          earned: const <WisaImportRule>[DontImportClass('3C')],
+          earned: const <EarnedWisaRule>[EarnedWisaRule(DontImportClass('3C'))],
         ),
         isNull,
       );
@@ -89,9 +91,9 @@ void main() {
         stored: const AppSettings(
           wisaRules: <WisaImportRule>[DontImportClass('3C')],
         ),
-        earned: <WisaImportRule>[
-          DontImportClass(sameClass),
-          const DontImportUserFromWisa('SMIT'),
+        earned: <EarnedWisaRule>[
+          EarnedWisaRule(DontImportClass(sameClass)),
+          const EarnedWisaRule(DontImportUserFromWisa('SMIT')),
         ],
       );
 
@@ -104,9 +106,9 @@ void main() {
       // document must still grow by one.
       final merged = mergeEarnedWisaRules(
         stored: const AppSettings(),
-        earned: const <WisaImportRule>[
-          DontImportClass('3C'),
-          DontImportClass('3C'),
+        earned: const <EarnedWisaRule>[
+          EarnedWisaRule(DontImportClass('3C')),
+          EarnedWisaRule(DontImportClass('3C')),
         ],
       );
 
@@ -118,7 +120,7 @@ void main() {
       expect(
         mergeEarnedWisaRules(
           stored: const AppSettings(),
-          earned: const <WisaImportRule>[],
+          earned: const <EarnedWisaRule>[],
         ),
         isNull,
       );
@@ -129,7 +131,9 @@ void main() {
       // to survive the wire shape #263's pull reads back.
       final merged = mergeEarnedWisaRules(
         stored: const AppSettings(),
-        earned: const <WisaImportRule>[DontImportUserFromWisa('SMIT')],
+        earned: const <EarnedWisaRule>[
+          EarnedWisaRule(DontImportUserFromWisa('SMIT')),
+        ],
       )!;
 
       final restored = AppSettings.fromJson(merged.settings.toJson());
@@ -138,6 +142,151 @@ void main() {
         (restored.wisaRules.single as DontImportUserFromWisa).userCode,
         'SMIT',
       );
+    });
+  });
+
+  group('provenance on an earned rule (#285)', () {
+    final at = DateTime.utc(2026, 6, 30, 14, 5);
+
+    test('stamps who added it, when, and for whom', () {
+      // The whole point of the record: a `DontImportUserFromWisa` stores a bare
+      // WISA code, so without this a colleague opening Instellingen next month
+      // sees an opaque string and cannot tell what removing it would undo.
+      final merged = mergeEarnedWisaRules(
+        stored: const AppSettings(),
+        earned: const <EarnedWisaRule>[
+          EarnedWisaRule(DontImportUserFromWisa('SMIT'), subject: 'Jan Smit'),
+        ],
+        addedBy: 'ann@school.example',
+        addedAt: at,
+      )!;
+
+      final provenance =
+          merged.settings.provenanceOf(const DontImportUserFromWisa('SMIT'));
+      expect(provenance, isNotNull);
+      expect(provenance!.subject, 'Jan Smit');
+      expect(provenance.addedBy, 'ann@school.example');
+      expect(provenance.addedAt, at);
+    });
+
+    test('records what it knows when the subject name is unknown', () {
+      // "By whom" is the load-bearing field — the record is a pointer to the
+      // person who remembers — so a missing name must not cost the stamp.
+      final merged = mergeEarnedWisaRules(
+        stored: const AppSettings(),
+        earned: const <EarnedWisaRule>[EarnedWisaRule(DontImportClass('3C'))],
+        addedBy: 'ann@school.example',
+        addedAt: at,
+      )!;
+
+      final provenance =
+          merged.settings.provenanceOf(const DontImportClass('3C'));
+      expect(provenance!.subject, isEmpty);
+      expect(provenance.addedBy, 'ann@school.example');
+      expect(provenance.addedAt, at);
+    });
+
+    test('writes no provenance at all when the pass knows nothing', () {
+      // An empty record is not the same as an absent one: the view reads absent
+      // as "onbekend", and storing three empty strings would be a document
+      // claiming to record something it does not.
+      final merged = mergeEarnedWisaRules(
+        stored: const AppSettings(),
+        earned: const <EarnedWisaRule>[EarnedWisaRule(DontImportClass('3C'))],
+      )!;
+
+      expect(merged.settings.wisaRuleProvenance, isEmpty);
+      expect(merged.settings.provenanceOf(const DontImportClass('3C')), isNull);
+    });
+
+    test('keeps the first operator\'s stamp when two decisions collapse', () {
+      // The union puts persisted rules first (#263) and the dedup key ignores
+      // provenance, so two operators earning the same rule collapse to one. The
+      // standing decision — the one the document has been running on — keeps its
+      // author. Deliberate, not incidental.
+      final first = RuleProvenance(
+        subject: 'Jan Smit',
+        addedBy: 'ann@school.example',
+        addedAt: DateTime.utc(2026, 1, 1),
+      );
+      final merged = mergeEarnedWisaRules(
+        stored: AppSettings(
+          wisaRules: const <WisaImportRule>[DontImportUserFromWisa('SMIT')],
+          wisaRuleProvenance: <String, RuleProvenance>{
+            'user:SMIT': first,
+          },
+        ),
+        earned: const <EarnedWisaRule>[
+          EarnedWisaRule(DontImportUserFromWisa('SMIT'), subject: 'J. Smit'),
+          EarnedWisaRule(DontImportClass('3C'), subject: '3C'),
+        ],
+        addedBy: 'bob@school.example',
+        addedAt: at,
+      )!;
+
+      expect(merged.settings.provenanceOf(const DontImportUserFromWisa('SMIT')),
+          first);
+      expect(
+        merged.settings.provenanceOf(const DontImportClass('3C'))!.addedBy,
+        'bob@school.example',
+      );
+    });
+
+    test('leaves the provenance of untouched rules alone', () {
+      final standing = RuleProvenance(
+        addedBy: 'ann@school.example',
+        addedAt: DateTime.utc(2025, 9, 1),
+      );
+      final merged = mergeEarnedWisaRules(
+        stored: AppSettings(
+          wisaRules: const <WisaImportRule>[MarkAsVirtual('V1')],
+          wisaRuleProvenance: <String, RuleProvenance>{'virtual:V1': standing},
+        ),
+        earned: const <EarnedWisaRule>[EarnedWisaRule(DontImportClass('3C'))],
+        addedBy: 'bob@school.example',
+        addedAt: at,
+      )!;
+
+      expect(merged.settings.provenanceOf(const MarkAsVirtual('V1')), standing);
+    });
+
+    test('survives the round-trip the store writes and #263 reads back', () {
+      final merged = mergeEarnedWisaRules(
+        stored: const AppSettings(),
+        earned: const <EarnedWisaRule>[
+          EarnedWisaRule(DontImportUserFromWisa('SMIT'), subject: 'Jan Smit'),
+        ],
+        addedBy: 'ann@school.example',
+        addedAt: at,
+      )!;
+
+      final restored = AppSettings.fromJson(merged.settings.toJson());
+      final provenance =
+          restored.provenanceOf(const DontImportUserFromWisa('SMIT'))!;
+
+      expect(provenance.subject, 'Jan Smit');
+      expect(provenance.addedBy, 'ann@school.example');
+      expect(provenance.addedAt, at);
+    });
+
+    test('does not move the WISA pull fingerprint', () {
+      // Who typed a rule changes nothing about what WISA returns, so a
+      // re-stamped document must not arm #238's drift gate — and the apply
+      // path's own re-credit (#276) depends on that staying true.
+      const stored = AppSettings(
+        wisaRules: <WisaImportRule>[DontImportClass('3C')],
+      );
+      final stamped = stored.copyWith(
+        wisaRuleProvenance: <String, RuleProvenance>{
+          'class:3C': RuleProvenance(
+            subject: '3C',
+            addedBy: 'ann@school.example',
+            addedAt: at,
+          ),
+        },
+      );
+
+      expect(wisaPullFingerprint(stamped), wisaPullFingerprint(stored));
     });
   });
 }

--- a/packages/account_state/test/wisa_rule_merge_test.dart
+++ b/packages/account_state/test/wisa_rule_merge_test.dart
@@ -31,13 +31,13 @@ void main() {
       final merged = mergeEarnedWisaRules(
         stored: const AppSettings(wisaRules: <WisaImportRule>[
           ReplaceInstitute(original: '111', replacement: '222'),
-          MarkAsVirtual('V1'),
+          DontImportUserFromWisa('SMIT'),
         ]),
         earned: const <EarnedWisaRule>[EarnedWisaRule(DontImportClass('3C'))],
       );
 
       expect(merged!.settings.wisaRules.map((r) => r.runtimeType).toList(),
-          <Type>[ReplaceInstitute, MarkAsVirtual, DontImportClass]);
+          <Type>[ReplaceInstitute, DontImportUserFromWisa, DontImportClass]);
     });
 
     test('leaves every other field of the document untouched', () {
@@ -239,15 +239,24 @@ void main() {
       );
       final merged = mergeEarnedWisaRules(
         stored: AppSettings(
-          wisaRules: const <WisaImportRule>[MarkAsVirtual('V1')],
-          wisaRuleProvenance: <String, RuleProvenance>{'virtual:V1': standing},
+          wisaRules: const <WisaImportRule>[
+            ReplaceInstitute(original: '111', replacement: '222'),
+          ],
+          wisaRuleProvenance: <String, RuleProvenance>{
+            'institute:111': standing,
+          },
         ),
         earned: const <EarnedWisaRule>[EarnedWisaRule(DontImportClass('3C'))],
         addedBy: 'bob@school.example',
         addedAt: at,
       )!;
 
-      expect(merged.settings.provenanceOf(const MarkAsVirtual('V1')), standing);
+      expect(
+        merged.settings.provenanceOf(
+          const ReplaceInstitute(original: '111', replacement: '222'),
+        ),
+        standing,
+      );
     });
 
     test('survives the round-trip the store writes and #263 reads back', () {

--- a/packages/wisa_api/CHANGELOG.md
+++ b/packages/wisa_api/CHANGELOG.md
@@ -11,9 +11,10 @@ Initial WISA SOAP connector for the Arcadia Account Manager port (issue #20).
 - `WisaSnapshot` — immutable per-sync result, implements
   `account_core.Snapshot`.
 - Import rules applied at snapshot construction:
-  `ReplaceInstitute`, `DontImportClass`, `DontImportUserFromWisa`,
-  `MarkAsVirtual`.
-- Dual workdate support (real + virtual) for schools marked virtual.
+  `ReplaceInstitute`, `DontImportClass`, `DontImportUserFromWisa`.
+- Dual workdate support (real + virtual) for schools marked virtual. Which
+  schools those are is the app's per-school setting, not an import rule — the
+  `MarkAsVirtual` rule was retired in #277 (as `MarkAsOurs` was in #286).
 - CSV parser with Belgian date format support and quoted-field handling.
 - Pluggable SOAP transport for headless record-and-replay tests.
 - Record-and-replay fixtures derived from real production data via the

--- a/packages/wisa_api/README.md
+++ b/packages/wisa_api/README.md
@@ -28,8 +28,11 @@ small SOAP envelope builder.
 - `WisaSnapshot` — immutable, includes `students`, `staff`, `classGroups`,
   `schools`, `fetchedAt`.
 - `WisaImportRule` sealed hierarchy: `ReplaceInstitute`, `DontImportClass`,
-  `DontImportUserFromWisa`, `MarkAsVirtual`. Rules are applied at snapshot
-  construction, not at link time.
+  `DontImportUserFromWisa`. Rules are applied at snapshot construction, not at
+  link time. Neither legacy school-marking rule is ported: `MarkAsVirtual`
+  (#277) and `MarkAsOurs` (#286) are the operator's WISA-scholen list in the
+  app, keyed by school id — `WisaSchool.isVirtual` is stamped on from there
+  before `sync`.
 
 Spec: [`docs/domain-model.md`](../../docs/domain-model.md) §3.3, §3.4,
 §3.11. Legacy reference: [`legacy-wpf/AccountApi/Wisa/`](../../legacy-wpf/AccountApi/Wisa/).

--- a/packages/wisa_api/lib/src/connector.dart
+++ b/packages/wisa_api/lib/src/connector.dart
@@ -97,9 +97,9 @@ class WisaConnector {
   }
 
   /// Pulls every school the credentials grant access to. Returns the
-  /// list as it would appear in a snapshot — but **without** the
-  /// [MarkAsVirtual] rule applied. Call [sync] for the rule-applied
-  /// view.
+  /// list as it would appear in a snapshot — but with every school
+  /// non-virtual: which of them is virtual is the operator's per-school
+  /// mark in Instellingen, stamped on by the app before [sync] (#277).
   Future<List<WisaSchool>> loadSchools() async {
     final csv = await _performQuery(WisaQuery.getSchools, const []);
     if (csv.isEmpty) {
@@ -126,13 +126,12 @@ class WisaConnector {
   /// [workDate] is used as the "Werkdatum" parameter for each query
   /// **unless** the school's `isVirtual` flag is set, in which case
   /// [virtualWorkDate] is used (falls back to [workDate] when null).
-  /// Apply [MarkAsVirtual] rules to [schools] before passing them in
-  /// (see [applySchoolRules]).
+  /// Flag [schools] from the operator's per-school virtual marks before
+  /// passing them in — the app's `markVirtualSchools` does that (#277).
   ///
   /// [rules] is the full set of import rules — `ReplaceInstitute`,
-  /// `DontImportClass`, and `DontImportUserFromWisa` are applied during
-  /// snapshot construction here; `MarkAsVirtual` should already be
-  /// reflected in the `isVirtual` flag of each school.
+  /// `DontImportClass`, and `DontImportUserFromWisa` — all applied during
+  /// snapshot construction here. No rule touches a school any more.
   Future<WisaSnapshot> sync({
     required Iterable<WisaSchool> schools,
     required DateTime workDate,
@@ -176,15 +175,6 @@ class WisaConnector {
       schools: schools.toList(),
     );
   }
-
-  /// Applies [MarkAsVirtual] rules to a freshly-loaded list of schools.
-  /// Convenience for callers that want to compute the post-rule school
-  /// list before passing it to [sync].
-  static List<WisaSchool> applySchoolRules(
-    Iterable<WisaSchool> schools,
-    Iterable<WisaImportRule> rules,
-  ) =>
-      applyRulesToSchools(schools, rules);
 
   Future<List<WisaClassGroup>> _loadClassGroups(
     WisaSchool school,

--- a/packages/wisa_api/lib/src/models/wisa_school.dart
+++ b/packages/wisa_api/lib/src/models/wisa_school.dart
@@ -13,12 +13,14 @@
 /// `MarkAsVirtual` import rule; it tells the connector that this school
 /// should be synced using the virtual workdate instead of the real one.
 ///
-/// [isOurs] marks a school we actually **manage** (as opposed to one that
-/// is merely group-visible through the shared credentials). It is set at
-/// snapshot construction time by the `MarkAsOurs` import rule, paralleling
-/// [isVirtual]. Group-wide leave detection (#113) needs it to tell a student
-/// who left *our* school but stayed in the group from one who left the group
-/// entirely; this slice only carries the flag — it changes no action yet.
+/// There is no ownership flag here (#286). Which schools we **manage** — as
+/// opposed to the sibling schools the shared credentials also reach — is the
+/// operator's WISA-scholen list in Instellingen, keyed by school id
+/// (`AppSettings.managedWisaSchoolIds`, #178). A snapshot-time `isOurs` flag
+/// existed alongside it until #286 and nothing read it: the settings list wins
+/// as soon as it holds a single school, which is every install that has ever
+/// pressed **Scholen ophalen**. An `isOurs` key in a cold snapshot written
+/// before #286 is ignored by [WisaSchool.fromJson].
 class WisaSchool {
   final int id;
 
@@ -28,17 +30,15 @@ class WisaSchool {
 
   /// The short code operators use day to day (`ISMAA`). Parsed from the
   /// `SMAGetInst` CSV's `DESCRIPTION` column, and what the school-marking
-  /// import rules (`MarkAsOurs`, `MarkAsVirtual`) match on.
+  /// import rule (`MarkAsVirtual`) matches on.
   final String code;
   final bool isVirtual;
-  final bool isOurs;
 
   const WisaSchool({
     required this.id,
     required this.name,
     required this.code,
     this.isVirtual = false,
-    this.isOurs = false,
   });
 
   /// Serializes to the connector's own snapshot shape. Round-trips with
@@ -48,7 +48,6 @@ class WisaSchool {
         'name': name,
         'code': code,
         'isVirtual': isVirtual,
-        'isOurs': isOurs,
       };
 
   /// Reads a snapshot school, migrating documents written before #208.
@@ -58,6 +57,10 @@ class WisaSchool {
   /// key is read back swapped. Nothing else distinguishes the two shapes, and
   /// the `code` key is written unconditionally, so the test is exact rather
   /// than a guess about the values.
+  ///
+  /// An `isOurs` key from a document written before #286 is ignored: the flag
+  /// is gone and the managed-school set comes from Settings (see the class
+  /// doc).
   factory WisaSchool.fromJson(Map<String, dynamic> json) {
     final legacy = !json.containsKey('code') && json.containsKey('description');
     return WisaSchool(
@@ -65,16 +68,14 @@ class WisaSchool {
       name: (legacy ? json['description'] : json['name']) as String,
       code: (legacy ? json['name'] : json['code']) as String,
       isVirtual: (json['isVirtual'] as bool?) ?? false,
-      isOurs: (json['isOurs'] as bool?) ?? false,
     );
   }
 
-  WisaSchool copyWith({bool? isVirtual, bool? isOurs}) => WisaSchool(
+  WisaSchool copyWith({bool? isVirtual}) => WisaSchool(
         id: id,
         name: name,
         code: code,
         isVirtual: isVirtual ?? this.isVirtual,
-        isOurs: isOurs ?? this.isOurs,
       );
 
   @override
@@ -84,13 +85,12 @@ class WisaSchool {
           id == other.id &&
           name == other.name &&
           code == other.code &&
-          isVirtual == other.isVirtual &&
-          isOurs == other.isOurs;
+          isVirtual == other.isVirtual;
 
   @override
-  int get hashCode => Object.hash(id, name, code, isVirtual, isOurs);
+  int get hashCode => Object.hash(id, name, code, isVirtual);
 
   @override
-  String toString() => 'WisaSchool(id: $id, name: $name, code: $code, '
-      'isVirtual: $isVirtual, isOurs: $isOurs)';
+  String toString() =>
+      'WisaSchool(id: $id, name: $name, code: $code, isVirtual: $isVirtual)';
 }

--- a/packages/wisa_api/lib/src/models/wisa_school.dart
+++ b/packages/wisa_api/lib/src/models/wisa_school.dart
@@ -9,9 +9,13 @@
 /// [code] always the short code, so no reader has to remember a swap —
 /// `parseSchoolRow` is the single place that untangles the CSV.
 ///
-/// [isVirtual] is set at snapshot construction time by the
-/// `MarkAsVirtual` import rule; it tells the connector that this school
-/// should be synced using the virtual workdate instead of the real one.
+/// [isVirtual] tells the connector that this school should be synced using the
+/// virtual workdate instead of the real one. It is stamped on just before the
+/// pull from the operator's per-school virtual marks in Instellingen
+/// (`AppSettings.virtualWisaSchoolIds`, keyed by school id, #203). A
+/// snapshot-time `MarkAsVirtual` import rule set the same flag by short code
+/// until #277 retired it: two surfaces for one flag could disagree, and the id
+/// the grid keys by survives a rename or a recode where a code does not.
 ///
 /// There is no ownership flag here (#286). Which schools we **manage** — as
 /// opposed to the sibling schools the shared credentials also reach — is the
@@ -29,8 +33,8 @@ class WisaSchool {
   final String name;
 
   /// The short code operators use day to day (`ISMAA`). Parsed from the
-  /// `SMAGetInst` CSV's `DESCRIPTION` column, and what the school-marking
-  /// import rule (`MarkAsVirtual`) matches on.
+  /// `SMAGetInst` CSV's `DESCRIPTION` column, and what the WISA-scholen grid
+  /// shows beneath each school's long name.
   final String code;
   final bool isVirtual;
 

--- a/packages/wisa_api/lib/src/rules/import_rules.dart
+++ b/packages/wisa_api/lib/src/rules/import_rules.dart
@@ -2,8 +2,8 @@
 ///
 /// Spec: `docs/domain-model.md` §3.11. Rules are applied **at snapshot
 /// construction time** — by the time a [WisaSnapshot] reaches the linker,
-/// every dropped class group, dropped staff member, rewritten institute
-/// number, and virtual-school flag has already been resolved.
+/// every dropped class group, dropped staff member and rewritten institute
+/// number has already been resolved.
 ///
 /// Legacy reference: `legacy-wpf/AccountApi/Rules/`. Each legacy rule's
 /// behaviour is preserved verbatim; only the shape changes (sealed
@@ -11,18 +11,26 @@
 library;
 
 import '../models/wisa_class_group.dart';
-import '../models/wisa_school.dart';
 import '../models/wisa_staff.dart';
 
-/// Base sealed type for the four WISA import rules. Each subtype knows
+/// Base sealed type for the three WISA import rules. Each subtype knows
 /// only how to test and modify its own target model — no `instanceof`
 /// dispatch on a generic `object`, unlike the legacy `IRule`.
 ///
-/// Legacy `WI_MarkAsOurs` has **no** port (#286). It flipped a
-/// `WisaSchool.isOurs` flag nothing read: the managed-school set comes from the
-/// operator's WISA-scholen grid in Instellingen (#178), which is authoritative
-/// the moment it holds a single school — so the rule could be saved and then
-/// silently do nothing.
+/// Neither legacy school-marking rule is ported any more, and for the same
+/// reason: the operator's WISA-scholen grid in Instellingen marks a school by
+/// **id** and a rule could only match its short code, so the two surfaces could
+/// disagree about one flag.
+///
+/// - `WI_MarkAsOurs` was dropped in #286. It flipped a `WisaSchool.isOurs` flag
+///   nothing read, the managed-school set coming from the grid (#178).
+/// - `WI_MarkAsVirtual` was dropped in #277. It flipped `WisaSchool.isVirtual`,
+///   which *is* read — the connector pulls a virtual school with the separate
+///   virtual werkdatum — but the grid sets the same flag through
+///   `AppSettings.virtualWisaSchoolIds`, and that mark is ticked in spring and
+///   cleared in autumn, which is a checkbox next to a school's name rather than
+///   an entry in a rules list. A persisted rule is migrated onto the grid's
+///   per-school flag when the settings document loads.
 sealed class WisaImportRule {
   const WisaImportRule();
 }
@@ -58,20 +66,6 @@ class ReplaceInstitute extends WisaImportRule {
       matches(g) ? g.copyWith(schoolCode: replacement) : g;
 }
 
-/// Flags schools whose [WisaSchool.code] equals [schoolCode] as virtual.
-/// The connector then syncs those schools with the virtual workdate
-/// instead of the real one. Mirrors legacy `MarkAsVirtual`
-/// (`RuleAction.WorkDate`).
-///
-/// Matches on the **short code** (`ISMV`), as it always did — before #208 that
-/// half was misfiled on `WisaSchool.name`, so this read `s.name`.
-class MarkAsVirtual extends WisaImportRule {
-  final String schoolCode;
-  const MarkAsVirtual(this.schoolCode);
-
-  bool matches(WisaSchool s) => s.code == schoolCode;
-}
-
 /// Applies all rules in [rules] to [groups], in order. Returns a new list;
 /// the input is not mutated.
 ///
@@ -97,7 +91,6 @@ List<WisaClassGroup> applyRulesToClassGroups(
         case ReplaceInstitute():
           g = r.apply(g);
         case DontImportUserFromWisa():
-        case MarkAsVirtual():
           break;
       }
     }
@@ -121,24 +114,4 @@ List<WisaStaff> applyRulesToStaff(
     result.add(s);
   }
   return result;
-}
-
-/// Applies the school-marking rule [MarkAsVirtual] in [rules] to [schools].
-/// Returns a new list with `isVirtual` flipped on matching schools; the input
-/// is not mutated.
-///
-/// The pass is additive — a school already flagged stays flagged — so unioning
-/// the operator's per-school virtual marks in (`markVirtualSchools`) can never
-/// un-virtualise a school a rule covers.
-List<WisaSchool> applyRulesToSchools(
-  Iterable<WisaSchool> schools,
-  Iterable<WisaImportRule> rules,
-) {
-  return [
-    for (final s in schools)
-      s.copyWith(
-        isVirtual:
-            s.isVirtual || rules.any((r) => r is MarkAsVirtual && r.matches(s)),
-      ),
-  ];
 }

--- a/packages/wisa_api/lib/src/rules/import_rules.dart
+++ b/packages/wisa_api/lib/src/rules/import_rules.dart
@@ -17,6 +17,12 @@ import '../models/wisa_staff.dart';
 /// Base sealed type for the four WISA import rules. Each subtype knows
 /// only how to test and modify its own target model — no `instanceof`
 /// dispatch on a generic `object`, unlike the legacy `IRule`.
+///
+/// Legacy `WI_MarkAsOurs` has **no** port (#286). It flipped a
+/// `WisaSchool.isOurs` flag nothing read: the managed-school set comes from the
+/// operator's WISA-scholen grid in Instellingen (#178), which is authoritative
+/// the moment it holds a single school — so the rule could be saved and then
+/// silently do nothing.
 sealed class WisaImportRule {
   const WisaImportRule();
 }
@@ -66,18 +72,6 @@ class MarkAsVirtual extends WisaImportRule {
   bool matches(WisaSchool s) => s.code == schoolCode;
 }
 
-/// Flags schools whose [WisaSchool.code] equals [schoolCode] as *ours*
-/// (managed). Group-wide leave detection (#113) uses the flag to tell a
-/// student gone from *our* school but still in the group from one gone from
-/// the whole group. Mirrors [MarkAsVirtual] — a snapshot-time school marker
-/// keyed by the short WISA school code.
-class MarkAsOurs extends WisaImportRule {
-  final String schoolCode;
-  const MarkAsOurs(this.schoolCode);
-
-  bool matches(WisaSchool s) => s.code == schoolCode;
-}
-
 /// Applies all rules in [rules] to [groups], in order. Returns a new list;
 /// the input is not mutated.
 ///
@@ -104,7 +98,6 @@ List<WisaClassGroup> applyRulesToClassGroups(
           g = r.apply(g);
         case DontImportUserFromWisa():
         case MarkAsVirtual():
-        case MarkAsOurs():
           break;
       }
     }
@@ -130,10 +123,13 @@ List<WisaStaff> applyRulesToStaff(
   return result;
 }
 
-/// Applies the school-marking rules ([MarkAsVirtual], [MarkAsOurs]) in
-/// [rules] to [schools]. Returns a new list with `isVirtual` / `isOurs`
-/// flipped on matching schools; the input is not mutated. A school can be
-/// flagged by both rules independently.
+/// Applies the school-marking rule [MarkAsVirtual] in [rules] to [schools].
+/// Returns a new list with `isVirtual` flipped on matching schools; the input
+/// is not mutated.
+///
+/// The pass is additive — a school already flagged stays flagged — so unioning
+/// the operator's per-school virtual marks in (`markVirtualSchools`) can never
+/// un-virtualise a school a rule covers.
 List<WisaSchool> applyRulesToSchools(
   Iterable<WisaSchool> schools,
   Iterable<WisaImportRule> rules,
@@ -143,7 +139,6 @@ List<WisaSchool> applyRulesToSchools(
       s.copyWith(
         isVirtual:
             s.isVirtual || rules.any((r) => r is MarkAsVirtual && r.matches(s)),
-        isOurs: s.isOurs || rules.any((r) => r is MarkAsOurs && r.matches(s)),
       ),
   ];
 }

--- a/packages/wisa_api/test/connector_test.dart
+++ b/packages/wisa_api/test/connector_test.dart
@@ -223,12 +223,8 @@ void main() {
       final c = buildConnector(t);
       final schools = await c.loadSchools();
       final ismaa = schools.firstWhere((s) => s.id == 25);
-      final markedVirtual = WisaConnector.applySchoolRules(
-        [ismaa],
-        const [MarkAsVirtual('ISMAA')],
-      );
       await c.sync(
-        schools: markedVirtual,
+        schools: [ismaa.copyWith(isVirtual: true)],
         workDate: DateTime(2024, 9, 1),
         virtualWorkDate: DateTime(2025, 9, 1),
       );

--- a/packages/wisa_api/test/models/models_equality_test.dart
+++ b/packages/wisa_api/test/models/models_equality_test.dart
@@ -121,23 +121,21 @@ void main() {
       expect(a.copyWith().isVirtual, isFalse);
     });
 
-    test('isOurs participates in equality and copyWith and round-trips', () {
-      const a = WisaSchool(id: 1, name: 'Sint-Maria', code: 'SMA');
-      const managed = WisaSchool(
-        id: 1,
-        name: 'Sint-Maria',
-        code: 'SMA',
-        isOurs: true,
-      );
-      expect(a, isNot(managed));
-      expect(a.copyWith(isOurs: true).isOurs, isTrue);
-      expect(a.copyWith().isOurs, isFalse);
-      expect(WisaSchool.fromJson(managed.toJson()), managed);
-      // Old snapshots without the key default to not-ours.
+    test('an isOurs key from a snapshot written before #286 is ignored', () {
+      // The flag is gone: ownership is the operator's WISA-scholen list in
+      // Settings. A cold snapshot that still carries the key must load, and read
+      // back equal to the same school without it, rather than throwing.
+      const school = WisaSchool(id: 1, name: 'Sint-Maria', code: 'SMA');
+      expect(school.toJson().containsKey('isOurs'), isFalse);
       expect(
-        WisaSchool.fromJson(
-            const {'id': 1, 'name': 'Sint-Maria', 'code': 'SMA'}).isOurs,
-        isFalse,
+        WisaSchool.fromJson(const {
+          'id': 1,
+          'name': 'Sint-Maria',
+          'code': 'SMA',
+          'isVirtual': false,
+          'isOurs': true,
+        }),
+        school,
       );
     });
 
@@ -149,13 +147,12 @@ void main() {
         'id': 25,
         'name': 'ISMAA',
         'description': 'Instituut Sancta Maria-A',
-        'isVirtual': false,
-        'isOurs': true,
+        'isVirtual': true,
       };
       final migrated = WisaSchool.fromJson(legacy);
       expect(migrated.name, 'Instituut Sancta Maria-A');
       expect(migrated.code, 'ISMAA');
-      expect(migrated.isOurs, isTrue);
+      expect(migrated.isVirtual, isTrue);
     });
 
     test('toString includes id, name, code, and virtual flag', () {

--- a/packages/wisa_api/test/rules/import_rules_test.dart
+++ b/packages/wisa_api/test/rules/import_rules_test.dart
@@ -76,41 +76,27 @@ void main() {
     });
   });
 
-  group('MarkAsVirtual', () {
-    test('flips isVirtual on the matching short school code', () {
-      // The rule keys off the short code, never the long name (#208).
-      const schools = [
-        WisaSchool(id: 1, name: 'Sint Maria', code: 'SMA'),
-        WisaSchool(id: 2, name: 'Sint Dimphna', code: 'SDK'),
+  group('no rule marks a school (#277, #286)', () {
+    test('the sealed hierarchy holds exactly the three record rules', () {
+      // Both school-marking rules are gone: `MarkAsOurs` was dead (#286) and
+      // `MarkAsVirtual` duplicated the WISA-scholen grid, which marks by school
+      // id instead (#277). Nothing in this package flags a `WisaSchool` any
+      // more, so an exhaustive switch over the hierarchy is the whole check —
+      // it stops compiling the moment a fourth kind appears.
+      const rules = <WisaImportRule>[
+        DontImportClass('1A'),
+        DontImportUserFromWisa('AAAAA'),
+        ReplaceInstitute(original: '111', replacement: '222'),
       ];
-      final out = applyRulesToSchools(schools, const [MarkAsVirtual('SMA')]);
-      expect(out[0].isVirtual, isTrue);
-      expect(out[1].isVirtual, isFalse);
-    });
-
-    test('does not match on the long school name', () {
-      const schools = [WisaSchool(id: 1, name: 'Sint Maria', code: 'SMA')];
-      final out =
-          applyRulesToSchools(schools, const [MarkAsVirtual('Sint Maria')]);
-      expect(out.single.isVirtual, isFalse);
-    });
-
-    test('is a no-op for class groups and staff', () {
-      final groups = [_g('1A')];
-      expect(applyRulesToClassGroups(groups, const [MarkAsVirtual('SMA')]),
-          groups);
-      final staff = [_s('AAAAA')];
-      expect(applyRulesToStaff(staff, const [MarkAsVirtual('SMA')]), staff);
-    });
-
-    test('leaves a school an earlier rule already flagged alone', () {
-      // The pass is additive, so unioning the operator's per-school virtual
-      // marks in afterwards can never un-virtualise a rule-marked school.
-      const schools = [
-        WisaSchool(id: 1, name: 'Sint Maria', code: 'SMA', isVirtual: true),
+      final kinds = <String>[
+        for (final r in rules)
+          switch (r) {
+            DontImportClass() => 'class',
+            DontImportUserFromWisa() => 'user',
+            ReplaceInstitute() => 'institute',
+          },
       ];
-      final out = applyRulesToSchools(schools, const [MarkAsVirtual('SDK')]);
-      expect(out.single.isVirtual, isTrue);
+      expect(kinds, <String>['class', 'user', 'institute']);
     });
   });
 

--- a/packages/wisa_api/test/rules/import_rules_test.dart
+++ b/packages/wisa_api/test/rules/import_rules_test.dart
@@ -94,44 +94,23 @@ void main() {
           applyRulesToSchools(schools, const [MarkAsVirtual('Sint Maria')]);
       expect(out.single.isVirtual, isFalse);
     });
-  });
-
-  group('MarkAsOurs', () {
-    test('flips isOurs on the matching short school code only', () {
-      const schools = [
-        WisaSchool(id: 1, name: 'Sint Maria', code: 'SMA'),
-        WisaSchool(id: 2, name: 'Sint Dimphna', code: 'SDK'),
-      ];
-      final out = applyRulesToSchools(schools, const [MarkAsOurs('SMA')]);
-      expect(out[0].isOurs, isTrue);
-      expect(out[1].isOurs, isFalse);
-      // No cross-contamination with the virtual marker.
-      expect(out[0].isVirtual, isFalse);
-    });
-
-    test('does not match on the long school name', () {
-      const schools = [WisaSchool(id: 1, name: 'Sint Maria', code: 'SMA')];
-      final out =
-          applyRulesToSchools(schools, const [MarkAsOurs('Sint Maria')]);
-      expect(out.single.isOurs, isFalse);
-    });
-
-    test('MarkAsVirtual and MarkAsOurs flag independently on one school', () {
-      const schools = [WisaSchool(id: 1, name: 'Sint Maria', code: 'SMA')];
-      final out = applyRulesToSchools(
-        schools,
-        const [MarkAsVirtual('SMA'), MarkAsOurs('SMA')],
-      );
-      expect(out.single.isVirtual, isTrue);
-      expect(out.single.isOurs, isTrue);
-    });
 
     test('is a no-op for class groups and staff', () {
       final groups = [_g('1A')];
-      expect(
-          applyRulesToClassGroups(groups, const [MarkAsOurs('SMA')]), groups);
+      expect(applyRulesToClassGroups(groups, const [MarkAsVirtual('SMA')]),
+          groups);
       final staff = [_s('AAAAA')];
-      expect(applyRulesToStaff(staff, const [MarkAsOurs('SMA')]), staff);
+      expect(applyRulesToStaff(staff, const [MarkAsVirtual('SMA')]), staff);
+    });
+
+    test('leaves a school an earlier rule already flagged alone', () {
+      // The pass is additive, so unioning the operator's per-school virtual
+      // marks in afterwards can never un-virtualise a rule-marked school.
+      const schools = [
+        WisaSchool(id: 1, name: 'Sint Maria', code: 'SMA', isVirtual: true),
+      ];
+      final out = applyRulesToSchools(schools, const [MarkAsVirtual('SDK')]);
+      expect(out.single.isVirtual, isTrue);
     });
   });
 


### PR DESCRIPTION
Four issues on the WISA import-rule machinery, worked as one chunk because they all touch the same sealed rule hierarchy, codec and settings editor.

## What changed

- **#276 — persist the rules a `DontImportFromWisa` apply earns.** New `mergeEarnedWisaRules` in `account_state` (dedupes through `WisaImportRules` itself, returns null when nothing new) plus `ReconcileController._persistEarnedWisaRules`, which collects rules across the pass, re-reads before writing, publishes, and re-credits the WISA pull so #238's drift gate is not falsely armed. Confirmation copy now says "blijvend voor iedereen"; `describeWisaRule` extracted so Log and Instellingen word a rule identically.
- **#285 — record who added a persisted rule, when, and for whom.** New `RuleProvenance` (subject / addedBy / addedAt, UTC-normalized) persisted beside the encoded rule and keyed by the now-public `wisaRuleKey`. The apply pass stamps `syncedBy`, one pass-wide instant, and the acting entry's label as subject; #273's editor stamps who/when and re-stamps on edit. Pre-#285 rules render `onbekend`. `wisaPullFingerprint` still encodes rules *without* provenance, so a re-stamp cannot arm #238's drift gate.
- **#286 — remove the dead `MarkAsOurs` rule.** Cut from the sealed hierarchy, `applyRulesToSchools`, the codec/key and the settings editor, along with `WisaSchool.isOurs` (the rule was its only writer) and three snapshot-flag fallbacks. `managedSchoolIdsOf` now returns a plain `Set<int>`; the empty set means "unconfigured ⇒ every school counts". Retired tags decode to null so old documents still load; unknown tags still throw.
- **#277 — retire `MarkAsVirtual`; the WISA-scholen grid becomes the only virtual-school surface.** Same removal pattern as #286, plus a migration: persisted marks are adopted onto `WisaSchoolProfile.virtual` in `AppSettings.fromJson` via `retiredVirtualCodeOf` + `adoptRetiredVirtualMarks`, dropped when the school is not ours or the code matches no row. `virtualByRule` and the locked-checkbox rendering are gone; `markVirtualSchools` sets the flag outright instead of additively.

## Test plan

Run per commit, each green on its own:

- `dart format --set-exit-if-changed .` — clean (312 files)
- `dart analyze --fatal-infos --fatal-warnings` — clean, 0 issues
- Unit + widget at tip: **1873 pass / 0 fail** — account_manager 490 (`flutter test`), account_state 575, account_actions 208, smartschool_api 150, azure_api 136, wisa_api 131, account_core 99, account_linker 76, account_store 8
- Integration: `flutter test integration_test/app_launch_test.dart -d windows` — **105 pass / 0 fail**, including one new end-to-end per issue

New coverage added by this chunk: 8 merge unit tests + 7 controller tests (#276), 12 provenance + 8 rule-merge + 6 widget + 3 controller + 4 timestamp tests (#285), 3 codec/widget/e2e tests (#286), 1 e2e (#277). Each new test was verified failing against the unpatched code before the fix was restored.

## Note on the chunk itself

The #286 worker found an unbraced `if` left in `AppSettings.fromJson` by this branch's own #285 commit. It passes `flutter analyze` but fails CI's `dart analyze --fatal-infos`, so the branch could not have gone green with it. Fixed inline in c1988d5 rather than filed, since both commits are unmerged here.

Closes #276
Closes #285
Closes #286
Closes #277