### PR TITLE
Sessions adopt the shared state; drift sees hand-edits, drops stale caches, and ends like a sync

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3457,6 +3457,82 @@ void main() {
   });
 
   testWidgets(
+      'a sync whose shared write fails still closes the open class, so the '
+      'drill-down never pairs the previous generation with the fresh view '
+      'end-to-end (#289)', (WidgetTester tester) async {
+    // The real app, real navigation. The bug is a composition one: the four
+    // derived caches were dropped on the far side of the store write, so a
+    // Cosmos write that timed out or threw left the class the operator had open
+    // — its documents read for the generation before — standing in front of the
+    // freshly linked view. Only an end-to-end run navigates the way that shows
+    // it: sync, drill in, sync again over a store that refuses the write, and
+    // look at what is still on screen.
+    useTallWindow(tester);
+    final inner = InMemoryLinkedStore();
+    final harness = ReconcileHarness(
+      linkedStore: inner,
+      // The first sync lands generation 1 so there is something to drill into;
+      // every write after it throws.
+      controllerStore: StallingLinkedStore(
+        inner: inner,
+        failWith: StateError('cosmos down'),
+        healthyWrites: 1,
+      ),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // Drill into the class the shared view just materialized.
+    await tester.tap(find.text('Acties'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('3C'));
+    await tester.tap(find.text('3C'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget,
+        reason: 'the drill-down is open on 3C');
+    expect(harness.controller.selectedClassroom?.classroom, '3C');
+
+    // WISA moves the student out of 3C, and the operator re-syncs — but the
+    // shared store refuses the write.
+    harness.wisaResult = wisaSnap(
+      fetchedAt: kFixtureDate.add(const Duration(hours: 1)),
+      students: [wisaStudent(classGroup: '3D')],
+    );
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining('Kon het gedeelde overzicht niet opslaan'),
+      findsWidgets,
+      reason: 'the write really did fail',
+    );
+
+    // Back on Acties: the class the operator had open is closed, because the
+    // view behind it was replaced. Before the fix the detail view was still
+    // there, joining the fresh entries to 3C's stale documents.
+    await tester.tap(find.text('Acties'));
+    await tester.pumpAndSettle();
+    expect(harness.controller.selectedClassroom, isNull);
+    expect(find.byKey(const ValueKey('actions-classroom-back')), findsNothing,
+        reason: 'a re-link closes the drill-down, write or no write');
+    expect(harness.controller.classroomPendingEntries, isEmpty);
+    // …and the session is still perfectly usable: it holds the view it linked.
+    expect(harness.controller.linked, isNotNull);
+  });
+
+  testWidgets(
       'applying a class\'s work updates its Acties badge on the way back to '
       'the overview, without a re-sync end-to-end (#236)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -5516,6 +5516,87 @@ void main() {
   });
 
   testWidgets(
+      'a drift check ends like a sync end-to-end: a terminal "Driftcontrole '
+      'voltooid" line, and the WISA-scholen grid named by the roster it had to '
+      'pull (#303)', (WidgetTester tester) async {
+    // The companion of the #207 journey above, for the operator whose first
+    // pass of the session is **Controleer op drift** rather than
+    // **Synchroniseer**. Both asymmetries #303 records show up here in the real
+    // app: the pass used to end on its "Gekoppeld: …" summary with nothing
+    // saying it had finished, and — although this branch really does pull WISA,
+    // because the session holds no roster yet — it left the grid on "School 25".
+    useTallWindow(tester);
+    final settings = SettingsHarness(
+      initial: AppSettings.fromJson(<String, dynamic>{
+        'wisa': const WisaConnection(server: 'db.school.example', port: '1433')
+            .toJson(),
+        'wisaSchools': <Map<String, dynamic>>[
+          <String, dynamic>{'schoolId': 25, 'ours': true},
+        ],
+      }),
+    );
+    final reconcile = ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(schoolId: 25)],
+        schools: <WisaSchool>[
+          parseSchoolRow('25,Instituut Sancta Maria-A,ISMAA'),
+        ],
+      ),
+      smartschool: ssSnap(
+          groups: const [], accounts: [ssAccount()], memberships: const []),
+      azure: azSnap(users: [azUser()]),
+      ourSchoolIds: const {25},
+      settingsStore: settings.store,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: reconcile.bootstrap,
+      settingsBootstrap: settings.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.pumpAndSettle();
+
+    // The Log panel says the pass is over, and says which pass it was.
+    expect(find.textContaining('Driftcontrole voltooid — '), findsOneWidget);
+    expect(find.textContaining('Klaar.'), findsWidgets);
+    expect(
+      find.textContaining('Sync voltooid'),
+      findsNothing,
+      reason: 'no sync ran — the closing line must not claim one did',
+    );
+    // It pulled WISA (nothing was in hand), so the freshness box carries the
+    // roster this pass fetched for itself.
+    expect(reconcile.wisaSyncs, 1);
+    expect(
+        find.byKey(const ValueKey('reconcile-last-sync-wisa')), findsOneWidget);
+
+    // …and having pulled it, the pass repaired the stored school profiles with
+    // it — the real grid, re-read from the document, with no Opslaan pressed.
+    await tester.tap(find.text('Instellingen'));
+    await tester.pumpAndSettle();
+    await openSettingsTab(tester, 'settings-tab-wisa');
+    await tester.ensureVisible(find.byKey(const ValueKey('settings-reload')));
+    await tester.tap(find.byKey(const ValueKey('settings-reload')));
+    await tester.pumpAndSettle();
+
+    final tile = find.byKey(const ValueKey('settings-wisa-school-25-ours'));
+    await tester.ensureVisible(tile);
+    await tester.pumpAndSettle();
+    expect((tester.widget<CheckboxListTile>(tile).title! as Text).data,
+        'Instituut Sancta Maria-A');
+    expect((tester.widget<CheckboxListTile>(tile).subtitle! as Text).data,
+        'ISMAA');
+    expect(find.text('School 25'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'the Settings/Algemeen werkdatum controls read clearly end-to-end: '
       'renamed virtual label + right-aligned switch instruction (#141)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3128,10 +3128,10 @@ void main() {
       linkedStore: linkedStore,
     ).controller.sync();
 
-    final resumed = await ReconcileHarness.resume(
-      store: snapshots,
-      linkedStore: linkedStore,
-    );
+    // Deliberately holding no seeded snapshot: since #287 a session that does
+    // adopts the shared state and gets the interactive tiles instead, and this
+    // scenario is about the passive card.
+    final resumed = ReconcileHarness(linkedStore: linkedStore);
     await tester.pumpWidget(AccountManagerApp(
       session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
       graph: graph,
@@ -3565,11 +3565,10 @@ void main() {
     );
     await operatorA.controller.sync();
 
-    final operatorB = await ReconcileHarness.resume(
-      store: snapshots,
-      linkedStore: linkedStore,
-      hub: hub,
-    );
+    // Deliberately holding no seeded snapshot: since #287 a session that does
+    // adopts the shared state, and this scenario is about what a session with
+    // *only* the shared documents keeps being offered.
+    final operatorB = ReconcileHarness(linkedStore: linkedStore, hub: hub);
     await tester.pumpWidget(AccountManagerApp(
       session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
       graph: graph,
@@ -4336,11 +4335,10 @@ void main() {
         .controller
         .sync();
 
-    // Session 2 is the real app over the same stores. It never syncs.
-    final resumed = await ReconcileHarness.resume(
-      store: snapshots,
-      linkedStore: linkedStore,
-    );
+    // Session 2 is the real app over the same stores. It never syncs, and holds
+    // no seeded snapshot to adopt from either (#287) — so this stays the purely
+    // passive read #115 is about.
+    final resumed = ReconcileHarness(linkedStore: linkedStore);
     await tester.pumpWidget(AccountManagerApp(
       session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
       graph: graph,
@@ -4391,11 +4389,10 @@ void main() {
         .controller
         .sync();
 
-    // Session 2 is the real app over the same stores. It never syncs.
-    final resumed = await ReconcileHarness.resume(
-      store: snapshots,
-      linkedStore: linkedStore,
-    );
+    // Session 2 is the real app over the same stores. It never syncs, and holds
+    // no seeded snapshot to adopt from either (#287) — so this stays the purely
+    // passive read #163 is about.
+    final resumed = ReconcileHarness(linkedStore: linkedStore);
     await tester.pumpWidget(AccountManagerApp(
       session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
       graph: graph,
@@ -4436,11 +4433,10 @@ void main() {
         .controller
         .sync();
 
-    // Session 2 is the real app over the same stores. It never syncs.
-    final resumed = await ReconcileHarness.resume(
-      store: snapshots,
-      linkedStore: linkedStore,
-    );
+    // Session 2 is the real app over the same stores. It never syncs, and holds
+    // no seeded snapshot to adopt from either (#287) — so this stays the purely
+    // passive read #119 is about.
+    final resumed = ReconcileHarness(linkedStore: linkedStore);
     await tester.pumpWidget(AccountManagerApp(
       session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
       graph: graph,
@@ -4481,16 +4477,14 @@ void main() {
     // handler and say nothing about it, which reads as an interactive screen
     // whose taps stopped working rather than as a view of the shared state.
     useTallWindow(tester);
-    final snapshots = InMemorySnapshotStore();
     final linkedStore = InMemoryLinkedStore();
-    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
-        .controller
-        .sync();
+    await ReconcileHarness(linkedStore: linkedStore).controller.sync();
 
-    final resumed = await ReconcileHarness.resume(
-      store: snapshots,
-      linkedStore: linkedStore,
-    );
+    // Deliberately holding no seeded snapshot: since #287 a session that does
+    // adopts the shared state and its tiles are interactive from the first
+    // frame (covered by its own scenario below). This is the session that has
+    // nothing to build a view from.
+    final resumed = ReconcileHarness(linkedStore: linkedStore);
     await tester.pumpWidget(AccountManagerApp(
       session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
       graph: graph,
@@ -4528,7 +4522,12 @@ void main() {
     await tester.tap(find.text('3C'));
     await tester.pumpAndSettle();
     expect(readOnly, findsOneWidget);
-    expect(find.textContaining('nog niet gesynchroniseerd'), findsOneWidget);
+    // Since #287 the notice names what is missing rather than reporting the
+    // absence of a sync: there is no snapshot here to build a view from.
+    expect(
+      find.textContaining('Geen opgeslagen momentopname'),
+      findsOneWidget,
+    );
     expect(find.byIcon(Icons.lock_outline), findsWidgets);
     expect(pendingTiles, findsNothing,
         reason: 'nothing in this class is actionable — that is the point');
@@ -4553,6 +4552,87 @@ void main() {
     expect(readOnly, findsNothing);
     expect(find.byIcon(Icons.lock_outline), findsNothing);
     expect(pendingTiles, findsWidgets);
+  });
+
+  testWidgets(
+      'the second operator of the day starts from the shared synced state: '
+      'Acties, Klasgroepen and Synchronisatie are all usable without pulling '
+      'anything (#287)', (WidgetTester tester) async {
+    // The everyday case this issue is about. Operator A syncs — minutes of WISA
+    // SOAP per school, the Smartschool group walk and the Azure read. Operator B
+    // launches the real app five minutes later onto the same shared stores.
+    //
+    // This is the layer that sees it: the seeding happens in the screens'
+    // bootstrap, the notice replaces a different widget on each of three tabs,
+    // and only a full-app run puts an operator in front of the result. Before
+    // #287 B was read-only everywhere until they repeated A's whole pull.
+    useTallWindow(tester);
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(
+      store: snapshots,
+      linkedStore: linkedStore,
+      syncedBy: 'jan@school.example',
+    ).controller.sync();
+
+    final operatorB = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: operatorB.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    // Synchronisatie says whose pull this session is working from — and both
+    // passes stay available for an operator who wants something fresher.
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('reconcile-adopted')), findsOneWidget);
+    expect(find.textContaining('jan@school.example'), findsWidgets);
+    expect(find.byKey(const ValueKey('reconcile-seed-refused')), findsNothing);
+    expect(
+      tester
+          .widget<FilledButton>(find.byKey(const ValueKey('reconcile-sync')))
+          .onPressed,
+      isNotNull,
+    );
+
+    // Klasgroepen: the inventory is live, not a wall of static rows, and it
+    // says where the view came from.
+    await openKlasgroepen(tester);
+    expect(find.byKey(const ValueKey('class-groups-read-only')), findsNothing);
+    expect(find.byKey(const ValueKey('class-groups-shared-state')),
+        findsOneWidget);
+    expect(find.text('Gedeelde synchronisatie'), findsOneWidget);
+
+    // Acties: drill into a class and the tiles are the interactive ones —
+    // choices, dry-run, apply — with the same notice above them.
+    await tester.tap(find.text('Acties'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('3C'));
+    await tester.tap(find.text('3C'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('actions-read-only')), findsNothing);
+    expect(find.byKey(const ValueKey('actions-shared-state')), findsOneWidget);
+    expect(find.byIcon(Icons.lock_outline), findsNothing);
+    final pendingTiles = find.byWidgetPredicate((w) =>
+        w.key is ValueKey<String> &&
+        (w.key! as ValueKey<String>).value.startsWith('entry-'));
+    expect(pendingTiles, findsWidgets);
+
+    // The whole of it without one connector round-trip, and without touching
+    // the shared view: no generation bump, so no client is asked to refetch.
+    expect(operatorB.wisaSyncs, 0);
+    expect(operatorB.ssSyncs, 0);
+    expect(operatorB.azSyncs, 0);
+    expect((await linkedStore.readSyncState()).generation, 1);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets(

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -7866,6 +7866,117 @@ void main() {
   });
 
   testWidgets(
+      'an edit made by hand in Office 365 shows up on the very next Controleer '
+      'op drift, with the rest of the account intact (#288)',
+      (WidgetTester tester) async {
+    // The report: an administrator renames someone in the Entra portal, the
+    // operator presses Controleer op drift, and nothing happens — the log says
+    // `0 gewijzigd` and the action list is unchanged. Only restarting the app
+    // (which re-seeds from the shared cold store) ever surfaced the edit, and by
+    // then the delta walk that dropped it had already advanced the token, so the
+    // change was never offered again.
+    //
+    // The cause is one query option: the request that *mints* the token carried
+    // no `$select`, so every resumed row came back as `{id, <what changed>}`.
+    // Read as a whole user such a row names no school, and the connector's
+    // client-side prefix test dropped it.
+    //
+    // Only this layer sees the whole thing: it needs the stored token and the
+    // seeded snapshot to make the pass incremental, the merge to keep the record
+    // whole, the linker to join the merged row, and the dispatch to turn the
+    // drift into the to-do the operator should have been handed.
+    useTallWindow(tester);
+    final azureWire = HandEditedUserGraph(
+      // Exactly what Graph sends for a display-name edit: the object id and the
+      // properties that changed. No UPN, no employeeId, no companyName.
+      row: <String, dynamic>{
+        'id': 'az1',
+        'displayName': 'Janneke Doe',
+        'givenName': 'Janneke',
+      },
+    );
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(wisaId: '1', classGroup: '3C')],
+        schools: [wisaSchool(1)],
+        classGroups: [wisaClassGroup('3C', adminCode: 'a3')],
+      ),
+      smartschool: ssSnap(
+        groups: [ssGroup('3C', code: '3C_ss', untis: '3C')],
+        accounts: [ssAccount()],
+        memberships: [member('jane', '3C_ss')],
+      ),
+      azureTransport: azureWire,
+      // Last night's snapshot: her account exactly in step with WISA, and the
+      // token this pass resumes from.
+      azureInitial: azSnap(
+        deltaToken: 'AZ-TOKEN',
+        users: [azUser(displayName: 'Jane Doe')],
+      ),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    // Yesterday's session: the seeded Azure snapshot is reused untouched, its
+    // token unspent, and the student has nothing to do.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(azureWire.resumeTokens, isEmpty);
+    expect(
+      harness.controller.pendingEntries.where((e) => e.family == 'student'),
+      isEmpty,
+      reason: 'the account starts in step with WISA, so the drift below is '
+          'entirely the hand-edit',
+    );
+
+    // Today: Check for drift, the only route to an Azure read in normal
+    // operation — and incrementally, from the stored token.
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // The pass really was the incremental one, so the sparse resumed row really
+    // was the only thing that could have carried the edit: no bulk read ran and
+    // the `employeeId` back-fill asked about nobody.
+    expect(azureWire.resumeTokens, <String>['AZ-TOKEN']);
+    expect(azureWire.bulkReads, 0);
+    expect(azureWire.employeeIdLookups, isEmpty);
+
+    // The edit landed — and nothing else moved. Before the fix this row was
+    // dropped whole; upserted raw it would instead have blanked the UPN and the
+    // `employeeId → wisaId` bridge the linker joins on.
+    expect(
+      harness.app.azure.snapshot!.users.single,
+      azUser(displayName: 'Janneke Doe', givenName: 'Janneke'),
+    );
+
+    // And the operator is handed the one to-do it means: put the WISA name back
+    // on the Office 365 account. Exactly one — a blanked record would have
+    // raised "Wijzig de school in Azure" beside it.
+    await tester.tap(find.text('Acties'));
+    await tester.pumpAndSettle();
+    final entry = harness.controller.pendingEntries
+        .singleWhere((e) => e.family == 'student');
+    expect(
+      entry.choices.map((c) => c.selected.changes.summary),
+      <String>['Wijzig de naam in Azure'],
+    );
+    await tester.tap(find.text('Jaar 3'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('3C'));
+    await tester.tap(find.text('3C'));
+    await tester.pumpAndSettle();
+    expect(find.text('Wijzig de naam in Azure'), findsOneWidget);
+  });
+
+  testWidgets(
       'a staff member who left WISA still gets their Office 365 account '
       'proposed for deletion (#269)', (WidgetTester tester) async {
     // The other half of #268, and the worse one. Anna Smit has left the school:

--- a/account_manager/lib/src/passwords/password_controller.dart
+++ b/account_manager/lib/src/passwords/password_controller.dart
@@ -64,7 +64,7 @@ class StudentRow {
 /// immediately (they are never queued), mirroring the legacy app.
 class PasswordController extends ChangeNotifier {
   PasswordController({
-    required ss.SmartschoolSnapshot? snapshot,
+    required ss.SmartschoolSnapshot? Function() snapshot,
     required PasswordQueueStore queue,
     required PasswordBackends backends,
     PasswordFileWriter writer = writePasswordExport,
@@ -73,20 +73,33 @@ class PasswordController extends ChangeNotifier {
     String studentGroupName = 'Leerlingen',
     String staffGroupName = 'Personeel',
     core.ILog? log,
-  })  : _snapshot = snapshot,
+  })  : _snapshotOf = snapshot,
+        _studentGroupName = studentGroupName,
+        _staffGroupName = staffGroupName,
         _queue = queue,
         _backends = backends,
         _writer = writer,
         _opener = opener,
         _generate = generatePassword,
         _log = log {
-    _indexTree();
-    studentRoot = _findGroupByName(studentGroupName);
-    _staffRoot = _findGroupByName(staffGroupName);
-    _loadStaff();
+    _reindex();
   }
 
-  final ss.SmartschoolSnapshot? _snapshot;
+  /// Where the Smartschool group tree comes from, read **live** rather than
+  /// captured (#287).
+  ///
+  /// The screen hands over `() => app.smartschool.snapshot`. Capturing the value
+  /// at bootstrap froze this screen on whatever the session held the instant it
+  /// was first opened — which, in a session that seeded from the cold store and
+  /// then synced, is the *older* of the two trees.
+  final ss.SmartschoolSnapshot? Function() _snapshotOf;
+
+  /// The snapshot the index below was built from, so [refresh] can tell a real
+  /// change from a repaint and cost nothing on the latter.
+  ss.SmartschoolSnapshot? _indexed;
+
+  final String _studentGroupName;
+  final String _staffGroupName;
   final PasswordQueueStore _queue;
   final PasswordBackends _backends;
   final PasswordFileWriter _writer;
@@ -94,38 +107,87 @@ class PasswordController extends ChangeNotifier {
   final String Function() _generate;
   final core.ILog? _log;
 
-  // --- Group-tree index (built once from the snapshot) -----------------------
+  // --- Group-tree index (rebuilt whenever the snapshot moves) ----------------
 
   final Map<String, List<core.Group>> _childrenByParent =
       <String, List<core.Group>>{};
   final Map<String, ss.SmartschoolAccount> _accountByUid =
       <String, ss.SmartschoolAccount>{};
   final Map<String, List<String>> _uidsByGroup = <String, List<String>>{};
+  final Map<String, core.Group> _groupsById = <String, core.Group>{};
 
   /// The "Leerlingen" root of the student class tree, or `null` when the last
   /// sync carried no such group (or there was no sync this session).
   core.Group? studentRoot;
   core.Group? _staffRoot;
 
-  void _indexTree() {
-    final snap = _snapshot;
-    if (snap == null) return;
-    for (final account in snap.accounts) {
-      _accountByUid[account.uid] = account;
-    }
-    for (final group in snap.groups) {
-      final parent = group.parentId?.value;
-      if (parent != null) {
-        _childrenByParent.putIfAbsent(parent, () => <core.Group>[]).add(group);
+  /// Rebuilds every index from the snapshot the provider answers with now.
+  void _reindex() {
+    final snap = _snapshotOf();
+    _indexed = snap;
+    _childrenByParent.clear();
+    _accountByUid.clear();
+    _uidsByGroup.clear();
+    _groupsById.clear();
+    _allStaff.clear();
+    if (snap != null) {
+      for (final account in snap.accounts) {
+        _accountByUid[account.uid] = account;
+      }
+      for (final group in snap.groups) {
+        _groupsById[group.id.value] = group;
+        final parent = group.parentId?.value;
+        if (parent != null) {
+          _childrenByParent
+              .putIfAbsent(parent, () => <core.Group>[])
+              .add(group);
+        }
+      }
+      for (final m in snap.memberships) {
+        _uidsByGroup.putIfAbsent(m.groupId.value, () => <String>[]).add(m.uid);
       }
     }
-    for (final m in snap.memberships) {
-      _uidsByGroup.putIfAbsent(m.groupId.value, () => <String>[]).add(m.uid);
-    }
+    studentRoot = _findGroupByName(_studentGroupName, snap);
+    _staffRoot = _findGroupByName(_staffGroupName, snap);
+    _loadStaff();
+    // `_loadStaff` returns early when there is no staff root, which would leave
+    // the previous tree's filtered list standing; re-filter unconditionally.
+    _applyStaffFilter();
   }
 
-  core.Group? _findGroupByName(String name) {
-    for (final group in _snapshot?.groups ?? const <core.Group>[]) {
+  /// Adopts a Smartschool snapshot that arrived after this screen opened — a
+  /// sync, a drift check, or an apply that patched the tree (#287).
+  ///
+  /// A no-op while the live snapshot is the one already indexed, so a listener
+  /// may call it on every repaint. When it does rebuild, the operator's place is
+  /// kept wherever it still exists: the open class is re-resolved by id and its
+  /// rows keep the targets already ticked, so a colleague's sync landing
+  /// mid-selection does not silently discard the work.
+  void refresh() {
+    if (identical(_snapshotOf(), _indexed)) return;
+    final String? openClassId = _selectedClass?.id.value;
+    final String? openStaffUid = _selectedStaff?.uid;
+    final ticked = <String, Set<PasswordTarget>>{
+      for (final row in _rows) row.username: <PasswordTarget>{...row.selected},
+    };
+
+    _reindex();
+
+    _selectedStaff = openStaffUid == null ? null : _accountByUid[openStaffUid];
+    final core.Group? again =
+        openClassId == null ? null : _groupsById[openClassId];
+    _selectedClass = again;
+    _rows.clear();
+    if (again != null) {
+      _rows.addAll(_directAccounts(again).map(
+        (a) => StudentRow(a)..selected.addAll(ticked[a.uid] ?? _bulk),
+      ));
+    }
+    notifyListeners();
+  }
+
+  core.Group? _findGroupByName(String name, ss.SmartschoolSnapshot? snap) {
+    for (final group in snap?.groups ?? const <core.Group>[]) {
       if (group.name == name) return group;
     }
     return null;

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -645,7 +645,8 @@ class ReconcileController extends ChangeNotifier {
   /// (each system pulled, linking, persisting) and once per action during an
   /// apply/dry-run, so the bar visibly *advances* rather than sitting as a
   /// motionless sweep that reads as a hung app. Reset to `0.0` when a pass
-  /// begins; meaningless (and unread) while not [busy].
+  /// begins and driven to `1.0` when it ends (#303); meaningless (and unread)
+  /// while not [busy].
   double get progress => _progress;
 
   /// Steps the pass indicator to [value] (clamped) and repaints. A pass only
@@ -1806,6 +1807,9 @@ class ReconcileController extends ChangeNotifier {
           'geen accountwijzigingen nodig.',
         );
         await _persistSystemMeta();
+        // The short path is a finished pass too, so its bar completes as well
+        // (#303) — it used to stop at the 0.25 the WISA pull left it on.
+        _setProgress(1.0);
         _logSyncComplete();
         _finish(ReconcilePhase.ready);
         return;
@@ -1871,15 +1875,22 @@ class ReconcileController extends ChangeNotifier {
   }
 
   /// Terminal "the pass is done, the screen is current" log line closing a
-  /// successful [sync] (#162). The [noChangesNeeded] path says so explicitly;
-  /// otherwise it names how many pending actions await the operator.
-  void _logSyncComplete() {
+  /// successful [sync] (#162) or [checkDrift] (#303). The [noChangesNeeded]
+  /// path says so explicitly; otherwise it names how many pending actions await
+  /// the operator.
+  ///
+  /// [pass] is the name the line opens with, because a drift check is not a
+  /// sync and saying so is the whole point of a terminal line: until #303 the
+  /// drift pass logged none at all, so it ended on [_link]'s "Gekoppeld: …" and
+  /// the operator could not tell from the Log panel whether it had finished or
+  /// was still running.
+  void _logSyncComplete({String pass = 'Sync'}) {
     // Name the operator who ran the pass when known (#169); an empty/unknown
     // operator degrades gracefully (nothing appended, no dangling "by ").
     final by = syncedBy.isEmpty ? '' : ' Operator: $syncedBy.';
     final message = _noChangesNeeded
-        ? 'Sync voltooid — geen accountwijzigingen nodig. Klaar.$by'
-        : 'Sync voltooid — ${pendingActions.length} openstaande actie(s). '
+        ? '$pass voltooid — geen accountwijzigingen nodig. Klaar.$by'
+        : '$pass voltooid — ${pendingActions.length} openstaande actie(s). '
             'Klaar.$by';
     log.addMessage(core.Origin.all, message);
   }
@@ -1893,6 +1904,18 @@ class ReconcileController extends ChangeNotifier {
   /// the roster the change never reached and publish that to the whole team
   /// (#238). The button is disabled with the same reason on screen; this guard
   /// is the backstop for every other caller.
+  ///
+  /// Ends exactly the way a [sync] does (#303): a terminal
+  /// "Driftcontrole voltooid — … Klaar." line, and a progress bar driven to the
+  /// end by [_relink]. Only the school-profile repair (#207) stays a
+  /// sync-and-only-sync affair, and deliberately: [_backfillSchoolProfiles]
+  /// writes WISA's school names and codes back over the stored ones, so the
+  /// authority to run it comes from the **pull**, not from the pass. A drift
+  /// check normally re-reads only Smartschool and Azure, and repairing the
+  /// settings document from a WISA snapshot pulled hours ago by somebody else
+  /// could undo a rename a fresher sync already recorded. The one branch below
+  /// that *does* pull WISA has exactly the authority a sync has, and repairs
+  /// with it.
   Future<void> checkDrift() async {
     if (busy) return;
     final blocked = driftBlockedReason;
@@ -1927,11 +1950,16 @@ class ReconcileController extends ChangeNotifier {
         await _renewLock();
         final pulledWith = _wisaFingerprint();
         log.addMessage(core.Origin.wisa, 'WISA ophalen…');
-        _recordPull(core.Origin.wisa, await app.sync(core.Origin.wisa));
+        final fresh = await app.sync(core.Origin.wisa) as wapi.WisaSnapshot;
+        _recordPull(core.Origin.wisa, fresh);
         _stampWisaPull(pulledWith);
+        // This branch really did pull WISA, so it may repair the stored school
+        // profiles on the strength of it, exactly as [sync] does (#303/#207).
+        await _backfillSchoolProfiles(fresh.schools);
       }
 
       await _relink();
+      _logSyncComplete(pass: 'Driftcontrole');
       _finish(ReconcilePhase.ready);
     } on Object catch (e) {
       _fail(e);
@@ -2549,6 +2577,11 @@ class ReconcileController extends ChangeNotifier {
     _groupDocs = null;
     _setProgress(0.9);
     await _persist(_linked!);
+    // The pass is done: complete the bar rather than leaving it stopped at 0.9
+    // for [_finish] to clear (#303). [_persist] reports its own failures and
+    // never throws, so this is the end of the pass either way — the shared view
+    // may not have landed, but nothing is still running.
+    _setProgress(1.0);
   }
 
   /// Names every WISA class the group link passed over because Smartschool

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -2529,6 +2529,24 @@ class ReconcileController extends ChangeNotifier {
     // This pass pulled and linked for itself, so the view is no longer somebody
     // else's to attribute (#287).
     _adoptedFrom = null;
+    // A re-link invalidates any open drill-down: the documents behind it were
+    // read for the view [_link] just replaced, and the live entries the screens
+    // join them against are the new one's. The remembered accordion path goes
+    // with them (#235), so it can never point at a node the fresh view no longer
+    // has, and the class inventory goes too — the Klasgroepen tab re-reads
+    // (#227).
+    //
+    // Sits here, before [_persist], and not on the far side of the store write
+    // it used to (#289). These are invalidations of *this session's* derived
+    // caches; whether the shared write lands has nothing to do with them, and a
+    // write that timed out or threw used to skip them entirely — leaving the
+    // open classroom joining fresh entries against the previous generation's
+    // documents. Written straight to the fields: the pass notifies once when it
+    // finishes.
+    _selectedClassroom = null;
+    _expandedPath = const <String>[];
+    _classroomAccounts = null;
+    _groupDocs = null;
     _setProgress(0.9);
     await _persist(_linked!);
   }
@@ -2843,16 +2861,6 @@ class ReconcileController extends ChangeNotifier {
       // Nudge every passive session to refetch: the whole view was rewritten,
       // so the signal names no narrower shard (#116).
       await _publish(ChangeSignal.viewChanged(generation: view.generation));
-      // A re-sync invalidates any open drill-down; the next open re-reads. The
-      // remembered accordion path goes with it (#235), so it can never point at
-      // a node this new generation no longer has. Written straight to the field:
-      // the pass notifies once when it finishes.
-      _selectedClassroom = null;
-      _expandedPath = const <String>[];
-      _classroomAccounts = null;
-      // The class inventory goes with it: the Klasgroepen tab re-reads the
-      // generation this pass just wrote (#227).
-      _groupDocs = null;
     } on TimeoutException {
       log.addError(
         core.Origin.all,

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:smartschool_api/smartschool_api.dart' as ss;
 import 'package:wisa_api/wisa_api.dart' as wapi;
 
+import '../format/timestamps.dart';
 import '../settings/wisa_rule_labels.dart';
 import 'log_buffer.dart';
 
@@ -568,6 +569,28 @@ class ReconcileController extends ChangeNotifier {
   double _progress = 0.0;
   ApplyStep? _applyStep;
   LinkedState? _linked;
+
+  /// The shared WISA stamp the linked view in hand was **adopted** from (#287),
+  /// or `null` when the view is this session's own — built by its [sync] or
+  /// [checkDrift] — or when there is no view at all.
+  ///
+  /// What lets the screens say *whose* pull this session is acting on, in place
+  /// of the "deze sessie heeft nog niet gesynchroniseerd" they used to show a
+  /// session that had every snapshot it needed sitting in memory.
+  SystemSyncMeta? _adoptedFrom;
+
+  /// Why [adoptStoredState] refused to build a view from the cold seed, or
+  /// `null` when it has not refused (#287). Sticky until a link succeeds: a
+  /// session that stays read-only owes the operator the reason for as long as
+  /// it stays that way.
+  String? _seedRefusedReason;
+
+  /// Whether adoption has already been tried this session. Each screen opens
+  /// with [openSession], and a `link()` over the whole roster is not something
+  /// to pay for three times — nor can the answer change without a pass that
+  /// links anyway.
+  bool _adoptAttempted = false;
+
   bool _noChangesNeeded = false;
   String? _error;
   List<ActionOutcomeEntry>? _dryRunResults;
@@ -655,6 +678,19 @@ class ReconcileController extends ChangeNotifier {
 
   /// The current derived view, or `null` before the first successful sync.
   LinkedState? get linked => _linked;
+
+  /// Whose shared sync the view in hand was built from, when this session
+  /// **adopted** it rather than pulling for itself (#287); `null` for a view
+  /// this session's own [sync] / [checkDrift] produced, and for no view at all.
+  ///
+  /// The screens read it to say when the state they are offering was pulled and
+  /// by whom, instead of demanding a sync the shared store already paid for.
+  SystemSyncMeta? get adoptedFrom => _adoptedFrom;
+
+  /// Why this session could not adopt the shared state and stays read-only, or
+  /// `null` when it did adopt (or has not tried) — the one blocking notice a
+  /// refused session owes the operator (#287).
+  String? get seedRefusedReason => _seedRefusedReason;
 
   /// True when the last [sync] found WISA unchanged — the "no account changes
   /// needed" banner.
@@ -1757,6 +1793,13 @@ class ReconcileController extends ChangeNotifier {
           !linkStale &&
           wisaSnapshotUnchanged(previous, fresh)) {
         _noChangesNeeded = true;
+        // This pass pulled WISA and found the roster the view was built from
+        // still current, so the view stops being somebody else's to attribute
+        // even though no re-link was needed (#287). Without this an adopted
+        // session would keep the shared-state notice up after taking the very
+        // sync it offered — the one path out of adoption that never reaches
+        // [_relink].
+        _adoptedFrom = null;
         log.addMessage(
           core.Origin.wisa,
           'WISA is ongewijzigd sinds de vorige synchronisatie — '
@@ -1919,6 +1962,159 @@ class ReconcileController extends ChangeNotifier {
     } on Object catch (e) {
       log.addError(core.Origin.all, 'Kon het overzicht niet laden: $e');
     }
+  }
+
+  /// A screen's opening read (#287): the shared overview, and then — when the
+  /// cold seed allows it — the linked view built from that same shared state.
+  ///
+  /// The two halves are kept apart on purpose. [loadOverview] is the passive
+  /// read it has always been (#115) and stays callable on its own;
+  /// [adoptStoredState] is the step that makes the session *usable* without a
+  /// pull. Every screen opens with this one call, and the adoption inside it
+  /// runs at most once however many screens the operator visits.
+  Future<void> openSession() async {
+    await loadOverview();
+    await adoptStoredState();
+  }
+
+  /// Builds this session's linked view from the snapshots bootstrap seeded from
+  /// the cold store, so an operator who opens the app five minutes after a
+  /// colleague synced can choose, dry-run and apply straight away (#287).
+  ///
+  /// Pulls nothing, and — the crux — persists nothing. [_persist] rewrites the
+  /// whole ~9.6k-document materialized view, bumps the generation and broadcasts
+  /// `viewChanged`; a startup link that persisted would have every launching
+  /// client rewrite the shared view for no reason at all. This runs the link
+  /// half of [_relink] alone, leaving the store exactly as it found it.
+  ///
+  /// The phase stays [ReconcilePhase.idle] for the same reason a passive read
+  /// does (#275): adopting is not a pass, and the Synchronisatie screen's
+  /// explainer must still be the first thing the operator reads.
+  ///
+  /// Refuses — leaving the session read-only with [seedRefusedReason] on screen
+  /// — when there is nothing honest to adopt: see [_seedRefusal]. Tried once per
+  /// session; the answer cannot change without a pass that links for itself.
+  ///
+  /// An apply on an adopted view is deliberately held to **exactly** the bar an
+  /// apply on a freshly-synced one is: no lease, no targeted re-pull first. The
+  /// difference between the two is one of degree, not of kind — a session that
+  /// did sync is also writing against snapshots that are minutes old, and every
+  /// action re-checks the record it is about to write through its own
+  /// `evaluate`. Raising the bar here and not there would buy nothing and would
+  /// re-introduce the per-session pull this exists to remove.
+  Future<void> adoptStoredState() async {
+    if (busy || _linked != null || _adoptAttempted) return;
+    _adoptAttempted = true;
+
+    final refusal = _seedRefusal();
+    if (refusal != null) {
+      // Reported on screen, not in the Log panel: nothing ran, and a session
+      // that has done nothing yet should still open on an empty log.
+      _seedRefusedReason = refusal;
+      notifyListeners();
+      return;
+    }
+
+    final from = _syncState.systems[core.Origin.wisa];
+    try {
+      await _link();
+      _adoptedFrom = from;
+      final by =
+          from == null || from.syncedBy.isEmpty ? '' : ' door ${from.syncedBy}';
+      final when = from == null ? '' : ' van ${formatFreshnessStamp(from.at)}';
+      log.addMessage(
+        core.Origin.all,
+        'Gedeelde staat$when$by overgenomen — geen ophaalactie nodig. '
+        'Synchroniseer wanneer je iets recenters wil.',
+      );
+      notifyListeners();
+    } on Object catch (e) {
+      // A failed adoption must leave the session exactly as read-only as it was
+      // — never half-linked — and must not read as a failed *pass*: nothing was
+      // pulled and nothing was written, so [error] (which the screens render as
+      // "de laatste sync is mislukt") stays untouched.
+      _linked = null;
+      _seedRefusedReason =
+          'Kon de gedeelde staat niet overnemen — synchroniseer om verder te '
+          'gaan.';
+      log.addError(core.Origin.all, 'Kon de gedeelde staat niet overnemen: $e');
+      notifyListeners();
+    }
+  }
+
+  /// Why the cold seed cannot honestly be adopted, or `null` when it can (#287).
+  ///
+  /// One reason, not a list: a refused session shows a single blocking notice,
+  /// and the first thing standing in the way is the thing the operator has to
+  /// deal with. In order of how fundamental they are:
+  ///
+  /// * a system with no seeded snapshot — there is simply no view to build;
+  /// * no shared WISA stamp at all — nobody has ever synced, so there is no
+  ///   colleague's pull to inherit;
+  /// * a saved setting that has moved since this session was constructed
+  ///   ([pendingSettingsReason] / [driftBlockedReason]) — adopting would act on
+  ///   a view built without it, which is the whole of what #238/#259/#264 refuse
+  ///   elsewhere;
+  /// * a werkdatum mismatch — the stored roster is *as of* a date today's
+  ///   settings no longer resolve to, so it may describe another school year.
+  ///
+  /// A stamp carrying **no** werkdatum is not a mismatch and does not refuse:
+  /// the field is null on a WISA pull from before #247 recorded it, and treating
+  /// an absence as a contradiction would strand every install whose shared view
+  /// predates that on a sync it does not need.
+  String? _seedRefusal() {
+    final missing = <String>[
+      if (app.wisa.snapshot == null) 'WISA',
+      if (app.smartschool.snapshot == null) 'Smartschool',
+      if (app.azure.snapshot == null) 'Azure AD',
+    ];
+    if (missing.isNotEmpty) {
+      return 'Geen opgeslagen momentopname voor ${_andList(missing)} — '
+          'synchroniseer om te beginnen.';
+    }
+    if (_syncState.systems[core.Origin.wisa] == null) {
+      return 'Er is nog geen gedeelde synchronisatie om over te nemen — '
+          'synchroniseer om te beginnen.';
+    }
+    final settings = pendingSettingsReason;
+    if (settings != null) return settings;
+    final drift = driftBlockedReason;
+    if (drift != null) return drift;
+    return _staleWorkDateReason();
+  }
+
+  /// Why the shared roster's **werkdatum** disqualifies it for this session, or
+  /// `null` when it is the one today's settings resolve to (#287/#247).
+  ///
+  /// WISA returns enrolments *as of* a work date, so a roster pulled on the
+  /// other side of the school-year rollover simply has none of the new intake in
+  /// it — which on the Acties screen reads exactly like a class that went
+  /// missing. That is the one freshness question this session cannot leave to
+  /// the operator's judgement, so it is the one it asks.
+  ///
+  /// Silent when no [liveSettings] holder is wired, exactly as every other gate
+  /// in this class is: there is then no document to resolve today's werkdatum
+  /// from, and inventing one would refuse every harness that models no settings.
+  String? _staleWorkDateReason() {
+    final live = liveSettings;
+    if (live == null) return null;
+    final stored = _syncState.systems[core.Origin.wisa]?.workDate;
+    if (stored == null) return null;
+    final today = live.current.wisa.workDate.resolve(_now());
+    if (_sameWorkDay(stored, today)) return null;
+    return 'De gedeelde momentopname is van werkdatum '
+        '${wapi.formatWerkdatum(stored)}; vandaag geldt '
+        '${wapi.formatWerkdatum(today)} — synchroniseer eerst.';
+  }
+
+  /// Whether two werkdatums name the same day on the operator's own calendar.
+  /// Compared as local calendar days, not as instants: the stored stamp is an
+  /// ISO timestamp and the resolved one is "now", so they are never equal to the
+  /// second even when they mean the same day.
+  static bool _sameWorkDay(DateTime a, DateTime b) {
+    final x = a.toLocal();
+    final y = b.toLocal();
+    return x.year == y.year && x.month == y.month && x.day == y.day;
   }
 
   /// Reacts to another operator's sync bumping the stored generation past this
@@ -2298,16 +2494,22 @@ class ReconcileController extends ChangeNotifier {
     );
   }
 
-  Future<void> _relink() async {
-    _phase = ReconcilePhase.linking;
-    _setProgress(0.75);
-    notifyListeners();
+  /// Recomputes the linked view from the snapshots in hand and reports what came
+  /// out — the **link half**, which writes nothing anywhere.
+  ///
+  /// Split out of [_relink] for #287: a session adopting the shared cold seed
+  /// needs exactly this and must not run the persist half behind it, or every
+  /// client would rewrite the whole materialized view on launch.
+  Future<void> _link() async {
     // Read before the link, stamped after it: `applier.link()` samples the very
     // same document, so this names exactly the settings the view about to be
     // built was linked with (#264).
     final linkedWith = _currentLinkFingerprint();
     _linked = await applier.link();
     _stampLink(linkedWith);
+    // A view now exists, so whatever kept this session read-only no longer
+    // does.
+    _seedRefusedReason = null;
     final s = _linked!.snapshot;
     log.addMessage(
       core.Origin.all,
@@ -2317,6 +2519,16 @@ class ReconcileController extends ChangeNotifier {
       '${s.warnings.length} waarschuwing(en).',
     );
     _logSkippedNamesakes(s.warnings);
+  }
+
+  Future<void> _relink() async {
+    _phase = ReconcilePhase.linking;
+    _setProgress(0.75);
+    notifyListeners();
+    await _link();
+    // This pass pulled and linked for itself, so the view is no longer somebody
+    // else's to attribute (#287).
+    _adoptedFrom = null;
     _setProgress(0.9);
     await _persist(_linked!);
   }

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -19,7 +19,8 @@ import 'dart:async';
 
 import 'package:account_actions/account_actions.dart' as actions;
 import 'package:account_core/account_core.dart' as core;
-import 'package:account_state/account_state.dart' show CandidateAction;
+import 'package:account_state/account_state.dart'
+    show CandidateAction, SystemSyncMeta;
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 // The `Werkdatum` SOAP parameter's own formatter, so the freshness line names
@@ -425,12 +426,17 @@ class EmptyLine extends StatelessWidget {
 /// responding. This says which of the two the operator is looking at, why, and
 /// offers the sync that turns one into the other.
 ///
-/// Two ways to get here, and the operator is told which: a **passive** session
-/// that only read the shared overview (`loadOverview()`, never synced), or one
-/// whose sync/drift pass **failed** before it could link. A failed pass never
-/// discards an existing linked view — `_fail` records the error and returns to
-/// `ready`, leaving `linked` untouched — so the failure wording only ever
-/// appears when this session had nothing linked to begin with.
+/// Three ways to get here, and the operator is told which: a session whose
+/// sync/drift pass **failed** before it could link, one that was **refused** the
+/// shared cold seed and says why ([ReconcileController.seedRefusedReason],
+/// #287), or one that has simply not opened yet. A failed pass never discards an
+/// existing linked view — `_fail` records the error and returns to `ready`,
+/// leaving `linked` untouched — so the failure wording only ever appears when
+/// this session had nothing linked to begin with.
+///
+/// Since #287 the ordinary passive session is *not* one of them: a session
+/// holding a usable cold seed adopts the shared state and renders
+/// [SharedStateNotice] instead, because the view it is offering is real.
 ///
 /// [keyValue] names the notice per screen, so a shell that has built both tabs
 /// still has one identifiable notice per view.
@@ -450,6 +456,16 @@ class ReadOnlyNotice extends StatelessWidget {
     final ColorScheme colors = Theme.of(context).colorScheme;
     final bool failed = controller.error != null;
     final bool lockedByOther = controller.syncLockedByOther;
+    // Why the shared state could not be adopted (#287) — the one blocking
+    // notice a refused session owes the operator. A pass that just failed is
+    // the more recent news, so it still speaks first.
+    final String? refused = controller.seedRefusedReason;
+    final String reason = failed
+        ? 'De laatste sync is mislukt, dus deze sessie heeft geen actuele '
+            'acties om toe te passen.'
+        : refused ??
+            'Deze sessie heeft nog niet gesynchroniseerd, dus deze acties '
+                'kunnen niet worden toegepast.';
 
     return Container(
       key: ValueKey(keyValue),
@@ -473,14 +489,8 @@ class ReadOnlyNotice extends StatelessWidget {
                     Text('Alleen-lezen overzicht', style: text.titleSmall),
                     const SizedBox(height: PlinkSpacing.s1),
                     Text(
-                      failed
-                          ? 'De laatste sync is mislukt, dus deze sessie heeft '
-                              'geen actuele acties om toe te passen. Hieronder '
-                              'staat het gedeelde overzicht van de vorige sync.'
-                          : 'Deze sessie heeft nog niet gesynchroniseerd, dus '
-                              'deze acties kunnen niet worden toegepast. '
-                              'Hieronder staat het gedeelde overzicht van de '
-                              'laatste sync.',
+                      '$reason Hieronder staat het gedeelde overzicht van de '
+                      'laatste sync.',
                       style: text.bodyMedium,
                     ),
                   ],
@@ -495,6 +505,119 @@ class ReadOnlyNotice extends StatelessWidget {
                 controller.busy || lockedByOther ? null : controller.sync,
             icon: const Icon(Icons.sync, size: 18),
             label: const Text('Synchroniseer'),
+          ),
+          // A dead Synchronise needs its reason on screen too — the same
+          // named-holder line the Reconcile screen shows (#108).
+          if (lockedByOther) ...<Widget>[
+            const SizedBox(height: PlinkSpacing.s2),
+            Text(
+              '${controller.syncLockOwner} is aan het synchroniseren…',
+              style: text.bodySmall,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// The announcement above a list this session is acting on but did **not** pull
+/// for itself (#287): the linked view was built from the cold seed a colleague's
+/// sync left in the shared store.
+///
+/// The counterpart of [ReadOnlyNotice], and deliberately not a warning. The
+/// tiles below it are the real interactive ones — choices, dry-run, apply — so
+/// this says only where the view came from and when, and leaves both passes
+/// within reach for an operator who decides they want something fresher. That is
+/// the whole product point of #287: the people who edit WISA are the people who
+/// use this app, so the tool shows how fresh the shared state is instead of
+/// demanding proof of freshness on every launch.
+///
+/// [keyValue] names it per screen, exactly as [ReadOnlyNotice] is named.
+class SharedStateNotice extends StatelessWidget {
+  const SharedStateNotice({
+    super.key,
+    required this.controller,
+    this.keyValue = 'actions-shared-state',
+  });
+
+  final ReconcileController controller;
+  final String keyValue;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final SystemSyncMeta? from = controller.adoptedFrom;
+    final bool lockedByOther = controller.syncLockedByOther;
+
+    // Dated as soon as it leaves today (#192), the same stamp the Synchronisatie
+    // screen's last-sync box renders — a pull from three days ago must not read
+    // like this morning's.
+    final String when =
+        from == null ? '' : ' van ${formatFreshnessStamp(from.at)}';
+    final String by =
+        from == null || from.syncedBy.isEmpty ? '' : ', door ${from.syncedBy}';
+    // The werkdatum the roster is *as of* (#247): it is what decides which
+    // school year the list below describes, and this session did not run the
+    // pull that chose it.
+    final DateTime? workDate = from?.workDate;
+    final String asOf = workDate == null
+        ? ''
+        : ' De klaslijsten zijn die van werkdatum '
+            '${wapi.formatWerkdatum(workDate)}.';
+
+    return Container(
+      key: ValueKey(keyValue),
+      padding: const EdgeInsets.all(PlinkSpacing.s4),
+      decoration: BoxDecoration(
+        border: Border.all(color: colors.primary),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Icon(Icons.groups_outlined, size: 18, color: colors.primary),
+              const SizedBox(width: PlinkSpacing.s3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text('Gedeelde synchronisatie', style: text.titleSmall),
+                    const SizedBox(height: PlinkSpacing.s1),
+                    Text(
+                      'Deze weergave komt van de gedeelde synchronisatie'
+                      '$when$by. Je kan er meteen mee werken.$asOf',
+                      style: text.bodyMedium,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: PlinkSpacing.s3),
+          Wrap(
+            spacing: PlinkSpacing.s3,
+            runSpacing: PlinkSpacing.s2,
+            children: <Widget>[
+              FilledButton.icon(
+                key: ValueKey('$keyValue-sync'),
+                onPressed:
+                    controller.busy || lockedByOther ? null : controller.sync,
+                icon: const Icon(Icons.sync, size: 18),
+                label: const Text('Synchroniseer'),
+              ),
+              OutlinedButton.icon(
+                key: ValueKey('$keyValue-drift'),
+                onPressed:
+                    controller.canCheckDrift ? controller.checkDrift : null,
+                icon: const Icon(Icons.difference_outlined, size: 18),
+                label: const Text('Controleer op drift'),
+              ),
+            ],
           ),
           // A dead Synchronise needs its reason on screen too — the same
           // named-holder line the Reconcile screen shows (#108).

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -93,10 +93,11 @@ class _ActionsScreenState extends State<ActionsScreen> {
     try {
       final services = await make();
       if (mounted) setState(() => _services = services);
-      // Passive-session read (#115): show the shared overview from the store
-      // without pulling or re-linking. Idempotent with the Reconcile screen's
-      // own read (both share the one controller). Fire-and-forget.
-      unawaited(services.controller.loadOverview());
+      // The session's opening read: the shared overview from the store (#115),
+      // and then the linked view built from the same shared state when the cold
+      // seed allows it (#287) — no pull either way. Idempotent with the other
+      // screens' own reads (all share the one controller). Fire-and-forget.
+      unawaited(services.controller.openSession());
     } on Object catch (e) {
       if (mounted) setState(() => _bootstrapError = e);
     } finally {
@@ -612,7 +613,7 @@ class _ActionsBodyState extends State<_ActionsBody>
     if (controller.loadingClassroom) {
       return slivers..add(_section(const LinearProgressIndicator()));
     }
-    slivers.addAll(_readOnlySlivers());
+    slivers.addAll(_stateNoticeSlivers());
 
     // Only the Personeel tab carries a per-list lookup; the mode switch that
     // used to sit beside it now lives once, at the top of the view (#226).
@@ -665,16 +666,23 @@ class _ActionsBodyState extends State<_ActionsBody>
   static const String _noMatchLabel =
       'Geen accounts die aan de filter voldoen.';
 
-  /// The read-only announcement shown above either drill-down when this session
-  /// has no linked view to act on (#214) — a passive session that only read the
-  /// shared overview, or one whose sync/drift pass failed before it could link.
-  /// Empty in an active session, where the tiles below are the interactive ones.
-  List<Widget> _readOnlySlivers() {
-    if (controller.linked != null) return const <Widget>[];
-    return <Widget>[
-      _section(ReadOnlyNotice(controller: controller)),
-      _gap(PlinkSpacing.s3),
-    ];
+  /// The announcement shown above either drill-down about where this session's
+  /// view comes from.
+  ///
+  /// Two of them, and never both: [ReadOnlyNotice] when there is no linked view
+  /// to act on (#214) — a session refused the shared seed, or one whose
+  /// sync/drift pass failed before it could link — and [SharedStateNotice] when
+  /// the tiles below *are* interactive but were built from the cold seed a
+  /// colleague's sync left behind (#287). Empty only in a session that pulled
+  /// for itself.
+  List<Widget> _stateNoticeSlivers() {
+    final Widget? notice = controller.linked == null
+        ? ReadOnlyNotice(controller: controller)
+        : controller.adoptedFrom == null
+            ? null
+            : SharedStateNotice(controller: controller);
+    if (notice == null) return const <Widget>[];
+    return <Widget>[_section(notice), _gap(PlinkSpacing.s3)];
   }
 
   /// A lazy sliver over pending [rows] (situation headers + entry tiles) — the

--- a/account_manager/lib/src/screens/class_groups_screen.dart
+++ b/account_manager/lib/src/screens/class_groups_screen.dart
@@ -84,10 +84,11 @@ class _ClassGroupsScreenState extends State<ClassGroupsScreen> {
     try {
       final services = await make();
       if (mounted) setState(() => _services = services);
-      // Passive-session read (#115): the shared overview and the class
-      // inventory straight from the store, with no pull and no re-link.
-      // Idempotent with the other screens' own reads (all share one controller).
-      unawaited(services.controller.loadOverview());
+      // The session's opening read: the shared overview and the class inventory
+      // straight from the store (#115), then the linked view built from that
+      // same shared state when the cold seed allows it (#287) — no pull either
+      // way. Idempotent with the other screens' own reads (one controller).
+      unawaited(services.controller.openSession());
     } on Object catch (e) {
       if (mounted) setState(() => _bootstrapError = e);
     } finally {
@@ -322,12 +323,21 @@ class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
 
     // Without a linked view there is nothing to choose, dry-run or apply, and
     // the static rows are otherwise indistinguishable from interactive ones
-    // whose taps stopped working (#214).
+    // whose taps stopped working (#214). With one this session adopted rather
+    // than pulled, the rows *are* interactive and the notice says whose sync
+    // they came from instead (#287).
     if (!active) {
       slivers
         ..add(_section(ReadOnlyNotice(
           controller: controller,
           keyValue: 'class-groups-read-only',
+        )))
+        ..add(_gap(PlinkSpacing.s4));
+    } else if (controller.adoptedFrom != null) {
+      slivers
+        ..add(_section(SharedStateNotice(
+          controller: controller,
+          keyValue: 'class-groups-shared-state',
         )))
         ..add(_gap(PlinkSpacing.s4));
     }

--- a/account_manager/lib/src/screens/passwords_screen.dart
+++ b/account_manager/lib/src/screens/passwords_screen.dart
@@ -40,6 +40,10 @@ class PasswordsScreen extends StatefulWidget {
 
 class _PasswordsScreenState extends State<PasswordsScreen> {
   PasswordController? _controller;
+
+  /// The reconcile stack this screen bootstrapped, kept so the listener below
+  /// can be detached again.
+  ReconcileServices? _services;
   Object? _error;
   bool _busy = false;
   int _attempts = 0;
@@ -52,9 +56,19 @@ class _PasswordsScreenState extends State<PasswordsScreen> {
 
   @override
   void dispose() {
+    _services?.controller.removeListener(_adoptSnapshot);
     _controller?.dispose();
     super.dispose();
   }
+
+  /// Re-reads the live Smartschool snapshot after a pass on another tab (#287).
+  ///
+  /// The tree this screen draws is the one the *session* holds, and the session
+  /// can acquire a newer one at any time — a sync, a drift check, or an apply
+  /// that patched an account. The reconcile controller notifies on all three;
+  /// [PasswordController.refresh] is identity-guarded, so a notification that
+  /// changed nothing here costs nothing.
+  void _adoptSnapshot() => _controller?.refresh();
 
   /// Bootstraps the shared stack (once), then builds the [PasswordController]
   /// over the current Smartschool snapshot, the shared password queue, and the
@@ -72,7 +86,11 @@ class _PasswordsScreenState extends State<PasswordsScreen> {
       final services = await make();
       if (!mounted) return;
       final controller = PasswordController(
-        snapshot: services.app.smartschool.snapshot,
+        // Read live rather than captured (#287): a session that opened this tab
+        // before its first sync — or before adopting the shared state — used to
+        // stay on whatever tree it held at that instant, for the rest of its
+        // life.
+        snapshot: () => services.app.smartschool.snapshot,
         queue: services.passwordQueue,
         backends: services.passwordBackends,
         writer: services.passwordFileWriter,
@@ -84,6 +102,9 @@ class _PasswordsScreenState extends State<PasswordsScreen> {
         controller.dispose();
         return;
       }
+      _services?.controller.removeListener(_adoptSnapshot);
+      _services = services;
+      services.controller.addListener(_adoptSnapshot);
       setState(() => _controller = controller);
     } on Object catch (e) {
       if (mounted) setState(() => _error = e);

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -53,9 +53,11 @@ class _ReconcileScreenState extends State<ReconcileScreen> {
     try {
       final services = await make();
       if (mounted) setState(() => _services = services);
-      // Passive-session read (#115): show the shared overview from the store
-      // without pulling or re-linking. Fire-and-forget; it notifies listeners.
-      unawaited(services.controller.loadOverview());
+      // The session's opening read: the shared overview from the store (#115),
+      // and then the linked view built from the same shared state when the cold
+      // seed allows it (#287) — no pull either way. Fire-and-forget; it
+      // notifies listeners.
+      unawaited(services.controller.openSession());
     } on Object catch (e) {
       if (mounted) setState(() => _bootstrapError = e);
     } finally {
@@ -202,6 +204,11 @@ class _Header extends StatelessWidget {
     // Synchroniseer used to report "geen accountwijzigingen nodig" over a save
     // it had skipped.
     final String? pendingSettings = controller.pendingSettingsReason;
+    // Whose sync this session is working from, when it adopted the shared state
+    // rather than pulling for itself (#287) — and, when it could not, the one
+    // blocking reason it stays read-only.
+    final SystemSyncMeta? adopted = controller.adoptedFrom;
+    final String? seedRefused = controller.seedRefusedReason;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -262,6 +269,41 @@ class _Header extends StatelessWidget {
               Icon(Icons.info_outline, size: 16, color: colors.primary),
               const SizedBox(width: PlinkSpacing.s2),
               Flexible(child: Text(pendingSettings, style: text.bodySmall)),
+            ],
+          ),
+        ],
+        if (adopted != null) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s3),
+          Row(
+            key: const ValueKey('reconcile-adopted'),
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(Icons.groups_outlined, size: 16, color: colors.primary),
+              const SizedBox(width: PlinkSpacing.s2),
+              Flexible(
+                child: Text(
+                  'Deze sessie werkt met de gedeelde synchronisatie van '
+                  '${formatFreshnessStamp(adopted.at)}'
+                  '${adopted.syncedBy.isEmpty ? '' : ', door '
+                      '${adopted.syncedBy}'}'
+                  ' — er is niets opgehaald.',
+                  style: text.bodySmall,
+                ),
+              ),
+            ],
+          ),
+        ],
+        if (seedRefused != null) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s3),
+          Row(
+            key: const ValueKey('reconcile-seed-refused'),
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(Icons.info_outline, size: 16, color: colors.primary),
+              const SizedBox(width: PlinkSpacing.s2),
+              Flexible(child: Text(seedRefused, style: text.bodySmall)),
             ],
           ),
         ],

--- a/account_manager/test/passwords/password_controller_test.dart
+++ b/account_manager/test/passwords/password_controller_test.dart
@@ -71,8 +71,13 @@ void main() {
     late List<String> opens;
     Object? openError;
 
-    PasswordController build({String Function()? gen}) => PasswordController(
-          snapshot: _snapshot(),
+    // One stable snapshot per controller: the provider is read live (#287), so
+    // handing it a factory that mints a fresh object each call would make every
+    // read look like a changed tree.
+    PasswordController build({String Function()? gen}) {
+      final snap = _snapshot();
+      return PasswordController(
+          snapshot: () => snap,
           queue: queue,
           backends: backends,
           generatePassword: gen ?? _seqGenerator(),
@@ -84,8 +89,8 @@ void main() {
             final error = openError;
             if (error != null) throw error;
             opens.add(path);
-          },
-        );
+          });
+    }
 
     setUp(() {
       queue = InMemoryPasswordQueueStore();
@@ -306,17 +311,20 @@ void main() {
     late List<(String, List<int>)> writes;
     late List<String> opens;
 
-    PasswordController build() => PasswordController(
-          snapshot: _snapshot(),
-          queue: queue,
-          backends: backends,
-          generatePassword: _seqGenerator(),
-          writer: (name, bytes) async {
-            writes.add((name, List<int>.of(bytes)));
-            return 'C:/exports/$name';
-          },
-          opener: (path) async => opens.add(path),
-        );
+    PasswordController build() {
+      final snap = _snapshot();
+      return PasswordController(
+        snapshot: () => snap,
+        queue: queue,
+        backends: backends,
+        generatePassword: _seqGenerator(),
+        writer: (name, bytes) async {
+          writes.add((name, List<int>.of(bytes)));
+          return 'C:/exports/$name';
+        },
+        opener: (path) async => opens.add(path),
+      );
+    }
 
     setUp(() {
       queue = InMemoryPasswordQueueStore();
@@ -333,8 +341,9 @@ void main() {
     test('orders the staff list alphabetically by name (#186)', () {
       // Three staff seeded out of alphabetical order across mixed casing; the
       // controller must expose them sorted by display name (alice, Bob, Charlie).
+      final snap = staffOrderSnap();
       final c = PasswordController(
-        snapshot: staffOrderSnap(),
+        snapshot: () => snap,
         queue: queue,
         backends: backends,
         generatePassword: _seqGenerator(),
@@ -346,13 +355,16 @@ void main() {
 
     /// The Personeel search over three staff whose names differ in case and in
     /// which half is distinctive: Charlie Zulu, alice Bravo, Bob Alpha.
-    PasswordController buildStaffSearch() => PasswordController(
-          snapshot: staffOrderSnap(),
-          queue: queue,
-          backends: backends,
-          generatePassword: _seqGenerator(),
-          writer: (name, bytes) async => 'C:/exports/$name',
-        );
+    PasswordController buildStaffSearch() {
+      final snap = staffOrderSnap();
+      return PasswordController(
+        snapshot: () => snap,
+        queue: queue,
+        backends: backends,
+        generatePassword: _seqGenerator(),
+        writer: (name, bytes) async => 'C:/exports/$name',
+      );
+    }
 
     test('searches any part of the full name, case-insensitively (#215)', () {
       final c = buildStaffSearch()..setStaffFilterText('ZUL');

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -318,6 +318,96 @@ void main() {
       );
       expect(h.controller.linked, isNotNull);
     });
+
+    test(
+        'a failing writeMaterialized still drops the drill-down caches, so the '
+        'open class cannot pair the previous generation with the fresh view '
+        '(#289)', () async {
+      final snapshots = InMemorySnapshotStore();
+      final linkedStore = InMemoryLinkedStore();
+
+      // Session 1 materializes generation 1, so there are stored documents for
+      // the next session to drill into.
+      final s1 = ReconcileHarness(store: snapshots, linkedStore: linkedStore);
+      await s1.controller.sync();
+
+      // Session 2 reads that view, opens a class and the Klasgroepen
+      // inventory — and its own writes fail.
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+        controllerStore: StallingLinkedStore(
+          inner: linkedStore,
+          failWith: StateError('cosmos down'),
+        ),
+      );
+      await s2.controller.loadOverview();
+      final classroom = s2.controller.schoolRollups
+          .expand((s) => s2.controller.childrenOf(s.key))
+          .expand((g) => s2.controller.childrenOf(g.key))
+          .single;
+      await s2.controller.openClassroom(classroom);
+      await s2.controller.loadGroups();
+      s2.controller.expandedPath = <String>[classroom.key];
+      expect(s2.controller.classroomAccounts, isNotEmpty);
+      expect(s2.controller.groupDocs, isNotEmpty);
+
+      await s2.controller.sync();
+
+      // The write really did fail…
+      expect(
+        s2.log.entries.where((e) => e.isError).map((e) => e.message),
+        contains(contains('Kon het gedeelde overzicht niet opslaan')),
+      );
+      // …and the session still holds the view it just linked.
+      expect(s2.controller.linked, isNotNull);
+      // The caches derived from the *previous* generation went with the
+      // re-link, whether or not the shared write landed.
+      expect(s2.controller.selectedClassroom, isNull,
+          reason: 'the open class was read for the view that was replaced');
+      expect(s2.controller.classroomAccounts, isNull);
+      expect(s2.controller.groupDocs, isNull);
+      expect(s2.controller.expandedPath, isEmpty);
+      // With nothing open, no live entry can be joined to a stale document.
+      expect(s2.controller.classroomPendingEntries, isEmpty);
+    });
+
+    test(
+        'a stalled writeMaterialized during a drift check drops them too '
+        '(#289)', () async {
+      final snapshots = InMemorySnapshotStore();
+      final linkedStore = InMemoryLinkedStore();
+
+      final s1 = ReconcileHarness(store: snapshots, linkedStore: linkedStore);
+      await s1.controller.sync();
+
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+        controllerStore: StallingLinkedStore(inner: linkedStore),
+        persistTimeout: const Duration(milliseconds: 50),
+      );
+      await s2.controller.loadOverview();
+      final classroom = s2.controller.schoolRollups
+          .expand((s) => s2.controller.childrenOf(s.key))
+          .expand((g) => s2.controller.childrenOf(g.key))
+          .single;
+      await s2.controller.openClassroom(classroom);
+      await s2.controller.loadGroups();
+      expect(s2.controller.classroomAccounts, isNotEmpty);
+
+      await s2.controller.checkDrift();
+
+      expect(
+        s2.log.entries.where((e) => e.isError).map((e) => e.message),
+        contains(contains(
+          'Het opslaan van het gedeelde overzicht duurde langer dan',
+        )),
+      );
+      expect(s2.controller.selectedClassroom, isNull);
+      expect(s2.controller.classroomAccounts, isNull);
+      expect(s2.controller.groupDocs, isNull);
+    });
   });
 
   group('check for drift', () {

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -2170,6 +2170,233 @@ void main() {
     });
   });
 
+  group('adopting the shared synced state (#287)', () {
+    /// Session 1 syncs, leaving cold snapshots and a materialized view behind;
+    /// session 2 is the fresh launch that seeds from them.
+    Future<(ReconcileHarness, InMemorySnapshotStore, InMemoryLinkedStore)>
+        sharedState({wapi.WisaSnapshot? wisa}) async {
+      final snapshots = InMemorySnapshotStore();
+      final linkedStore = InMemoryLinkedStore();
+      final s1 = ReconcileHarness(
+        wisa: wisa,
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      await s1.controller.sync();
+      return (s1, snapshots, linkedStore);
+    }
+
+    test(
+        'a seeded session links from the shared state without pulling or '
+        'persisting', () async {
+      final (_, snapshots, linkedStore) = await sharedState();
+      final generationBefore = (await linkedStore.readSyncState()).generation;
+      final hub = InMemorySignalHub();
+
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+        hub: hub,
+      );
+      expect(s2.controller.linked, isNull, reason: 'nothing linked on open');
+
+      await s2.controller.openSession();
+
+      // The whole point: a usable view, and not one connector was touched.
+      expect(s2.controller.linked, isNotNull);
+      expect(s2.wisaSyncs, 0);
+      expect(s2.ssSyncs, 0);
+      expect(s2.azSyncs, 0);
+      // It says whose pull it is working from.
+      expect(s2.controller.adoptedFrom?.syncedBy, 'operator@school.example');
+      expect(s2.controller.seedRefusedReason, isNull);
+      // And the shared store is exactly as it was: no generation bump, no
+      // rewrite of the ~9.6k documents, no nudge to every other operator.
+      expect((await linkedStore.readSyncState()).generation, generationBefore);
+      expect(hub.published, isEmpty);
+      // Reading the store is still not a pass (#275).
+      expect(s2.controller.phase, ReconcilePhase.idle);
+    });
+
+    test('the adopted view carries every account, school-wide', () async {
+      final (s1, snapshots, linkedStore) = await sharedState();
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+
+      await s2.controller.openSession();
+
+      // The same pending work the syncing session derived — without an open
+      // classroom, which is what a flat school-wide list needs (#295).
+      expect(s2.controller.selectedClassroom, isNull);
+      expect(
+        s2.controller.pendingEntries.map((e) => e.targetId),
+        s1.controller.pendingEntries.map((e) => e.targetId),
+      );
+      expect(s2.controller.pendingEntries, isNotEmpty);
+    });
+
+    test('adoption runs once however many screens open the session', () async {
+      final (_, snapshots, linkedStore) = await sharedState();
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+
+      await s2.controller.openSession();
+      final first = s2.controller.linked;
+      // The Acties and Klasgroepen tabs open the same controller.
+      await s2.controller.openSession();
+      await s2.controller.openSession();
+
+      expect(identical(s2.controller.linked, first), isTrue,
+          reason: 'a link over the whole roster is not paid for three times');
+    });
+
+    test('a session with no seeded snapshot refuses, and says which', () async {
+      final linkedStore = InMemoryLinkedStore();
+      await ReconcileHarness(linkedStore: linkedStore).controller.sync();
+
+      // The everyday first launch on a machine whose cold store is empty.
+      final fresh = ReconcileHarness(linkedStore: linkedStore);
+      await fresh.controller.openSession();
+
+      expect(fresh.controller.linked, isNull);
+      expect(fresh.controller.adoptedFrom, isNull);
+      expect(
+        fresh.controller.seedRefusedReason,
+        contains('Geen opgeslagen momentopname voor WISA, Smartschool en '
+            'Azure AD'),
+      );
+      expect(fresh.wisaSyncs, 0);
+    });
+
+    test('a store nobody has ever synced has nothing to adopt', () async {
+      final snapshots = InMemorySnapshotStore();
+      // Seeds without a shared sync record: a cold store written by a pass
+      // whose materialize never landed.
+      await ReconcileHarness(store: snapshots).controller.sync();
+
+      final s2 = await ReconcileHarness.resume(store: snapshots);
+      await s2.controller.openSession();
+
+      expect(s2.controller.linked, isNull);
+      expect(
+        s2.controller.seedRefusedReason,
+        contains('nog geen gedeelde synchronisatie'),
+      );
+    });
+
+    test('a werkdatum today no longer resolves to refuses, naming both dates',
+        () async {
+      // The shared roster was pulled three days ago and is *as of* that date;
+      // this session's settings track "now", which is the fixture date.
+      final stale = kFixtureDate.subtract(const Duration(days: 3));
+      final (_, snapshots, linkedStore) = await sharedState(
+        wisa: wisaSnap(workDate: stale),
+      );
+
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      await s2.controller.openSession();
+
+      expect(s2.controller.linked, isNull);
+      expect(s2.controller.seedRefusedReason,
+          contains(wapi.formatWerkdatum(stale)));
+      expect(s2.controller.seedRefusedReason,
+          contains(wapi.formatWerkdatum(kFixtureDate)));
+    });
+
+    test('a werkdatum that still matches today is adopted', () async {
+      final (_, snapshots, linkedStore) = await sharedState(
+        wisa: wisaSnap(workDate: kFixtureDate),
+      );
+
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      await s2.controller.openSession();
+
+      expect(s2.controller.linked, isNotNull);
+      expect(s2.controller.adoptedFrom?.workDate, kFixtureDate);
+    });
+
+    test('a saved setting the seed predates refuses until a sync', () async {
+      final (_, snapshots, linkedStore) = await sharedState();
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      // The operator changes an Azure pull input in Instellingen before the
+      // first screen finishes opening. The seeded snapshot was pulled without
+      // it, so adopting would act on a view the save never reached.
+      s2.liveSettings.publish(
+        s2.liveSettings.current.copyWith(schoolPrefix: 'NIEUW'),
+      );
+
+      await s2.controller.openSession();
+
+      expect(s2.controller.linked, isNull);
+      expect(s2.controller.seedRefusedReason, contains('Instellingen'));
+    });
+
+    test('a real sync takes the view over from the adopted one', () async {
+      final (_, snapshots, linkedStore) = await sharedState();
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      await s2.controller.openSession();
+      expect(s2.controller.adoptedFrom, isNotNull);
+
+      // The operator decides they want something fresher after all.
+      s2.wisaResult = wisaSnap(
+        fetchedAt: kFixtureDate.add(const Duration(hours: 1)),
+        students: [wisaStudent(classGroup: '3D')],
+      );
+      await s2.controller.sync();
+
+      expect(s2.wisaSyncs, 1);
+      expect(s2.controller.linked, isNotNull);
+      expect(s2.controller.adoptedFrom, isNull,
+          reason: 'this view is this session\'s own now');
+      expect((await linkedStore.readSyncState()).generation, 2);
+    });
+
+    test('a refusal clears once a sync has produced a view', () async {
+      final linkedStore = InMemoryLinkedStore();
+      await ReconcileHarness(linkedStore: linkedStore).controller.sync();
+      final fresh = ReconcileHarness(linkedStore: linkedStore);
+      await fresh.controller.openSession();
+      expect(fresh.controller.seedRefusedReason, isNotNull);
+
+      await fresh.controller.sync();
+
+      expect(fresh.controller.seedRefusedReason, isNull);
+      expect(fresh.controller.linked, isNotNull);
+    });
+
+    test('an adopted session can dry-run and apply without syncing first',
+        () async {
+      final (_, snapshots, linkedStore) = await sharedState();
+      final s2 = await ReconcileHarness.resume(
+        store: snapshots,
+        linkedStore: linkedStore,
+      );
+      await s2.controller.openSession();
+
+      await s2.controller.dryRun();
+
+      expect(s2.controller.dryRunResults, isNotNull);
+      expect(s2.controller.dryRunResults, isNotEmpty);
+      expect(s2.wisaSyncs, 0, reason: 'still no pull anywhere in this session');
+    });
+  });
+
   group('realtime signals (#116)', () {
     test('a sync publishes syncStarted → viewChanged → syncEnded', () async {
       final hub = InMemorySignalHub();

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -198,6 +198,41 @@ void main() {
           'Sync voltooid — geen accountwijzigingen nodig. Klaar. '
           'Operator: operator@school.example.');
     });
+
+    test('a drift check closes with a terminal line of its own (#303)',
+        () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+      h.log.clear();
+
+      await h.controller.checkDrift();
+
+      // Until #303 a drift pass logged no closing line at all: it ended on
+      // `_link`'s "Gekoppeld: …" summary, which reads exactly like a pass still
+      // in flight. It gets the same line a sync gets — named for the pass that
+      // actually ran, because a drift check is not a sync.
+      expect(
+          h.log.entries.last.message,
+          'Driftcontrole voltooid — 4 openstaande actie(s). Klaar. '
+          'Operator: operator@school.example.');
+      expect(
+        h.log.entries.where((e) => e.message.startsWith('Sync voltooid')),
+        isEmpty,
+        reason: 'the drift pass must not claim to have synced',
+      );
+    });
+
+    test('an empty operator degrades gracefully on the drift line too (#303)',
+        () async {
+      final h = ReconcileHarness(syncedBy: '');
+      await h.controller.sync();
+      h.log.clear();
+
+      await h.controller.checkDrift();
+
+      expect(h.log.entries.last.message,
+          'Driftcontrole voltooid — 4 openstaande actie(s). Klaar.');
+    });
   });
 
   group('the pass reports itself in Dutch (#258)', () {
@@ -509,6 +544,59 @@ void main() {
 
       expect(settings.saves, 0,
           reason: 'a sync must not rewrite the settings document for nothing');
+    });
+
+    test('a drift check that pulls WISA repairs the document too (#303)',
+        () async {
+      // The repair follows the *pull*, not the pass. `checkDrift` normally
+      // re-reads only Smartschool and Azure — but a session holding no roster
+      // yet pulls WISA first, and that branch has exactly the authority a sync
+      // has, so it heals the profiles with it instead of leaving the operator's
+      // grid saying "School 25" until they happen to press Synchroniseer.
+      final settings = InMemorySettingsStore(legacy);
+      final h = ReconcileHarness(
+        wisa: wisaSnap(schools: pulled),
+        settingsStore: settings,
+        schoolProfiles: legacy.wisaSchools,
+      );
+
+      await h.controller.checkDrift();
+
+      expect(h.wisaSyncs, 1,
+          reason: 'no roster in hand, so the drift pass pulls one');
+      final saved = await settings.load();
+      expect(
+        saved.wisaSchools.map((p) => p.name),
+        ['Instituut Sancta Maria-A', 'Instituut Sancta Maria-B'],
+      );
+      expect(saved.wisaSchools.map((p) => p.code), ['ISMAA', 'ISMAB']);
+      expect(saved.wisaSchools.first.ours, isTrue);
+      expect(saved.wisaSchools.last.virtual, isTrue);
+      expect(h.log.entries.where((e) => e.isError), isEmpty);
+    });
+
+    test(
+        'a drift check over the roster in hand leaves the document alone '
+        '(#303)', () async {
+      // The deliberate other half of that decision. The merge writes WISA's
+      // name over the stored one, so a snapshot somebody else pulled hours ago
+      // must not get to overwrite a rename a fresher sync already recorded — and
+      // an ordinary drift pass never re-reads WISA, so it has nothing newer to
+      // say about the school list than the document already holds.
+      final settings = _RecordingSettingsStore(legacy);
+      final h = ReconcileHarness(
+        wisaInitial: wisaSnap(schools: pulled),
+        wisa: wisaSnap(schools: pulled),
+        settingsStore: settings,
+        schoolProfiles: legacy.wisaSchools,
+      );
+
+      await h.controller.checkDrift();
+
+      expect(h.wisaSyncs, 0,
+          reason: 'the roster in hand is the one a drift pass links against');
+      expect(settings.saves, 0);
+      expect((await settings.load()).wisaSchools.first.name, isEmpty);
     });
 
     test('a failing settings store is logged, never fails the sync', () async {
@@ -1502,7 +1590,9 @@ void main() {
       // the issue asks for.
       expect(seen.where((v) => v > 0.0 && v < 1.0).length,
           greaterThanOrEqualTo(3));
-      expect(h.controller.progress, greaterThanOrEqualTo(0.9));
+      // …and it *finishes*: the bar used to stop on the 0.9 `_relink` set
+      // before persisting and be cleared from there (#303).
+      expect(h.controller.progress, 1.0);
     });
 
     test('an unchanged re-sync still advances past the start', () async {
@@ -1519,6 +1609,9 @@ void main() {
       expectMonotonic(seen);
       expect(seen.any((v) => v > 0.0), isTrue,
           reason: 'even the short no-changes path moves the bar off zero');
+      // The short path is a finished pass too, so it completes the bar as well
+      // — it used to stop on the 0.25 the WISA pull left it at (#303).
+      expect(h.controller.progress, 1.0);
     });
 
     test('a drift check steps the bar forward through its stages', () async {
@@ -1531,6 +1624,7 @@ void main() {
       expect(seen.first, 0.0);
       expectMonotonic(seen);
       expect(seen.where((v) => v > 0.0 && v < 1.0), isNotEmpty);
+      expect(h.controller.progress, 1.0, reason: 'and reaches the end (#303)');
     });
 
     test('an apply advances once per action, reaching 1.0', () async {

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -478,6 +478,78 @@ class SharedDepartmentStaffGraph implements az.GraphTransport {
       );
 }
 
+/// A [az.GraphTransport] answering a resumed `/users/delta` the way Graph
+/// answers it after somebody edited an account **by hand** in the Office 365 /
+/// Entra portal (#288): the row carries the object id and the properties that
+/// changed, and nothing else.
+///
+/// That sparseness is Graph's documented contract for a changed instance, and it
+/// is what made every hand-edit invisible. Read as a whole user, such a row
+/// names no school, so the connector's client-side prefix test threw it away —
+/// permanently, because the walk that dropped it still advanced the token. The
+/// operator pressed **Controleer op drift**, read `0 gewijzigd`, and only a
+/// restart (re-seeding from the shared cold store) ever showed the edit.
+///
+/// The bulk read and the `employeeId` back-fill both answer empty, so a test can
+/// prove the delta walk really was the only leg that could have delivered it.
+///
+/// Wire it into [ReconcileHarness.azureTransport] together with an
+/// `azureInitial` carrying the token to resume from and the record the row
+/// edits.
+class HandEditedUserGraph implements az.GraphTransport {
+  HandEditedUserGraph({required this.row, this.freshToken = 'AZ-NEXT'});
+
+  /// The one sparse row the resumed walk reports — `{id, <changed props>}`.
+  final Map<String, dynamic> row;
+
+  /// The token this walk leaves behind for the next pass.
+  final String freshToken;
+
+  final List<az.GraphRequest> requests = <az.GraphRequest>[];
+
+  /// Every delta token Graph was asked to resume from, in order.
+  final List<String> resumeTokens = <String>[];
+
+  /// Every `employeeId in (…)` filter the connector issued.
+  final List<String> employeeIdLookups = <String>[];
+
+  /// How many `$filter`-scoped bulk reads ran — none, on an incremental pass.
+  int bulkReads = 0;
+
+  @override
+  Future<az.GraphResponse> send(az.GraphRequest request) async {
+    requests.add(request);
+    final String path = request.url.path;
+    if (path.contains('/members') || path.contains('groups')) {
+      return _ok(<String, dynamic>{'value': const <Object>[]});
+    }
+    if (path.contains('users/delta')) {
+      final String token = request.url.queryParameters[r'$deltatoken'] ?? '';
+      if (token != 'latest') resumeTokens.add(token);
+      return _ok(<String, dynamic>{
+        '@odata.deltaLink':
+            'https://graph.microsoft.com/v1.0/users/delta?\$deltatoken='
+                '$freshToken',
+        'value':
+            token == 'latest' ? const <Object>[] : <Map<String, dynamic>>[row],
+      });
+    }
+    final String filter = request.url.queryParameters[r'$filter'] ?? '';
+    if (filter.startsWith('employeeId in')) {
+      employeeIdLookups.add(filter);
+      return _ok(<String, dynamic>{'value': const <Object>[]});
+    }
+    bulkReads++;
+    return _ok(<String, dynamic>{'value': const <Object>[]});
+  }
+
+  static az.GraphResponse _ok(Map<String, dynamic> body) => az.GraphResponse(
+        statusCode: 200,
+        headers: const <String, String>{'content-type': 'application/json'},
+        body: jsonEncode(body),
+      );
+}
+
 /// A [az.GraphTransport] answering the way the tenant answers on the pass that
 /// has to notice a staff member **left** WISA (#269).
 ///

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1144,6 +1144,7 @@ wapi.WisaSnapshot wisaSnap({
   List<wapi.WisaStaff> staff = const [],
   List<wapi.WisaSchool> schools = const [],
   List<wapi.WisaClassGroup> classGroups = const [],
+  DateTime? workDate,
 }) =>
     wapi.WisaSnapshot(
       fetchedAt: fetchedAt ?? kFixtureDate,
@@ -1151,6 +1152,11 @@ wapi.WisaSnapshot wisaSnap({
       staff: staff,
       classGroups: classGroups,
       schools: schools,
+      // The date the roster is *as of* (#247). Left unstamped by default, as a
+      // hand-built fixture is; a test about which school year the shared state
+      // describes (#287) sets it, and the controller then folds it into the
+      // per-system freshness the next session reads back.
+      workDate: workDate,
     );
 
 ss.SmartschoolSnapshot ssSnap({

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -2678,13 +2678,22 @@ class InMemorySnapshotStore implements SnapshotStore {
 /// persist-stall the reconcile controller must survive (#168), and since #254
 /// the same for the narrow post-apply write-back.
 class StallingLinkedStore implements LinkedStore {
-  StallingLinkedStore({InMemoryLinkedStore? inner, this.failWith})
-      : _in = inner ?? InMemoryLinkedStore();
+  StallingLinkedStore({
+    InMemoryLinkedStore? inner,
+    this.failWith,
+    this.healthyWrites = 0,
+  }) : _in = inner ?? InMemoryLinkedStore();
 
   final InMemoryLinkedStore _in;
 
   /// When set, a write throws this instead of hanging.
   final Object? failWith;
+
+  /// How many `writeMaterialized` calls land in [_in] normally before the
+  /// stall/throw begins — so one session can materialize a healthy generation,
+  /// drill into it, and only *then* meet a store that will not take the next
+  /// view (#289).
+  int healthyWrites;
 
   /// True once a write was attempted — proves the controller reached persist.
   bool writeAttempted = false;
@@ -2702,6 +2711,17 @@ class StallingLinkedStore implements LinkedStore {
     void Function(String message)? onProgress,
   }) {
     writeAttempted = true;
+    if (healthyWrites > 0) {
+      healthyWrites--;
+      return _in.writeMaterialized(
+        view,
+        syncedBy: syncedBy,
+        at: at,
+        droppedDecisions: droppedDecisions,
+        systemSyncs: systemSyncs,
+        onProgress: onProgress,
+      );
+    }
     return _stall<void>();
   }
 
@@ -3544,6 +3564,8 @@ class ReconcileHarness {
   static Future<ReconcileHarness> resume({
     required SnapshotStore store,
     InMemoryLinkedStore? linkedStore,
+    LinkedStore? controllerStore,
+    Duration? persistTimeout,
     InMemorySignalHub? hub,
     SignalSubscriber? subscriber,
     wapi.WisaSnapshot? wisa,
@@ -3571,6 +3593,8 @@ class ReconcileHarness {
       azure: azure,
       store: store,
       linkedStore: linkedStore,
+      controllerStore: controllerStore,
+      persistTimeout: persistTimeout,
       hub: hub,
       subscriber: subscriber,
       wisaInitial: wisaSeed,

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -221,6 +221,75 @@ void main() {
   });
 
   testWidgets(
+      'a session that adopted the shared state says so, and one that could not '
+      'says why (#287)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+        .controller
+        .sync();
+
+    // The seeded launch: it inherits the colleague's pull and says whose.
+    final adopting = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: adopting.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('reconcile-adopted')), findsOneWidget);
+    expect(
+      find.textContaining('werkt met de gedeelde synchronisatie'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('operator@school.example'), findsWidgets);
+    expect(find.byKey(const ValueKey('reconcile-seed-refused')), findsNothing);
+    expect(adopting.wisaSyncs, 0);
+    // Both buttons stay exactly as available as they were.
+    expect(
+      tester
+          .widget<FilledButton>(find.byKey(const ValueKey('reconcile-sync')))
+          .onPressed,
+      isNotNull,
+    );
+    expect(
+      tester
+          .widget<OutlinedButton>(find.byKey(const ValueKey('reconcile-drift')))
+          .onPressed,
+      isNotNull,
+    );
+  });
+
+  testWidgets(
+      'a session that could not adopt the shared state surfaces one blocking '
+      'reason (#287)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(linkedStore: linkedStore).controller.sync();
+
+    // The launch with nothing seeded: the shared overview is readable, but
+    // there is no snapshot to build a view from.
+    final refused = ReconcileHarness(linkedStore: linkedStore);
+    await tester.pumpWidget(
+      _wrap(ReconcileScreen(bootstrap: refused.bootstrap)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('reconcile-adopted')), findsNothing);
+    expect(
+        find.byKey(const ValueKey('reconcile-seed-refused')), findsOneWidget);
+    expect(
+      find.textContaining('Geen opgeslagen momentopname'),
+      findsOneWidget,
+      reason: 'a refused session owes the operator exactly one reason',
+    );
+    expect(refused.wisaSyncs, 0);
+  });
+
+  testWidgets(
       'while a sync runs the header shows a determinate progress bar that has '
       'advanced past the start (#176)', (WidgetTester tester) async {
     final gate = Completer<void>();

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -1147,11 +1147,11 @@ void main() {
   // --- Passive-session drill-downs (no pull, no link) ----------------------
 
   testWidgets(
-      'a passive session drills into a classroom read-only via readClassroom, '
-      'loading only that class (#115/#154)', (WidgetTester tester) async {
-    // Tall, like its siblings: the read-only notice #214 added above the list
-    // costs the first card its place on an 800×600 fold, and this test is about
-    // which class was read, not about where the fold falls.
+      'a seeded session adopts the shared state and still reads only the class '
+      'it drills into (#115/#154/#287)', (WidgetTester tester) async {
+    // Tall, like its siblings: the notice above the list costs the first card
+    // its place on an 800×600 fold, and this test is about which class was
+    // read, not about where the fold falls.
     _useTallWindow(tester);
     final snapshots = InMemorySnapshotStore();
     final linkedStore = InMemoryLinkedStore();
@@ -1171,16 +1171,17 @@ void main() {
     // session rendered (#210).
     expect(find.text('Jaar 3'), findsOneWidget);
     expect(find.text('School 1'), findsNothing);
-    expect(s2.controller.linked, isNull,
-        reason: 'link() is never called in a passive session');
-    // Nothing loaded until the operator drills in.
+    // Since #287 the cold seed is linked on open, so this session can act — and
+    // it got there without asking any of the three systems for anything.
+    expect(s2.controller.linked, isNotNull);
+    expect(s2.controller.adoptedFrom?.syncedBy, 'operator@school.example');
+    // The drill-down is still lazy: nothing is read until the operator opens a
+    // class, and then only that class.
     expect(s2.controller.classroomAccounts, isNull);
 
     await _drill(tester, node: 'Jaar 3', classroom: '3C');
 
-    // Only the 3C class was read; the read-only account tile renders.
     expect(s2.controller.classroomAccounts, hasLength(1));
-    expect(find.text('Jane Doe'), findsOneWidget);
     expect(s2.wisaSyncs, 0);
     expect(s2.ssSyncs, 0);
     expect(s2.azSyncs, 0);
@@ -1464,7 +1465,14 @@ void main() {
     // The state is named instead of silently swapping in static cards.
     expect(readOnly, findsOneWidget);
     expect(find.text('Alleen-lezen overzicht'), findsOneWidget);
-    expect(find.textContaining('nog niet gesynchroniseerd'), findsOneWidget);
+    // Since #287 the notice names *why* there is nothing to act on rather than
+    // reporting the absence of a sync: this session holds no seeded snapshot to
+    // build a view from, which is a thing only a pull can fix.
+    expect(
+      find.textContaining('Geen opgeslagen momentopname voor WISA, '
+          'Smartschool en Azure AD'),
+      findsOneWidget,
+    );
 
     // …with the sync affordance right there, and live.
     expect(tester.widget<FilledButton>(readOnlySync).onPressed, isNotNull);
@@ -1501,6 +1509,68 @@ void main() {
   });
 
   testWidgets(
+      'a session that adopted the shared state says whose sync it is working '
+      'from, and its tiles are the interactive ones (#287)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // Operator A syncs; operator B opens Acties five minutes later and never
+    // presses Synchroniseer. Before #287 that second session got the
+    // "nog niet gesynchroniseerd" read-only notice and static cards, after
+    // minutes of WISA/Smartschool/Azure traffic were the only way out of it.
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+        .controller
+        .sync();
+
+    final s2 = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: s2.bootstrap)));
+    await tester.pumpAndSettle();
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+
+    // The shared-state notice replaces the read-only one, and names the pull.
+    expect(readOnly, findsNothing);
+    expect(find.byKey(const ValueKey('actions-shared-state')), findsOneWidget);
+    expect(find.text('Gedeelde synchronisatie'), findsOneWidget);
+    expect(find.textContaining('operator@school.example'), findsWidgets);
+
+    // The tiles below it really are interactive — no locks, real entry tiles —
+    // and no system was asked for anything to get here.
+    expect(find.byIcon(Icons.lock_outline), findsNothing);
+    expect(
+      find.byWidgetPredicate((w) =>
+          w.key is ValueKey<String> &&
+          (w.key! as ValueKey<String>).value.startsWith('entry-')),
+      findsWidgets,
+    );
+    expect(s2.wisaSyncs, 0);
+    expect(s2.ssSyncs, 0);
+    expect(s2.azSyncs, 0);
+
+    // Both passes stay within reach for an operator who wants something
+    // fresher; taking one makes the view this session's own.
+    final sync = find.byKey(const ValueKey('actions-shared-state-sync'));
+    expect(
+      tester
+          .widget<OutlinedButton>(
+            find.byKey(const ValueKey('actions-shared-state-drift')),
+          )
+          .onPressed,
+      isNotNull,
+    );
+    await tester.ensureVisible(sync);
+    await tester.tap(sync);
+    await tester.pumpAndSettle();
+
+    expect(s2.wisaSyncs, 1);
+    expect(s2.controller.adoptedFrom, isNull);
+    expect(find.byKey(const ValueKey('actions-shared-state')), findsNothing);
+  });
+
+  testWidgets(
       'a session whose sync failed is told the sync failed, not that it never '
       'ran (#214)', (WidgetTester tester) async {
     _useTallWindow(tester);
@@ -1530,17 +1600,15 @@ void main() {
       "the read-only banner's sync is disabled and named when another operator "
       'holds the lease (#214/#108)', (WidgetTester tester) async {
     _useTallWindow(tester);
-    final snapshots = InMemorySnapshotStore();
     final linkedStore = InMemoryLinkedStore();
-    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
-        .controller
-        .sync();
+    await ReconcileHarness(linkedStore: linkedStore).controller.sync();
     await linkedStore.acquireLease(owner: 'mieke@school', now: kFixtureDate);
 
-    final s2 = await ReconcileHarness.resume(
-      store: snapshots,
-      linkedStore: linkedStore,
-    );
+    // Deliberately *not* a seeded session: since #287 one of those adopts the
+    // shared state and gets the interactive tiles plus [SharedStateNotice]
+    // instead. This is the session with nothing to build a view from, which is
+    // the one the read-only banner is for.
+    final s2 = ReconcileHarness(linkedStore: linkedStore);
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: s2.bootstrap)));
     await tester.pumpAndSettle();
 

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -526,16 +526,13 @@ void main() {
       'a passive session says it is read-only and renders static rows (#214)',
       (WidgetTester tester) async {
     _useTallWindow(tester);
-    final snapshots = InMemorySnapshotStore();
     final linkedStore = InMemoryLinkedStore();
-    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
-        .controller
-        .sync();
+    await ReconcileHarness(linkedStore: linkedStore).controller.sync();
 
-    final s2 = await ReconcileHarness.resume(
-      store: snapshots,
-      linkedStore: linkedStore,
-    );
+    // Deliberately *not* a seeded session: since #287 one of those adopts the
+    // shared state and its rows really are interactive (covered below). This is
+    // the session holding no snapshot to build a view from at all.
+    final s2 = ReconcileHarness(linkedStore: linkedStore);
     await tester.pumpWidget(_wrap(ClassGroupsScreen(bootstrap: s2.bootstrap)));
     await tester.pumpAndSettle();
 
@@ -551,6 +548,41 @@ void main() {
     expect(find.textContaining('(manueel)'), findsWidgets);
     // Nothing interactive: a passive session has nothing to apply.
     expect(find.byKey(const ValueKey('entry-group-2B')), findsNothing);
+  });
+
+  testWidgets(
+      'a seeded session works from the shared sync instead, and says so (#287)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    // The same two operators, except this one launched onto a cold store a
+    // colleague had already filled — which is the everyday case.
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+        .controller
+        .sync();
+
+    final s2 = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(_wrap(ClassGroupsScreen(bootstrap: s2.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The inventory is live rather than static, and the notice says where the
+    // view came from instead of demanding a sync for it.
+    expect(s2.controller.linked, isNotNull);
+    expect(_readOnly, findsNothing);
+    expect(find.byKey(const ValueKey('class-groups-shared-state')),
+        findsOneWidget);
+    expect(find.text('Gedeelde synchronisatie'), findsOneWidget);
+    expect(find.textContaining('operator@school.example'), findsWidgets);
+    expect(find.byIcon(Icons.lock_outline), findsNothing);
+    expect(find.byKey(const ValueKey('entry-group-2B')), findsOneWidget);
+    // And not one connector was asked for anything.
+    expect(s2.wisaSyncs, 0);
+    expect(s2.ssSyncs, 0);
+    expect(s2.azSyncs, 0);
   });
 
   testWidgets(

--- a/account_manager/test/screens/passwords_screen_test.dart
+++ b/account_manager/test/screens/passwords_screen_test.dart
@@ -83,6 +83,31 @@ void main() {
   });
 
   testWidgets(
+      'the class tree tracks a sync that lands after this tab was opened '
+      '(#287)', (WidgetTester tester) async {
+    // The screen used to capture `app.smartschool.snapshot` once, at bootstrap.
+    // A session that opened Wachtwoorden before its first sync — or before it
+    // adopted the shared state — therefore stayed on that empty tree for the
+    // rest of its life, however many syncs landed behind it.
+    final harness = ReconcileHarness(smartschool: _snap());
+    await tester
+        .pumpWidget(_wrap(PasswordsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    final class3c = find.byKey(const ValueKey('password-class-3C'));
+    expect(class3c, findsNothing, reason: 'nothing synced yet');
+
+    // A pass on another tab brings the group tree in.
+    await harness.controller.sync();
+    await tester.pumpAndSettle();
+
+    expect(class3c, findsOneWidget);
+    await tester.tap(class3c);
+    await tester.pumpAndSettle();
+    expect(find.text('jane'), findsOneWidget);
+  });
+
+  testWidgets(
       'Leerlingen: select a class, check a target, generate → confirm pushes '
       'live and reports success (#180)', (WidgetTester tester) async {
     final harness = ReconcileHarness(ssInitial: _snap());

--- a/packages/azure_api/lib/src/connector.dart
+++ b/packages/azure_api/lib/src/connector.dart
@@ -89,8 +89,9 @@ class AzureConnector {
   /// minted during *this* sync — from this pass's delta walk, or from
   /// [UserManager.latestDeltaToken] on a full read — never a carried-over older
   /// one. That is what makes [AzureSnapshot.fetchedAt] a truthful age for the
-  /// token it ships with, and what keeps a token from silently ageing past
-  /// Graph's 30-day limit while every sync appears to succeed.
+  /// token it ships with, and what keeps a token from silently ageing past the
+  /// lifetime Graph gives a `user` delta link (7 days) while every sync appears
+  /// to succeed.
   ///
   /// [expectedEmployeeIds] are the WISA ids this pass expects to find accounts
   /// for. Any that the prefix-scoped read did not turn up are looked up
@@ -132,7 +133,17 @@ class AzureConnector {
 
     final UserDelta delta;
     try {
-      delta = await users.delta(deltaToken, prefix);
+      // The previous user list goes *into* the walk, not just over it: a
+      // resumed row is sparse (id plus what changed), so it has to be merged
+      // onto the record it updates before it can be classified or applied
+      // (#288).
+      delta = await users.delta(
+        deltaToken,
+        prefix,
+        known: {
+          for (final u in previous?.users ?? const <AzureUser>[]) u.id: u
+        },
+      );
     } on GraphException catch (e) {
       if (!e.isRejectedDeltaToken) rethrow;
       _log?.addMessage(
@@ -147,8 +158,9 @@ class AzureConnector {
     // No `@odata.deltaLink` on the final page means this walk produced no
     // resume point. Keeping the old token here (the pre-#213 behaviour) let a
     // token stop advancing while every sync still reported success, until it
-    // aged past Graph's 30-day limit and every later pass died on it. Dropping
-    // it costs one full read next pass and always leaves a fresh token behind.
+    // aged past the lifetime Graph gives a `user` delta link (7 days) and every
+    // later pass died on it. Dropping it costs one full read next pass and
+    // always leaves a fresh token behind.
     if (delta.deltaToken == null) {
       _log?.addMessage(
         core.Origin.azure,
@@ -249,19 +261,40 @@ class AzureConnector {
 
     final byId = {for (final u in current) u.id: u};
     var added = 0;
+    var repaired = 0;
     for (final u in adopted) {
-      if (byId.containsKey(u.id)) continue;
+      final existing = byId[u.id];
+      if (existing == null) {
+        byId[u.id] = u;
+        added++;
+        continue;
+      }
+      // The object id is already here, but this record is not the one we
+      // already had: it came straight off Graph with the full `$select`, so it
+      // wins (#288). Skipping on mere id presence meant the connector fetched
+      // the correct record over the wire and then threw it away — which is how
+      // a record a sparse delta row had degraded stayed degraded.
+      if (existing == u) continue;
       byId[u.id] = u;
-      added++;
+      repaired++;
     }
-    if (added == 0) return current;
-    _log?.addMessage(
-      core.Origin.azure,
-      'Azure: $added bestaand(e) account(s) overgenomen die via employeeId '
-      'gevonden zijn maar niet aan de schoolfilter voldoen (overgestapte '
-      'leerlingen, en personeelsleden van wie onze school niet vooraan in '
-      '"department" staat).',
-    );
+    if (added == 0 && repaired == 0) return current;
+    if (added > 0) {
+      _log?.addMessage(
+        core.Origin.azure,
+        'Azure: $added bestaand(e) account(s) overgenomen die via employeeId '
+        'gevonden zijn maar niet aan de schoolfilter voldoen (overgestapte '
+        'leerlingen, en personeelsleden van wie onze school niet vooraan in '
+        '"department" staat).',
+      );
+    }
+    if (repaired > 0) {
+      _log?.addMessage(
+        core.Origin.azure,
+        'Azure: $repaired account(s) bijgewerkt met de volledige gegevens uit '
+        'de employeeId-opzoeking.',
+      );
+    }
     return byId.values.toList();
   }
 
@@ -362,6 +395,11 @@ class AzureConnector {
 
   /// Upserts [delta.changed] and drops [delta.removedIds] over [base], keeping
   /// the result keyed by Azure object id.
+  ///
+  /// A whole-record upsert is only safe because [UserManager.delta] was handed
+  /// the same [base] and has already merged each sparse Graph row onto the
+  /// record it updates (#288); the entries here are complete users, not
+  /// fragments.
   static List<AzureUser> _applyDelta(List<AzureUser> base, UserDelta delta) {
     final byId = {for (final u in base) u.id: u};
     for (final id in delta.removedIds) {

--- a/packages/azure_api/lib/src/graph/graph_request.dart
+++ b/packages/azure_api/lib/src/graph/graph_request.dart
@@ -83,6 +83,13 @@ class GraphException implements Exception {
   ///   returns it for a genuinely malformed query, which must stay loud rather
   ///   than silently degrade into an expensive full read on every pass.
   ///
+  /// Do not read that message as the lifetime: the number in Graph's text is
+  /// generic, and the documented lifetime of a `directoryObject`/`user` delta
+  /// link is **7 days**, not 30 (#288). Nothing here depends on the figure —
+  /// the recovery is driven by the reply, not by a clock — but the operator
+  /// reading the log should not be told a token has a month left when it has a
+  /// week.
+  ///
   /// The classification lives on the reply rather than on the connector because
   /// two layers need it: `UserManager.delta` hands it to `GraphClient` as the
   /// failure shape it expects — so the transport logs it as a detail instead of

--- a/packages/azure_api/lib/src/models/azure_user.dart
+++ b/packages/azure_api/lib/src/models/azure_user.dart
@@ -93,6 +93,48 @@ class AzureUser implements core.AzureUser {
   static bool isRemoved(Map<String, dynamic> json) =>
       json.containsKey('@removed');
 
+  /// This user with every property [json] actually carries written over it,
+  /// leaving the ones it stays silent about untouched (#288).
+  ///
+  /// The merge [AzureUser.fromGraphJson] cannot do. Graph represents a changed
+  /// instance in a delta walk by its `id` plus *at least* the properties that
+  /// changed, so a resumed row for a hand-edited account is routinely
+  /// `{"id": "…", "displayName": "…"}` and nothing more. Read as a whole user
+  /// that row is a wreck — blank `upn`, blank `displayName`, no `employeeId`,
+  /// which is the `employeeId → wisaId` bridge the linker joins on — and
+  /// upserting it over the previous snapshot destroyed the record it was
+  /// supposed to update.
+  ///
+  /// Presence, not emptiness, decides: a property Graph *sent* wins even when
+  /// it is `null` (that is how a cleared `employeeId` or `companyName` arrives),
+  /// a property Graph omitted keeps its current value. `id` is the one
+  /// exception — an empty incoming id never replaces the one this record is
+  /// keyed by.
+  AzureUser mergeGraphJson(Map<String, dynamic> json) {
+    String str(String key, String current) =>
+        json.containsKey(key) ? ((json[key] as String?) ?? '') : current;
+    String? nullable(String key, String? current) {
+      if (!json.containsKey(key)) return current;
+      final v = json[key] as String?;
+      return (v == null || v.isEmpty) ? null : v;
+    }
+
+    final incomingId = (json['id'] as String?) ?? '';
+    return AzureUser(
+      id: incomingId.isEmpty ? id : incomingId,
+      upn: str('userPrincipalName', upn),
+      employeeId: nullable('employeeId', employeeId),
+      displayName: str('displayName', displayName),
+      givenName: str('givenName', givenName),
+      surname: str('surname', surname),
+      companyName: nullable('companyName', companyName),
+      department: nullable('department', department),
+      accountEnabled: json.containsKey('accountEnabled')
+          ? ((json['accountEnabled'] as bool?) ?? true)
+          : accountEnabled,
+    );
+  }
+
   /// Serializes to the connector's own cache shape (not Graph's). Round-trips
   /// with [AzureUser.fromJson] for the on-disk "last known good" snapshot.
   Map<String, dynamic> toJson() => {

--- a/packages/azure_api/lib/src/user_manager.dart
+++ b/packages/azure_api/lib/src/user_manager.dart
@@ -8,6 +8,11 @@ import 'models/azure_user.dart';
 class UserDelta {
   /// Users created or changed since the last sync, already filtered to the
   /// school (by `companyName` / `department`).
+  ///
+  /// Every entry is a **whole** record: a sparse Graph row (id plus the changed
+  /// properties, the ordinary shape of a resumed walk) has been merged onto the
+  /// record the caller passed in as `known`, so upserting one of these can never
+  /// blank a field the row stayed silent about (#288).
   final List<AzureUser> changed;
 
   /// Azure object ids of users Graph reported as removed (`@removed`). Not
@@ -256,8 +261,19 @@ class UserManager {
   /// delta token representing "now" via `$deltatoken=latest`. Paired with
   /// [load] on the first sync so the bulk read stays `$filter`-scoped (PAIN-2)
   /// while still establishing a resume point.
+  ///
+  /// **The `$select` is not decoration.** A delta token encodes the query
+  /// options of the request that minted it, and Graph honours *those* on every
+  /// resume — a `$select` added to the resume itself is ignored. Priming
+  /// without one therefore produced rows carrying only `id` and whatever
+  /// changed, which [_walkDelta] could not classify and silently dropped: every
+  /// hand-edit made in the Entra portal vanished, permanently, because the walk
+  /// that dropped it still advanced the token (#288).
   Future<String?> latestDeltaToken() async {
-    final url = _graph.uri('users/delta', query: {r'$deltatoken': 'latest'});
+    final url = _graph.uri(
+      'users/delta',
+      query: {r'$deltatoken': 'latest', r'$select': _select},
+    );
     final result = await _graph.getDelta(url);
     return result.deltaToken;
   }
@@ -265,17 +281,37 @@ class UserManager {
   /// Incremental delta read: resumes from a token returned by a previous
   /// [deltaInitial]/[delta] call. Only changed and removed users come back.
   ///
+  /// [known] is the caller's current user list keyed by Azure object id — the
+  /// previous snapshot. A resumed row is Graph's `id` plus *at least* the
+  /// changed properties, so it is merged onto `known[id]` before anything looks
+  /// at it (#288): the school test then judges the *whole* record rather than a
+  /// fragment that mentions neither `companyName` nor `department`, and the
+  /// record the caller upserts keeps the `upn`, `employeeId` and `displayName`
+  /// the row never spoke about. A sparse row about a user [known] does not hold
+  /// stays unclassifiable and is dropped, exactly as before.
+  ///
   /// This is the one read whose caller (`AzureConnector.sync`) comes prepared
   /// for a refusal: a token Graph no longer accepts is recovered from with a
   /// full read (#213). The transport is told so, so it logs that reply as a
   /// detail rather than as an error the operator should act on (#229). Every
   /// other failure — including a resume that fails for any other reason — stays
   /// an error.
-  Future<UserDelta> delta(String deltaToken, String schoolPrefix) {
-    final url = _graph.uri('users/delta', query: {r'$deltatoken': deltaToken});
+  Future<UserDelta> delta(
+    String deltaToken,
+    String schoolPrefix, {
+    Map<String, AzureUser> known = const <String, AzureUser>{},
+  }) {
+    final url = _graph.uri(
+      'users/delta',
+      // Graph resumes on the options the token was minted with, so this is
+      // belt-and-braces for a token minted elsewhere; [latestDeltaToken] is
+      // where it actually takes effect.
+      query: {r'$deltatoken': deltaToken, r'$select': _select},
+    );
     return _walkDelta(
       url,
       schoolPrefix,
+      known: known,
       expected: (e) => e.isRejectedDeltaToken,
     );
   }
@@ -283,6 +319,7 @@ class UserManager {
   Future<UserDelta> _walkDelta(
     Uri url,
     String schoolPrefix, {
+    Map<String, AzureUser> known = const <String, AzureUser>{},
     GraphFailurePredicate? expected,
   }) async {
     final result = await _graph.getDelta(url, expected: expected);
@@ -294,7 +331,10 @@ class UserManager {
         if (id != null) removedIds.add(id);
         continue;
       }
-      final user = AzureUser.fromGraphJson(row);
+      final previous = known[(row['id'] as String?) ?? ''];
+      final user = previous == null
+          ? AzureUser.fromGraphJson(row)
+          : previous.mergeGraphJson(row);
       if (_belongsToSchool(user, schoolPrefix)) changed.add(user);
     }
     _log?.addMessage(

--- a/packages/azure_api/test/connector_test.dart
+++ b/packages/azure_api/test/connector_test.dart
@@ -249,6 +249,141 @@ void main() {
     });
   });
 
+  group('a resumed delta row is sparse (#288)', () {
+    /// The account the previous snapshot holds, complete.
+    const stored = AzureUser(
+      id: 'az1',
+      upn: 'jane.doe@student.school.example',
+      employeeId: 'W1',
+      displayName: 'Jane Doe',
+      givenName: 'Jane',
+      surname: 'Doe',
+      companyName: 'GBS',
+      department: '3C',
+    );
+
+    AzureSnapshot previousWith(List<AzureUser> users) => AzureSnapshot(
+          fetchedAt: DateTime.utc(2026, 6, 1),
+          deltaToken: 'OLDTOKEN',
+          users: users,
+          groups: const [],
+        );
+
+    /// A delta walk answering with [rows] and nothing else — no groups, no bulk
+    /// read, no back-fill hits.
+    GraphResponse Function(GraphRequest) walkOf(
+      List<Map<String, dynamic>> rows, {
+      List<Map<String, dynamic>> backfill = const [],
+    }) =>
+        (req) {
+          final path = req.url.path;
+          if (path.contains('/members') || path.contains('groups')) {
+            return jsonOk({'value': const <Object>[]});
+          }
+          if (path.contains('users/delta')) {
+            return jsonOk({
+              '@odata.deltaLink':
+                  'https://graph.microsoft.com/v1.0/users/delta?\$deltatoken=T2',
+              'value': rows,
+            });
+          }
+          final filter = req.url.queryParameters[r'$filter'] ?? '';
+          if (filter.startsWith('employeeId in')) {
+            return jsonOk({'value': backfill});
+          }
+          return jsonOk({'value': const <Object>[]});
+        };
+
+    test('a hand-edit in Entra reaches the snapshot with the record intact',
+        () async {
+      // The report: an administrator renames someone in the O365 portal, the
+      // resumed walk reports `{id, displayName}` — and the connector both
+      // dropped the row (it names no school) and, for the rows it did keep,
+      // upserted the fragment over the record, wiping the UPN and the
+      // `employeeId → wisaId` bridge the linker joins on.
+      final connector = connectorWith(FakeGraphTransport(walkOf(
+        <Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'az1',
+            'displayName': 'Janneke Doe',
+            'givenName': 'Janneke',
+          },
+        ],
+      )));
+
+      final snapshot = await connector.sync(
+        deltaToken: 'OLDTOKEN',
+        previous: previousWith(const [stored]),
+      );
+
+      expect(
+        snapshot.users.single,
+        stored.copyWith(displayName: 'Janneke Doe', givenName: 'Janneke'),
+      );
+    });
+
+    test('a sparse row never blanks the record of a user it does not name',
+        () async {
+      final connector = connectorWith(FakeGraphTransport(walkOf(
+        <Map<String, dynamic>>[
+          <String, dynamic>{'id': 'az1', 'accountEnabled': false},
+        ],
+      )));
+
+      final snapshot = await connector.sync(
+        deltaToken: 'OLDTOKEN',
+        previous: previousWith(const [
+          stored,
+          AzureUser(
+            id: 'az2',
+            upn: 'jan.peeters@student.school.example',
+            employeeId: 'W2',
+            displayName: 'Jan Peeters',
+            companyName: 'GBS',
+          ),
+        ]),
+      );
+
+      final byId = {for (final u in snapshot.users) u.id: u};
+      expect(byId['az1'], stored.copyWith(accountEnabled: false));
+      expect(byId['az2']?.displayName, 'Jan Peeters');
+    });
+
+    test(
+        'the employeeId back-fill repairs a record instead of skipping it on '
+        'object-id presence', () async {
+      // The safety net was disarmed too: the back-fill re-fetched the right
+      // record with the full `$select` and then dropped it on the floor because
+      // the object id was already in the map. A record Graph just handed us
+      // wins over one we are unsure about.
+      const degraded = AzureUser(id: 'az1', upn: '', companyName: 'GBS');
+      final connector = connectorWith(FakeGraphTransport(walkOf(
+        const <Map<String, dynamic>>[],
+        backfill: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'az1',
+            'userPrincipalName': 'jane.doe@student.school.example',
+            'employeeId': 'W1',
+            'displayName': 'Jane Doe',
+            'givenName': 'Jane',
+            'surname': 'Doe',
+            'companyName': 'GBS',
+            'department': '3C',
+            'accountEnabled': true,
+          },
+        ],
+      )));
+
+      final snapshot = await connector.sync(
+        deltaToken: 'OLDTOKEN',
+        previous: previousWith(const [degraded]),
+        expectedEmployeeIds: const ['W1'],
+      );
+
+      expect(snapshot.users.single, stored);
+    });
+  });
+
   group('rejected delta token (#213)', () {
     /// Routes a delta *resume* to [rejection] while the full-read path
     /// (`$deltatoken=latest` + the `$filter` bulk read) succeeds.

--- a/packages/azure_api/test/models_test.dart
+++ b/packages/azure_api/test/models_test.dart
@@ -41,6 +41,57 @@ void main() {
       expect(user.displayName, '');
     });
 
+    group('mergeGraphJson (#288)', () {
+      const stored = AzureUser(
+        id: 'az1',
+        upn: 'jane.doe@student.school.example',
+        employeeId: 'W1',
+        displayName: 'Jane Doe',
+        givenName: 'Jane',
+        surname: 'Doe',
+        companyName: 'GBS',
+        department: '3C',
+      );
+
+      test('a property the row omits keeps its current value', () {
+        final merged = stored.mergeGraphJson(<String, dynamic>{
+          'id': 'az1',
+          'displayName': 'Janneke Doe',
+        });
+        expect(merged, stored.copyWith(displayName: 'Janneke Doe'));
+      });
+
+      test('a property the row sends as null is cleared', () {
+        final merged = stored.mergeGraphJson(<String, dynamic>{
+          'id': 'az1',
+          'employeeId': null,
+          'department': null,
+        });
+        expect(merged.employeeId, isNull);
+        expect(merged.department, isNull);
+        expect(merged.companyName, 'GBS', reason: 'unmentioned, so untouched');
+      });
+
+      test('accountEnabled follows presence, not truthiness', () {
+        expect(
+            stored
+                .mergeGraphJson(<String, dynamic>{'id': 'az1'}).accountEnabled,
+            isTrue);
+        expect(
+          stored.mergeGraphJson(<String, dynamic>{
+            'id': 'az1',
+            'accountEnabled': false
+          }).accountEnabled,
+          isFalse,
+        );
+      });
+
+      test('an empty incoming id never replaces the one we are keyed by', () {
+        expect(stored.mergeGraphJson(<String, dynamic>{'id': ''}).id, 'az1');
+        expect(stored.mergeGraphJson(const <String, dynamic>{}).id, 'az1');
+      });
+    });
+
     test('isRemoved detects @removed delta entries', () {
       expect(
         AzureUser.isRemoved({

--- a/packages/azure_api/test/user_manager_test.dart
+++ b/packages/azure_api/test/user_manager_test.dart
@@ -181,6 +181,145 @@ void main() {
     });
   });
 
+  group('a resumed delta row is sparse (#288)', () {
+    /// The nine fields [AzureUser] reads, as one `$select` value.
+    const allFields = 'id,userPrincipalName,employeeId,displayName,givenName,'
+        'surname,companyName,department,accountEnabled';
+
+    /// One delta page carrying [rows], closed by a deltaLink.
+    FakeGraphTransport walkOf(List<Map<String, dynamic>> rows) =>
+        FakeGraphTransport(
+          (_) => jsonOk(<String, dynamic>{
+            '@odata.deltaLink':
+                'https://graph.microsoft.com/v1.0/users/delta?\$deltatoken=T2',
+            'value': rows,
+          }),
+        );
+
+    /// The record the previous snapshot holds for the hand-edited student.
+    const stored = AzureUser(
+      id: 'az1',
+      upn: 'jane.doe@student.school.example',
+      employeeId: '1',
+      displayName: 'Jane Doe',
+      givenName: 'Jane',
+      surname: 'Doe',
+      companyName: 'GBS',
+    );
+
+    test('the token-minting request carries the full \$select', () async {
+      // Graph encodes the *initial* request's query options into the token and
+      // replays those on every resume, so this is the request that decides
+      // whether a resumed row arrives with anything on it at all. Priming
+      // without a `$select` is the whole bug.
+      final transport = FakeGraphTransport(
+        (_) => jsonOk(readFixture('delta_latest.json')),
+      );
+      await UserManager(clientWith(transport)).latestDeltaToken();
+      expect(
+          transport.requests.single.url.queryParameters[r'$select'], allFields);
+    });
+
+    test('the resume carries it too', () async {
+      final transport = walkOf(const <Map<String, dynamic>>[]);
+      await UserManager(clientWith(transport)).delta('T1', 'GBS');
+      final request = transport.requests.single;
+      expect(request.url.queryParameters[r'$deltatoken'], 'T1');
+      expect(request.url.queryParameters[r'$select'], allFields);
+    });
+
+    test('a hand-edit lands and the rest of the record survives', () async {
+      // Exactly what Graph sends for a display-name edit made in the Entra
+      // portal: the object id, and the properties that changed. Read as a whole
+      // user this row is a wreck — no UPN, no employeeId, no companyName — and
+      // the school test then threw it away, so the edit was lost for good
+      // (the walk still advances the token, so it is never offered again).
+      final transport = walkOf(<Map<String, dynamic>>[
+        <String, dynamic>{
+          'id': 'az1',
+          'displayName': 'Janneke Doe',
+          'givenName': 'Janneke',
+        },
+      ]);
+
+      final delta = await UserManager(clientWith(transport)).delta(
+        'T1',
+        'GBS',
+        known: const <String, AzureUser>{'az1': stored},
+      );
+
+      expect(
+        delta.changed.single,
+        stored.copyWith(displayName: 'Janneke Doe', givenName: 'Janneke'),
+      );
+    });
+
+    test('a sparse row that only flips accountEnabled is kept', () async {
+      final transport = walkOf(<Map<String, dynamic>>[
+        <String, dynamic>{'id': 'az1', 'accountEnabled': false},
+      ]);
+
+      final delta = await UserManager(clientWith(transport)).delta(
+        'T1',
+        'GBS',
+        known: const <String, AzureUser>{'az1': stored},
+      );
+
+      expect(delta.changed.single.accountEnabled, isFalse);
+      expect(delta.changed.single.employeeId, '1',
+          reason: 'the bridge to WISA must not be blanked by a silent row');
+      expect(delta.changed.single.upn, 'jane.doe@student.school.example');
+    });
+
+    test('a property Graph sends as null really is cleared', () async {
+      // Presence decides, not emptiness: this is how a cleared employeeId
+      // arrives, and it must not be mistaken for "the row said nothing".
+      final transport = walkOf(<Map<String, dynamic>>[
+        <String, dynamic>{'id': 'az1', 'employeeId': null},
+      ]);
+
+      final delta = await UserManager(clientWith(transport)).delta(
+        'T1',
+        'GBS',
+        known: const <String, AzureUser>{'az1': stored},
+      );
+
+      expect(delta.changed.single.employeeId, isNull);
+      expect(delta.changed.single.displayName, 'Jane Doe');
+    });
+
+    test('a sparse row moving someone out of our school is dropped', () async {
+      // The merge is not a way to keep everybody: judged whole, this record no
+      // longer belongs to us, so it leaves the changed set (and the connector
+      // stops carrying it).
+      final transport = walkOf(<Map<String, dynamic>>[
+        <String, dynamic>{'id': 'az1', 'companyName': 'OTHER'},
+      ]);
+
+      final delta = await UserManager(clientWith(transport)).delta(
+        'T1',
+        'GBS',
+        known: const <String, AzureUser>{'az1': stored},
+      );
+
+      expect(delta.changed, isEmpty);
+    });
+
+    test('a sparse row about a user we have never seen is still dropped',
+        () async {
+      // Nothing to merge it onto and nothing in it to classify it by. A
+      // genuinely new account arrives with its properties, so this only ever
+      // covers strangers.
+      final transport = walkOf(<Map<String, dynamic>>[
+        <String, dynamic>{'id': 'az-unknown', 'displayName': 'Someone Else'},
+      ]);
+
+      final delta = await UserManager(clientWith(transport)).delta('T1', 'GBS');
+
+      expect(delta.changed, isEmpty);
+    });
+  });
+
   group('getUser', () {
     test('returns the parsed user', () async {
       final transport =


### PR DESCRIPTION
Four issues in the session-startup / drift seam, chunked together because #288, #289 and #303 all land on the same reconcile pass that #287 restructures.

## What changed

- **#287 — a session starts from the shared synced state instead of forcing a sync.** `_relink()` is split into a link half and a persist half. New `adoptStoredState()` runs the link half alone: no pull, no `_persist()`, no generation bump, no `viewChanged`. The three screens now open via `openSession()` = `loadOverview()` + adoption, leaving `loadOverview()`'s passive contract and #275's idle explainer intact. Refusal to seed is one blocking `SharedStateNotice` (missing seed / no shared sync / moved settings fingerprint / a werkdatum that no longer matches today's resolved date — a null stored werkdatum is an absence, not a mismatch), replacing the "nog niet gesynchroniseerd" banner on Acties and Klasgroepen with a matching line on the Synchronisatie header. `pendingEntries` is now school-wide on the adopted view with no `openClassroom`, which is what #295 needs. Passwords reads `app.smartschool.snapshot` through a provider with an identity-guarded `refresh()`. Existing passive-session tests were retargeted to genuinely unseeded harnesses rather than relaxed.
- **#288 — hand-edits in O365 now survive a drift check.** `latestDeltaToken()` minted the token *without* `$select`, so every resumed `/users/delta` row came back as `{id, <changed props>}`. Such a row names no school, so the client-side prefix test dropped it — permanently, since the walk still advanced the token — and rows that did pass were upserted raw, blanking `upn` / `employeeId` / `displayName`. Fixed by adding `$select` to both the mint and the resume (verified against production Graph: a resume carrying `$select` returns 200, not 400), adding presence-based `AzureUser.mergeGraphJson` (an explicit `null` still clears), threading the previous user list into `UserManager.delta` as `known` so the school test judges the merged whole record, and letting `_adoptByEmployeeId` overwrite a differing record instead of skipping on object-id presence. Also corrected the delta-link lifetime in the comments: 7 days for `user`, not 30.
- **#289 — drill-down caches no longer keep the old generation when the materialized write fails.** The four session-derived caches (`_selectedClassroom`, `_expandedPath`, `_classroomAccounts`, `_groupDocs`) were cleared at the end of `_persist()`, *after* the awaited `writeMaterialized` — so a timed-out or thrown Cosmos write skipped them while `_linked` had already been swapped in `_relink()`. The four resets moved up into `_relink()` right after `_link()`; `adoptStoredState()`, which bumps no generation, is untouched.
- **#303 — a drift pass now ends the way a sync does.** (Follow-up filed by the #289 worker during this batch.) `checkDrift()` closes with its own terminal line via a `pass:` parameter on `_logSyncComplete`, and both `_relink()` and the unchanged-WISA shortcut drive `progress` to 1.0. The school-profile repair was resolved explicitly rather than copied: it follows the *pull*, not the pass, so only `checkDrift`'s WISA-pulling branch back-fills, while an ordinary drift pass deliberately leaves the document alone — documented in the method doc and pinned by a test.

## Test plan

Run per commit, each green on its own; figures below are at the branch tip:

- `dart format --set-exit-if-changed .` — clean (312 files, 0 changed)
- `dart analyze --fatal-infos --fatal-warnings` — clean over the workspace
- `dart test packages/*/test` — **1397 pass / 11 skipped** (live opt-ins, self-skipping)
- `flutter test` (account_manager) — **512 pass / 0 fail** (from 490 at branch point)
- `flutter test integration_test/app_launch_test.dart -d windows` — **109 pass / 0 fail**, one new end-to-end per issue

Every new test was verified failing against the unpatched code first: #287 by stubbing out `adoptStoredState`, #288 with the lib fix stashed, #289 with two regression tests plus an e2e, #303 with 6 unit tests and the e2e failing on the stashed controller change. Test fakes gained `StallingLinkedStore.healthyWrites` and `ReconcileHarness.resume(controllerStore:, persistTimeout:)`.

One #303 detail worth knowing: the completed progress bar is asserted at unit level only, because `_finish` clears the bar in the same frame it completes, so it is not observable end-to-end. The two user-visible halves — the closing log line and the healed Instellingen school name — are covered by the integration test.

Closes #287
Closes #288
Closes #289
Closes #303