### PR TITLE
Acties foundations: the decision becomes the unit of work

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2067,6 +2067,68 @@ void main() {
   });
 
   testWidgets(
+      'the Smartschool-namesake notice names the group\'s code end-to-end, it '
+      'does not diff it (#306)', (WidgetTester tester) async {
+    // The last bare-`before` field #305 left standing, in the real app. `2G` is
+    // a WISA class Smartschool already carries on a group that is not flagged
+    // official, so the app proposes no create and instead tells the operator to
+    // repair the group by hand — an informational notice that writes nothing
+    // (`canApply == false`). Under that heading its three fields read
+    //
+    //   name: 2G → 2G
+    //   code: G2G → ∅
+    //   officiële klas: nee → ja
+    //
+    // The outer two are the repair being asked for. The middle one is not a
+    // value moving at all: the code is how the operator finds the group in
+    // Smartschool, and through the before → after template it claims the notice
+    // clears it.
+    //
+    // End-to-end rather than on the action alone, because the line the operator
+    // reads is assembled across the whole path: the group dispatch's
+    // `ChangeSet`, the collapse of the notice and its "negeer deze klas" half
+    // into one either/or, the radio that decides whose fields are on screen, and
+    // only then `fieldChangeLine`. "No cleared field anywhere on this card" is
+    // also a claim about the page as composed — this tab renders the second
+    // namesake class and the two ordinary new classes beside it.
+    useTallWindow(tester);
+    final harness = namesakeClassChoiceHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+    expect(harness.controller.error, isNull);
+
+    final entry = find.byKey(const ValueKey('entry-group-2G'));
+    await tester.ensureVisible(entry);
+    await tester.tap(entry);
+    await tester.pumpAndSettle();
+
+    // The notice is the pre-selected half, and it states the code as a fact.
+    expect(
+      find.textContaining(
+          'Deze klas bestaat in Smartschool maar is geen officiële klas'),
+      findsWidgets,
+    );
+    expect(find.text('code: G2G'), findsOneWidget);
+
+    // The repair it *is* asking for still reads as the transition it is.
+    expect(find.text('officiële klas: nee → ja'), findsOneWidget);
+
+    // And nothing on this page claims a field is being emptied — least of all
+    // an action that cannot be applied.
+    expect(find.textContaining('→ ∅'), findsNothing,
+        reason: 'a notice that writes nothing clears nothing');
+    expect(harness.soap.soapActions.where((a) => a.endsWith('#saveClass')),
+        isEmpty,
+        reason: 'opening a card writes nothing');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'the badges count one pending item per either/or, so the Klasgroepen '
       'rollup agrees with the list the tab renders end-to-end (#251)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -15,6 +15,7 @@ import 'package:account_manager/src/screens/home_screen.dart';
 import 'package:account_manager/src/screens/passwords_screen.dart';
 import 'package:account_manager/src/screens/reconcile_screen.dart';
 import 'package:account_manager/src/screens/settings_screen.dart';
+import 'package:account_manager/src/screens/system_indicator.dart';
 import 'package:account_manager/src/shell/app_shell.dart';
 import 'package:account_state/account_state.dart'
     show
@@ -3162,6 +3163,111 @@ void main() {
   });
 
   testWidgets(
+      'a system cell means "work you can do on this screen": the class that '
+      'carries the Office 365 roster write says so, the students it diagnoses '
+      'do not, end-to-end (#298)', (WidgetTester tester) async {
+    // The real app, real fonts, real navigation, real rail. Same #245 fixture:
+    // every class exists in all three systems and is in sync with Smartschool,
+    // so the *only* work anywhere is the Azure roster — which is exactly the
+    // state that used to render three ticks and say nothing.
+    //
+    // Only a full-app run puts both halves of the rule on screen at once. The
+    // Klasgroepen cells are composed from the stored documents plus the live
+    // dispatch, the Acties cards from a second projection of that same
+    // dispatch, and the rule is that the two must disagree about who owns the
+    // write: the class does, the ~3000 students do not.
+    useTallWindow(tester);
+    final harness = azureClassMembershipHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+    expect(harness.controller.error, isNull);
+    expect(find.byType(ClassGroupsScreen), findsOneWidget);
+
+    SystemIndicatorState cellOf(String klas, Origin system) => tester
+        .widget<SystemIndicatorCell>(
+          find.byKey(ValueKey('class-cell-$klas-${system.name}')),
+        )
+        .state;
+
+    // `1A` is present in all three systems, so the old reading was three ticks.
+    // Under #298 the Office 365 cell carries the pending roster write while the
+    // other two stay green.
+    expect(cellOf('1A', Origin.wisa), SystemIndicatorState.inOrder);
+    expect(cellOf('1A', Origin.smartschool), SystemIndicatorState.inOrder);
+    expect(cellOf('1A', Origin.azure), SystemIndicatorState.needsWork);
+    expect(cellOf('1B', Origin.azure), SystemIndicatorState.needsWork);
+
+    // The three states are distinguishable without colour too — the icon
+    // changes shape, so a monochrome screenshot still reads.
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('class-cell-1A-azure')),
+        matching: find.byIcon(Icons.pending_outlined),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('class-cell-1A-wisa')),
+        matching: find.byIcon(Icons.check_circle_outline),
+      ),
+      findsOneWidget,
+    );
+
+    // And the row's own line names the system it writes to, so the cell and the
+    // card agree instead of the operator having to infer it from a group name.
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('class-row-1A')),
+        matching: find.text('Office 365 ·'),
+      ),
+      findsOneWidget,
+    );
+
+    // The students the same fact is reported on are informational only, so
+    // nothing over on Acties turns orange for them: their cards still carry the
+    // diagnosis, marked "(manueel)", and raise no applyable work at all.
+    await tester.tap(find.text('Acties'));
+    await tester.pumpAndSettle();
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    await tester.ensureVisible(toggle);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
+    await tester.ensureVisible(yearNode);
+    await tester.tap(yearNode);
+    await tester.pumpAndSettle();
+    final classNode = find.byKey(const ValueKey('rollup-class-class|1|1|1A'));
+    await tester.ensureVisible(classNode);
+    await tester.tap(classNode);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Jane Doe'), findsOneWidget);
+    expect(
+      find.textContaining('Ontbreekt in de Office 365-klasgroep GBS-1A'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('(manueel)'), findsWidgets);
+    final studentWork = harness.controller.pendingEntries
+        .where((e) => e.family == 'student')
+        .expand(workSystemsOfEntry)
+        .toList();
+    expect(
+      studentWork,
+      isEmpty,
+      reason: 'Office 365 class membership is a property of the group, so the '
+          'write is one per class on Klasgroepen — colouring it per student '
+          'would paint the whole school orange at the rollover',
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'a passive session marks the same informational candidate "(manueel)" on '
       'the account card end-to-end (#255)', (WidgetTester tester) async {
     // The same #245 fixture, read the way most operators meet it: session 1
@@ -3930,10 +4036,22 @@ void main() {
     // claim on Office 365.
     await tester.tap(moveBulk);
     await tester.pumpAndSettle();
-    expect(find.textContaining('3 wijzigingen'), findsOneWidget);
-    expect(find.textContaining('Office 365'), findsNothing,
-        reason: "summing every decision on every card would quote Sam's "
-            'rename and then not write it');
+    // Scoped to the dialog: since #298 the cards behind it lead each line with
+    // the system it writes to, so Sam's rename puts "Office 365 ·" on screen —
+    // which is the point of that issue and says nothing about this pass.
+    final confirmation = find.byType(AlertDialog);
+    expect(
+      find.descendant(
+          of: confirmation, matching: find.textContaining('3 wijzigingen')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: confirmation, matching: find.textContaining('Office 365')),
+      findsNothing,
+      reason: "summing every decision on every card would quote Sam's "
+          'rename and then not write it',
+    );
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2676,6 +2676,76 @@ void main() {
   });
 
   testWidgets(
+      'an expanded card states its summary once and its member counts as '
+      'counts end-to-end (#300)', (WidgetTester tester) async {
+    // The reported card, in the real app: `1A` exists everywhere and carries
+    // one decision, the Office 365 roster write. It read
+    //
+    //   Werk het ledenbestand van GBS-1A bij (1 toevoegen, 1 verwijderen)
+    //   **Werk het ledenbestand van GBS-1A bij (1 toevoegen, 1 verwijderen)**
+    //   leden toevoegen: ∅ → 1
+    //   leden verwijderen: ∅ → 1
+    //
+    // — the collapsed preview and the #281 decision heading saying the same
+    // sentence one line apart, and two quantities pushed through the
+    // before/after diff template.
+    //
+    // Asserted end-to-end rather than on the widget alone, because both halves
+    // are claims about *composition*. "Once" is a count over the whole card as
+    // the inventory builds it, and this tab also renders a same-situation bulk
+    // header carrying that identical summary — a widget test scoped to one row
+    // cannot see that the page as a whole still reads correctly. And the count
+    // shape starts in the dispatch's `ChangeSet`, travels through the
+    // alternative collapse, and only becomes a line of text in the tile.
+    useTallWindow(tester);
+    final harness = azureClassMembershipHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+    expect(harness.controller.error, isNull);
+
+    const String summary =
+        'Werk het ledenbestand van GBS-1A bij (1 toevoegen, 1 verwijderen)';
+    final Finder row = find.byKey(const ValueKey('class-row-1A'));
+    expect(
+        find.descendant(of: row, matching: find.text(summary)), findsOneWidget);
+
+    final Finder tile = find.byKey(const ValueKey('entry-group-1A'));
+    await tester.ensureVisible(tile);
+    await tester.tap(tile);
+    await tester.pumpAndSettle();
+
+    // Once, still — the decision's heading replaced the preview instead of
+    // joining it, and it is the heading that stayed: it groups the diff under
+    // it and it still names the system the write lands in (#281/#298).
+    expect(
+      find.descendant(of: row, matching: find.text(summary)),
+      findsOneWidget,
+      reason: 'the card said it twice, one line above the other',
+    );
+    final Finder block = find.byKey(const ValueKey('entry-choice-group-1A-0'));
+    expect(find.descendant(of: block, matching: find.text(summary)),
+        findsOneWidget);
+    expect(find.descendant(of: block, matching: find.text('Office 365 ·')),
+        findsOneWidget);
+
+    // The numbers under it read as the quantities they are.
+    expect(
+        find.descendant(of: block, matching: find.text('leden toevoegen: 1')),
+        findsOneWidget);
+    expect(
+        find.descendant(of: block, matching: find.text('leden verwijderen: 1')),
+        findsOneWidget);
+    expect(find.textContaining('∅ →'), findsNothing,
+        reason: 'a count is not a field whose old value was empty');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'an Office 365 group Graph already holds under our address is adopted, '
       'and the create stops being offered end-to-end (#280)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -373,6 +373,22 @@ void main() {
       ),
       findsOneWidget,
     );
+    // The header states the workload and stops there (#294): the global
+    // "Dry-run alles" / "Alles toepassen" pair that wrote every account in the
+    // school off one dialog is gone, and nothing on the overview replaces it.
+    // Whatever the operator applies, they reach by opening it first.
+    expect(
+      find.descendant(
+        of: find.byType(ActionsScreen),
+        matching: find.textContaining('openstaande actie(s)'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('actions-dry-run')), findsNothing);
+    expect(find.byKey(const ValueKey('actions-apply')), findsNothing);
+    expect(find.text('Dry-run alles'), findsNothing);
+    expect(find.text('Alles toepassen'), findsNothing);
+
     await tester.tap(find.text('Jaar 3'));
     await tester.pumpAndSettle();
     await tester.ensureVisible(find.text('3C'));
@@ -380,16 +396,22 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Wijzig de klas in Smartschool'), findsWidgets);
 
-    // Dry-run all from the header: the projected changes render, nothing writes.
-    await tester.ensureVisible(find.byKey(const ValueKey('actions-dry-run')));
-    await tester.tap(find.byKey(const ValueKey('actions-dry-run')));
+    // Open the one account in 3C and dry-run it: the projected changes render,
+    // nothing writes.
+    final String id =
+        harness.controller.classroomPendingEntries.single.targetId;
+    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(ValueKey('entry-dry-run-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-dry-run-$id')));
     await tester.pumpAndSettle();
     expect(find.text('Resultaat van de dry-run'), findsOneWidget);
     expect(harness.soap.soapActions, isEmpty);
 
-    // Apply all: confirm the dialog, the Smartschool write happens for real.
-    await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
-    await tester.tap(find.byKey(const ValueKey('actions-apply')));
+    // Apply it: confirm the dialog, the Smartschool write happens for real.
+    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
@@ -624,6 +646,30 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  /// Drills the Actions overview into the leaver bucket, where the two departed
+  /// students of [twoDepartedHarness] sit as a single cohort.
+  Future<void> drillZonderKlas(WidgetTester tester) async {
+    await tester.tap(find.text('Niet toegewezen'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('Zonder klas'));
+    await tester.tap(find.text('Zonder klas'));
+    await tester.pumpAndSettle();
+  }
+
+  /// Presses the open classroom's one cohort header — the bulk apply that
+  /// stands where the header's global "Alles toepassen" used to (#294). The
+  /// cohort is on screen above the button, which is the whole difference.
+  Future<void> tapCohortApply(
+    WidgetTester tester,
+    ReconcileHarness harness,
+  ) async {
+    final String key = harness.controller.classroomPendingSituations.single.key;
+    final Finder bulk = find.byKey(ValueKey('situation-apply-$key'));
+    await tester.ensureVisible(bulk);
+    await tester.tap(bulk);
+    await tester.pumpAndSettle();
+  }
+
   /// Opens the Klasgroepen tab from the navigation rail (#227). The class
   /// inventory is a destination of its own now, not a node inside Acties.
   Future<void> openKlasgroepen(WidgetTester tester) async {
@@ -672,13 +718,12 @@ void main() {
     ));
     await tester.pumpAndSettle();
     await syncThenOpenActions(tester);
+    await drillZonderKlas(tester);
 
     // Idle: no dialog.
     expect(progressDialog, findsNothing);
 
-    await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
-    await tester.tap(find.byKey(const ValueKey('actions-apply')));
-    await tester.pumpAndSettle();
+    await tapCohortApply(tester, harness);
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
@@ -741,10 +786,9 @@ void main() {
     ));
     await tester.pumpAndSettle();
     await syncThenOpenActions(tester);
+    await drillZonderKlas(tester);
 
-    await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
-    await tester.tap(find.byKey(const ValueKey('actions-apply')));
-    await tester.pumpAndSettle();
+    await tapCohortApply(tester, harness);
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
     expect(progressDialog, findsOneWidget);
@@ -760,7 +804,8 @@ void main() {
       reason: 'the failure is reported on the page, not behind a stuck modal',
     );
     // The app is usable again: the affordances are live and reachable.
-    await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
+    final String key = harness.controller.classroomPendingSituations.single.key;
+    await tester.ensureVisible(find.byKey(ValueKey('situation-apply-$key')));
     expect(tester.takeException(), isNull);
   });
 
@@ -1365,10 +1410,15 @@ void main() {
     expect(find.byKey(ValueKey('entry-student-${entry.targetId}')),
         findsOneWidget);
 
-    // Apply all: the Smartschool departure writes against the recording SOAP
-    // transport; Azure (Graph) is never called.
-    await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
-    await tester.tap(find.byKey(const ValueKey('actions-apply')));
+    // Apply the row: the Smartschool departure writes against the recording
+    // SOAP transport; Azure (Graph) is never called.
+    await tester
+        .ensureVisible(find.byKey(ValueKey('entry-student-${entry.targetId}')));
+    await tester.tap(find.byKey(ValueKey('entry-student-${entry.targetId}')));
+    await tester.pumpAndSettle();
+    await tester
+        .ensureVisible(find.byKey(ValueKey('entry-apply-${entry.targetId}')));
+    await tester.tap(find.byKey(ValueKey('entry-apply-${entry.targetId}')));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
@@ -5092,10 +5142,15 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Maak een nieuw Smartschool account'), findsWidgets);
 
-    // Apply all for real (against the recording SOAP transport): the create runs
-    // and its minted password is captured into the shared queue.
-    await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
-    await tester.tap(find.byKey(const ValueKey('actions-apply')));
+    // Apply the row for real (against the recording SOAP transport): the create
+    // runs and its minted password is captured into the shared queue.
+    final String createId =
+        harness.controller.classroomPendingEntries.single.targetId;
+    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$createId')));
+    await tester.tap(find.byKey(ValueKey('entry-student-$createId')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$createId')));
+    await tester.tap(find.byKey(ValueKey('entry-apply-$createId')));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3130,6 +3130,74 @@ void main() {
   });
 
   testWidgets(
+      'the "laat de groep staan" notice states its facts end-to-end, it does '
+      'not diff them (#305)', (WidgetTester tester) async {
+    // The reported card, in the real app. `GBS-9Z` is the group of a class that
+    // stopped running, still holding its 21 members, and the pre-selected half
+    // of its either/or is the notice that leaves it alone. It read
+    //
+    //   Laat de Office 365-groep GBS-9Z staan — klas 9Z bestaat niet meer …
+    //   mail: GBS-9Z@student.school.example → ∅
+    //   leden: 21 → ∅
+    //
+    // — a heading promising the group stays, over two lines saying its address
+    // and its 21 members are going away. That is what the *other* radio does,
+    // and it is the reading a bulk pass would run.
+    //
+    // End-to-end rather than on the widget alone, because the shape has to
+    // survive the whole path the operator's card is built from: the group
+    // dispatch's `ChangeSet`, the alternative collapse into one choice, the
+    // radio that swaps which option's fields are on screen, and only then a
+    // line of text in the tile. And "no arrow anywhere" is a claim about the
+    // page as composed — this tab also renders a same-situation bulk header
+    // over the two stale groups, which a row-scoped widget test cannot see.
+    useTallWindow(tester);
+    final harness = staleClassGroupHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+    expect(harness.controller.error, isNull);
+
+    final entry = find.byKey(const ValueKey('entry-group-GBS-9Z'));
+    await tester.ensureVisible(entry);
+    await tester.tap(entry);
+    await tester.pumpAndSettle();
+
+    // The default half is the notice, and under its heading are two facts.
+    expect(
+      find.text('Laat de Office 365-groep GBS-9Z staan — klas 9Z bestaat niet '
+          'meer in WISA of Smartschool'),
+      findsWidgets,
+    );
+    expect(find.text('mail: GBS-9Z@student.school.example'), findsOneWidget);
+    expect(find.text('leden: 21'), findsOneWidget);
+    expect(find.textContaining('→ ∅'), findsNothing,
+        reason: 'the option that writes nothing clears nothing — and no other '
+            'card on this page diffs against an empty half either');
+
+    // Flip to the delete and the same two facts are the inventory of what goes,
+    // joined by the consequence that was never a field value at all.
+    final delete =
+        find.byKey(const ValueKey('alt-GBS-9Z-DeleteAzureClassGroup'));
+    await tester.ensureVisible(delete);
+    await tester.tap(delete);
+    await tester.pumpAndSettle();
+
+    expect(find.text('mail: GBS-9Z@student.school.example'), findsOneWidget);
+    expect(find.text('leden: 21'), findsOneWidget);
+    expect(find.text('postvak, Teams en bestanden: verdwijnen mee'),
+        findsOneWidget);
+    expect(find.textContaining('→ ∅'), findsNothing);
+    expect(harness.graph.deletedGroups, isEmpty,
+        reason: 'picking a radio writes nothing on its own');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       "a student's Office 365 class group is reported on their own account "
       'end-to-end, pointing at the one class-level write (#245)',
       (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1849,9 +1849,10 @@ void main() {
         findsNothing);
 
     // The bulk header offers the one resolution for both classes.
-    final key = harness.controller.groupPendingEntries
-        .firstWhere((e) => e.targetId == '1A')
-        .situationKey;
+    final key = harness.controller.groupPendingSituations
+        .firstWhere((c) => c.label.startsWith('Voeg deze klas toe aan '
+            'Smartschool'))
+        .key;
     final bulk = find.byKey(ValueKey('situation-apply-$key'));
     await tester.ensureVisible(bulk);
     expect(
@@ -1936,15 +1937,18 @@ void main() {
         reason: 'the opt-out is an alternative to pick, never a to-do that '
             'also runs');
 
-    // The namesake classes form a bulk subset of their own. Pooling them with
+    // The namesake classes form a bulk cohort of their own. Pooling them with
     // the new classes would have filed them under a header offering to create
     // classes that already exist.
-    final namesakeKey = harness.controller.groupPendingEntries
-        .firstWhere((e) => e.targetId == '2G')
-        .situationKey;
-    final newKey = harness.controller.groupPendingEntries
-        .firstWhere((e) => e.targetId == '1A')
-        .situationKey;
+    final cohorts = harness.controller.groupPendingSituations;
+    final namesakeKey = cohorts
+        .firstWhere((c) => c.label.startsWith('Deze klas bestaat in '
+            'Smartschool'))
+        .key;
+    final newKey = cohorts
+        .firstWhere((c) => c.label.startsWith('Voeg deze klas toe aan '
+            'Smartschool'))
+        .key;
     expect(namesakeKey, isNot(newKey));
 
     final namesakeBulk = find.byKey(ValueKey('situation-apply-$namesakeKey'));
@@ -1956,27 +1960,25 @@ void main() {
       reason: 'the header names one either/or led by the hand-fix notice',
     );
 
-    // Run that whole subset. It is not a no-op — each class still needs its
-    // Office 365 group (#228), which is a decision of its own — but nothing it
-    // writes touches the class's import: no Smartschool class is created, and
-    // no DontImportClass rule is written.
+    // And it offers nothing to run, out loud. Since #292 the cohort is that one
+    // decision rather than the whole card, and that decision's pre-selected
+    // resolution is a hand repair the app cannot perform — so the button counts
+    // zero and is dead. Under the old grouping it was live, because the classes
+    // also need an Office 365 group (#228): pressing a header that said "this
+    // class is already there" wrote something else entirely.
     final pulls = harness.wisaSyncs;
-    await tester.tap(namesakeBulk);
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-    await tester.pumpAndSettle();
-
     expect(
-      harness.controller.applyResults!.map((r) => r.changes.summary),
-      isNot(contains('Negeer deze klas bij het importeren uit WISA')),
-      reason: 'the rule would drop the classes the app just said to repair',
+      find.descendant(
+          of: namesakeBulk,
+          matching: find.text('Alles toepassen '
+              '(0)')),
+      findsOneWidget,
     );
+    expect(tester.widget<FilledButton>(namesakeBulk).onPressed, isNull,
+        reason: 'nothing to write means nothing to press');
     expect(harness.soap.soapActions.where((a) => a.endsWith('#saveClass')),
         isEmpty,
         reason: 'Smartschool already holds 2G and 2H');
-    // A DontImportClass rule re-pulls WISA, so an untouched pull count is the
-    // proof that none was written.
-    expect(harness.wisaSyncs, pulls);
 
     // The two classes are still on the list, still asking for the hand repair.
     for (final id in const ['2G', '2H']) {
@@ -1990,7 +1992,7 @@ void main() {
       );
     }
 
-    // And the fix did not simply silence the list: the other subset still
+    // And the fix did not simply silence the list: the other cohort still
     // creates the genuinely new classes, and blacklists neither.
     final newBulk = find.byKey(ValueKey('situation-apply-$newKey'));
     await tester.ensureVisible(newBulk);
@@ -2000,11 +2002,15 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(harness.soap.soapActions.where((a) => a.endsWith('#saveClass')),
-        hasLength(2));
+        hasLength(2),
+        reason: '1A and 1B are created; 2G and 2H are not touched');
     expect(
       harness.controller.applyResults!.map((r) => r.changes.summary),
       isNot(contains('Negeer deze klas bij het importeren uit WISA')),
+      reason: 'the rule would drop the classes the app just said to repair',
     );
+    // A DontImportClass rule re-pulls WISA, so an untouched pull count is the
+    // proof that none was written.
     expect(harness.wisaSyncs, pulls);
     expect(tester.takeException(), isNull);
   });
@@ -3761,7 +3767,7 @@ void main() {
     expect(find.text('Tom Tas'), findsNothing,
         reason: 'the operator is looking at 3C — Tom is not on this page');
 
-    final key = harness.controller.classroomPendingEntries.first.situationKey;
+    final key = harness.controller.classroomPendingSituations.single.key;
     final bulk = find.byKey(ValueKey('situation-apply-$key'));
     await tester.ensureVisible(bulk);
     // The header line the count sits on is Dutch, like the rest of the screen
@@ -3806,6 +3812,100 @@ void main() {
     expect(klas3C, findsNothing, reason: 'the class the operator cleared');
     expect(
         find.descendant(of: klas3D, matching: find.text('1')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'a bulk apply covers one decision everywhere it occurs, and writes '
+      'nothing else on the cards it touches end-to-end (#292)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation, over the real Smartschool and
+    // Graph write paths. The September rollover in miniature: three students
+    // moved up into `4A` while Smartschool still has all three in last year's
+    // `3C`, so every one of them needs the same class change — and one of them,
+    // Sam, also has a stale Office 365 display name.
+    //
+    // Both halves of the defect are only visible here. The header's cohort is
+    // built by the controller, rendered by the shared tile library and scoped by
+    // the drill-down, and what the button behind it writes is decided a fourth
+    // place again: the old grouping keyed on the family plus the sorted set of
+    // *every* decision on a card, so Sam fell into a subset of his own and the
+    // operator read "2 accounts in dezelfde situatie" for work that three
+    // students needed. Pressing the other header then wrote Sam's Office 365
+    // rename along with his class change, under a label that named neither.
+    useTallWindow(tester);
+    final harness = rolloverHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    expect(harness.controller.error, isNull);
+
+    // Drill into 4A, where all three students now belong.
+    final jaar4 = find.byKey(const ValueKey('rollup-grade-grades|4'));
+    await tester.ensureVisible(jaar4);
+    await tester.tap(jaar4);
+    await tester.pumpAndSettle();
+    final klas4A = find.byKey(const ValueKey('rollup-class-class|1|4|4A'));
+    await tester.ensureVisible(klas4A);
+    await tester.tap(klas4A);
+    await tester.pumpAndSettle();
+    expect(harness.controller.selectedClassroom?.classroom, '4A');
+
+    // One header for the class change, and it counts all three — Sam included,
+    // whatever else his card carries.
+    expect(
+      find.text('Wijzig de klas in Smartschool — 3 accounts in dezelfde '
+          'situatie'),
+      findsOneWidget,
+    );
+    final moveKey = harness.controller.classroomPendingSituations
+        .firstWhere((c) => c.label == 'Wijzig de klas in Smartschool')
+        .key;
+    final moveBulk = find.byKey(ValueKey('situation-apply-$moveKey'));
+    await tester.ensureVisible(moveBulk);
+    expect(
+      find.descendant(of: moveBulk, matching: find.text('Alles toepassen (3)')),
+      findsOneWidget,
+    );
+    // Sam's second decision is on his card, and gets no bulk header of its own:
+    // he is the only student who needs it.
+    expect(find.text('Wijzig de naam in Azure'), findsOneWidget);
+    expect(find.textContaining('Wijzig de naam in Azure — '), findsNothing);
+
+    // The confirmation names the one decision: three Smartschool writes, and no
+    // claim on Office 365.
+    await tester.tap(moveBulk);
+    await tester.pumpAndSettle();
+    expect(find.textContaining('3 wijzigingen'), findsOneWidget);
+    expect(find.textContaining('Office 365'), findsNothing,
+        reason: "summing every decision on every card would quote Sam's "
+            'rename and then not write it');
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    // Three class moves in Smartschool…
+    expect(
+      harness.soap.soapActions.where((a) => a.endsWith('#saveUserToClass')),
+      hasLength(3),
+      reason: 'one pass covered the whole class, Sam included',
+    );
+    expect(
+      harness.controller.applyResults!.map((r) => r.changes.summary),
+      everyElement('Wijzig de klas in Smartschool'),
+    );
+    // …and not a single Office 365 write. Sam's rename is a decision the
+    // operator never pressed.
+    expect(
+      harness.graph.requests.where((r) => r.method == 'PATCH'),
+      isEmpty,
+      reason: 'the bulk pass wrote the decision on the header and no other',
+    );
+    // It is still his to make, still on the screen.
+    expect(find.text('Wijzig de naam in Azure'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 
@@ -8648,7 +8748,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // The bulk header offers the one resolution for both hires.
-    final key = entries.first.situationKey;
+    final key = harness.controller.classroomPendingSituations.single.key;
     final bulk = find.byKey(ValueKey('situation-apply-$key'));
     await tester.ensureVisible(bulk);
     expect(

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -185,10 +185,10 @@ class PendingActionOption {
 /// dialog (#234).
 ///
 /// Built by [ReconcileController.applyScope] from the **selected**, applyable
-/// option of each choice — exactly the actions `applyAll` / `applyEntries` /
-/// `applyEntry` would run — so the dialog names the systems the pass genuinely
-/// reaches instead of the hard-coded "Smartschool and Azure AD" it used to
-/// claim for every action.
+/// option of each choice — exactly the actions `applyEntries` / `applyEntry`
+/// would run — so the dialog names the systems the pass genuinely reaches
+/// instead of the hard-coded "Smartschool and Azure AD" it used to claim for
+/// every action.
 class ApplyScope {
   const ApplyScope({required this.systems, required this.chained});
 
@@ -1794,7 +1794,7 @@ class ReconcileController extends ChangeNotifier {
 
   /// What a confirmed apply of [entries] would actually write (#234) — the
   /// systems the apply-confirmation dialog names, derived from the very options
-  /// [applyAll] / [applyEntries] / [applyEntry] would run.
+  /// [applyEntries] / [applyEntry] would run.
   ///
   /// Pass the confirmation dialog the *same* list the pass will run over
   /// (#252): the dialog and the write agreeing is the whole point of building
@@ -2373,16 +2373,12 @@ class ReconcileController extends ChangeNotifier {
     }
   }
 
-  /// Dry-runs the chosen resolution of **every** pending entry (PAIN-3): the
-  /// full apply path, zero writes. Results land in [dryRunResults].
-  Future<void> dryRun() => dryRunEntries(pendingEntries);
-
-  /// Applies the chosen resolution of every pending entry for real, refreshing
-  /// the linked view from the State layer's incremental patches as it goes.
-  /// Only the **selected** alternative of each choice runs — a departed student
-  /// is unregistered *or* deleted, never both (#110). Results land in
-  /// [applyResults].
-  Future<void> applyAll() => applyEntries(pendingEntries);
+  // There is deliberately no `applyAll` / `dryRun` over the whole linked view
+  // (#294). Every pass starts from a list the operator is looking at: one card
+  // ([applyEntry]), one decision across its cohort ([applyDecisions]), or a
+  // scoped selection ([applyEntries]). A method that took "everything pending"
+  // existed only to serve a header button that wrote every account in the
+  // school on the strength of a dialog nobody could verify.
 
   /// Dry-runs one entry's chosen resolution (#110): the per-row preview.
   Future<void> dryRunEntry(PendingAccountEntry entry) =>
@@ -2441,8 +2437,8 @@ class ReconcileController extends ChangeNotifier {
       _run(decisions, dry: true);
 
   /// Runs the selected, applyable option of every decision in [decisions]
-  /// through the apply path (dry or real). Shared by the global, per-entry, and
-  /// per-cohort affordances so all three behave identically (#110). Each option
+  /// through the apply path (dry or real). Shared by the per-entry and
+  /// per-cohort affordances so both behave identically (#110). Each option
   /// is bound to its own target; on a real write the applier patches the
   /// snapshot and returns a fresh linked view we adopt as the pass proceeds.
   ///

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -281,6 +281,13 @@ class PendingChoice {
   /// so two departed students share one bulk-apply subset, and — since #283 —
   /// routes a pass's verdict back to the decision it is the verdict of.
   String get situationId => alternatives.first.situationId;
+
+  /// A short human description of *this* decision (#292): both sides of an
+  /// either/or, or the lone action's summary. What a [SituationCohort] leads
+  /// with, so the header names the one decision it applies and nothing else.
+  String get situationLabel => isChoice
+      ? alternatives.map((a) => a.changes.summary).join(' / ')
+      : selected.changes.summary;
 }
 
 /// The pending actions for **one** linked account, staff member, or class group
@@ -305,24 +312,73 @@ class PendingAccountEntry {
   /// The decision points for this target, in dispatch order.
   final List<PendingChoice> choices;
 
-  /// A stable signature of this entry's *situation* — its family plus the sorted
-  /// set of its choices' [PendingChoice.situationId]. Two entries with the same
-  /// key are "in the same situation", so a bulk apply can act on the subset.
-  String get situationKey {
-    final ids = choices.map((c) => c.situationId).toList()..sort();
-    return '$family|${ids.join(',')}';
-  }
-
-  /// A short human description of the situation (the choices' summaries), used as
-  /// the header of a same-situation subset.
-  String get situationLabel => choices.map((c) {
-        if (!c.isChoice) return c.selected.changes.summary;
-        return c.alternatives.map((a) => a.changes.summary).join(' / ');
-      }).join('; ');
-
   /// Whether an apply pass would write anything for this entry — at least one
   /// selected option is applyable.
   bool get canApply => choices.any((c) => c.selected.canApply);
+}
+
+/// One account's stake in one decision (#292): the card the decision sits on,
+/// and the decision itself. The unit of work every bulk affordance acts on.
+///
+/// Both halves, because neither is enough on its own. The [choice] is what a
+/// pass runs and what a cohort is keyed by; the [entry] is what the pass owes
+/// the shared store afterwards (`_shareApplied` patches *targets*, and a choice
+/// carries only a display label) and what the operator is shown.
+class PendingDecision {
+  const PendingDecision({required this.entry, required this.choice});
+
+  /// The card this decision was raised on.
+  final PendingAccountEntry entry;
+
+  /// The decision itself, with its alternatives and the operator's pick.
+  final PendingChoice choice;
+
+  /// The decision's identity, by the same rule everything else keys on.
+  String get situationId => choice.situationId;
+
+  /// Whether an apply pass would write anything for **this decision** — the
+  /// selected alternative is applyable. Deliberately not
+  /// [PendingAccountEntry.canApply], which answers for the whole card: a
+  /// namesake class whose import decision is a hand-fix notice still has an
+  /// applyable Office 365 group decision beside it, and a cohort of the former
+  /// must not count itself as work.
+  bool get canApply => choice.selected.canApply;
+}
+
+/// Every account that raises one and the same decision (#292) — the subset a
+/// bulk apply of that decision covers.
+///
+/// The cohort replaces the "same combination of decisions" grouping that keyed
+/// on the family plus the sorted set of *every* decision on a card. Two students
+/// who both need their class changed in Smartschool landed in different subsets
+/// the moment one of them also needed an email fix, so the one operation the app
+/// exists for at the September rollover — every student changes class — was
+/// fragmented hardest of all. One decision, one cohort; a card with three
+/// decisions appears in three of them.
+class SituationCohort {
+  const SituationCohort({required this.key, required this.decisions})
+      : assert(decisions.length > 0);
+
+  /// The cohort's identity — the family plus the [PendingChoice.situationId] it
+  /// groups. Family included because a situation is only unique within one: the
+  /// three dispatchers name their action classes independently.
+  final String key;
+
+  /// The accounts raising this decision, in first-seen order.
+  final List<PendingDecision> decisions;
+
+  /// How many accounts are in the cohort.
+  int get length => decisions.length;
+
+  /// What this decision reads as — both sides of an either/or, or the lone
+  /// action's summary. Taken off the first member because every member of a
+  /// cohort answers the same question.
+  String get label => decisions.first.choice.situationLabel;
+
+  /// How many of them a bulk apply would actually write — the count the "Alles
+  /// toepassen (n)" button quotes. Zero for a cohort of informational notices,
+  /// which is what disables the button.
+  int get applyableCount => decisions.where((d) => d.canApply).length;
 }
 
 /// One colliding Smartschool account inside a [DuplicateMailWarning] (#109),
@@ -903,28 +959,60 @@ class ReconcileController extends ChangeNotifier {
     return entries;
   }
 
-  /// The pending entries grouped into "same situation" subsets (#110), in
-  /// first-seen order. Each subset shares a [PendingAccountEntry.situationKey],
-  /// so it can be bulk-applied ("apply this resolution to all departed
-  /// students") while each entry keeps its own chosen alternative.
-  List<List<PendingAccountEntry>> get pendingSituations =>
-      _groupSituations(pendingEntries);
+  /// The pending entries grouped into "same situation" cohorts (#110/#292), in
+  /// first-seen order. Each cohort is **one** decision and every account that
+  /// raises it, so it can be bulk-applied ("unregister every departed student")
+  /// while each account keeps its own chosen alternative.
+  List<SituationCohort> get pendingSituations =>
+      situationCohorts(pendingEntries);
 
-  /// Groups [entries] into "same situation" subsets in first-seen order — the
+  /// Groups the decisions of [entries] into cohorts in first-seen order — the
   /// shared grouping the global list and the per-classroom / per-group
-  /// drill-downs all use (#110/#154).
-  static List<List<PendingAccountEntry>> _groupSituations(
+  /// drill-downs all use (#110/#154/#292).
+  ///
+  /// Public and static because a screen must be able to group the list it is
+  /// *showing* rather than read a cohort off the controller and hope the two
+  /// agree: the Personeel search narrows the classroom list, the Klasgroepen
+  /// search narrows the inventory, and #252 is precisely what happens when a
+  /// bulk button's cohort is resolved anywhere other than the rows on screen.
+  ///
+  /// One entry contributes one member per decision it carries, so an account
+  /// with three decisions is in three cohorts. Non-applyable decisions stay in:
+  /// they are part of the situation, they are counted in the header's "n
+  /// accounts", and [SituationCohort.applyableCount] — not the length — is what
+  /// the apply button quotes and is gated on.
+  static List<SituationCohort> situationCohorts(
     List<PendingAccountEntry> entries,
   ) {
     final order = <String>[];
-    final bySituation = <String, List<PendingAccountEntry>>{};
+    final byKey = <String, List<PendingDecision>>{};
     for (final e in entries) {
-      final key = e.situationKey;
-      if (!bySituation.containsKey(key)) order.add(key);
-      (bySituation[key] ??= <PendingAccountEntry>[]).add(e);
+      for (final c in e.choices) {
+        final key = '${e.family}|${c.situationId}';
+        if (!byKey.containsKey(key)) order.add(key);
+        (byKey[key] ??= <PendingDecision>[])
+            .add(PendingDecision(entry: e, choice: c));
+      }
     }
-    return [for (final key in order) bySituation[key]!];
+    return [
+      for (final key in order)
+        SituationCohort(key: key, decisions: byKey[key]!),
+    ];
   }
+
+  /// Every decision of [entries], in dispatch order — the whole-card reading of
+  /// the same list a cohort holds one decision of (#292).
+  ///
+  /// What the "do everything on this account" affordances run through, so the
+  /// per-card apply and the per-decision apply share one pass rather than two
+  /// that can drift apart.
+  static List<PendingDecision> decisionsOf(
+    Iterable<PendingAccountEntry> entries,
+  ) =>
+      <PendingDecision>[
+        for (final e in entries)
+          for (final c in e.choices) PendingDecision(entry: e, choice: c),
+      ];
 
   /// The live pending entries for the accounts of the currently-open classroom
   /// (#154): the interactive tiles the Actions drill-down builds for one class,
@@ -940,10 +1028,10 @@ class ReconcileController extends ChangeNotifier {
     ];
   }
 
-  /// [classroomPendingEntries] grouped into same-situation subsets, so the
+  /// [classroomPendingEntries] grouped into same-situation cohorts, so the
   /// per-class list keeps the bulk-apply affordance of the old flat list (#154).
-  List<List<PendingAccountEntry>> get classroomPendingSituations =>
-      _groupSituations(classroomPendingEntries);
+  List<SituationCohort> get classroomPendingSituations =>
+      situationCohorts(classroomPendingEntries);
 
   /// The live group ("Klasgroepen") pending entries (#154): the interactive
   /// tiles the group drill-down builds. Empty in a passive session.
@@ -955,9 +1043,9 @@ class ReconcileController extends ChangeNotifier {
     ];
   }
 
-  /// [groupPendingEntries] grouped into same-situation subsets (#154).
-  List<List<PendingAccountEntry>> get groupPendingSituations =>
-      _groupSituations(groupPendingEntries);
+  /// [groupPendingEntries] grouped into same-situation cohorts (#154).
+  List<SituationCohort> get groupPendingSituations =>
+      situationCohorts(groupPendingEntries);
 
   /// The count shown in the Actions header (#154): the live entry count in an
   /// active session, or the summed top-level rollup pending counts in a passive
@@ -1701,7 +1789,8 @@ class ReconcileController extends ChangeNotifier {
   /// **selected** applyable option of each choice (#110). A departed student
   /// counts once (the chosen resolution), not twice, and the informational group
   /// actions are excluded.
-  int get applyableCount => _selectedActions(pendingEntries).length;
+  int get applyableCount =>
+      _selectedActions(decisionsOf(pendingEntries)).length;
 
   /// What a confirmed apply of [entries] would actually write (#234) — the
   /// systems the apply-confirmation dialog names, derived from the very options
@@ -1719,8 +1808,19 @@ class ReconcileController extends ChangeNotifier {
   /// the visible action never names. The follow-up cannot be counted, because
   /// its own `evaluate` decides at apply time whether it runs at all; it can
   /// only be named.
-  ApplyScope applyScope(Iterable<PendingAccountEntry> entries) {
-    final selected = _selectedActions(entries);
+  ApplyScope applyScope(Iterable<PendingAccountEntry> entries) =>
+      applyScopeForDecisions(decisionsOf(entries));
+
+  /// What a confirmed apply of [decisions] would write — [applyScope] narrowed
+  /// to the decision, which is what a cohort's confirmation dialog needs (#292).
+  ///
+  /// Summing every decision of every card in the cohort over-claims, and
+  /// visibly: "apply the class change to these 14 students" would quote the
+  /// email fixes and Office 365 renames that happen to share their cards, and
+  /// then not write them. The dialog names one decision because the pass runs
+  /// one decision.
+  ApplyScope applyScopeForDecisions(Iterable<PendingDecision> decisions) {
+    final selected = _selectedActions(decisions);
     if (selected.isEmpty) return ApplyScope.empty;
     final systems = <core.Origin>[for (final o in selected) o.changes.system];
     final chained = <core.Origin>{
@@ -1729,15 +1829,14 @@ class ReconcileController extends ChangeNotifier {
     return ApplyScope(systems: systems, chained: chained);
   }
 
-  /// The live actions to run for [entries]: the selected, applyable option of
-  /// every choice, in order.
+  /// The live actions to run for [decisions]: each one's selected option, in
+  /// order, skipping the ones no apply pass would write.
   List<PendingActionOption> _selectedActions(
-    Iterable<PendingAccountEntry> entries,
+    Iterable<PendingDecision> decisions,
   ) =>
       [
-        for (final e in entries)
-          for (final c in e.choices)
-            if (c.selected.canApply) c.selected,
+        for (final d in decisions)
+          if (d.canApply) d.choice.selected,
       ];
 
   /// Runs the smart sync: pull WISA, diff against the retained snapshot, and
@@ -2276,14 +2375,14 @@ class ReconcileController extends ChangeNotifier {
 
   /// Dry-runs the chosen resolution of **every** pending entry (PAIN-3): the
   /// full apply path, zero writes. Results land in [dryRunResults].
-  Future<void> dryRun() => _run(pendingEntries, dry: true);
+  Future<void> dryRun() => dryRunEntries(pendingEntries);
 
   /// Applies the chosen resolution of every pending entry for real, refreshing
   /// the linked view from the State layer's incremental patches as it goes.
   /// Only the **selected** alternative of each choice runs — a departed student
   /// is unregistered *or* deleted, never both (#110). Results land in
   /// [applyResults].
-  Future<void> applyAll() => _run(pendingEntries, dry: false);
+  Future<void> applyAll() => applyEntries(pendingEntries);
 
   /// Dry-runs one entry's chosen resolution (#110): the per-row preview.
   Future<void> dryRunEntry(PendingAccountEntry entry) =>
@@ -2293,50 +2392,83 @@ class ReconcileController extends ChangeNotifier {
   Future<void> applyEntry(PendingAccountEntry entry) =>
       applyEntries(<PendingAccountEntry>[entry]);
 
-  /// Applies the chosen resolution of every entry in [entries] (#110) — the
-  /// bulk "apply this resolution to all of these" pass. Each entry keeps its
-  /// own chosen alternative, so a subset of departed students can be
-  /// unregistered while another is deleted.
+  /// Applies **every** chosen resolution on each of [entries] (#110) — the
+  /// whole-card pass. Each entry keeps its own chosen alternative, so one
+  /// departed student can be unregistered while another is deleted.
   ///
-  /// It takes the entries themselves rather than a `situationKey` to resolve
-  /// back through [pendingEntries], and that is the whole of #252. The bulk
-  /// header this runs for is rendered over a **scoped** list — the open
-  /// classroom's entries, or the group drill-down's, minus whatever the search
-  /// box filters out — while re-resolving a key against [pendingEntries] means
-  /// every entry in the entire linked view, across every class. A button
-  /// labelled "Alles toepassen (1)" therefore wrote every account group-wide
-  /// that happened to share the situation, none of which the operator had seen.
-  /// Passing the very list the header counted makes that mismatch structurally
-  /// impossible: label, confirmation scope ([applyScope]) and write are one
+  /// The per-decision counterpart is [applyDecisions] (#292); this is the "do
+  /// everything on this account" reading, which stays because it is not blind —
+  /// every decision it runs is on screen on the card above the button.
+  ///
+  /// It takes the entries themselves rather than a key to resolve back through
+  /// [pendingEntries], and that is the whole of #252. The affordance this runs
+  /// for is rendered over a **scoped** list — the open classroom's entries, or
+  /// the group drill-down's, minus whatever the search box filters out — while
+  /// re-resolving a key against [pendingEntries] means every entry in the entire
+  /// linked view, across every class. A button labelled "Alles toepassen (1)"
+  /// therefore wrote every account group-wide that happened to share the
+  /// situation, none of which the operator had seen. Passing the very list the
+  /// header counted makes that mismatch structurally impossible: label,
+  /// confirmation scope ([applyScope]) and write are one
   /// list.
   Future<void> applyEntries(Iterable<PendingAccountEntry> entries) =>
-      _run(entries, dry: false);
+      _run(decisionsOf(entries), dry: false);
 
   /// Dry-runs [entries]' chosen resolutions — [applyEntries] with no writes.
   Future<void> dryRunEntries(Iterable<PendingAccountEntry> entries) =>
-      _run(entries, dry: true);
+      _run(decisionsOf(entries), dry: true);
 
-  /// Runs the selected, applyable option of every choice in [entries] through
-  /// the apply path (dry or real). Shared by the global, per-entry, and
-  /// per-situation affordances so all three behave identically (#110). Each
-  /// option is bound to its own target; on a real write the applier patches the
+  /// Applies **one nominated decision per account** (#292) — the bulk pass a
+  /// [SituationCohort]'s "Alles toepassen" runs, and the seam a school-wide
+  /// apply-all builds on.
+  ///
+  /// The difference from [applyEntries] is the whole of #292: given the same
+  /// fourteen students, `applyEntries` writes every selected decision on each of
+  /// their cards, while this writes only the decision the operator read on the
+  /// header. Bulk-applying "Wijzig Klas in Smartschool" therefore stops
+  /// silently writing the email fixes and Office 365 renames that happen to
+  /// share those cards — a claim the operator could not have verified, because
+  /// the header named one action and the pass ran whatever else was there.
+  ///
+  /// Each member still contributes its **own** selected alternative, exactly as
+  /// the whole-card pass does: a cohort of departed students where one is set to
+  /// unregister and one to delete applies each as chosen.
+  Future<void> applyDecisions(Iterable<PendingDecision> decisions) =>
+      _run(decisions, dry: false);
+
+  /// Dry-runs [decisions] — [applyDecisions] with no writes.
+  Future<void> dryRunDecisions(Iterable<PendingDecision> decisions) =>
+      _run(decisions, dry: true);
+
+  /// Runs the selected, applyable option of every decision in [decisions]
+  /// through the apply path (dry or real). Shared by the global, per-entry, and
+  /// per-cohort affordances so all three behave identically (#110). Each option
+  /// is bound to its own target; on a real write the applier patches the
   /// snapshot and returns a fresh linked view we adopt as the pass proceeds.
   ///
-  /// It takes the *entries* rather than the resolved options because a real pass
-  /// owes the shared store a patch afterwards (#254), and the entries are what
-  /// name the targets it touched — an option carries only a display label.
+  /// It takes [PendingDecision]s rather than the resolved options because a real
+  /// pass owes the shared store a patch afterwards (#254), and the decisions are
+  /// what name the targets it touched — an option carries only a display label.
+  /// Since #292 that is also what lets one pass serve both readings of "apply":
+  /// the whole card is simply every decision on it.
   Future<void> _run(
-    Iterable<PendingAccountEntry> entries, {
+    Iterable<PendingDecision> decisions, {
     required bool dry,
   }) async {
     if (busy || _linked == null) return;
-    final selected = _selectedActions(entries);
-    // The targets this pass writes to, captured before it starts: the entries
-    // are derived from the pre-apply linked view, which the pass replaces.
-    final touched = <PendingAccountEntry>[
-      for (final e in entries)
-        if (e.choices.any((c) => c.selected.canApply)) e,
-    ];
+    final selected = _selectedActions(decisions);
+    // The targets this pass writes to, captured before it starts: the decisions
+    // are derived from the pre-apply linked view, which the pass replaces. One
+    // patch per target however many of its decisions this pass runs — a card
+    // has one stored document.
+    final touched = <PendingAccountEntry>[];
+    final seen = <String>{};
+    for (final d in decisions) {
+      if (!d.canApply) continue;
+      if (seen.add('${d.entry.family}|${d.entry.targetId}')) {
+        touched.add(d.entry);
+      }
+    }
     _begin(ReconcilePhase.applying);
 
     final options =

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -30,6 +30,14 @@ import 'package:wisa_api/wisa_api.dart' as wapi show formatWerkdatum;
 
 import '../format/timestamps.dart';
 import '../reconcile/reconcile_controller.dart';
+import 'system_indicator.dart';
+
+// The system vocabulary both action screens speak (#298) — what a coloured
+// WISA / Smartschool / Office 365 cell means, and how an action line names the
+// system it writes to. Re-exported so a screen that already imports the tile
+// library gets it without a second import, exactly as `systemLabel` was reached
+// before it moved there.
+export 'system_indicator.dart';
 
 // ---------------------------------------------------------------------------
 // Rows.
@@ -112,18 +120,6 @@ String? sharedViewFreshness(ReconcileController controller) {
   return 'Generatie ${state.generation}$when$who$asOf';
 }
 
-/// The Dutch name the operator knows a system by — the same names the action
-/// summaries and the rest of the screen use (#234). Azure AD is "Office 365"
-/// throughout this app, so the dialog says that and not the tenant's technical
-/// name.
-String systemLabel(core.Origin system) => switch (system) {
-      core.Origin.azure => 'Office 365',
-      core.Origin.smartschool => 'Smartschool',
-      core.Origin.wisa => 'WISA',
-      core.Origin.all => 'alle systemen',
-      core.Origin.other => 'een ander systeem',
-    };
-
 /// Joins system names the way Dutch reads them: "a", "a en b", "a, b en c".
 String _joinSystems(Iterable<core.Origin> systems) {
   final names = <String>[
@@ -196,10 +192,17 @@ String applyConfirmationMessage(ApplyScope scope) {
 /// The account card used to render a bare bullet for every candidate (#255), so
 /// a student's informational candidate — since #245 the student family has one —
 /// read like due work next to a badge that counted it zero.
+///
+/// The system the action lands in is **not** in the string: [ActionLine] puts
+/// it in front as a tag of its own (#298), so the summary stays the one
+/// addressable string the dialogs and outcome rows also quote. That tag also
+/// took over from the leading bullet these lines used to carry — two leaders on
+/// one line read as a typo, and the interactive tile's lines never had one, so
+/// dropping it is what finally makes the two identical.
 String readOnlyCandidateLine(actions.Alternatives<CandidateAction> choice) {
   final summary = choice.selected.summary;
-  if (choice.isChoice) return '• $summary (keuze)';
-  return choice.selected.canApply ? '• $summary' : '• $summary (manueel)';
+  if (choice.isChoice) return '$summary (keuze)';
+  return choice.selected.canApply ? summary : '$summary (manueel)';
 }
 
 // ---------------------------------------------------------------------------
@@ -793,6 +796,9 @@ class SituationHeader extends StatelessWidget {
 /// The collapsed line one [PendingChoice] reads as: an either/or is marked
 /// "(keuze)" on its pre-selected half, an informational action "(manueel)", and
 /// an ordinary one is its bare summary.
+///
+/// Rendered through [ActionLine], which leads it with the system it writes to
+/// (#298); the system is deliberately not spliced into the string here.
 String pendingChoiceLine(PendingChoice c) {
   final summary = c.selected.changes.summary;
   if (c.isChoice) return '$summary (keuze)';
@@ -833,8 +839,14 @@ class PendingEntryTile extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
+            // Each line led by the system it writes to (#298): one card can
+            // raise work in two systems and the summaries do not always say
+            // where they land.
             for (final c in entry.choices)
-              Text(pendingChoiceLine(c), style: text.bodySmall),
+              ActionLine(
+                system: c.selected.changes.system,
+                line: pendingChoiceLine(c),
+              ),
           ],
         ),
         childrenPadding: const EdgeInsets.fromLTRB(

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -207,7 +207,7 @@ String readOnlyCandidateLine(actions.Alternatives<CandidateAction> choice) {
 // ---------------------------------------------------------------------------
 
 /// Shows the apply-confirmation dialog and, on confirm, runs [apply] behind the
-/// modal progress dialog (#110/#243). Shared by the global, per-situation, and
+/// modal progress dialog (#110/#243). Shared by the per-situation and
 /// per-entry apply affordances so a write is always one deliberate confirmation
 /// followed by one visible pass.
 ///
@@ -256,10 +256,10 @@ Future<void> confirmAndApply(
 /// operator had usually scrolled past — so the app looked hung, and nothing
 /// stopped them scrolling, switching family tab, or navigating away mid-write.
 ///
-/// Every affordance goes through here — global, per-situation, per-entry, and
-/// dry-run as well as apply — so the pass behaves the same wherever it is
-/// started. A dry-run over hundreds of accounts is exactly as slow and was
-/// exactly as silent.
+/// Every affordance goes through here — per-situation and per-entry, dry-run as
+/// well as apply — so the pass behaves the same wherever it is started. A
+/// dry-run over hundreds of accounts is exactly as slow and was exactly as
+/// silent.
 ///
 /// The dialog's lifetime is bound to [run]'s future rather than to any observed
 /// controller state: it is dismissed in a `finally`, so a pass that fails — or

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -1334,15 +1334,23 @@ class ChoiceControl extends StatelessWidget {
 
 /// How one [actions.FieldChange] reads on a card.
 ///
-/// Two shapes, because a `ChangeSet` describes two kinds of thing (#300). A
-/// **transition** is a value moving, and reads as one: `mail: ∅ → 1a@…`. A
-/// **count** is a quantity the action acts on, and reads as the number it is:
-/// `leden toevoegen: 21`. Put through the transition template a count claimed
-/// the field used to be empty and is becoming 21 — a sentence about nothing
-/// that happens to the group.
-String fieldChangeLine(actions.FieldChange f) => f.isCount
-    ? '${f.field}: ${f.after}'
-    : '${f.field}: ${f.before ?? '∅'} → ${f.after ?? '∅'}';
+/// Three shapes, because a `ChangeSet` describes three kinds of thing (#300,
+/// #305). A **transition** is a value moving, and reads as one:
+/// `mail: ∅ → 1a@…`. A **count** is a quantity the action acts on, and reads as
+/// the number it is: `leden toevoegen: 21`. A **statement** is a fact about the
+/// record an informational notice is describing, and reads as that fact:
+/// `mail: GBS-9Z@…`.
+///
+/// Put through the transition template, the two of them that are not
+/// transitions each claimed something untrue: a count, that the field used to
+/// be empty and is becoming 21; a statement, that the value it names is being
+/// cleared — on a notice whose whole point is that nothing is written.
+String fieldChangeLine(actions.FieldChange f) => switch (f.shape) {
+      actions.FieldChangeShape.count => '${f.field}: ${f.after}',
+      actions.FieldChangeShape.statement => '${f.field}: ${f.before}',
+      actions.FieldChangeShape.transition =>
+        '${f.field}: ${f.before ?? '∅'} → ${f.after ?? '∅'}',
+    };
 
 /// The per-field diff (or a lifecycle note) for a single option — the one that
 /// stands alone, or the one selected inside a [ChoiceControl].

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -805,6 +805,87 @@ String pendingChoiceLine(PendingChoice c) {
   return c.selected.canApply ? summary : '$summary (manueel)';
 }
 
+/// The expandable card both action screens build a record with pending work on
+/// — the Acties [PendingEntryTile] and the Klasgroepen class row.
+///
+/// It exists for one rule neither screen can hold on its own (#300). A
+/// collapsed card previews its decisions as summary lines; since #281 the
+/// expanded body *leads every decision with the very same sentence*, because
+/// that heading is what tells the operator which diff belongs to which
+/// decision. So on a card carrying one action the operator read it twice, one
+/// line directly above the other:
+///
+/// > Werk het ledenbestand van SSM-1A bij (21 toevoegen, 17 verwijderen)
+/// > **Werk het ledenbestand van SSM-1A bij (21 toevoegen, 17 verwijderen)**
+///
+/// The heading is the one that has to stay: it groups the block under it, it is
+/// uniform across every decision (#281), and it is what #295's details pane —
+/// which has no collapsed row at all — will read [entryDetail] for. So the
+/// *preview* gives way instead. [subtitle] is therefore built with whether the
+/// card is open, which is the one thing an [ExpansionTile] does not hand its
+/// own subtitle.
+class PendingCardTile extends StatefulWidget {
+  const PendingCardTile({
+    super.key,
+    required this.tileKey,
+    this.leading,
+    required this.title,
+    required this.subtitle,
+    required this.children,
+  });
+
+  /// Names the tile itself (`entry-<family>-<targetId>`). Deliberately not this
+  /// widget's own [key]: the screens' tests and #295's row builder address the
+  /// [ExpansionTile], and two widgets answering to one key would make
+  /// `find.byKey` ambiguous.
+  final Key tileKey;
+
+  final Widget? leading;
+  final Widget title;
+
+  /// The collapsed body, told whether the card is open so it can drop what the
+  /// expanded body now says. `null` renders no subtitle at all.
+  final Widget? Function(BuildContext context, bool expanded) subtitle;
+
+  final List<Widget> children;
+
+  @override
+  State<PendingCardTile> createState() => _PendingCardTileState();
+}
+
+class _PendingCardTileState extends State<PendingCardTile> {
+  bool _expanded = false;
+
+  @override
+  void didUpdateWidget(PendingCardTile oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A new [tileKey] builds a fresh [ExpansionTile], which starts collapsed.
+    // Without this the two would drift apart — an open card recycled onto
+    // another record would hide its preview while showing nothing instead.
+    if (oldWidget.tileKey != widget.tileKey) _expanded = false;
+  }
+
+  @override
+  Widget build(BuildContext context) => ExpansionTile(
+        key: widget.tileKey,
+        shape: const Border(),
+        collapsedShape: const Border(),
+        leading: widget.leading,
+        title: widget.title,
+        subtitle: widget.subtitle(context, _expanded),
+        onExpansionChanged: (bool expanded) =>
+            setState(() => _expanded = expanded),
+        childrenPadding: const EdgeInsets.fromLTRB(
+          PlinkSpacing.s5,
+          0,
+          PlinkSpacing.s5,
+          PlinkSpacing.s4,
+        ),
+        expandedCrossAxisAlignment: CrossAxisAlignment.start,
+        children: widget.children,
+      );
+}
+
 /// One account's pending resolution (#110): a single expandable row showing the
 /// selected summary, the mutually-exclusive choice (as radios) when there is
 /// one, the per-field diff, and per-entry dry-run / apply.
@@ -829,33 +910,28 @@ class PendingEntryTile extends StatelessWidget {
         border: Border.all(color: hairline),
         borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
       ),
-      child: ExpansionTile(
-        key: ValueKey('entry-${entry.family}-${entry.targetId}'),
-        shape: const Border(),
-        collapsedShape: const Border(),
+      child: PendingCardTile(
+        tileKey: ValueKey('entry-${entry.family}-${entry.targetId}'),
         leading: PlinkBadge(entry.family),
         title: Text(entry.target, style: text.bodyLarge),
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            // Each line led by the system it writes to (#298): one card can
-            // raise work in two systems and the summaries do not always say
-            // where they land.
-            for (final c in entry.choices)
-              ActionLine(
-                system: c.selected.changes.system,
-                line: pendingChoiceLine(c),
+        // The whole subtitle here is the preview, so an open card has none:
+        // every line it holds is repeated as a heading below (#300).
+        subtitle: (context, expanded) => expanded
+            ? null
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  // Each line led by the system it writes to (#298): one card
+                  // can raise work in two systems and the summaries do not
+                  // always say where they land.
+                  for (final c in entry.choices)
+                    ActionLine(
+                      system: c.selected.changes.system,
+                      line: pendingChoiceLine(c),
+                    ),
+                ],
               ),
-          ],
-        ),
-        childrenPadding: const EdgeInsets.fromLTRB(
-          PlinkSpacing.s5,
-          0,
-          PlinkSpacing.s5,
-          PlinkSpacing.s4,
-        ),
-        expandedCrossAxisAlignment: CrossAxisAlignment.start,
         children: entryDetail(context, controller: controller, entry: entry),
       ),
     );
@@ -955,6 +1031,13 @@ String choiceHeading(PendingChoice choice) =>
 /// was on the card. Under its own heading each diff belongs to something, and a
 /// card with two decisions reads as two.
 ///
+/// That heading is also why an open card drops its collapsed preview (#300):
+/// the two say the same sentence, and on a card carrying one decision the
+/// operator read it twice in a row. The heading is the half that stays — it
+/// groups the block under it, and [entryDetail] has to stand on its own in
+/// #295's details pane, where there is no collapsed row to have previewed
+/// anything.
+///
 /// The verdict lines pooled the same way and for the same reason (#283): one
 /// apply on that card produces two of them, and below both decisions they said
 /// what happened without saying to which question. So the block carries the part
@@ -993,8 +1076,14 @@ class EntryChoiceBlock extends StatelessWidget {
           Divider(height: 1, color: Theme.of(context).dividerColor),
           const SizedBox(height: PlinkSpacing.s3),
         ],
-        Text(
-          choiceHeading(choice),
+        // Led by the system it writes to, exactly as the collapsed preview is
+        // (#298). Since #300 that preview gives way while the card is open, so
+        // this heading is the only thing left saying where the write lands —
+        // and a summary that names a group ("Werk het ledenbestand van GBS-1A
+        // bij") does not say it.
+        ActionLine(
+          system: choice.selected.changes.system,
+          line: choiceHeading(choice),
           style: text.bodySmall?.copyWith(fontWeight: FontWeight.w600),
         ),
         const SizedBox(height: PlinkSpacing.s1),
@@ -1243,6 +1332,18 @@ class ChoiceControl extends StatelessWidget {
   }
 }
 
+/// How one [actions.FieldChange] reads on a card.
+///
+/// Two shapes, because a `ChangeSet` describes two kinds of thing (#300). A
+/// **transition** is a value moving, and reads as one: `mail: ∅ → 1a@…`. A
+/// **count** is a quantity the action acts on, and reads as the number it is:
+/// `leden toevoegen: 21`. Put through the transition template a count claimed
+/// the field used to be empty and is becoming 21 — a sentence about nothing
+/// that happens to the group.
+String fieldChangeLine(actions.FieldChange f) => f.isCount
+    ? '${f.field}: ${f.after}'
+    : '${f.field}: ${f.before ?? '∅'} → ${f.after ?? '∅'}';
+
 /// The per-field diff (or a lifecycle note) for a single option — the one that
 /// stands alone, or the one selected inside a [ChoiceControl].
 class OptionDetail extends StatelessWidget {
@@ -1270,10 +1371,7 @@ class OptionDetail extends StatelessWidget {
               for (final f in fields)
                 Padding(
                   padding: const EdgeInsets.only(bottom: PlinkSpacing.s1),
-                  child: Text(
-                    '${f.field}: ${f.before ?? '∅'} → ${f.after ?? '∅'}',
-                    style: text.bodySmall,
-                  ),
+                  child: Text(fieldChangeLine(f), style: text.bodySmall),
                 ),
             ],
     );

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -36,17 +36,17 @@ import '../reconcile/reconcile_controller.dart';
 // ---------------------------------------------------------------------------
 
 /// One row of a per-classroom (or per-group) pending list: a same-situation
-/// bulk header or a single account entry. Flattening the situation → entries
-/// tree into a linear list lets a lazy [SliverList] build only the on-screen
-/// rows (#111/#154).
+/// bulk header or a single account entry. Flattening the cohorts → entries tree
+/// into a linear list lets a lazy [SliverList] build only the on-screen rows
+/// (#111/#154).
 sealed class PendingRow {
   const PendingRow();
 }
 
 class SituationHeaderRow extends PendingRow {
-  const SituationHeaderRow(this.entries);
+  const SituationHeaderRow(this.cohort);
 
-  final List<PendingAccountEntry> entries;
+  final SituationCohort cohort;
 }
 
 class EntryRow extends PendingRow {
@@ -55,19 +55,26 @@ class EntryRow extends PendingRow {
   final PendingAccountEntry entry;
 }
 
-/// Flattens same-situation [situations] into the linear [PendingRow] list a
-/// lazy sliver builds from: a bulk header only where more than one account
-/// shares the situation, then that subset's entries.
-List<PendingRow> pendingRows(List<List<PendingAccountEntry>> situations) {
-  final rows = <PendingRow>[];
-  for (final subset in situations) {
-    if (subset.length > 1) rows.add(SituationHeaderRow(subset));
-    for (final entry in subset) {
-      rows.add(EntryRow(entry));
-    }
-  }
-  return rows;
-}
+/// Flattens [cohorts] and [entries] into the linear [PendingRow] list a lazy
+/// sliver builds from: the bulk headers, then one tile per account.
+///
+/// The headers lead rather than each sitting above its own run of rows, and
+/// since #292 they have to. A cohort is one decision, so an account with three
+/// decisions belongs to three of them; interleaving would mean rendering its
+/// card three times, once under each. Klasgroepen already collects its bulk
+/// affordances above the inventory for the same reason (its rows are sorted by
+/// class name, so a cohort was never contiguous there either), and this is that
+/// shape. Both lists therefore read the same way: what can be done in bulk on
+/// top, the accounts themselves below, each exactly once.
+List<PendingRow> pendingRows(
+  List<SituationCohort> cohorts,
+  List<PendingAccountEntry> entries,
+) =>
+    <PendingRow>[
+      for (final cohort in cohorts)
+        if (cohort.length > 1) SituationHeaderRow(cohort),
+      for (final entry in entries) EntryRow(entry),
+    ];
 
 // ---------------------------------------------------------------------------
 // Wording.
@@ -691,39 +698,46 @@ class MessagePanel extends StatelessWidget {
 // Interactive tiles.
 // ---------------------------------------------------------------------------
 
-/// The bulk header of one "same situation" subset (#110): the "apply this
-/// resolution to all" affordance that honours each entry's own chosen
-/// alternative. Rendered as its own row in the lazy list, only when more than
-/// one account shares the situation.
+/// The bulk header of one [SituationCohort] (#110/#292): the "apply this one
+/// decision to every account that needs it" affordance, honouring each
+/// account's own chosen alternative. Rendered as its own row in the lazy list,
+/// only when more than one account raises the decision.
 ///
-/// Every affordance here acts on [entries] — the exact subset this header was
-/// built over and counts (#252). That list is already scoped by whatever list
-/// rendered it: the open classroom's pending entries, or the class inventory's,
-/// narrowed further by the search box. The bulk pass used to re-resolve the
-/// situation key against the *whole* linked view instead, so a header reading
-/// "Alles toepassen (1)" inside one class wrote every account group-wide in the
-/// same situation. The label, the confirmation scope and the write are now one
-/// list, so they cannot drift apart again.
+/// Every affordance here acts on [cohort]'s decisions — the exact members this
+/// header was built over and counts (#252). That list is already scoped by
+/// whatever list rendered it: the open classroom's pending entries, or the class
+/// inventory's, narrowed further by the search box. The bulk pass used to
+/// re-resolve the situation key against the *whole* linked view instead, so a
+/// header reading "Alles toepassen (1)" inside one class wrote every account
+/// group-wide in the same situation. The label, the confirmation scope and the
+/// write are one list, so they cannot drift apart again.
+///
+/// Since #292 that list is one decision deep as well as scoped. The header names
+/// a single decision, so the pass behind it writes a single decision: pressing
+/// "Wijzig Klas in Smartschool" on fourteen students no longer also writes the
+/// email fix one of them happens to need. That is what makes the claim on the
+/// button verifiable at all — the operator can read one action's description and
+/// know what the button does to everyone in the cohort.
 class SituationHeader extends StatelessWidget {
   const SituationHeader({
     super.key,
     required this.controller,
-    required this.entries,
+    required this.cohort,
     this.noun = 'accounts',
   });
 
   final ReconcileController controller;
-  final List<PendingAccountEntry> entries;
+  final SituationCohort cohort;
 
-  /// What this subset is a subset *of*, in Dutch — "accounts" in a classroom,
+  /// What this cohort is a cohort *of*, in Dutch — "accounts" in a classroom,
   /// "klassen" in the class inventory (#227).
   final String noun;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
-    final key = entries.first.situationKey;
-    final applyable = entries.where((e) => e.canApply).length;
+    final String key = cohort.key;
+    final int applyable = cohort.applyableCount;
 
     return Padding(
       padding: const EdgeInsets.only(
@@ -734,7 +748,7 @@ class SituationHeader extends StatelessWidget {
         children: <Widget>[
           Expanded(
             child: Text(
-              '${entries.first.situationLabel} — ${entries.length} '
+              '${cohort.label} — ${cohort.length} '
               '$noun in dezelfde situatie',
               style: text.titleSmall,
             ),
@@ -748,7 +762,7 @@ class SituationHeader extends StatelessWidget {
                       context,
                       controller: controller,
                       dry: true,
-                      run: () => controller.dryRunEntries(entries),
+                      run: () => controller.dryRunDecisions(cohort.decisions),
                     ),
             child: const Text('Dry-run alles'),
           ),
@@ -760,11 +774,13 @@ class SituationHeader extends StatelessWidget {
                 : () => confirmAndApply(
                       context,
                       controller: controller,
-                      title: 'Toepassen op ${entries.length} $noun?',
-                      // The dialog is scoped to the very entries the pass below
-                      // runs over — the ones this header counted (#234/#252).
-                      scope: controller.applyScope(entries),
-                      apply: () => controller.applyEntries(entries),
+                      title: 'Toepassen op ${cohort.length} $noun?',
+                      // The dialog is scoped to the very decisions the pass
+                      // below runs — the ones this header counted (#234/#252),
+                      // and only those (#292).
+                      scope:
+                          controller.applyScopeForDecisions(cohort.decisions),
+                      apply: () => controller.applyDecisions(cohort.decisions),
                     ),
             child: Text('Alles toepassen ($applyable)'),
           ),

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -31,8 +31,10 @@ export 'action_tiles.dart' show applyConfirmationMessage, systemLabel;
 /// loaded (via `LinkedStore.readClassroom`) and built only when the operator
 /// drills into it.
 /// The per-class list itself renders through a lazy [SliverList] so only the
-/// on-screen tiles build. The global "Dry-run all" / "Apply all" act on every
-/// pending entry across all classes.
+/// on-screen tiles build. Every apply starts from something the operator has
+/// opened — one card, or one decision across the cohort shown above it; the
+/// header's global "Dry-run alles" / "Alles toepassen" pair was removed in #294
+/// precisely because it did not.
 ///
 /// One view-wide switch above the family tab bar — "toon enkel accounts met
 /// acties", on by default — collapses all of that to the work list (#226):
@@ -746,9 +748,19 @@ class _ActionsBodyState extends State<_ActionsBody>
       ];
 }
 
-/// The Actions title plus the global "Dry-run all" / "Apply all" affordances
-/// (#110/#154): the secondary escape hatch that acts on every pending entry's
-/// chosen resolution, across all classes.
+/// The Actions title and how much work is pending — and, since #294, nothing
+/// that acts on it.
+///
+/// It used to carry a global "Dry-run alles" / "Alles toepassen" pair that ran
+/// every pending action of every family in every class in one pass. There is no
+/// safe reading of that: the drill-down below is collapsed, so the operator had
+/// seen none of the changes, and at a September changeover the count behind the
+/// button is in the thousands. Its confirmation named systems and a number,
+/// which is not the same as having looked. Bulk itself is not gone — it lives on
+/// the per-decision cohort header, where the cohort is on screen and one action
+/// deep — but the affordance that applied what nobody had read is.
+///
+/// The count line stays. It states how much work exists; it is not a button.
 class _ActionsHeader extends StatelessWidget {
   const _ActionsHeader({
     required this.controller,
@@ -786,50 +798,6 @@ class _ActionsHeader extends StatelessWidget {
           },
           style: text.bodyMedium,
         ),
-        const SizedBox(height: PlinkSpacing.s4),
-        Wrap(
-          spacing: PlinkSpacing.s3,
-          runSpacing: PlinkSpacing.s2,
-          children: <Widget>[
-            OutlinedButton.icon(
-              key: const ValueKey('actions-dry-run'),
-              onPressed: controller.busy || controller.applyableCount == 0
-                  ? null
-                  : () => runWithProgress(
-                        context,
-                        controller: controller,
-                        dry: true,
-                        run: controller.dryRun,
-                      ),
-              icon: const Icon(Icons.visibility_outlined),
-              label: const Text('Dry-run alles'),
-            ),
-            TextButton.icon(
-              key: const ValueKey('actions-apply'),
-              onPressed: controller.busy || controller.applyableCount == 0
-                  ? null
-                  : () => confirmAndApply(
-                        context,
-                        controller: controller,
-                        title: 'Openstaande acties toepassen?',
-                        scope: controller.applyScope(controller.pendingEntries),
-                        apply: controller.applyAll,
-                      ),
-              icon: const Icon(Icons.play_arrow_outlined),
-              label: const Text('Alles toepassen'),
-            ),
-          ],
-        ),
-        if (controller.busy) ...<Widget>[
-          const SizedBox(height: PlinkSpacing.s4),
-          // Determinate, like the Reconcile header's (#176/#243): the value
-          // exists on the very same controller, and an indeterminate sweep here
-          // was a motionless bar that read as a hung app.
-          LinearProgressIndicator(
-            key: const ValueKey('actions-progress'),
-            value: controller.progress,
-          ),
-        ],
       ],
     );
   }

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -388,24 +388,23 @@ class _ActionsBodyState extends State<_ActionsBody>
     ];
   }
 
-  /// The active-session pending situations narrowed by the name search. The
-  /// "only with actions" toggle is a no-op here — every pending entry already
-  /// carries an action — so only the search filters, dropping any subset left
-  /// empty so the same-situation headers stay in sync (#187).
-  List<List<PendingAccountEntry>> _filterSituations(
-    List<List<PendingAccountEntry>> situations,
+  /// The active-session pending entries narrowed by the name search. The "only
+  /// with actions" toggle is a no-op here — every pending entry already carries
+  /// an action — so only the search filters (#187).
+  ///
+  /// The cohorts are grouped *from this result* rather than filtered afterwards
+  /// (#292), so a bulk header can only ever cover accounts the search left on
+  /// screen: label, confirmation scope and write come from one list, which is
+  /// the standing rule since #252.
+  List<PendingAccountEntry> _filterEntries(
+    List<PendingAccountEntry> entries,
   ) {
     final query = _query;
-    if (query.isEmpty) return situations;
-    final out = <List<PendingAccountEntry>>[];
-    for (final subset in situations) {
-      final kept = <PendingAccountEntry>[
-        for (final e in subset)
-          if (query.matches(e.target)) e,
-      ];
-      if (kept.isNotEmpty) out.add(kept);
-    }
-    return out;
+    if (query.isEmpty) return entries;
+    return <PendingAccountEntry>[
+      for (final e in entries)
+        if (query.matches(e.target)) e,
+    ];
   }
 
   /// Rebuilds the sliver content for the newly-selected family, and — when the
@@ -625,13 +624,15 @@ class _ActionsBodyState extends State<_ActionsBody>
         : const <Widget>[];
 
     if (controller.linked != null) {
-      final situations = controller.classroomPendingSituations;
-      if (situations.isEmpty) {
+      final all = controller.classroomPendingEntries;
+      if (all.isEmpty) {
         return slivers
           ..add(_section(const EmptyLine('Geen openstaande acties in deze '
               'klas.')));
       }
-      final rows = pendingRows(_filterSituations(situations));
+      final shown = _filterEntries(all);
+      final rows =
+          pendingRows(ReconcileController.situationCohorts(shown), shown);
       slivers
         ..addAll(searchSlivers)
         ..add(rows.isEmpty
@@ -694,8 +695,8 @@ class _ActionsBodyState extends State<_ActionsBody>
           itemBuilder: (context, index) {
             final row = rows[index];
             return switch (row) {
-              SituationHeaderRow(:final entries) =>
-                SituationHeader(controller: controller, entries: entries),
+              SituationHeaderRow(:final cohort) =>
+                SituationHeader(controller: controller, cohort: cohort),
               EntryRow(:final entry) =>
                 PendingEntryTile(controller: controller, entry: entry),
             };

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -58,6 +58,26 @@ export 'action_tiles.dart' show applyConfirmationMessage, systemLabel;
 /// linked — can only show the stored documents, so both drill-downs say so out
 /// loud rather than quietly swapping in static cards (#214).
 ///
+/// Every action line names the system it writes to (#298): one card can raise
+/// work in two systems and the summaries do not always say where they land. The
+/// three-way system indicator that reads *needs work* rather than *exists*
+/// arrives with the flat list of #295; its vocabulary — and the principle it
+/// shares with Klasgroepen — already lives in `system_indicator.dart`.
+///
+/// **Colour by work that can be done on this screen.** Klasgroepen highlights a
+/// row on `MaterializedGroup.needsAttention`, informational notices included
+/// (#225/#250), because there the manual notice *is* the work the operator
+/// does on that screen. Here an informational candidate is a diagnosis of work
+/// that happens elsewhere, so it colours nothing, raises no badge and puts no
+/// row in the work list — `pendingDecisionCount` has counted it zero since
+/// #245/#255, and the indicators apply that same predicate. The case that
+/// forces the rule is `AzureClassGroupMembership`: Office 365 class membership
+/// is a property of the group, so the write is one `SyncAzureClassGroupMembers`
+/// per class on Klasgroepen. Colouring it here would paint ~3000 student rows
+/// orange at the rollover for work this screen structurally cannot do. (#290
+/// proposed the opposite and was closed; the action still declares
+/// `canApply => false`.)
+///
 /// Shares the one memoized [ReconcileServices] (and so the one
 /// [ReconcileController]) with the Reconcile and Passwords screens, so a sync
 /// run on Reconcile populates the actions shown here.
@@ -1258,8 +1278,9 @@ class _AccountTile extends StatelessWidget {
           for (final c in candidateChoices(account.candidates))
             Padding(
               padding: const EdgeInsets.only(top: PlinkSpacing.s1),
-              child: Text(
-                readOnlyCandidateLine(c),
+              child: ActionLine(
+                system: c.selected.system,
+                line: readOnlyCandidateLine(c),
                 style: text.bodySmall?.copyWith(color: muted),
               ),
             ),

--- a/account_manager/lib/src/screens/class_groups_screen.dart
+++ b/account_manager/lib/src/screens/class_groups_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:account_actions/account_actions.dart' show ActionOutcome;
+import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart'
     show MaterializedGroup, candidateChoices, pendingDecisionCount;
 import 'package:flutter/material.dart';
@@ -14,16 +15,25 @@ import 'action_tiles.dart';
 /// The **Klasgroepen** tab (#227): the full class inventory.
 ///
 /// Every class the last sync linked is a row here — not only the ones that
-/// raised something — with a presence column per system (WISA · Smartschool ·
-/// Office 365) and the rows that need work highlighted. That inversion is the
-/// whole point. The Acties drill-down listed changes, so a *wrong* proposal
-/// looked exactly like every right one: `2G` was offered for creation although
+/// raised something — with a column per system (WISA · Smartschool · Office
+/// 365) and the rows that need work highlighted. That inversion is the whole
+/// point. The Acties drill-down listed changes, so a *wrong* proposal looked
+/// exactly like every right one: `2G` was offered for creation although
 /// Smartschool already had it (#225), and nothing on screen could have shown
-/// otherwise. Three ticks on a row means the class is correct everywhere, and
-/// anything else stands out.
+/// otherwise. Three green ticks on a row means the class is correct everywhere,
+/// and anything else stands out.
 ///
-/// Three things the layout is deliberate about:
+/// Four things the layout is deliberate about:
 ///
+/// - **A cell means "work you can do on this screen", not mere presence**
+///   (#298). Until then the three cells answered *does this class exist in
+///   system X* and nothing else, so `1A` — present everywhere and carrying a
+///   pending Office 365 roster write — read as three ticks with nothing saying
+///   the pending work was an Azure one. A cell now shows the worst of presence
+///   and pending work for that one system: red missing, orange work pending,
+///   green in order. [SystemIndicatorCell] and the principle behind it live in
+///   `system_indicator.dart`, shared with Acties so a coloured cell means the
+///   same thing on both screens.
 /// - **The Office 365 column is per *class*, not per row.** Sub-groups get no
 ///   group of their own (#228), so `2F ECO` / `2F MAW` / `2F MOW` / `2F STEMW`
 ///   are all served by the one group `<PREFIX>-2F`. Each such row names that
@@ -37,8 +47,15 @@ import 'action_tiles.dart';
 /// - **Informational notices are not buried.** A class Smartschool already
 ///   holds, or an Office 365 group left behind by a class that is gone, is real
 ///   manual work with no automated write, so it contributes nothing to a pending
-///   count (#225/#250). The filter and the highlight therefore key on
-///   [MaterializedGroup.needsAttention], never on the pending count.
+///   count (#225/#250). The filter and the row **highlight** therefore key on
+///   [MaterializedGroup.needsAttention], never on the pending count — and that
+///   stays true under #298, which is not the contradiction it looks like. The
+///   reconciling principle is *colour by work that can be done on this screen*:
+///   here the manual notice is the work you do on this screen, so it lights the
+///   row; in Acties an informational candidate diagnoses work that happens
+///   somewhere else, so it colours nothing there. The system **cells** are the
+///   narrower reading — they promise a write, so they count only applyable
+///   work. See the library doc of `system_indicator.dart`.
 ///
 /// A class that needs work is inspected — and, where it is applyable, dry-run
 /// and applied — right here, through the same tiles Acties uses
@@ -644,7 +661,7 @@ class _SectionTitle extends StatelessWidget {
 /// entry tiles are (`entry-group-<klas>`), so opening it offers the same
 /// radios, the same per-field diff and the same dry-run / apply pair. A class
 /// with nothing to do — the majority, and the reason this tab exists — is a
-/// plain card: name, description, three presence cells.
+/// plain card: name, description, three system cells.
 class _ClassRow extends StatelessWidget {
   const _ClassRow({
     required this.controller,
@@ -697,11 +714,12 @@ class _ClassRow extends StatelessWidget {
         if (group.description.isNotEmpty)
           Text(group.description, style: text.bodySmall),
         const SizedBox(height: PlinkSpacing.s2),
-        _PresenceRow(group: group),
+        _SystemRow(group: group, work: _workSystems()),
         for (final line in _lines(entry, group)) ...<Widget>[
           const SizedBox(height: PlinkSpacing.s1),
-          Text(
-            line,
+          ActionLine(
+            system: line.system,
+            line: line.text,
             style: entry == null
                 ? text.bodySmall
                     ?.copyWith(color: Theme.of(context).disabledColor)
@@ -757,23 +775,49 @@ class _ClassRow extends StatelessWidget {
 
   /// The collapsed summary lines: the live choices in an active session, the
   /// stored candidates in a passive one — each worded exactly as Acties words
-  /// it, so an either/or reads as the one decision it is (#251).
-  List<String> _lines(PendingAccountEntry? entry, MaterializedGroup group) {
+  /// it, so an either/or reads as the one decision it is (#251), and each
+  /// carrying the system it writes to so [ActionLine] can lead with it (#298).
+  List<({core.Origin system, String text})> _lines(
+    PendingAccountEntry? entry,
+    MaterializedGroup group,
+  ) {
     if (entry != null) {
-      return <String>[for (final c in entry.choices) pendingChoiceLine(c)];
+      return <({core.Origin system, String text})>[
+        for (final c in entry.choices)
+          (system: c.selected.changes.system, text: pendingChoiceLine(c)),
+      ];
     }
-    return <String>[
+    return <({core.Origin system, String text})>[
       for (final c in candidateChoices(group.candidates))
-        readOnlyCandidateLine(c),
+        (system: c.selected.system, text: readOnlyCandidateLine(c)),
     ];
+  }
+
+  /// The systems this row has applyable work in (#298) — what turns a cell
+  /// orange.
+  ///
+  /// An **active** session answers from the live dispatch, which drops a
+  /// decision the moment it is applied; a passive one from the stored
+  /// candidates, which is all it has. The same split
+  /// [_ClassRowModel.attentionIn] makes, and for the same reason: in an active
+  /// session a class with no entry has nothing left to do, whatever the
+  /// document that was materialized before the last apply still says.
+  Set<core.Origin> _workSystems() {
+    if (!active) return workSystemsOfCandidates(row.group.candidates);
+    final PendingAccountEntry? entry = row.entry;
+    return entry == null ? const <core.Origin>{} : workSystemsOfEntry(entry);
   }
 }
 
-/// The three presence cells of one class: WISA · Smartschool · Office 365.
-class _PresenceRow extends StatelessWidget {
-  const _PresenceRow({required this.group});
+/// The three system cells of one class: WISA · Smartschool · Office 365 (#227),
+/// each reading *work you can do here* rather than mere presence since #298.
+class _SystemRow extends StatelessWidget {
+  const _SystemRow({required this.group, required this.work});
 
   final MaterializedGroup group;
+
+  /// The systems this class has applyable work in.
+  final Set<core.Origin> work;
 
   @override
   Widget build(BuildContext context) {
@@ -791,87 +835,36 @@ class _PresenceRow extends StatelessWidget {
     final String azureDetail = g.azureGroupName ??
         (isSubGroup ? 'nog geen groep voor $bare' : 'nog geen groep');
 
+    // Each cell is addressable on its own — `class-cell-<klas>-<systeem>` — so
+    // a test, and the flat list of #295, can ask one row what it says about one
+    // system rather than counting icons across three.
+    Widget cell(core.Origin system, bool present,
+            {String? detail, String? note}) =>
+        Expanded(
+          child: SystemIndicatorCell(
+            key: ValueKey('class-cell-${g.label}-${system.name}'),
+            system: system,
+            state: systemIndicatorState(
+              present: present,
+              hasWork: work.contains(system),
+            ),
+            detail: detail,
+            note: note,
+          ),
+        );
+
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Expanded(child: _PresenceCell(system: 'WISA', present: g.inWisa)),
-        Expanded(
-          child: _PresenceCell(system: 'Smartschool', present: g.inSmartschool),
-        ),
-        Expanded(
-          child: _PresenceCell(
-            system: 'Office 365',
-            present: g.inAzure,
-            detail: azureDetail,
-            note: isSubGroup ? 'deelgroep van $bare' : null,
-          ),
+        cell(core.Origin.wisa, g.inWisa),
+        cell(core.Origin.smartschool, g.inSmartschool),
+        cell(
+          core.Origin.azure,
+          g.inAzure,
+          detail: azureDetail,
+          note: isSubGroup ? 'deelgroep van $bare' : null,
         ),
       ],
-    );
-  }
-}
-
-class _PresenceCell extends StatelessWidget {
-  const _PresenceCell({
-    required this.system,
-    required this.present,
-    this.detail,
-    this.note,
-  });
-
-  final String system;
-  final bool present;
-
-  /// The name of the thing that is (or is not) there — the Office 365 group.
-  final String? detail;
-
-  /// A second line that explains the row's relationship to [detail].
-  final String? note;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final ColorScheme colors = Theme.of(context).colorScheme;
-    final Color muted = Theme.of(context).disabledColor;
-
-    return Padding(
-      padding: const EdgeInsets.only(right: PlinkSpacing.s2),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Icon(
-            present ? Icons.check_circle_outline : Icons.remove_circle_outline,
-            size: 16,
-            color: present ? colors.primary : muted,
-          ),
-          const SizedBox(width: PlinkSpacing.s1),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                Text(
-                  system,
-                  style: text.bodySmall,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                if (detail != null)
-                  Text(
-                    detail!,
-                    style: text.bodySmall?.copyWith(color: muted),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                if (note != null)
-                  Text(
-                    note!,
-                    style: text.bodySmall?.copyWith(color: muted),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-              ],
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/account_manager/lib/src/screens/class_groups_screen.dart
+++ b/account_manager/lib/src/screens/class_groups_screen.dart
@@ -408,31 +408,37 @@ class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
   /// every new class of the year"), so they sit here, each acting on exactly the
   /// classes it names.
   ///
-  /// [shown] is the set of class names the search left standing, and a subset is
+  /// [shown] is the set of class names the search left standing, and a cohort is
   /// narrowed to it: a button that acts on "exactly the classes it names" must
   /// not quietly write to classes the operator filtered off the screen, and a
-  /// subset left with one class is no longer a bulk affordance at all — its one
+  /// cohort left with one class is no longer a bulk affordance at all — its one
   /// row carries the same action.
+  ///
+  /// Since #292 a cohort is one *decision* rather than one combination of them,
+  /// so a class new to Smartschool that also lacks an Office 365 group appears
+  /// under both headers, and pressing either writes only what that header names.
   List<Widget> _bulkSlivers(bool active, Set<String> shown) {
     if (!active) return const <Widget>[];
-    final subsets = <List<PendingAccountEntry>>[];
-    for (final subset in controller.groupPendingSituations) {
-      final kept = <PendingAccountEntry>[
-        for (final e in subset)
-          if (shown.contains(e.targetId)) e,
+    final cohorts = <SituationCohort>[];
+    for (final cohort in controller.groupPendingSituations) {
+      final kept = <PendingDecision>[
+        for (final d in cohort.decisions)
+          if (shown.contains(d.entry.targetId)) d,
       ];
-      if (kept.length > 1) subsets.add(kept);
+      if (kept.length > 1) {
+        cohorts.add(SituationCohort(key: cohort.key, decisions: kept));
+      }
     }
-    if (subsets.isEmpty) return const <Widget>[];
+    if (cohorts.isEmpty) return const <Widget>[];
     return <Widget>[
       _section(const _SectionTitle('Klassen in dezelfde situatie')),
       SliverPadding(
         padding: _hPad,
         sliver: SliverList.builder(
-          itemCount: subsets.length,
+          itemCount: cohorts.length,
           itemBuilder: (context, index) => SituationHeader(
             controller: controller,
-            entries: subsets[index],
+            cohort: cohorts[index],
             noun: 'klassen',
           ),
         ),

--- a/account_manager/lib/src/screens/class_groups_screen.dart
+++ b/account_manager/lib/src/screens/class_groups_screen.dart
@@ -657,11 +657,12 @@ class _SectionTitle extends StatelessWidget {
 
 /// One class of the inventory.
 ///
-/// A class with live work is an [ExpansionTile] keyed exactly as the Acties
+/// A class with live work is a [PendingCardTile] keyed exactly as the Acties
 /// entry tiles are (`entry-group-<klas>`), so opening it offers the same
-/// radios, the same per-field diff and the same dry-run / apply pair. A class
-/// with nothing to do — the majority, and the reason this tab exists — is a
-/// plain card: name, description, three system cells.
+/// radios, the same per-field diff and the same dry-run / apply pair — and
+/// gives way with the same preview lines (#300). A class with nothing to do —
+/// the majority, and the reason this tab exists — is a plain card: name,
+/// description, three system cells.
 class _ClassRow extends StatelessWidget {
   const _ClassRow({
     required this.controller,
@@ -707,27 +708,33 @@ class _ClassRow extends StatelessWidget {
       ],
     );
 
-    final Widget body = Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        if (group.description.isNotEmpty)
-          Text(group.description, style: text.bodySmall),
-        const SizedBox(height: PlinkSpacing.s2),
-        _SystemRow(group: group, work: _workSystems()),
-        for (final line in _lines(entry, group)) ...<Widget>[
-          const SizedBox(height: PlinkSpacing.s1),
-          ActionLine(
-            system: line.system,
-            line: line.text,
-            style: entry == null
-                ? text.bodySmall
-                    ?.copyWith(color: Theme.of(context).disabledColor)
-                : text.bodySmall,
-          ),
-        ],
-      ],
-    );
+    // The row's own body: what the class *is* (description, three system
+    // cells), and — while [showLines] — a preview of what it owes. The preview
+    // is dropped on an open card, because the expanded body leads every
+    // decision with the same sentence (#300); the cells and the description are
+    // facts about the class and stay either way.
+    Widget body({required bool showLines}) => Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            if (group.description.isNotEmpty)
+              Text(group.description, style: text.bodySmall),
+            const SizedBox(height: PlinkSpacing.s2),
+            _SystemRow(group: group, work: _workSystems()),
+            if (showLines)
+              for (final line in _lines(entry, group)) ...<Widget>[
+                const SizedBox(height: PlinkSpacing.s1),
+                ActionLine(
+                  system: line.system,
+                  line: line.text,
+                  style: entry == null
+                      ? text.bodySmall
+                          ?.copyWith(color: Theme.of(context).disabledColor)
+                      : text.bodySmall,
+                ),
+              ],
+          ],
+        );
 
     // Every row is addressable by its class name, whether or not it has work —
     // the inventory is the thing being verified, so a test (and the element
@@ -745,7 +752,9 @@ class _ClassRow extends StatelessWidget {
           children: <Widget>[
             title,
             const SizedBox(height: PlinkSpacing.s2),
-            body,
+            // Nothing to expand, so nothing repeats it: a passive row keeps its
+            // candidate lines.
+            body(showLines: true),
           ],
         ),
       );
@@ -755,19 +764,10 @@ class _ClassRow extends StatelessWidget {
       key: rowKey,
       margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
       decoration: decoration,
-      child: ExpansionTile(
-        key: ValueKey('entry-group-${entry.targetId}'),
-        shape: const Border(),
-        collapsedShape: const Border(),
+      child: PendingCardTile(
+        tileKey: ValueKey('entry-group-${entry.targetId}'),
         title: title,
-        subtitle: body,
-        childrenPadding: const EdgeInsets.fromLTRB(
-          PlinkSpacing.s5,
-          0,
-          PlinkSpacing.s5,
-          PlinkSpacing.s4,
-        ),
-        expandedCrossAxisAlignment: CrossAxisAlignment.start,
+        subtitle: (context, expanded) => body(showLines: !expanded),
         children: entryDetail(context, controller: controller, entry: entry),
       ),
     );
@@ -777,6 +777,9 @@ class _ClassRow extends StatelessWidget {
   /// stored candidates in a passive one — each worded exactly as Acties words
   /// it, so an either/or reads as the one decision it is (#251), and each
   /// carrying the system it writes to so [ActionLine] can lead with it (#298).
+  ///
+  /// A preview, and only that: an open card renders the decisions themselves
+  /// and these lines stand down (#300).
   List<({core.Origin system, String text})> _lines(
     PendingAccountEntry? entry,
     MaterializedGroup group,

--- a/account_manager/lib/src/screens/system_indicator.dart
+++ b/account_manager/lib/src/screens/system_indicator.dart
@@ -1,0 +1,291 @@
+/// The shared **system vocabulary** the two action screens speak (#298): what a
+/// WISA / Smartschool / Office 365 cell means, and how one action line names the
+/// system it writes to.
+///
+/// ## What a coloured cell means
+///
+/// A cell used to answer *does this record exist in system X* and nothing else,
+/// so class `1A` — present in all three systems and carrying a pending Office
+/// 365 roster write — read as three ticks. The ticks were not wrong; they
+/// answered a different question than the one the operator asks when they look
+/// at the row. Since #298 a cell shows the **worst** of two axes for that one
+/// system:
+///
+/// - [SystemIndicatorState.missing] (red) — the record is not there at all;
+/// - [SystemIndicatorState.needsWork] (orange) — it is there, and this screen
+///   has work pending against that system;
+/// - [SystemIndicatorState.inOrder] (green) — it is there and nothing is due.
+///
+/// Missing wins over pending work: a record that does not exist is the bigger
+/// fact, and the work is usually the creation of it.
+///
+/// ## The reconciling principle: colour by work that can be done *on this
+/// screen*
+///
+/// The two screens look like they disagree, and they do not. Klasgroepen keys
+/// its row **highlight** on `MaterializedGroup.needsAttention`, informational
+/// notices included (#225/#250), because there the manual notice *is* the work
+/// the operator does on that screen — a class Smartschool already holds, or an
+/// Office 365 group left behind by a class that is gone, is answered right
+/// there. In Acties an informational candidate is a diagnosis of work that
+/// happens somewhere else, so it colours nothing.
+///
+/// Both are the same rule: **a coloured cell means work you can do here.** The
+/// next reader will otherwise see two rules and assume one is a bug.
+///
+/// The concrete case is `AzureClassGroupMembership`, the student family's only
+/// informational member. Office 365 class membership is a property of the
+/// *group*, so the write is `SyncAzureClassGroupMembers` on Klasgroepen — one
+/// per class rather than one per student. If it coloured a student's Office 365
+/// cell, the September rollover would paint ~3000 accounts orange for work the
+/// Acties screen structurally cannot do. It stays visible in the details pane
+/// as context, marked "(manueel)".
+///
+/// (#290 proposed the opposite — making that action applyable per student. It
+/// was closed on 2026-08-22 and the action still declares `canApply => false`,
+/// so this file's reading is the one in force.)
+///
+/// The predicate is not new. `hasPending`, `pendingDecisionCount` and the tile
+/// badge have counted informational candidates as zero since #245/#255; the
+/// indicators simply apply that same predicate.
+library;
+
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart'
+    show CandidateAction, candidateChoices;
+import 'package:flutter/material.dart';
+import 'package:plink_design_system/plink_design_system.dart';
+
+import '../reconcile/reconcile_controller.dart';
+
+/// The Dutch name the operator knows a system by — the same names the action
+/// summaries and the rest of the screen use (#234). Azure AD is "Office 365"
+/// throughout this app, so the dialog says that and not the tenant's technical
+/// name.
+String systemLabel(core.Origin system) => switch (system) {
+      core.Origin.azure => 'Office 365',
+      core.Origin.smartschool => 'Smartschool',
+      core.Origin.wisa => 'WISA',
+      core.Origin.all => 'alle systemen',
+      core.Origin.other => 'een ander systeem',
+    };
+
+/// What one system cell says about one record, worst first (#298).
+enum SystemIndicatorState {
+  /// The record does not exist in that system — red.
+  missing,
+
+  /// It exists there, and this screen has applyable work pending against it —
+  /// orange.
+  needsWork,
+
+  /// It exists there and nothing is due — green.
+  inOrder,
+}
+
+/// Derives a cell's reading from the two axes (#298): presence, and whether the
+/// pending work of this record lands in that system.
+///
+/// [hasWork] must already have been narrowed to **applyable** work — see
+/// [workSystemsOfEntry] and [workSystemsOfCandidates], which are the only two
+/// ways this app computes it. An informational candidate is not work this
+/// screen can do, so it never reaches here.
+SystemIndicatorState systemIndicatorState({
+  required bool present,
+  required bool hasWork,
+}) {
+  if (!present) return SystemIndicatorState.missing;
+  return hasWork
+      ? SystemIndicatorState.needsWork
+      : SystemIndicatorState.inOrder;
+}
+
+/// The systems the applyable pending work of one **live** entry writes to.
+///
+/// One per decision, read off the alternative the operator has actually
+/// selected — the same resolution an apply pass would run, so the cell cannot
+/// promise a write the button would not make. A decision whose selected half is
+/// informational contributes nothing.
+///
+/// `Origin.wisa` can appear: the `DontImportFromWisa` family's `ChangeSet`
+/// carries it although the connector is read-only and the apply lands as a
+/// shared import rule (#276). That is deliberate — a WISA cell says *there is a
+/// decision about the WISA side of this record*, not *the app will write to
+/// WISA*, and the confirmation dialog is where the difference is spelled out.
+Set<core.Origin> workSystemsOfEntry(PendingAccountEntry entry) => <core.Origin>{
+      for (final choice in entry.choices)
+        if (choice.selected.canApply) choice.selected.changes.system,
+    };
+
+/// The same reading off the **stored** candidates, which is all a passive
+/// session has (#214/#255). Collapsed through [candidateChoices] first, so an
+/// either/or is judged on its pre-selected half exactly as the live path is.
+Set<core.Origin> workSystemsOfCandidates(
+  Iterable<CandidateAction> candidates,
+) =>
+    <core.Origin>{
+      for (final choice in candidateChoices(candidates))
+        if (choice.selected.canApply) choice.selected.system,
+    };
+
+/// The icon a state reads as. Deliberately distinct shapes as well as colours,
+/// so the three states survive a monochrome screenshot and a colour-blind
+/// operator.
+IconData systemIndicatorIcon(SystemIndicatorState state) => switch (state) {
+      SystemIndicatorState.inOrder => Icons.check_circle_outline,
+      SystemIndicatorState.needsWork => Icons.pending_outlined,
+      SystemIndicatorState.missing => Icons.remove_circle_outline,
+    };
+
+/// The colour a state reads as, per theme.
+///
+/// Named here rather than taken from the [ColorScheme] because the Plink
+/// palette has no health colours to borrow: `primary` is the magenta **spark**,
+/// reserved for the one primary action on a page, and a wall of magenta ticks
+/// would both drown the spark and say "look here" about the rows that need
+/// nothing. Green / orange / red is the vocabulary #291 and #295 settled on.
+Color systemIndicatorColor(BuildContext context, SystemIndicatorState state) {
+  final bool dark = Theme.of(context).brightness == Brightness.dark;
+  return switch (state) {
+    SystemIndicatorState.inOrder =>
+      dark ? const Color(0xFF5FB89A) : const Color(0xFF1F7A5A),
+    SystemIndicatorState.needsWork =>
+      dark ? const Color(0xFFE0A458) : const Color(0xFF9A5B00),
+    SystemIndicatorState.missing =>
+      dark ? const Color(0xFFE57373) : Theme.of(context).colorScheme.error,
+  };
+}
+
+/// The one-line Dutch reading of a cell, for its tooltip and its semantics.
+String systemIndicatorTooltip(core.Origin system, SystemIndicatorState state) =>
+    switch (state) {
+      SystemIndicatorState.inOrder => '${systemLabel(system)} staat in orde',
+      SystemIndicatorState.needsWork =>
+        '${systemLabel(system)} heeft werk openstaan',
+      SystemIndicatorState.missing => 'Bestaat niet in ${systemLabel(system)}',
+    };
+
+/// One system cell of a row: the icon in its state's colour, the system's Dutch
+/// name, and optionally the thing that is (or is not) there.
+///
+/// Shared so Klasgroepen's inventory rows and the flat Acties list of #295 mean
+/// the same thing by a coloured cell — the point of #298. Callers give it a
+/// [key] so a test (and #295's row builder) can address one cell of one row.
+class SystemIndicatorCell extends StatelessWidget {
+  const SystemIndicatorCell({
+    super.key,
+    required this.system,
+    required this.state,
+    this.detail,
+    this.note,
+  });
+
+  /// Which system this cell answers for.
+  final core.Origin system;
+
+  /// What it answers.
+  final SystemIndicatorState state;
+
+  /// The name of the thing that is (or is not) there — the Office 365 group.
+  final String? detail;
+
+  /// A second line that explains the row's relationship to [detail].
+  final String? note;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final Color muted = Theme.of(context).disabledColor;
+
+    return Padding(
+      padding: const EdgeInsets.only(right: PlinkSpacing.s2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Tooltip(
+            message: systemIndicatorTooltip(system, state),
+            child: Icon(
+              systemIndicatorIcon(state),
+              size: 16,
+              color: systemIndicatorColor(context, state),
+            ),
+          ),
+          const SizedBox(width: PlinkSpacing.s1),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Text(
+                  systemLabel(system),
+                  style: text.bodySmall,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (detail != null)
+                  Text(
+                    detail!,
+                    style: text.bodySmall?.copyWith(color: muted),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                if (note != null)
+                  Text(
+                    note!,
+                    style: text.bodySmall?.copyWith(color: muted),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One collapsed action line, led by the system it writes to (#298).
+///
+/// One card can raise work in two systems — a class new to Smartschool that also
+/// lacks its Office 365 group — and the summaries do not always say where they
+/// land ("Werk het ledenbestand van GBS-1A bij" names a group, not a system).
+/// With the system in front, a row's lines and its cells tell the same story.
+///
+/// The tag is a [Text] of its own rather than a prefix spliced into [line], so
+/// the summary stays one addressable string: the whole app — the confirmation
+/// dialog, the outcome rows, the details pane — quotes an action by its
+/// summary, and a decorated copy on one screen would no longer match it.
+class ActionLine extends StatelessWidget {
+  const ActionLine({
+    super.key,
+    required this.system,
+    required this.line,
+    this.style,
+  });
+
+  /// The system the action writes to — `ChangeSet.system` / `CandidateAction
+  /// .system`.
+  final core.Origin system;
+
+  /// The line as the screens word it (`pendingChoiceLine` /
+  /// `readOnlyCandidateLine`), untouched.
+  final String line;
+
+  /// The body style; defaults to `bodySmall`. A passive session passes the
+  /// disabled colour so an inert card still reads as inert (#214).
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextStyle? base = style ?? Theme.of(context).textTheme.bodySmall;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          '${systemLabel(system)} ·',
+          style: base?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(width: PlinkSpacing.s1),
+        Expanded(child: Text(line, style: base)),
+      ],
+    );
+  }
+}

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -282,7 +282,7 @@ void main() {
       await h.controller.sync();
       h.log.clear();
 
-      await h.controller.dryRun();
+      await h.controller.dryRunEntries(h.controller.pendingEntries);
 
       final messages = h.log.entries.map((e) => e.message).toList();
       expect(messages.first, startsWith('Dry-run gestart voor '));
@@ -297,7 +297,7 @@ void main() {
       await h.controller.sync();
       h.log.clear();
 
-      await h.controller.applyAll();
+      await h.controller.applyEntries(h.controller.pendingEntries);
 
       final messages = h.log.entries.map((e) => e.message).toList();
       expect(messages.first, startsWith('Toepassen gestart voor '));
@@ -1000,7 +1000,7 @@ void main() {
       final h = ReconcileHarness();
       await h.controller.sync();
 
-      await h.controller.dryRun();
+      await h.controller.dryRunEntries(h.controller.pendingEntries);
 
       final results = h.controller.dryRunResults;
       expect(results, isNotNull);
@@ -1025,7 +1025,7 @@ void main() {
       await h.controller.sync();
       final linkedBefore = h.controller.linked;
 
-      await h.controller.applyAll();
+      await h.controller.applyEntries(h.controller.pendingEntries);
 
       final results = h.controller.applyResults;
       expect(results, isNotNull);
@@ -1100,7 +1100,7 @@ void main() {
       final before = pendingByNode(h.controller);
       expect(before.values, contains(greaterThan(0)));
 
-      await h.controller.dryRun();
+      await h.controller.dryRunEntries(h.controller.pendingEntries);
 
       expect(pendingByNode(h.controller), before);
       expect(h.soap.soapActions, isEmpty, reason: 'nothing was written');
@@ -1120,7 +1120,7 @@ void main() {
       await h.controller.sync();
       expect(klas3C(h.controller).pendingCount, 1);
 
-      await h.controller.applyAll();
+      await h.controller.applyEntries(h.controller.pendingEntries);
 
       expect(
         h.controller.applyResults!.map((r) => r.outcome),
@@ -1227,7 +1227,7 @@ void main() {
       await h.controller.sync();
       final before = await h.linkedStore.readSyncState();
 
-      await h.controller.dryRun();
+      await h.controller.dryRunEntries(h.controller.pendingEntries);
 
       expect(
           (await h.linkedStore.readSyncState()).generation, before.generation);
@@ -1270,7 +1270,7 @@ void main() {
       final h = ReconcileHarness(controllerStore: failing);
       await h.controller.sync();
 
-      await h.controller.applyAll();
+      await h.controller.applyEntries(h.controller.pendingEntries);
 
       expect(failing.appliedWriteAttempted, isTrue);
       expect(h.controller.phase, ReconcilePhase.ready);
@@ -1292,7 +1292,7 @@ void main() {
       );
       await h.controller.sync();
 
-      await h.controller.applyAll();
+      await h.controller.applyEntries(h.controller.pendingEntries);
 
       expect(stalling.appliedWriteAttempted, isTrue);
       expect(h.controller.phase, ReconcilePhase.ready);
@@ -1347,7 +1347,7 @@ void main() {
       expect(h.controller.applyableCount,
           lessThan(h.controller.pendingActions.length));
 
-      await h.controller.applyAll();
+      await h.controller.applyEntries(h.controller.pendingEntries);
 
       expect(h.controller.error, isNull);
       expect(
@@ -1458,7 +1458,7 @@ void main() {
       await h.controller.sync();
 
       final steps = recordSteps(h.controller);
-      await h.controller.applyAll();
+      await h.controller.applyEntries(h.controller.pendingEntries);
 
       expect(steps.map((s) => s.total).toSet(), <int>{steps.length},
           reason: 'the planned total never moves mid-pass');
@@ -1483,7 +1483,7 @@ void main() {
       await h.controller.sync();
 
       final steps = recordSteps(h.controller);
-      await h.controller.dryRun();
+      await h.controller.dryRunEntries(h.controller.pendingEntries);
 
       expect(steps, isNotEmpty);
       expect(steps.map((s) => s.dry), everyElement(isTrue));
@@ -1633,7 +1633,7 @@ void main() {
       expect(h.controller.applyableCount, 4);
 
       final seen = recordProgress(h.controller);
-      await h.controller.applyAll();
+      await h.controller.applyEntries(h.controller.pendingEntries);
 
       expect(seen.first, 0.0);
       expectMonotonic(seen);
@@ -2573,7 +2573,7 @@ void main() {
       );
       await s2.controller.openSession();
 
-      await s2.controller.dryRun();
+      await s2.controller.dryRunEntries(s2.controller.pendingEntries);
 
       expect(s2.controller.dryRunResults, isNotNull);
       expect(s2.controller.dryRunResults, isNotEmpty);

--- a/account_manager/test/reconcile/reconcile_decision_cohort_test.dart
+++ b/account_manager/test/reconcile/reconcile_decision_cohort_test.dart
@@ -1,0 +1,257 @@
+import 'package:account_actions/account_actions.dart' as actions;
+import 'package:account_core/account_core.dart' show Origin;
+import 'package:account_manager/src/reconcile/reconcile_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'reconcile_fakes.dart';
+
+/// #292 — the **decision**, not the account, is the unit a bulk apply acts on.
+///
+/// The grouping used to key on the family plus the sorted set of *every*
+/// decision on a card, so two students who both needed their Smartschool class
+/// changed fell into different subsets the moment one of them also needed a
+/// name fix — and the pass behind the header ran every selected option of every
+/// card it was given, so applying "the class change" also wrote the name fix.
+/// Both halves are fixed here: one decision, one cohort; and a cohort's apply
+/// runs that decision alone.
+void main() {
+  const String move = 'Wijzig de klas in Smartschool';
+  const String rename = 'Wijzig de naam in Azure';
+  const String moveKey = 'student|MoveToSmartschoolClassGroup';
+  const String renameKey = 'student|ModifyAzureName';
+
+  SituationCohort cohort(ReconcileHarness h, String key) =>
+      h.controller.pendingSituations.firstWhere((c) => c.key == key);
+
+  PendingAccountEntry studentNamed(ReconcileHarness h, String name) =>
+      h.controller.pendingEntries.firstWhere((e) => e.target == name);
+
+  List<String> summariesOf(ReconcileHarness h) =>
+      h.controller.applyResults!.map((r) => r.changes.summary).toList();
+
+  List<String> graphPatches(ReconcileHarness h) => h.graph.requests
+      .where((r) => r.method == 'PATCH')
+      .map((r) => r.url.path)
+      .toList();
+
+  int smartschoolMoves(ReconcileHarness h) =>
+      h.soap.soapActions.where((a) => a.endsWith('#saveUserToClass')).length;
+
+  /// Two WISA-departed Smartschool accounts, each raising the unregister *vs*
+  /// delete either/or — one cohort with two members that resolve differently.
+  ReconcileHarness departedHarness() => ReconcileHarness(
+        wisa: wisaSnap(students: const []),
+        smartschool: ssSnap(
+          groups: const [],
+          accounts: [
+            ssAccount(
+              uid: 'jane',
+              accountId: '1',
+              mail: 'jane.doe@student.school.example',
+            ),
+            ssAccount(
+              uid: 'john',
+              accountId: '2',
+              mail: 'john.roe@student.school.example',
+            ),
+          ],
+          memberships: const [],
+        ),
+        azure: azSnap(users: const []),
+      );
+
+  group('one decision, one cohort (#292)', () {
+    test(
+        'every student needing the class change is in its cohort, whatever '
+        'else is on their card', () async {
+      final h = rolloverHarness();
+      await h.controller.sync();
+
+      expect(
+        cohort(h, moveKey).decisions.map((d) => d.entry.target),
+        <String>['Sam Sels', 'Sara Segers', 'Tom Tas'],
+        reason: "Sam's stale Office 365 name used to file him under a "
+            'combination of his own, so the class change reached two of three',
+      );
+      expect(cohort(h, moveKey).label, move);
+    });
+
+    test('a card with two decisions appears in both cohorts', () async {
+      final h = rolloverHarness();
+      await h.controller.sync();
+
+      expect(
+        cohort(h, renameKey).decisions.map((d) => d.entry.target),
+        <String>['Sam Sels'],
+      );
+      final sam = studentNamed(h, 'Sam Sels');
+      expect(sam.choices.map((c) => c.situationId), <String>[
+        'ModifyAzureName',
+        'MoveToSmartschoolClassGroup',
+      ]);
+    });
+
+    test('the cohort a screen renders is grouped from the rows it shows',
+        () async {
+      // The standing rule since #252: label, confirmation scope and write come
+      // from one list. A search box narrows the entries, and the cohorts are
+      // regrouped from what survived — never filtered back out of the whole
+      // linked view.
+      final h = rolloverHarness();
+      await h.controller.sync();
+      final shown = h.controller.pendingEntries
+          .where((e) => e.family == 'student' && e.target != 'Tom Tas')
+          .toList();
+
+      final cohorts = ReconcileController.situationCohorts(shown);
+      expect(
+        cohorts.firstWhere((c) => c.key == moveKey).length,
+        2,
+        reason: 'Tom is off the screen, so no button may reach him',
+      );
+    });
+  });
+
+  group('a cohort applies its own decision and nothing else (#292)', () {
+    test('the class change is written for all three, the name fix for none',
+        () async {
+      final h = rolloverHarness();
+      await h.controller.sync();
+
+      await h.controller.applyDecisions(cohort(h, moveKey).decisions);
+
+      expect(summariesOf(h), <String>[move, move, move]);
+      expect(smartschoolMoves(h), 3);
+      expect(graphPatches(h), isEmpty,
+          reason: "Sam's Office 365 name is a decision the operator did not "
+              'press — a bulk pass that wrote it would be writing something '
+              'nobody read on the header');
+    });
+
+    test("the decision the pass skipped is still Sam's to make afterwards",
+        () async {
+      final h = rolloverHarness();
+      await h.controller.sync();
+
+      await h.controller.applyDecisions(cohort(h, moveKey).decisions);
+
+      expect(
+        cohort(h, renameKey).decisions.map((d) => d.entry.target),
+        <String>['Sam Sels'],
+        reason: 'the pass answered one question and left the other open, '
+            'rather than resolving it on his behalf',
+      );
+      expect(graphPatches(h), isEmpty);
+    });
+
+    test('each member still contributes its own selected alternative',
+        () async {
+      // A cohort of departed students where one is set to unregister and one to
+      // delete applies each as chosen — the #110 guarantee, unchanged by the
+      // move to per-decision passes.
+      final h = departedHarness();
+      await h.controller.sync();
+      final departure =
+          cohort(h, 'student|${actions.smartschoolDepartureAlternative}');
+      expect(departure.length, 2);
+
+      h.controller.chooseAlternative(
+        entry: departure.decisions.last.entry,
+        group: actions.smartschoolDepartureAlternative,
+        kind: 'DeleteStudentFromSmartschool',
+      );
+      // Re-read after the pick, exactly as the header does: `chooseAlternative`
+      // notifies and the cohort is rebuilt from the entries on screen.
+      final chosen =
+          cohort(h, 'student|${actions.smartschoolDepartureAlternative}');
+
+      await h.controller.applyDecisions(chosen.decisions);
+
+      expect(summariesOf(h), hasLength(2));
+      expect(
+          summariesOf(h), contains('Schrijf de leerling uit in Smartschool'));
+      expect(summariesOf(h), contains('Verwijder dit account uit Smartschool'));
+    });
+
+    test('the whole-card apply still writes every decision on that card',
+        () async {
+      // The convenience #292 deliberately keeps: it is not blind, because every
+      // decision on the card is on screen above the button.
+      final h = rolloverHarness();
+      await h.controller.sync();
+
+      await h.controller.applyEntry(studentNamed(h, 'Sam Sels'));
+
+      expect(summariesOf(h), containsAll(<String>[rename, move]));
+      expect(graphPatches(h), hasLength(1));
+      expect(smartschoolMoves(h), 1);
+    });
+  });
+
+  group('the confirmation dialog describes the one decision (#292)', () {
+    test('a cohort scope counts and names only its own decision', () async {
+      final h = rolloverHarness();
+      await h.controller.sync();
+
+      final scope =
+          h.controller.applyScopeForDecisions(cohort(h, moveKey).decisions);
+
+      expect(
+          scope.systems,
+          <Origin>[
+            Origin.smartschool,
+            Origin.smartschool,
+            Origin.smartschool,
+          ],
+          reason: 'three class changes — never the Office 365 rename that '
+              "shares Sam's card");
+      expect(scope.chained, isEmpty);
+    });
+
+    test('the whole-card scope over the same students still counts everything',
+        () async {
+      // The contrast that makes the narrowing visible: the same three accounts,
+      // read as cards rather than as one decision, are four writes across two
+      // systems.
+      final h = rolloverHarness();
+      await h.controller.sync();
+      final students = h.controller.pendingEntries
+          .where((e) => e.family == 'student')
+          .toList();
+
+      final scope = h.controller.applyScope(students);
+
+      expect(scope.systems, hasLength(4));
+      expect(scope.systems, contains(Origin.azure));
+    });
+  });
+
+  group('a verdict still lands under the decision it answers (#283)', () {
+    test('a per-decision pass routes its rows to the right block', () async {
+      // A dry run settles nothing, so both of Sam's decisions are still on his
+      // card to be answered — which is exactly the state that makes the routing
+      // observable.
+      final h = rolloverHarness();
+      await h.controller.sync();
+
+      await h.controller.dryRunDecisions(cohort(h, moveKey).decisions);
+
+      final sam = studentNamed(h, 'Sam Sels');
+      final moveChoice = sam.choices
+          .singleWhere((c) => c.situationId == 'MoveToSmartschoolClassGroup');
+      final renameChoice =
+          sam.choices.singleWhere((c) => c.situationId == 'ModifyAzureName');
+
+      expect(
+        h.controller
+            .applyOutcomesForChoice(sam, moveChoice)
+            .map((r) => r.changes.summary),
+        <String>[move],
+      );
+      expect(h.controller.applyOutcomesForChoice(sam, renameChoice), isEmpty,
+          reason: 'the pass never touched that decision, so its block reports '
+              'nothing');
+      expect(h.controller.unroutedApplyOutcomesFor(sam), isEmpty);
+    });
+  });
+}

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1531,7 +1531,7 @@ ReconcileHarness appliedClassWorkHarness({
 /// A harness for the classroom-scoped bulk apply (#252). One managed school,
 /// two third-year classes, and the **same** student situation in both: every
 /// student's Office 365 display name is stale, so each raises a lone
-/// `ModifyAzureName` and they all share one `situationKey`.
+/// `ModifyAzureName` and they all fall into one decision cohort.
 ///
 /// 3C holds two of them (Sam and Sara) — enough for the same-situation bulk
 /// header to render at all, since it only appears above a subset of more than
@@ -1621,6 +1621,102 @@ ReconcileHarness crossClassSituationHarness() => ReconcileHarness(
 const String kSam3C = 'az-sam-3c';
 const String kSara3C = 'az-sara-3c';
 const String kTom3D = 'az-tom-3d';
+
+/// A harness for the September rollover (#292). Three students moved up into
+/// `4A` while Smartschool still has all three sitting in last year's `3C`, so
+/// every one of them raises the very same decision — `MoveToSmartschoolClassGroup`.
+///
+/// One of them, Sam, *also* has a stale Office 365 display name. That is the
+/// whole fixture: a second, unrelated decision on one of the three cards.
+/// Grouping on the family plus the sorted set of every decision on a card put
+/// Sam in a subset of his own, so the bulk header for the class change covered
+/// two students instead of three — and the one it did cover, it covered together
+/// with whatever else was on their cards.
+///
+/// The rollover is when this matters. Every student in the school changes class
+/// at once, alongside whatever else drifted on their record over the summer, so
+/// the operation the app most needs to do in one pass is the one the old
+/// grouping fragmented hardest.
+ReconcileHarness rolloverHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(
+              wisaId: '1', classGroup: '4A', firstName: 'Sam', name: 'Sels'),
+          wisaStudent(
+              wisaId: '2', classGroup: '4A', firstName: 'Sara', name: 'Segers'),
+          wisaStudent(
+              wisaId: '3', classGroup: '4A', firstName: 'Tom', name: 'Tas'),
+        ],
+        schools: [wisaSchool(1)],
+        classGroups: [
+          wisaClassGroup('4A', adminCode: 'a4', schoolCode: '111'),
+          wisaClassGroup('3C', adminCode: 'a3', schoolCode: '111'),
+        ],
+      ),
+      smartschool: ssSnap(
+        groups: [
+          ssGroup('4A', code: '4A_ss', untis: '4A'),
+          ssGroup('3C', code: '3C_ss', untis: '3C'),
+        ],
+        accounts: [
+          ssAccount(
+            uid: 'sam',
+            accountId: '1',
+            mail: 'sam.sels@student.school.example',
+            givenName: 'Sam',
+            surname: 'Sels',
+          ),
+          ssAccount(
+            uid: 'sara',
+            accountId: '2',
+            mail: 'sara.segers@student.school.example',
+            givenName: 'Sara',
+            surname: 'Segers',
+          ),
+          ssAccount(
+            uid: 'tom',
+            accountId: '3',
+            mail: 'tom.tas@student.school.example',
+            givenName: 'Tom',
+            surname: 'Tas',
+          ),
+        ],
+        // Still in last year's class — the move every one of them needs.
+        memberships: [
+          member('sam', '3C_ss'),
+          member('sara', '3C_ss'),
+          member('tom', '3C_ss'),
+        ],
+      ),
+      // Only Sam's display name is stale, so only Sam carries a second decision.
+      azure: azSnap(users: [
+        azUser(
+          id: kSamRollover,
+          upn: 'sam.sels@student.school.example',
+          employeeId: '1',
+        ),
+        azUser(
+          id: kSaraRollover,
+          upn: 'sara.segers@student.school.example',
+          employeeId: '2',
+          displayName: 'Sara Segers',
+        ),
+        azUser(
+          id: kTomRollover,
+          upn: 'tom.tas@student.school.example',
+          employeeId: '3',
+          displayName: 'Tom Tas',
+        ),
+      ]),
+      ourSchoolIds: const {1},
+    );
+
+/// The Azure object ids of [rolloverHarness]'s three students. A test proves a
+/// per-decision bulk apply left the *other* decisions alone by finding no Graph
+/// write against [kSamRollover].
+const String kSamRollover = 'az-sam-4a';
+const String kSaraRollover = 'az-sara-4a';
+const String kTomRollover = 'az-tom-4a';
 
 /// A harness for the managed-school class-group scope (#205). WISA hands the
 /// session class groups from two schools, and the sibling school's arrive

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1875,6 +1875,10 @@ ReconcileHarness azureClassGroupHarness({
 ///
 /// The four prefixed non-class groups are here too — they must not appear in the
 /// inventory at all, let alone in that subset.
+///
+/// `GBS-9Z` still holds the 21 members its class left behind (#305): both halves
+/// of the either/or name that number, and a stale group with an empty roster
+/// cannot show whether the card *states* it or claims it is being cleared.
 ReconcileHarness staleClassGroupHarness() => ReconcileHarness(
       wisa: wisaSnap(
         students: [wisaStudent(wisaId: '1', classGroup: '1A')],
@@ -1904,7 +1908,8 @@ ReconcileHarness staleClassGroupHarness() => ReconcileHarness(
         ],
         groups: [
           azClassGroup('1A', memberIds: const ['az1']),
-          azClassGroup('9Z'),
+          azClassGroup('9Z',
+              memberIds: List<String>.generate(21, (int i) => 'az-oud-$i')),
           azClassGroup('8Y'),
           azNonClassGroup('GBS - GOK'),
           azNonClassGroup('GBS-OKAN'),

--- a/account_manager/test/reconcile/reconcile_pending_choice_test.dart
+++ b/account_manager/test/reconcile/reconcile_pending_choice_test.dart
@@ -63,16 +63,21 @@ void main() {
           reason: 'unregister (keep the account) is the safe default');
     });
 
-    test('the two departed accounts share one situation subset', () async {
+    test('the two departed accounts share one situation cohort', () async {
       final h = departedHarness();
       await h.controller.sync();
 
-      final studentSituations = h.controller.pendingSituations
-          .where((s) => s.every((e) => e.family == 'student'))
+      final studentCohorts = h.controller.pendingSituations
+          .where((c) => c.decisions.every((d) => d.entry.family == 'student'))
           .toList();
-      expect(studentSituations, hasLength(1),
+      expect(studentCohorts, hasLength(1),
           reason: 'both departed students are the same situation');
-      expect(studentSituations.single, hasLength(2));
+      expect(studentCohorts.single.length, 2);
+      expect(
+        studentCohorts.single.key,
+        'student|${actions.smartschoolDepartureAlternative}',
+        reason: 'a cohort is keyed by the one decision it groups (#292)',
+      );
     });
   });
 
@@ -289,20 +294,24 @@ void main() {
       final entries = h.controller.groupPendingEntries;
       expect(entries.map((e) => e.targetId), containsAll(<String>['1A', '1B']));
 
-      final key = entries.firstWhere((e) => e.targetId == '1A').situationKey;
-      final subset = entries.where((e) => e.situationKey == key).toList();
+      final cohort = h.controller.groupPendingSituations.firstWhere(
+          (c) => c.key == 'group|${actions.classImportAlternative}');
       expect(
-        subset.map((e) => e.targetId),
+        cohort.decisions.map((d) => d.entry.targetId),
         containsAll(<String>['1A', '1B']),
         reason: 'both new classes are the same situation, bulk-applied at once',
       );
       final pulls = h.wisaSyncs;
 
-      await h.controller.applyEntries(subset);
+      await h.controller.applyDecisions(cohort.decisions);
 
       final summaries = summariesOf(h);
       expect(summaries.where((s) => s == create), hasLength(2));
       expect(summaries, isNot(contains(ignore)));
+      expect(summaries, hasLength(2),
+          reason: 'the cohort is one decision, so the pass writes that '
+              "decision and nothing else on the classes' cards — their "
+              'Office 365 groups are a decision of their own (#292)');
       expect(h.wisaSyncs, pulls);
     });
 
@@ -379,13 +388,25 @@ void main() {
         importChoiceOf(entryFor(h, '1A')).situationId,
         actions.classImportAlternative,
       );
+      final cohorts = h.controller.groupPendingSituations;
+      final namesake = cohorts.firstWhere(
+        (c) => c.key == 'group|${actions.namesakeClassAlternative}',
+      );
+      final fresh = cohorts.firstWhere(
+        (c) => c.key == 'group|${actions.classImportAlternative}',
+      );
       expect(
-        entryFor(h, '2G').situationKey,
-        isNot(entryFor(h, '1A').situationKey),
+        namesake.decisions.map((d) => d.entry.targetId),
+        <String>['2G', '2H'],
         reason: '"create this class" and "this class is already there" are two '
             'situations, so they get two bulk headers',
       );
-      expect(entryFor(h, '2G').situationKey, entryFor(h, '2H').situationKey);
+      expect(
+          fresh.decisions.map((d) => d.entry.targetId), <String>['1A', '1B']);
+      expect(namesake.applyableCount, 0,
+          reason: 'the hand-fix notice writes nothing, so its cohort offers '
+              'nothing to apply — the Office 365 group beside it on the same '
+              'cards is a cohort of its own (#292)');
     });
 
     test('"apply to all" creates the new classes and blacklists no namesake',
@@ -519,16 +540,16 @@ void main() {
       final entries = staffEntries(h);
       expect(entries, hasLength(2));
 
-      final key = entries.first.situationKey;
-      final subset = entries.where((e) => e.situationKey == key).toList();
+      final cohort = h.controller.pendingSituations.firstWhere(
+          (c) => c.key == 'staff|${actions.staffImportAlternative}');
       expect(
-        subset,
-        hasLength(2),
+        cohort.decisions.map((d) => d.entry.targetId),
+        entries.map((e) => e.targetId),
         reason: 'both new hires are the same situation, bulk-applied at once',
       );
       final pulls = h.wisaSyncs;
 
-      await h.controller.applyEntries(subset);
+      await h.controller.applyDecisions(cohort.decisions);
 
       final summaries = summariesOf(h);
       expect(summaries.where((s) => s == createAzure), hasLength(2));

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -112,17 +112,19 @@ void main() {
     // The one fixture student's applyable actions surface as a pending indicator.
     expect(find.text('2 openstaande acties'), findsOneWidget);
 
-    // …but the pending actions moved to the Actions tab: neither the title, the
-    // global apply, nor any entry tile is on the Reconcile screen (#154).
+    // …but the pending actions moved to the Actions tab: neither the title, an
+    // apply affordance, nor any entry tile is on the Reconcile screen (#154).
     expect(find.textContaining('Pending actions'), findsNothing);
-    expect(find.byKey(const ValueKey('actions-apply')), findsNothing);
     expect(find.byKey(const ValueKey('reconcile-apply')), findsNothing);
-    expect(
-      find.byWidgetPredicate((w) =>
-          w.key is ValueKey<String> &&
-          (w.key! as ValueKey<String>).value.startsWith('entry-')),
-      findsNothing,
-    );
+    for (final String prefix in <String>['entry-', 'situation-']) {
+      expect(
+        find.byWidgetPredicate((w) =>
+            w.key is ValueKey<String> &&
+            (w.key! as ValueKey<String>).value.startsWith(prefix)),
+        findsNothing,
+        reason: 'no "$prefix" affordance belongs on Synchronisatie',
+      );
+    }
 
     // A second sync with unchanged WISA: the no-changes banner.
     harness.wisaResult =

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -1242,10 +1242,12 @@ void main() {
     await tester.tap(find.text('3C'));
     await tester.pumpAndSettle();
     expect(harness.controller.linked, isNull, reason: 'passive session');
-    expect(find.text('• Schrijf de leerling uit in Smartschool (keuze)'),
+    expect(find.text('Schrijf de leerling uit in Smartschool (keuze)'),
         findsOneWidget);
-    expect(find.text('• Verwijder dit account uit Smartschool'), findsNothing,
+    expect(find.text('Verwijder dit account uit Smartschool'), findsNothing,
         reason: 'the delete is the alternative, not a second to-do');
+    // And since #298 the line says where the write lands.
+    expect(find.text('Smartschool ·'), findsOneWidget);
   });
 
   testWidgets(
@@ -1283,11 +1285,14 @@ void main() {
     expect(find.text('Sam Sels'), findsOneWidget);
 
     expect(
-      find.text('• Zit in de verkeerde Office 365-klasgroep: GBS-1A in plaats '
+      find.text('Zit in de verkeerde Office 365-klasgroep: GBS-1A in plaats '
           'van GBS-1B. Werk het ledenbestand van beide klassen bij. (manueel)'),
       findsOneWidget,
       reason: 'the operator must be able to tell manual work from due work',
     );
+    // The line names the system it concerns (#298) — and that tag is the only
+    // marking it gets: an informational candidate colours no indicator.
+    expect(find.text('Office 365 ·'), findsOneWidget);
 
     // …and it stays a "(manueel)" line, never a "(keuze)" one: it stands alone.
     expect(find.textContaining('(keuze)'), findsNothing);
@@ -1307,8 +1312,9 @@ void main() {
     await tester.pumpAndSettle();
 
     await _drill(tester, node: 'Jaar 3', classroom: '3C');
-    expect(find.text('• Wijzig de klas in Smartschool'), findsOneWidget);
+    expect(find.text('Wijzig de klas in Smartschool'), findsOneWidget);
     expect(find.textContaining('(manueel)'), findsNothing);
+    expect(find.text('Smartschool ·'), findsOneWidget);
   });
 
   testWidgets(
@@ -1500,7 +1506,7 @@ void main() {
     expect(find.text('Jane Doe'), findsOneWidget);
     expect(find.byIcon(Icons.lock_outline), findsWidgets);
     final candidate = tester.widget<Text>(
-      find.text('• Wijzig de klas in Smartschool'),
+      find.text('Wijzig de klas in Smartschool'),
     );
     expect(
       candidate.style?.color,

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -381,9 +381,7 @@ void main() {
 
     expect(
         find.textContaining('accounts in dezelfde situatie'), findsOneWidget);
-    final key = harness.controller.pendingEntries
-        .firstWhere((e) => e.family == 'student')
-        .situationKey;
+    final key = harness.controller.classroomPendingSituations.single.key;
     final bulkApply = ValueKey('situation-apply-$key');
     expect(find.byKey(bulkApply), findsOneWidget);
 
@@ -433,10 +431,12 @@ void main() {
 
     final inClass = harness.controller.classroomPendingEntries;
     expect(inClass, hasLength(2), reason: '3C holds Sam and Sara');
-    final key = inClass.first.situationKey;
+    final key = harness.controller.classroomPendingSituations.single.key;
     expect(
-      harness.controller.pendingEntries.where((e) => e.situationKey == key),
-      hasLength(3),
+      harness.controller.pendingSituations
+          .firstWhere((c) => c.key == key)
+          .length,
+      3,
       reason: "Tom's 3D entry is the very same situation, group-wide",
     );
 
@@ -470,8 +470,10 @@ void main() {
         reason: 'the operator never opened 3D — it must not be written');
     // …and Tom's work is still pending, waiting for someone to open his class.
     expect(
-      harness.controller.pendingEntries.where((e) => e.situationKey == key),
-      hasLength(1),
+      harness.controller.pendingSituations
+          .firstWhere((c) => c.key == key)
+          .length,
+      1,
     );
   });
 
@@ -1820,9 +1822,7 @@ void main() {
       await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
 
       // The same-situation bulk dry-run.
-      final key = harness.controller.pendingEntries
-          .firstWhere((e) => e.family == 'student')
-          .situationKey;
+      final key = harness.controller.classroomPendingSituations.single.key;
       final bulkDryRun = find.byKey(ValueKey('situation-dry-run-$key'));
       await tester.ensureVisible(bulkDryRun);
       await tester.tap(bulkDryRun);

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -147,6 +147,63 @@ void main() {
     expect(find.byKey(ValueKey('entry-dry-run-$id')), findsOneWidget);
   });
 
+  testWidgets('an open account card states its summary once (#300)',
+      (WidgetTester tester) async {
+    // The same duplication the class rows had, on the tile this screen owns.
+    // The collapsed card previews its decisions; since #281 the expanded body
+    // leads each of them with the very same sentence, so opening the card
+    // printed every summary twice, one line directly above the other. Jane
+    // raises two — an Azure rename and a Smartschool class move — so this also
+    // pins that the preview goes as a whole rather than per decision.
+    _useTallWindow(tester);
+    final harness = ReconcileHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+
+    final id = harness.controller.classroomPendingEntries.single.targetId;
+    final Finder tile = find.byKey(ValueKey('entry-student-$id'));
+    const List<String> summaries = <String>[
+      'Wijzig de naam in Azure',
+      'Wijzig de klas in Smartschool',
+    ];
+
+    for (final summary in summaries) {
+      expect(find.descendant(of: tile, matching: find.text(summary)),
+          findsOneWidget,
+          reason: 'collapsed, $summary is previewed once');
+    }
+
+    await tester.ensureVisible(tile);
+    await tester.tap(tile);
+    await tester.pumpAndSettle();
+
+    for (final (index, summary) in summaries.indexed) {
+      expect(
+        find.descendant(of: tile, matching: find.text(summary)),
+        findsOneWidget,
+        reason: 'the decision heading takes the preview line\'s place rather '
+            'than joining it',
+      );
+      expect(
+        find.descendant(
+          of: find.byKey(ValueKey('entry-choice-student-$id-$index')),
+          matching: find.text(summary),
+        ),
+        findsOneWidget,
+        reason: 'and the half that survives is the heading, which groups the '
+            'diff below it',
+      );
+    }
+    // Still led by the system it writes to (#298): with the preview gone, the
+    // headings are the only place on an open card that says so.
+    expect(find.descendant(of: tile, matching: find.text('Smartschool ·')),
+        findsOneWidget);
+    expect(find.descendant(of: tile, matching: find.text('Office 365 ·')),
+        findsOneWidget);
+  });
+
   testWidgets('cancelling the apply dialog writes nothing (#154)',
       (WidgetTester tester) async {
     _useTallWindow(tester);

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -44,7 +44,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Niet geconfigureerd'), findsOneWidget);
-    expect(find.byKey(const ValueKey('actions-dry-run')), findsNothing);
+    expect(
+        find.byKey(const ValueKey('actions-only-with-actions')), findsNothing);
   });
 
   testWidgets('a failed bootstrap offers a retry, in Dutch (#253)',
@@ -111,29 +112,39 @@ void main() {
   });
 
   testWidgets(
-      'the global Dry-run all / Apply all act across all classes (#154)',
-      (WidgetTester tester) async {
+      'the header states the workload and offers nothing that acts on all of '
+      'it (#294)', (WidgetTester tester) async {
+    // The global "Dry-run alles" / "Alles toepassen" pair used to sit here and
+    // write every pending action in every class off one dialog, over a
+    // drill-down the operator had not opened. What replaces it is nothing: the
+    // count is a statement of how much work exists, and every way to act on
+    // that work is reached by looking at it first.
     _useTallWindow(tester);
     final harness = ReconcileHarness();
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    // Dry-run everything from the header — no drill needed, nothing written.
-    await tester.tap(find.byKey(const ValueKey('actions-dry-run')));
-    await tester.pumpAndSettle();
-    expect(find.text('Resultaat van de dry-run'), findsOneWidget);
-    expect(harness.soap.soapActions, isEmpty);
+    expect(
+      find.textContaining(
+          '${harness.controller.totalPendingCount} openstaande actie(s)'),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('actions-dry-run')), findsNothing);
+    expect(find.byKey(const ValueKey('actions-apply')), findsNothing);
+    expect(find.text('Dry-run alles'), findsNothing);
+    expect(find.text('Alles toepassen'), findsNothing);
+    expect(find.byKey(const ValueKey('actions-progress')), findsNothing);
 
-    // Apply everything: confirm the dialog, the Smartschool write happens.
-    await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
-    await tester.tap(find.byKey(const ValueKey('actions-apply')));
+    // Per-entry apply is untouched — bulk moves down to where the cohort is on
+    // screen, it is not taken away.
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
+    final id = harness.controller.classroomPendingEntries.single.targetId;
+    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
     await tester.pumpAndSettle();
-    expect(find.text('Openstaande acties toepassen?'), findsOneWidget);
-    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-    await tester.pumpAndSettle();
-    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
-    expect(harness.soap.soapActions, isNotEmpty);
+    expect(find.byKey(ValueKey('entry-apply-$id')), findsOneWidget);
+    expect(find.byKey(ValueKey('entry-dry-run-$id')), findsOneWidget);
   });
 
   testWidgets('cancelling the apply dialog writes nothing (#154)',
@@ -143,9 +154,14 @@ void main() {
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
+    await _drill(tester, node: 'Jaar 3', classroom: '3C');
 
-    await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
-    await tester.tap(find.byKey(const ValueKey('actions-apply')));
+    final id = harness.controller.classroomPendingEntries.single.targetId;
+    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Annuleer'));
     await tester.pumpAndSettle();
@@ -1684,11 +1700,17 @@ void main() {
           .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
       await tester.pumpAndSettle();
 
+      await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
+
       // Idle: no dialog.
       expect(dialog, findsNothing);
 
-      await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
-      await tester.tap(find.byKey(const ValueKey('actions-apply')));
+      // Driven from the cohort header — the two departed students are one
+      // decision, on screen, above the button that applies it.
+      final bulk = find.byKey(ValueKey(
+          'situation-apply-${harness.controller.classroomPendingSituations.single.key}'));
+      await tester.ensureVisible(bulk);
+      await tester.tap(bulk);
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
       await tester.pumpAndSettle();
@@ -1752,9 +1774,13 @@ void main() {
           .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
       await tester.pumpAndSettle();
 
+      await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
+
       // A dry-run needs no confirmation, so it goes straight into the pass.
-      await tester.ensureVisible(find.byKey(const ValueKey('actions-dry-run')));
-      await tester.tap(find.byKey(const ValueKey('actions-dry-run')));
+      final bulkDryRun = find.byKey(ValueKey(
+          'situation-dry-run-${harness.controller.classroomPendingSituations.single.key}'));
+      await tester.ensureVisible(bulkDryRun);
+      await tester.tap(bulkDryRun);
       await tester.pumpAndSettle();
 
       expect(dialog, findsOneWidget);
@@ -1787,8 +1813,12 @@ void main() {
           .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
       await tester.pumpAndSettle();
 
-      await tester.ensureVisible(find.byKey(const ValueKey('actions-apply')));
-      await tester.tap(find.byKey(const ValueKey('actions-apply')));
+      await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
+
+      final bulk = find.byKey(ValueKey(
+          'situation-apply-${harness.controller.classroomPendingSituations.single.key}'));
+      await tester.ensureVisible(bulk);
+      await tester.tap(bulk);
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
       await tester.pumpAndSettle();
@@ -1810,10 +1840,10 @@ void main() {
       );
     });
 
-    testWidgets('the per-situation and per-entry affordances run behind it too',
+    testWidgets('the per-entry affordance runs behind it too',
         (WidgetTester tester) async {
       _useTallWindow(tester);
-      var gate = Completer<void>();
+      final gate = Completer<void>();
       final harness = twoDeparted(gate: () => gate.future);
       await harness.controller.sync();
       await tester
@@ -1821,21 +1851,7 @@ void main() {
       await tester.pumpAndSettle();
       await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
 
-      // The same-situation bulk dry-run.
-      final key = harness.controller.classroomPendingSituations.single.key;
-      final bulkDryRun = find.byKey(ValueKey('situation-dry-run-$key'));
-      await tester.ensureVisible(bulkDryRun);
-      await tester.tap(bulkDryRun);
-      await tester.pumpAndSettle();
-      expect(dialog, findsOneWidget);
-      expect(find.text('Dry-run bezig…'), findsOneWidget);
-      expect(line(tester, 'actions-progress-count'), 'Actie 1 van 2');
-      gate.complete();
-      await tester.pumpAndSettle();
-      expect(dialog, findsNothing);
-
-      // The per-entry apply, which is a pass of exactly one.
-      gate = Completer<void>();
+      // A pass of exactly one, next to the two-account cohort pass above.
       final entry = harness.controller.pendingEntries
           .firstWhere((e) => e.target == 'Sofie Claes');
       final id = entry.targetId;

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -1048,6 +1048,46 @@ void main() {
     expect(harness.graph.deletedGroups, isEmpty);
   });
 
+  testWidgets(
+      'the stale-group card states the group\'s facts instead of diffing them '
+      '(#305)', (WidgetTester tester) async {
+    // `GBS-9Z` is the group of a class that stopped running, still holding its
+    // 21 members. Under the heading "Laat de Office 365-groep GBS-9Z staan"
+    // its two fields read
+    //
+    //   mail: GBS-9Z@student.school.example → ∅
+    //   leden: 21 → ∅
+    //
+    // — the address and the members going away, which is precisely what the
+    // *other* radio does and what this one promises not to.
+    _useTallWindow(tester);
+    final harness = staleClassGroupHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('entry-group-GBS-9Z')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('mail: GBS-9Z@student.school.example'), findsOneWidget);
+    expect(find.text('leden: 21'), findsOneWidget);
+    expect(find.textContaining('→ ∅'), findsNothing,
+        reason: 'the option that writes nothing clears nothing');
+
+    // The delete beside it names the same facts — the inventory of what goes,
+    // not three fields each being emptied. "verdwijnen mee" was never a value.
+    await tester
+        .tap(find.byKey(const ValueKey('alt-GBS-9Z-DeleteAzureClassGroup')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('mail: GBS-9Z@student.school.example'), findsOneWidget);
+    expect(find.text('leden: 21'), findsOneWidget);
+    expect(find.text('postvak, Teams en bestanden: verdwijnen mee'),
+        findsOneWidget);
+    expect(find.textContaining('→ ∅'), findsNothing);
+  });
+
   testWidgets('classes sort by year, numerically (#227)',
       (WidgetTester tester) async {
     expect(compareClassNames('2A', '10A'), lessThan(0));

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -1,4 +1,6 @@
+import 'package:account_core/account_core.dart' as core;
 import 'package:account_manager/src/screens/class_groups_screen.dart';
+import 'package:account_manager/src/screens/system_indicator.dart';
 import 'package:account_state/account_state.dart' show InMemoryLinkedStore;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -21,6 +23,18 @@ final Finder _filter =
 final Finder _search = find.byKey(const ValueKey('class-groups-search'));
 
 Finder _row(String klas) => find.byKey(ValueKey('class-row-$klas'));
+
+/// What one row's cell says about one system (#298).
+SystemIndicatorState _cell(
+  WidgetTester tester,
+  String klas,
+  core.Origin system,
+) =>
+    tester
+        .widget<SystemIndicatorCell>(
+          find.byKey(ValueKey('class-cell-$klas-${system.name}')),
+        )
+        .state;
 
 /// Types [needle] into the inventory search box and settles.
 Future<void> _type(WidgetTester tester, String needle) async {
@@ -114,6 +128,104 @@ void main() {
         findsOneWidget);
     expect(find.descendant(of: row, matching: find.text('Eerste jaar A')),
         findsOneWidget);
+    for (final system in const <core.Origin>[
+      core.Origin.wisa,
+      core.Origin.smartschool,
+      core.Origin.azure,
+    ]) {
+      expect(_cell(tester, '1A', system), SystemIndicatorState.inOrder);
+    }
+  });
+
+  testWidgets(
+      'a class that is present everywhere but carries a pending Office 365 '
+      'write says so on its Office 365 cell (#298)',
+      (WidgetTester tester) async {
+    // The screenshot in the issue: `1A` exists in WISA, Smartschool and Office
+    // 365 and is carrying an Azure roster write, so it used to render three
+    // ticks with nothing on the card saying the pending work was an Azure one.
+    _useTallWindow(tester);
+    final harness = azureClassMembershipHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(_cell(tester, '1A', core.Origin.wisa), SystemIndicatorState.inOrder);
+    expect(_cell(tester, '1A', core.Origin.smartschool),
+        SystemIndicatorState.inOrder);
+    expect(
+      _cell(tester, '1A', core.Origin.azure),
+      SystemIndicatorState.needsWork,
+      reason: 'the class is carrying a stale Office 365 roster',
+    );
+
+    // And the line itself names the system it writes to, so the card and the
+    // cell tell the same story.
+    expect(
+      find.descendant(of: _row('1A'), matching: find.text('Office 365 ·')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: _row('1A'),
+        matching: find.textContaining('Werk het ledenbestand van GBS-1A bij'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
+      'a class with no Office 365 group reads missing, not pending '
+      '(#298)', (WidgetTester tester) async {
+    // Missing beats work pending: `2F ECO` is in WISA and Smartschool and has
+    // no group at all, and the create it raises is exactly the work of making
+    // one. The cell must say the group is absent, not that it needs a tweak.
+    _useTallWindow(tester);
+    final harness = azureClassGroupHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(_cell(tester, '2F ECO', core.Origin.wisa),
+        SystemIndicatorState.inOrder);
+    expect(_cell(tester, '2F ECO', core.Origin.smartschool),
+        SystemIndicatorState.inOrder);
+    expect(_cell(tester, '2F ECO', core.Origin.azure),
+        SystemIndicatorState.missing);
+  });
+
+  testWidgets(
+      'an informational-only class colours no cell, and still lights its row '
+      '(#298)', (WidgetTester tester) async {
+    // `GBS-9Z` is the group of a class that stopped running. Its decision is an
+    // either/or whose default half is the "laat staan" notice (#271), so there
+    // is no write pending and the Office 365 cell stays green — while the row
+    // itself is highlighted, because `needsAttention` counts the notice and on
+    // this screen the notice *is* the work (#225/#250).
+    _useTallWindow(tester);
+    final harness = azureClassGroupHarness(withStaleGroup: true);
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(_cell(tester, 'GBS-9Z', core.Origin.azure),
+        SystemIndicatorState.inOrder);
+    expect(_cell(tester, 'GBS-9Z', core.Origin.wisa),
+        SystemIndicatorState.missing);
+    expect(_cell(tester, 'GBS-9Z', core.Origin.smartschool),
+        SystemIndicatorState.missing);
+
+    final ColorScheme colors =
+        Theme.of(tester.element(_row('GBS-9Z'))).colorScheme;
+    final Container box = tester.widget<Container>(_row('GBS-9Z'));
+    expect(
+      ((box.decoration! as BoxDecoration).border! as Border).top.color,
+      colors.primary,
+      reason: 'the row still asks something of the operator',
+    );
   });
 
   testWidgets(

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -421,6 +421,62 @@ void main() {
   });
 
   testWidgets(
+      'an open row states its summary once, and its member counts as counts '
+      '(#300)', (WidgetTester tester) async {
+    // Class `1A` raises one decision: the Office 365 roster write. Collapsed,
+    // the row previews it; since #281 the expanded body leads that decision
+    // with the very same sentence, so opening the row printed it twice, one
+    // line directly above the other. And the roster numbers went through the
+    // before/after template — "leden toevoegen: ∅ → 1" — which claims a field
+    // used to be empty and is becoming 1, true of nothing that happens here.
+    _useTallWindow(tester);
+    final harness = azureClassMembershipHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    const String summary =
+        'Werk het ledenbestand van GBS-1A bij (1 toevoegen, 1 verwijderen)';
+    const ValueKey<String> block = ValueKey('entry-choice-group-1A-0');
+
+    // Collapsed, the preview says it — once.
+    expect(find.descendant(of: _row('1A'), matching: find.text(summary)),
+        findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('entry-group-1A')));
+    await tester.pumpAndSettle();
+
+    // Open, it is still said once: the decision's heading takes the preview's
+    // place rather than joining it.
+    expect(
+      find.descendant(of: _row('1A'), matching: find.text(summary)),
+      findsOneWidget,
+      reason: 'the heading replaces the collapsed preview, it does not repeat '
+          'it',
+    );
+    expect(
+      find.descendant(of: find.byKey(block), matching: find.text(summary)),
+      findsOneWidget,
+      reason: 'and the surviving half is the heading, which groups the diff '
+          'below it',
+    );
+    // It is still led by the system it writes to (#298) — with the preview
+    // gone, this heading is the only thing on the card that says so.
+    expect(
+      find.descendant(
+          of: find.byKey(block), matching: find.text('Office 365 ·')),
+      findsOneWidget,
+    );
+
+    // And the numbers read as the quantities they are.
+    expect(find.text('leden toevoegen: 1'), findsOneWidget);
+    expect(find.text('leden verwijderen: 1'), findsOneWidget);
+    expect(find.textContaining('∅ →'), findsNothing,
+        reason: 'a count is not a field whose old value was empty');
+  });
+
+  testWidgets(
       'a row with two decisions puts each one\'s fields under its own heading '
       '(#281)', (WidgetTester tester) async {
     // `5WW1` is new to Smartschool *and* has no Office 365 group, so its row

--- a/account_manager/test/screens/system_indicator_test.dart
+++ b/account_manager/test/screens/system_indicator_test.dart
@@ -1,0 +1,215 @@
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_manager/src/screens/system_indicator.dart';
+import 'package:account_state/account_state.dart' show CandidateAction;
+import 'package:flutter_test/flutter_test.dart';
+
+import '../reconcile/reconcile_fakes.dart';
+
+CandidateAction _candidate({
+  required String kind,
+  required core.Origin system,
+  bool canApply = true,
+  String? alternativeGroup,
+  bool isDefaultAlternative = false,
+  String family = 'student',
+}) =>
+    CandidateAction(
+      family: family,
+      kind: kind,
+      system: system,
+      summary: kind,
+      canApply: canApply,
+      alternativeGroup: alternativeGroup,
+      isDefaultAlternative: isDefaultAlternative,
+    );
+
+void main() {
+  group('a cell shows the worst of presence and pending work (#298)', () {
+    test('a record that is not there reads missing, work pending or not', () {
+      expect(
+        systemIndicatorState(present: false, hasWork: false),
+        SystemIndicatorState.missing,
+      );
+      expect(
+        systemIndicatorState(present: false, hasWork: true),
+        SystemIndicatorState.missing,
+        reason: 'not existing is the bigger fact; the work is usually the '
+            'creation of it',
+      );
+    });
+
+    test('a record that is there reads by its pending work', () {
+      expect(
+        systemIndicatorState(present: true, hasWork: true),
+        SystemIndicatorState.needsWork,
+      );
+      expect(
+        systemIndicatorState(present: true, hasWork: false),
+        SystemIndicatorState.inOrder,
+      );
+    });
+  });
+
+  group('which systems a stored record has work in (#298)', () {
+    test('an applyable candidate names its system', () {
+      expect(
+        workSystemsOfCandidates(<CandidateAction>[
+          _candidate(
+            kind: 'SyncAzureClassGroupMembers',
+            system: core.Origin.azure,
+            family: 'group',
+          ),
+        ]),
+        <core.Origin>{core.Origin.azure},
+      );
+    });
+
+    test('an informational candidate names none', () {
+      // The concrete case the issue turns on: `AzureClassGroupMembership`
+      // diagnoses an Office 365 roster problem the *class* row fixes, so a
+      // student's Office 365 cell must stay green.
+      expect(
+        workSystemsOfCandidates(<CandidateAction>[
+          _candidate(
+            kind: 'AzureClassGroupMembership',
+            system: core.Origin.azure,
+            canApply: false,
+          ),
+        ]),
+        isEmpty,
+      );
+      expect(
+        systemIndicatorState(
+          present: true,
+          hasWork: workSystemsOfCandidates(<CandidateAction>[
+            _candidate(
+              kind: 'AzureClassGroupMembership',
+              system: core.Origin.azure,
+              canApply: false,
+            ),
+          ]).contains(core.Origin.azure),
+        ),
+        SystemIndicatorState.inOrder,
+      );
+    });
+
+    test('an either/or is judged on the half that would actually run', () {
+      // A stale class group's "leave it alone" notice is the default, so the
+      // pair is not work until the operator switches to the delete.
+      final notice = _candidate(
+        kind: 'KeepStaleAzureClassGroup',
+        system: core.Origin.azure,
+        canApply: false,
+        alternativeGroup: 'stale-group',
+        isDefaultAlternative: true,
+        family: 'group',
+      );
+      final delete = _candidate(
+        kind: 'DeleteAzureClassGroup',
+        system: core.Origin.azure,
+        alternativeGroup: 'stale-group',
+        family: 'group',
+      );
+
+      expect(
+          workSystemsOfCandidates(<CandidateAction>[notice, delete]), isEmpty);
+      expect(
+        workSystemsOfCandidates(<CandidateAction>[
+          _candidate(
+            kind: 'KeepStaleAzureClassGroup',
+            system: core.Origin.azure,
+            canApply: false,
+            alternativeGroup: 'stale-group',
+          ),
+          _candidate(
+            kind: 'DeleteAzureClassGroup',
+            system: core.Origin.azure,
+            alternativeGroup: 'stale-group',
+            isDefaultAlternative: true,
+            family: 'group',
+          ),
+        ]),
+        <core.Origin>{core.Origin.azure},
+      );
+    });
+
+    test('two systems on one record are both named', () {
+      expect(
+        workSystemsOfCandidates(<CandidateAction>[
+          _candidate(
+            kind: 'AddClassToSmartschool',
+            system: core.Origin.smartschool,
+            family: 'group',
+          ),
+          _candidate(
+            kind: 'CreateAzureClassGroup',
+            system: core.Origin.azure,
+            family: 'group',
+          ),
+        ]),
+        <core.Origin>{core.Origin.smartschool, core.Origin.azure},
+      );
+    });
+  });
+
+  group('the live dispatch reads the same way (#298)', () {
+    test(
+        'the class carries the Office 365 work; its students carry none, '
+        'because the write is one per class', () async {
+      // The #245 fixture: both classes have their Office 365 group and are in
+      // sync with Smartschool, so the only work anywhere is the Azure roster —
+      // Jane is missing from GBS-1A, Sam sits in GBS-1A instead of GBS-1B.
+      final harness = azureClassMembershipHarness();
+      await harness.controller.sync();
+
+      final klas = harness.controller.groupPendingEntries
+          .firstWhere((e) => e.targetId == '1A');
+      expect(
+        workSystemsOfEntry(klas),
+        <core.Origin>{core.Origin.azure},
+        reason: 'the roster write lands in Office 365, and the row must say so',
+      );
+
+      final students = harness.controller.pendingEntries
+          .where((e) => e.family == 'student')
+          .toList();
+      expect(students, isNotEmpty);
+      for (final student in students) {
+        expect(
+          student.choices.map((c) => c.selected.kind),
+          everyElement('AzureClassGroupMembership'),
+        );
+        expect(
+          workSystemsOfEntry(student),
+          isEmpty,
+          reason: '${student.target}: informational only — colouring it would '
+              'paint every student orange at the rollover for work the Acties '
+              'screen cannot do',
+        );
+      }
+    });
+
+    test('a class that is right everywhere has no work in any system',
+        () async {
+      final harness = azureClassGroupHarness();
+      await harness.controller.sync();
+
+      // `1A` is correct in all three systems, so it raises no entry at all.
+      expect(
+        harness.controller.groupPendingEntries.where((e) => e.targetId == '1A'),
+        isEmpty,
+      );
+      for (final system in const <core.Origin>[
+        core.Origin.wisa,
+        core.Origin.smartschool,
+        core.Origin.azure,
+      ]) {
+        expect(
+          systemIndicatorState(present: true, hasWork: false),
+          SystemIndicatorState.inOrder,
+          reason: '$system',
+        );
+      }
+    });
+  });
+}

--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -51,6 +51,42 @@ from the next snapshot.
 same projected record while performing **no** writes. The detail dialog and the
 "apply" button share this one path.
 
+### `canApply` and `canApplyToAll`
+
+Two independent flags, on all three families:
+
+| Flag | Question | Default |
+|---|---|---|
+| `canApply` | Can the app write this at all? `false` for an informational action, whose `apply` throws. | `true` |
+| `canApplyToAll` | May it be written to **many** records in one pass? (#293) | `false` |
+
+`canApply` is the mechanism, `canApplyToAll` is the sanction, and the sanction
+presupposes the mechanism — `canApplyToAll` is never `true` where `canApply` is
+`false`.
+
+`canApplyToAll` ports legacy's `AccountAction.canBeAppliedToAll`, which the two
+account families carried and granted deliberately, action by action. The line it
+draws: **mechanical corrections and provisioning** may go in bulk;
+**destructive** actions (delete, unregister, remove, and the blacklists, which
+are destructive in effect) and **judgement** actions — the name and address
+modifiers, where the operator is meant to look at the record — never do.
+
+It lives on the action rather than in a list of kinds held by the screen: such a
+list drifts from what the domain sanctions, and an action added later silently
+inherits whatever the list's default happens to be. Declared here, a new action
+is withheld until someone decides otherwise.
+
+The group family had no legacy answer to port — the legacy Klassen view offered
+no bulk apply at all — so each of its four grants is a decision recorded in the
+action's own doc comment. `SyncAzureClassGroupMembers` is the headline one: at
+the September rollover every class's Office 365 roster is wrong at once, the
+diff is computed per class from the roster already held, and the write is
+idempotent with removals limited to our own students.
+
+`test/can_apply_to_all_test.dart` pins the exact granted set per family. Its
+classification switches are exhaustive over the sealed families, so adding an
+action makes that file fail to compile until the new action is classified.
+
 ## Dispatch (§6.3)
 
 `studentActions(snapshot, config)` walks the snapshot's student records and,

--- a/packages/account_actions/lib/src/change_set.dart
+++ b/packages/account_actions/lib/src/change_set.dart
@@ -1,6 +1,23 @@
 import 'package:account_core/account_core.dart' show Origin;
 
-/// One field-level detail of an action's diff, in one of two shapes.
+/// Which of the three things a [FieldChange] is saying.
+///
+/// A `ChangeSet` field used to be able to say only one of them, so the other
+/// two were written as transitions and read as claims about nothing that
+/// happens (#300, #305).
+enum FieldChangeShape {
+  /// A value moving: `mail: ∅ → GBS-1A@student.school.example`.
+  transition,
+
+  /// A quantity the action acts on: `leden toevoegen: 21` (#300).
+  count,
+
+  /// A fact about the record as it stands: `mail: GBS-9Z@…` (#305).
+  statement,
+}
+
+/// One field-level detail of an action's description, in one of three
+/// [FieldChangeShape]s.
 ///
 /// **A transition** — the default constructor. [before] and [after] are the
 /// human-readable current and proposed values; either may be null (a field
@@ -11,43 +28,67 @@ import 'package:account_core/account_core.dart' show Origin;
 /// group's roster write adds 21 members and removes 17, and neither number is
 /// the new value of a field. Rendered through the transition template that read
 /// `leden toevoegen: ∅ → 21` — a claim that a field used to be empty and is
-/// becoming 21, which is not what happened to anything (#300). [isCount] is how
-/// a description says which of the two it is, so the UI can state a quantity
-/// instead of diffing it.
+/// becoming 21, which is not what happened to anything (#300).
+///
+/// **A statement** — [FieldChange.statement]. An informational notice does not
+/// propose anything; it describes the record it is telling the operator about.
+/// The "leave this Office 365 group standing" half of the stale-group either/or
+/// names the group's address and its member count, and through the transition
+/// template those read `mail: GBS-9Z@… → ∅` and `leden: 21 → ∅` — the address
+/// and the 21 members being cleared, the exact opposite of the option's own
+/// heading (#305).
+///
+/// [shape] is how a description says which of the three it is, so a renderer
+/// can state a quantity or a fact instead of diffing it.
 class FieldChange {
   final String field;
 
-  /// The current value — always null for a count, which has no "before" half.
+  /// The current value — the left half of a transition, or the value a
+  /// [FieldChange.statement] states. Always null for a count.
   final String? before;
 
-  /// The proposed value, or — when [isCount] — the quantity itself.
+  /// The proposed value, or — for a [FieldChange.count] — the quantity itself.
+  /// Always null for a statement, which has nothing it moves to.
   final String? after;
 
-  /// Whether [after] is a quantity this action acts on rather than the value
-  /// the field is moving to (#300).
-  final bool isCount;
+  /// Which of the three things this field is saying (#300, #305).
+  final FieldChangeShape shape;
 
   const FieldChange(
     this.field, {
     this.before,
     this.after,
-    this.isCount = false,
-  }) : assert(
-          !isCount || before == null,
+    this.shape = FieldChangeShape.transition,
+  })  : assert(
+          shape != FieldChangeShape.count || before == null,
           'a count states one number; it has no "before" half',
+        ),
+        assert(
+          shape != FieldChangeShape.statement || after == null,
+          'a statement says what is; it has nothing it moves to',
         );
 
   /// [amount] things this action will act on — members added, members removed.
   ///
   /// The number lands in [after] so every consumer that reads a field's value
-  /// keeps working; [isCount] is what stops it being read as a transition.
+  /// keeps working; [shape] is what stops it being read as a transition.
   FieldChange.count(String field, int amount)
-      : this(field, after: '$amount', isCount: true);
+      : this(field, after: '$amount', shape: FieldChangeShape.count);
+
+  /// [value] is what the record holds, stated rather than diffed (#305).
+  ///
+  /// It lands in [before] — the slot that has always meant "what is there now",
+  /// which is precisely what a statement is about.
+  const FieldChange.statement(String field, String value)
+      : this(field, before: value, shape: FieldChangeShape.statement);
 
   @override
-  String toString() => isCount
-      ? 'FieldChange($field: $after)'
-      : 'FieldChange($field: ${before ?? '∅'} → ${after ?? '∅'})';
+  String toString() => switch (shape) {
+        FieldChangeShape.count => 'FieldChange($field: $after)',
+        FieldChangeShape.statement => 'FieldChange($field: $before)',
+        FieldChangeShape.transition =>
+          'FieldChange($field: ${before ?? '∅'} → ${after ?? '∅'})',
+      };
 }
 
 /// A pure description of what an action would change, produced by

--- a/packages/account_actions/lib/src/change_set.dart
+++ b/packages/account_actions/lib/src/change_set.dart
@@ -1,19 +1,53 @@
 import 'package:account_core/account_core.dart' show Origin;
 
-/// One field-level change an action would make, for the diff UI.
+/// One field-level detail of an action's diff, in one of two shapes.
 ///
-/// [before] and [after] are the human-readable current and proposed values;
-/// either may be null (a field being set for the first time, or cleared).
+/// **A transition** — the default constructor. [before] and [after] are the
+/// human-readable current and proposed values; either may be null (a field
+/// being set for the first time, or cleared).
+///
+/// **A quantity** — [FieldChange.count]. Some actions describe themselves with
+/// a number rather than with a value moving from one thing to another: a class
+/// group's roster write adds 21 members and removes 17, and neither number is
+/// the new value of a field. Rendered through the transition template that read
+/// `leden toevoegen: ∅ → 21` — a claim that a field used to be empty and is
+/// becoming 21, which is not what happened to anything (#300). [isCount] is how
+/// a description says which of the two it is, so the UI can state a quantity
+/// instead of diffing it.
 class FieldChange {
   final String field;
+
+  /// The current value — always null for a count, which has no "before" half.
   final String? before;
+
+  /// The proposed value, or — when [isCount] — the quantity itself.
   final String? after;
 
-  const FieldChange(this.field, {this.before, this.after});
+  /// Whether [after] is a quantity this action acts on rather than the value
+  /// the field is moving to (#300).
+  final bool isCount;
+
+  const FieldChange(
+    this.field, {
+    this.before,
+    this.after,
+    this.isCount = false,
+  }) : assert(
+          !isCount || before == null,
+          'a count states one number; it has no "before" half',
+        );
+
+  /// [amount] things this action will act on — members added, members removed.
+  ///
+  /// The number lands in [after] so every consumer that reads a field's value
+  /// keeps working; [isCount] is what stops it being read as a transition.
+  FieldChange.count(String field, int amount)
+      : this(field, after: '$amount', isCount: true);
 
   @override
-  String toString() =>
-      'FieldChange($field: ${before ?? '∅'} → ${after ?? '∅'})';
+  String toString() => isCount
+      ? 'FieldChange($field: $after)'
+      : 'FieldChange($field: ${before ?? '∅'} → ${after ?? '∅'})';
 }
 
 /// A pure description of what an action would change, produced by

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -71,6 +71,20 @@ sealed class GroupAction {
   /// (UI / State layer) gate the "apply" affordance on this.
   bool get canApply => true;
 
+  /// Whether this action may be written to **many** classes in one pass (#293)
+  /// — the group half of [StudentAction.canApplyToAll]. Defaults to `false`;
+  /// see [StudentAction.canApplyToAll] for why the flag lives on the action.
+  ///
+  /// **No legacy answer to port.** `canBeAppliedToAll` existed only on the two
+  /// account families; the legacy Klassen view offered no bulk apply at all, so
+  /// every member of this family is a decision made here rather than inherited.
+  /// The same line is drawn: the mechanical class syncs and the class-group
+  /// provisioning are granted ([AddToSmartschool], [ModifySmartschoolData],
+  /// [CreateAzureClassGroup], [SyncAzureClassGroupMembers]); the blacklist
+  /// ([DoNotImportFromWisa]) and the delete ([DeleteAzureClassGroup]) are
+  /// withheld, and the informational members cannot have it at all.
+  bool get canApplyToAll => false;
+
   /// The key shared by mutually-exclusive alternatives resolving the same
   /// situation (#110). `null` (the default) means the action stands on its own.
   /// The group family has three: [classImportAlternative] for a class
@@ -250,6 +264,17 @@ class DoNotImportFromWisa extends GroupAction {
       ? namesakeClassAlternative
       : classImportAlternative;
 
+  /// **Never in bulk** (#293). Blacklisting a class is a judgement about one
+  /// class, and the failure it causes is silent and hard to undo: the class
+  /// drops out of the next WISA snapshot while whatever exists downstream
+  /// survives, unmanaged. That is precisely what #244 and #250 were filed for
+  /// after "Alles toepassen" did it to a year's worth of classes at once. The
+  /// polarity of its alternative group already keeps it off the selected path;
+  /// withholding the flag means it cannot be bulk-applied even when an operator
+  /// deliberately switches to it.
+  @override
+  bool get canApplyToAll => false;
+
   wapi.DontImportClass _rule() => wapi.DontImportClass(_wisa.name);
 
   @override
@@ -318,6 +343,14 @@ class AddToSmartschool extends GroupAction {
 
   @override
   bool get isDefaultAlternative => true;
+
+  /// **In bulk** (#293). Importing the new classes is the start-of-year
+  /// operation this family exists for, and the created class is derived
+  /// mechanically from the WISA one — nothing here asks the operator to judge a
+  /// single class. It is also the half of [classImportAlternative] that a bulk
+  /// pass is *meant* to write; the blacklist beside it withholds the flag.
+  @override
+  bool get canApplyToAll => true;
 
   /// The official Smartschool class to create, derived from the WISA class and
   /// the resolved parent. Untis is set to the class name (legacy
@@ -608,6 +641,13 @@ class ModifySmartschoolData extends GroupAction {
       group.smartschool != null &&
       (_instituteDiffers || _untisDiffers || _descriptionDiffers);
 
+  /// **In bulk** (#293). Three mechanical field copies — institute number and
+  /// description down from WISA, Untis converged to the class name — with no
+  /// judgement in any of them, and Untis drift in particular tends to show up
+  /// across a whole year's classes at once.
+  @override
+  bool get canApplyToAll => true;
+
   /// The Smartschool group as it will look once synced. Institute number and
   /// description are pulled from WISA; Untis is converged to the class name
   /// (legacy's fixed remediation target); everything else
@@ -748,6 +788,14 @@ class CreateAzureClassGroup extends GroupAction {
   @override
   Set<Origin> get unlockedSystems => const {Origin.azure};
 
+  /// **In bulk** (#293). Provisioning, and provisioning that arrives a year at a
+  /// time: every new class needs its Office 365 group, and both the name and
+  /// the membership are derived — the [AzureClassGroupPlan] answers each of
+  /// them, and a class whose name would not survive as a `mailNickname` yields
+  /// no proposal to bulk-apply in the first place.
+  @override
+  bool get canApplyToAll => true;
+
   @override
   ChangeSet describeChanges() => ChangeSet(
         system: Origin.azure,
@@ -854,6 +902,25 @@ class SyncAzureClassGroupMembers extends GroupAction {
   @override
   bool evaluate() =>
       plan.owner && group.azure != null && plan.membershipDiffers;
+
+  /// **In bulk — the group family's headline grant** (#293), and the one this
+  /// flag was decided on explicitly rather than by analogy.
+  ///
+  /// At the September rollover every class's Office 365 roster is wrong at once,
+  /// for the same reason every student's Smartschool class is: the classes
+  /// turned over. Applying this one action across the school in a single pass is
+  /// exactly the operation the rollover needs, and it is safe to do so on three
+  /// counts — the diff is computed per class from the roster the app already
+  /// holds, it is idempotent (a class already in sync does not
+  /// [evaluate] true, and re-running writes the same membership), and its
+  /// removals are limited to students this app can account for, so a bulk pass
+  /// can never strip staff or titular members it does not own.
+  ///
+  /// The counterpart per-account view, `AzureClassGroupMembership`, stays
+  /// informational precisely so this class-level write is the single place the
+  /// membership is repaired — bulk or not.
+  @override
+  bool get canApplyToAll => true;
 
   @override
   ChangeSet describeChanges() => ChangeSet(
@@ -1045,6 +1112,14 @@ class DeleteAzureClassGroup extends GroupAction {
 
   @override
   bool get isDefaultAlternative => false;
+
+  /// **Never in bulk** (#293), and the clearest case in the whole port: Graph
+  /// takes the group's mailbox, its Team and its SharePoint files with it, and
+  /// none of that comes back. A fourth guard beside the three above — the
+  /// operator flips this radio on one row, and even then no bulk affordance may
+  /// offer it.
+  @override
+  bool get canApplyToAll => false;
 
   @override
   ChangeSet describeChanges() => ChangeSet(

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -556,7 +556,12 @@ class ClassExistsAsSmartschoolGroup extends GroupAction {
             before: _namesake.name,
             after: _wisa.name,
           ),
-          FieldChange('code', before: _namesake.id.value),
+          // A fact, not a transition (#306): the code is how the operator
+          // finds the group in Smartschool, and this notice writes nothing at
+          // all. As a transition it read `code: G2G → ∅` — the code being
+          // cleared. Its neighbours here *are* transitions: the rename and the
+          // make-it-official are the repair being asked for.
+          FieldChange.statement('code', _namesake.id.value),
           FieldChange(
             'officiële klas',
             before: _namesake.official ? 'ja' : 'nee',

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -928,13 +928,15 @@ class SyncAzureClassGroupMembers extends GroupAction {
         summary: 'Werk het ledenbestand van ${plan.displayName} bij '
             '(${plan.membersToAdd.length} toevoegen, '
             '${plan.membersToRemove.length} verwijderen)',
+        // Counts, not transitions (#300): "21 members will be added" is a
+        // quantity this write acts on, and describing it as a field whose old
+        // value was empty and whose new value is 21 describes nothing that
+        // happens to this group.
         fields: [
           if (plan.membersToAdd.isNotEmpty)
-            FieldChange('leden toevoegen',
-                after: '${plan.membersToAdd.length}'),
+            FieldChange.count('leden toevoegen', plan.membersToAdd.length),
           if (plan.membersToRemove.isNotEmpty)
-            FieldChange('leden verwijderen',
-                after: '${plan.membersToRemove.length}'),
+            FieldChange.count('leden verwijderen', plan.membersToRemove.length),
         ],
       );
 

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -1060,9 +1060,14 @@ class AzureClassGroupWithoutClass extends GroupAction {
         system: Origin.azure,
         summary: 'Laat de Office 365-groep ${_azure?.displayName} staan — '
             'klas ${group.className} bestaat niet meer in WISA of Smartschool',
+        // Nothing is written here, so nothing moves: these two lines describe
+        // the group the operator is being told about (#305). Put through the
+        // before → after template they read `mail: GBS-9Z@… → ∅` and
+        // `leden: 21 → ∅` — the address and the members going away, which is
+        // what the *other* half of this either/or does.
         fields: [
-          FieldChange('mail', before: _azure?.mail ?? ''),
-          FieldChange('leden', before: '${_azure?.memberIds.length ?? 0}'),
+          FieldChange.statement('mail', _azure?.mail ?? ''),
+          FieldChange.statement('leden', '${_azure?.memberIds.length ?? 0}'),
         ],
       );
 
@@ -1128,12 +1133,17 @@ class DeleteAzureClassGroup extends GroupAction {
         system: Origin.azure,
         summary: 'Verwijder de Office 365-groep ${_azure?.displayName} van de '
             'verdwenen klas ${group.className}',
+        // What the delete takes with it, stated (#305). The summary above
+        // already says the group goes; these lines are the inventory of it, and
+        // an arrow on each one claimed three separate fields were being
+        // cleared — least of all `postvak, Teams en bestanden: verdwijnen
+        // mee → ∅`, which was never a value in the first place.
         fields: [
-          FieldChange('mail', before: _azure?.mail ?? ''),
-          FieldChange('leden', before: '${_azure?.memberIds.length ?? 0}'),
-          const FieldChange(
+          FieldChange.statement('mail', _azure?.mail ?? ''),
+          FieldChange.statement('leden', '${_azure?.memberIds.length ?? 0}'),
+          const FieldChange.statement(
             'postvak, Teams en bestanden',
-            before: 'verdwijnen mee',
+            'verdwijnen mee',
           ),
         ],
       );

--- a/packages/account_actions/lib/src/staff_action.dart
+++ b/packages/account_actions/lib/src/staff_action.dart
@@ -69,6 +69,21 @@ sealed class StaffAction {
   /// [StudentAction.canApply] and [GroupAction.canApply].
   bool get canApply => true;
 
+  /// Whether this action may be written to **many** records in one pass (#293)
+  /// — the staff half of [StudentAction.canApplyToAll], ported from legacy's
+  /// `AccountAction.canBeAppliedToAll`
+  /// (`Action\StaffAccount\AccountAction.cs:23`). Defaults to `false`; see
+  /// [StudentAction.canApplyToAll] for why the flag lives on the action rather
+  /// than in the screen, and for the line legacy drew between mechanical and
+  /// judgement work.
+  ///
+  /// Legacy granted it to three staff actions. Two are ported and override this
+  /// ([AddStaffToAzure], [ModifySmartschoolStaffEmail]); the third,
+  /// `AddToStaffGroup`, is the Office 365 `-Personeel` placement this package
+  /// still defers (see the README), so there is no Dart action to carry the
+  /// grant yet.
+  bool get canApplyToAll => false;
+
   /// The action types this one **unlocks** on the same target (#240) — the staff
   /// family's half of the chaining [StudentAction.unlocks] introduced for
   /// students (#230) and extended to class groups in #245, deliberately the same
@@ -199,6 +214,20 @@ class AddStaffToAzure extends StaffAction {
   @override
   bool get isDefaultAlternative => true;
 
+  /// Provisioning goes in bulk (legacy `AddToAzure(…, true, true)`), the staff
+  /// twin of [AddStudentToAzure]'s grant: a term's new hires arrive together.
+  ///
+  /// It is the applyable half of [staffImportAlternative], so a bulk pass only
+  /// ever provisions — the opt-out beside it is not the default and is not
+  /// bulk-applyable either, so no pass can blacklist a cohort of new staff.
+  ///
+  /// Its [unlocks] chain still runs per record, so the Smartschool create rides
+  /// along even though [AddStaffToSmartschool] withholds the grant on its own:
+  /// the chain is a consequence of *this* action being sanctioned, and the same
+  /// two writes legacy performed.
+  @override
+  bool get canApplyToAll => true;
+
   String get _displayName => '${_wisa.firstName} ${_wisa.lastName}'.trim();
 
   String _projectedUpn() =>
@@ -308,6 +337,15 @@ class AddStaffToAzure extends StaffAction {
 /// the account is built from the Azure record with the WISA [wapi.WisaStaff.code]
 /// as its `accountId` (spec §4) and the WISA `wisaId` as its copy-code (`fax`);
 /// the group placement (Leerkrachten / Leerlingen) is deferred (see README).
+///
+/// **Not bulk-applyable** (#293), deliberately unlike its student twin
+/// [AddStudentToSmartschool]: legacy passed `AddToSmartschool(…, true, false)`
+/// here and `(…, true, true)` there, the one place the two families disagree
+/// about the same operation. The asymmetry is preserved rather than tidied — a
+/// staff account raised on its own means the #240 chain did not carry it, so
+/// something about that record is unusual and an operator should look. The
+/// ordinary new-hire path is unaffected: [AddStaffToAzure] is bulk-applyable and
+/// [unlocks] this create behind it, per record.
 class AddStaffToSmartschool extends StaffAction {
   const AddStaffToSmartschool(super.staff, super.config);
 
@@ -673,6 +711,12 @@ class ModifySmartschoolStaffEmail extends StaffAction {
   bool evaluate() =>
       _domainOf(_ss.mail) == config.azureDomain.toLowerCase() &&
       !_eq(_ss.mail, _az.upn);
+
+  /// Copying the Azure UPN down to Smartschool is mechanical, so it goes in bulk
+  /// (legacy `ModifySmartschoolStaffEmail(…, true, true)`) — the staff twin of
+  /// [ModifySmartschoolStudentEmail]'s grant.
+  @override
+  bool get canApplyToAll => true;
 
   @override
   ChangeSet describeChanges() => ChangeSet(

--- a/packages/account_actions/lib/src/student_action.dart
+++ b/packages/account_actions/lib/src/student_action.dart
@@ -73,6 +73,30 @@ sealed class StudentAction {
   /// has carried informational members since #54.
   bool get canApply => true;
 
+  /// Whether this action may be written to **many** records in one pass (#293)
+  /// — the port of legacy's `AccountAction.canBeAppliedToAll`
+  /// (`Action\StudentAccount\AccountAction.cs:22`), which defaulted to `false`
+  /// and was granted action by action.
+  ///
+  /// Distinct from [canApply], which says whether the app can write the action
+  /// *at all*. A bulk affordance needs both: [canApply] is the mechanism,
+  /// [canApplyToAll] is the sanction. It is therefore never `true` where
+  /// [canApply] is `false`, and a test pins that for all three families.
+  ///
+  /// **A property of the action, never a list of kinds held in the UI.** Such a
+  /// list drifts from what the domain actually sanctions, and an action added
+  /// later silently inherits whatever the list's default happened to be.
+  /// Declared here, a new action is conservative until someone decides
+  /// otherwise — which is the whole reason the default is `false`.
+  ///
+  /// The line legacy drew over a decade of use, and this port keeps: mechanical
+  /// corrections and provisioning may go in bulk; **destructive** actions
+  /// ([RemoveStudentFromAzure], [DeleteStudentFromSmartschool],
+  /// [UnregisterStudentFromSmartschool]) and **judgement** actions — the name
+  /// and address modifiers, where the operator is meant to look at the record —
+  /// never do.
+  bool get canApplyToAll => false;
+
   /// The action types this one **unlocks** on the same target (#230).
   ///
   /// Provisioning a brand-new student is a chain, not a single action: the
@@ -178,6 +202,11 @@ class AddStudentToAzure extends StudentAction {
   /// reaches both systems and the confirmation dialog says both (#234).
   @override
   Set<Origin> get unlockedSystems => const {Origin.smartschool};
+
+  /// Provisioning goes in bulk (legacy `AddToAzure(…, true, true)`): a new
+  /// intake arrives as a cohort, and creating their accounts is mechanical.
+  @override
+  bool get canApplyToAll => true;
 
   @override
   ChangeSet describeChanges() {
@@ -301,6 +330,13 @@ class AddStudentToSmartschool extends StudentAction {
       account.isInOurWisa &&
       account.azure != null &&
       account.smartschool == null;
+
+  /// Provisioning goes in bulk (legacy `AddToSmartschool(…, true, true)`), the
+  /// second half of the same intake pass [AddStudentToAzure] leads. Note the
+  /// staff twin [AddStaffToSmartschool] is deliberately **not** bulk-applyable:
+  /// legacy withheld it there and this port keeps the asymmetry.
+  @override
+  bool get canApplyToAll => true;
 
   ss.SmartschoolAccount _build() {
     final wisa = _wisa;
@@ -622,6 +658,12 @@ class ModifyAzureStudentEmail extends StudentAction {
 
   String get _newUpn => '${_localPart(_az.upn)}@${config.studentDomain}';
 
+  /// A mechanical domain correction, so it goes in bulk (legacy
+  /// `ModifyAzureStudentEmail(…, true, true)`, and the same grant on the dead
+  /// `ChangeEmail` that stated the rule twice).
+  @override
+  bool get canApplyToAll => true;
+
   @override
   ChangeSet describeChanges() => ChangeSet(
         system: Origin.azure,
@@ -701,6 +743,12 @@ class ModifyAzureSchool extends StudentAction {
   @override
   bool evaluate() => !_eq(_az.companyName, config.schoolPrefix);
 
+  /// Stamping our own prefix on our own students is mechanical, so it goes in
+  /// bulk (legacy `ModifyAzureSchool(…, true, true)`) — and it is what makes a
+  /// transferred student's adoption stick, a repair that arrives per intake.
+  @override
+  bool get canApplyToAll => true;
+
   @override
   ChangeSet describeChanges() => ChangeSet(
         system: Origin.azure,
@@ -732,6 +780,11 @@ class ModifyAccountId extends StudentAction {
 
   @override
   bool evaluate() => _wisa.wisaId.value.trim() != _ss.accountId.trim();
+
+  /// Copying one id onto another is mechanical, so it goes in bulk (legacy
+  /// `ModifyAccountID(…, true, true)`).
+  @override
+  bool get canApplyToAll => true;
 
   @override
   ChangeSet describeChanges() => ChangeSet(
@@ -795,6 +848,11 @@ class ModifySmartschoolStudentEmail extends StudentAction {
   bool evaluate() =>
       _domainOf(_ss.mail) == config.azureDomain.toLowerCase() &&
       !_eq(_ss.mail, _az.upn);
+
+  /// Copying the Azure UPN down to Smartschool is mechanical, so it goes in
+  /// bulk (legacy `ModifySmartschoolStudentEmail(…, true, true)`).
+  @override
+  bool get canApplyToAll => true;
 
   @override
   ChangeSet describeChanges() => ChangeSet(
@@ -888,6 +946,11 @@ class ModifySmartschoolStemId extends StudentAction {
   @override
   bool evaluate() => _wisaStemId != _ss.stemId;
 
+  /// A mechanical WISA → Smartschool copy, so it goes in bulk (legacy
+  /// `ModifySmartschoolStemID(…, true, true)`).
+  @override
+  bool get canApplyToAll => true;
+
   @override
   ChangeSet describeChanges() => ChangeSet(
         system: Origin.smartschool,
@@ -914,6 +977,14 @@ class ModifySmartschoolBirthPlace extends StudentAction {
 
   @override
   bool evaluate() => !_eq(_ss.birthPlace, _wisa.birthPlace);
+
+  /// A mechanical WISA → Smartschool copy, so it goes in bulk (legacy
+  /// `ModifySmartschoolBirthPlace(…, true, true)`). Note the *name* and
+  /// *address* modifiers beside it are deliberately withheld: those are the
+  /// fields where WISA and Smartschool legitimately disagree and the operator is
+  /// meant to look at the record.
+  @override
+  bool get canApplyToAll => true;
 
   @override
   ChangeSet describeChanges() => ChangeSet(
@@ -1001,6 +1072,13 @@ class MoveToSmartschoolClassGroup extends StudentAction {
   @override
   bool evaluate() =>
       !_isAdultEducation && placement.className != placement.currentClassName;
+
+  /// The bulk action the app exists for (legacy
+  /// `MoveToSmartschoolClassGroup(…, true, true)`): at the September rollover
+  /// **every** student changes class group, and the move is a mechanical
+  /// consequence of the WISA class they already sit in.
+  @override
+  bool get canApplyToAll => true;
 
   @override
   ChangeSet describeChanges() => ChangeSet(

--- a/packages/account_actions/test/azure_class_group_test.dart
+++ b/packages/account_actions/test/azure_class_group_test.dart
@@ -248,7 +248,7 @@ void main() {
 
       expect(
           fields.map((f) => f.field), ['leden toevoegen', 'leden verwijderen']);
-      expect(fields.every((f) => f.isCount), isTrue);
+      expect(fields.every((f) => f.shape == FieldChangeShape.count), isTrue);
       expect(fields.map((f) => f.after), ['2', '1']);
       expect(fields.every((f) => f.before == null), isTrue,
           reason: 'a count has no "before" half to diff against');
@@ -469,6 +469,47 @@ void main() {
         contains('postvak, Teams en bestanden'),
       );
       expect(delete.unlocks, isEmpty, reason: 'nothing follows a delete');
+    });
+
+    test('both halves state the group\'s facts, they do not diff them (#305)',
+        () {
+      // The notice's whole content is "this group stays", and under that
+      // heading its two fields read "mail: SSM-9Z@… → ∅" and "leden: 21 → ∅" —
+      // the address and the 21 members being cleared, which is what the *other*
+      // radio does. Neither field is a value moving anywhere, so neither may be
+      // described as one.
+      final actions = groupActionsFor(
+        orphan(azureClassGroup('9Z',
+            memberIds: List<String>.generate(21, (int i) => 'az-$i'))),
+      );
+
+      final notice = actions
+          .whereType<AzureClassGroupWithoutClass>()
+          .single
+          .describeChanges();
+      expect(notice.fields.map((f) => f.field), ['mail', 'leden']);
+      expect(
+        notice.fields.every((f) => f.shape == FieldChangeShape.statement),
+        isTrue,
+        reason: 'a notice that writes nothing cannot describe a transition',
+      );
+      expect(notice.fields.map((f) => f.before),
+          ['SSM-9Z@student.school.example', '21']);
+      expect(notice.fields.every((f) => f.after == null), isTrue,
+          reason: 'a statement has no half to move to');
+
+      // The delete's arrow at least pointed at a real deletion, but its three
+      // fields are still the inventory of what goes, not three fields being
+      // cleared one by one — least of all "verdwijnen mee", never a value.
+      final delete =
+          actions.whereType<DeleteAzureClassGroup>().single.describeChanges();
+      expect(delete.fields.map((f) => f.field),
+          ['mail', 'leden', 'postvak, Teams en bestanden']);
+      expect(
+        delete.fields.every((f) => f.shape == FieldChangeShape.statement),
+        isTrue,
+      );
+      expect(delete.fields.last.before, 'verdwijnen mee');
     });
 
     test('applying the delete asks Graph to delete that one group', () async {

--- a/packages/account_actions/test/azure_class_group_test.dart
+++ b/packages/account_actions/test/azure_class_group_test.dart
@@ -228,6 +228,33 @@ void main() {
       );
     });
 
+    test('the member numbers are counts, not before/after transitions (#300)',
+        () {
+      // The reported card read "leden toevoegen: ∅ → 21" — the diff template
+      // claiming a field used to be empty and is becoming 21, which is not
+      // what happens to anything. The numbers are quantities this write acts
+      // on, and the description has to say so or every renderer repeats it.
+      final fields = groupActionsFor(
+        linkedGroup(
+          wisa: wisaGroup(),
+          smartschool: ssGroup(),
+          azure: azureClassGroup('3A', memberIds: const ['az-old']),
+        ),
+        azurePlanFor: (_) => azurePlan(
+          membersToAdd: const ['az-new', 'az-second'],
+          membersToRemove: const ['az-old'],
+        ),
+      ).single.describeChanges().fields;
+
+      expect(
+          fields.map((f) => f.field), ['leden toevoegen', 'leden verwijderen']);
+      expect(fields.every((f) => f.isCount), isTrue);
+      expect(fields.map((f) => f.after), ['2', '1']);
+      expect(fields.every((f) => f.before == null), isTrue,
+          reason: 'a count has no "before" half to diff against');
+      expect(fields.first.toString(), 'FieldChange(leden toevoegen: 2)');
+    });
+
     test('membership in sync raises nothing', () {
       final actions = groupActionsFor(
         linkedGroup(

--- a/packages/account_actions/test/can_apply_to_all_test.dart
+++ b/packages/account_actions/test/can_apply_to_all_test.dart
@@ -1,0 +1,281 @@
+/// Pins **which** actions may be bulk-applied (#293) — the port of legacy's
+/// `AccountAction.canBeAppliedToAll`.
+///
+/// The point of the flag is that the sanction is a property of the action, so
+/// this file is the one place the whole answer is written down. Two mechanisms
+/// make granting a new one a deliberate edit here:
+///
+/// - the `_bulkApplyable` switches are **exhaustive over the sealed families**,
+///   so adding a `StudentAction` / `StaffAction` / `GroupAction` subclass makes
+///   this file fail to compile until the new action is classified;
+/// - each family's instance list is size-pinned, so the new action also has to
+///   be added to what the assertions actually run over.
+library;
+
+import 'package:account_actions/account_actions.dart';
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+// ---------------------------------------------------------------------------
+// The sanctioned set, one exhaustive switch per family.
+// ---------------------------------------------------------------------------
+
+/// Legacy `Action\StudentAccount\*`: the eight grants of `canBeAppliedToAll`,
+/// plus `ModifyAzureSchool` and `ModifyAzureStudentEmail` — legacy passes
+/// `true, true` to both, and `ModifyAzureStudentEmail` is also where the dead
+/// `ChangeEmail` class's identical grant lands in this port.
+bool _bulkApplyable(StudentAction a) => switch (a) {
+      AddStudentToAzure() => true,
+      AddStudentToSmartschool() => true,
+      ModifyAzureStudentEmail() => true,
+      ModifyAzureSchool() => true,
+      ModifyAccountId() => true,
+      ModifySmartschoolStemId() => true,
+      ModifySmartschoolBirthPlace() => true,
+      ModifySmartschoolStudentEmail() => true,
+      MoveToSmartschoolClassGroup() => true,
+      // Judgement: the operator is meant to look at the record.
+      ModifyAzureName() => false,
+      ModifySmartschoolName() => false,
+      ModifySmartschoolStudentAddress() => false,
+      // Destructive.
+      UnregisterStudentFromSmartschool() => false,
+      DeleteStudentFromSmartschool() => false,
+      RemoveStudentFromAzure() => false,
+      // Informational — cannot be applied at all.
+      AzureClassGroupMembership() => false,
+    };
+
+/// Legacy `Action\StaffAccount\*` granted three; `AddToStaffGroup` is not
+/// ported (the deferred `-Personeel` placement), leaving two.
+bool _bulkApplyableStaff(StaffAction a) => switch (a) {
+      AddStaffToAzure() => true,
+      ModifySmartschoolStaffEmail() => true,
+      // Legacy passes `true, false` here, unlike the student twin.
+      AddStaffToSmartschool() => false,
+      UpdateStaffWisaName() => false,
+      SetStaffCopyCode() => false,
+      DontImportStaffFromWisa() => false,
+      RemoveStaffFromSmartschool() => false,
+      RemoveStaffFromAzure() => false,
+    };
+
+/// The group family has no legacy answer to port — legacy's Klassen view had no
+/// bulk apply — so every one of these is a decision made in #293.
+bool _bulkApplyableGroup(GroupAction a) => switch (a) {
+      AddToSmartschool() => true,
+      ModifySmartschoolData() => true,
+      CreateAzureClassGroup() => true,
+      SyncAzureClassGroupMembers() => true,
+      // Withheld: a blacklist is a per-class judgement, a delete takes the
+      // mailbox, Team and files with it.
+      DoNotImportFromWisa() => false,
+      DeleteAzureClassGroup() => false,
+      // Informational — cannot be applied at all.
+      CreateInSmartschool() => false,
+      ClassExistsAsSmartschoolGroup() => false,
+      DoNotImportFromSmartschool() => false,
+      AzureClassGroupWithoutClass() => false,
+    };
+
+// ---------------------------------------------------------------------------
+// One instance of every action in each family. The bound records are
+// irrelevant: `canApplyToAll` is a constant of the class, never of the target.
+// ---------------------------------------------------------------------------
+
+List<StudentAction> _studentActions() {
+  final cfg = config();
+  final account = fullySynced();
+  final placement = classPlacement();
+  const azurePlacement = AzureClassPlacement(className: '3A');
+  return <StudentAction>[
+    AddStudentToAzure(account, cfg),
+    AddStudentToSmartschool(account, cfg, placement: placement),
+    UnregisterStudentFromSmartschool(account, cfg),
+    DeleteStudentFromSmartschool(account, cfg),
+    RemoveStudentFromAzure(account, cfg),
+    ModifyAzureStudentEmail(account, cfg),
+    ModifyAzureName(account, cfg),
+    ModifyAzureSchool(account, cfg),
+    ModifySmartschoolStudentAddress(account, cfg),
+    ModifyAccountId(account, cfg),
+    ModifySmartschoolStemId(account, cfg),
+    ModifySmartschoolBirthPlace(account, cfg),
+    MoveToSmartschoolClassGroup(account, cfg, placement),
+    AzureClassGroupMembership(account, cfg, azurePlacement),
+    ModifySmartschoolStudentEmail(account, cfg),
+    ModifySmartschoolName(account, cfg),
+  ];
+}
+
+List<StaffAction> _staffActions() {
+  final cfg = staffConfig();
+  final staff = fullySyncedStaff();
+  return <StaffAction>[
+    AddStaffToAzure(staff, cfg),
+    AddStaffToSmartschool(staff, cfg),
+    RemoveStaffFromSmartschool(staff, cfg),
+    RemoveStaffFromAzure(staff, cfg),
+    DontImportStaffFromWisa(staff, cfg),
+    UpdateStaffWisaName(staff, cfg),
+    ModifySmartschoolStaffEmail(staff, cfg),
+    SetStaffCopyCode(staff, cfg),
+  ];
+}
+
+List<GroupAction> _groupActions() {
+  final linked = linkedGroup(
+    wisa: wisaGroup(),
+    smartschool: ssGroup(),
+    smartschoolNamesake: ssGroup(),
+    azure: azureClassGroup('3A'),
+  );
+  final placement = groupPlacement();
+  final plan = azurePlan();
+  return <GroupAction>[
+    DoNotImportFromWisa(linked),
+    AddToSmartschool(linked, placement),
+    CreateInSmartschool(linked, placement),
+    ClassExistsAsSmartschoolGroup(linked),
+    DoNotImportFromSmartschool(linked),
+    ModifySmartschoolData(linked),
+    CreateAzureClassGroup(linked, plan),
+    SyncAzureClassGroupMembers(linked, plan),
+    AzureClassGroupWithoutClass(linked),
+    DeleteAzureClassGroup(linked),
+  ];
+}
+
+Set<Type> _granted<T>(List<T> actions, bool Function(T) flag) => {
+      for (final a in actions)
+        if (flag(a)) a.runtimeType,
+    };
+
+void main() {
+  group('canApplyToAll (#293)', () {
+    test('the student family grants it to exactly nine actions', () {
+      expect(
+        _granted<StudentAction>(_studentActions(), (a) => a.canApplyToAll),
+        <Type>{
+          AddStudentToAzure,
+          AddStudentToSmartschool,
+          ModifyAzureStudentEmail,
+          ModifyAzureSchool,
+          ModifyAccountId,
+          ModifySmartschoolStemId,
+          ModifySmartschoolBirthPlace,
+          ModifySmartschoolStudentEmail,
+          MoveToSmartschoolClassGroup,
+        },
+        reason: 'legacy AccountAction(…, canBeAppliedToAll: true) — granting a '
+            'new one is a deliberate edit to this test',
+      );
+    });
+
+    test('the staff family grants it to exactly two actions', () {
+      expect(
+        _granted<StaffAction>(_staffActions(), (a) => a.canApplyToAll),
+        <Type>{AddStaffToAzure, ModifySmartschoolStaffEmail},
+        reason: 'legacy granted AddToAzure, ModifySmartschoolStaffEmail and '
+            'AddToStaffGroup; the last is not ported',
+      );
+    });
+
+    test('the group family grants it to exactly four actions', () {
+      expect(
+        _granted<GroupAction>(_groupActions(), (a) => a.canApplyToAll),
+        <Type>{
+          AddToSmartschool,
+          ModifySmartschoolData,
+          CreateAzureClassGroup,
+          SyncAzureClassGroupMembers,
+        },
+        reason: 'no legacy answer to port — each of these was decided in #293',
+      );
+    });
+
+    test('every action matches its recorded classification', () {
+      for (final a in _studentActions()) {
+        expect(a.canApplyToAll, _bulkApplyable(a), reason: '${a.runtimeType}');
+      }
+      for (final a in _staffActions()) {
+        expect(a.canApplyToAll, _bulkApplyableStaff(a),
+            reason: '${a.runtimeType}');
+      }
+      for (final a in _groupActions()) {
+        expect(a.canApplyToAll, _bulkApplyableGroup(a),
+            reason: '${a.runtimeType}');
+      }
+    });
+
+    test('an informational action is never bulk-applyable', () {
+      // The sanction presupposes the mechanism: canApplyToAll ⇒ canApply.
+      for (final a in _studentActions()) {
+        if (!a.canApply) {
+          expect(a.canApplyToAll, isFalse, reason: '${a.runtimeType}');
+        }
+      }
+      for (final a in _staffActions()) {
+        if (!a.canApply) {
+          expect(a.canApplyToAll, isFalse, reason: '${a.runtimeType}');
+        }
+      }
+      for (final a in _groupActions()) {
+        if (!a.canApply) {
+          expect(a.canApplyToAll, isFalse, reason: '${a.runtimeType}');
+        }
+      }
+      // Guard the guard: the families really do carry informational members, so
+      // the loops above are not vacuous.
+      expect(_studentActions().where((a) => !a.canApply), isNotEmpty);
+      expect(_groupActions().where((a) => !a.canApply), isNotEmpty);
+    });
+
+    test('destructive actions are withheld across every family', () {
+      final withheld = <Type>{
+        // Students.
+        UnregisterStudentFromSmartschool,
+        DeleteStudentFromSmartschool,
+        RemoveStudentFromAzure,
+        // Staff.
+        RemoveStaffFromSmartschool,
+        RemoveStaffFromAzure,
+        // Groups.
+        DeleteAzureClassGroup,
+        // The blacklists, which are destructive in effect: the record drops out
+        // of the next WISA snapshot while what exists downstream survives.
+        DontImportStaffFromWisa,
+        DoNotImportFromWisa,
+      };
+      final granted = <Type>{
+        ..._granted<StudentAction>(_studentActions(), (a) => a.canApplyToAll),
+        ..._granted<StaffAction>(_staffActions(), (a) => a.canApplyToAll),
+        ..._granted<GroupAction>(_groupActions(), (a) => a.canApplyToAll),
+      };
+      expect(granted.intersection(withheld), isEmpty);
+    });
+
+    test('the default is false, so a new action is conservative', () {
+      // Nothing pins this but the base classes themselves; the families below
+      // are the proof that "not overridden" reads as withheld.
+      expect(
+        _studentActions().where((a) => a.canApplyToAll),
+        hasLength(9),
+      );
+      expect(_staffActions().where((a) => a.canApplyToAll), hasLength(2));
+      expect(_groupActions().where((a) => a.canApplyToAll), hasLength(4));
+    });
+
+    test('each family list covers its whole sealed family', () {
+      // A count, because the exhaustive switches above catch a *new* subclass
+      // at compile time but cannot tell that it was also added here.
+      expect(_studentActions().map((a) => a.runtimeType).toSet(), hasLength(16),
+          reason: 'StudentAction has 16 members');
+      expect(_staffActions().map((a) => a.runtimeType).toSet(), hasLength(8),
+          reason: 'StaffAction has 8 members');
+      expect(_groupActions().map((a) => a.runtimeType).toSet(), hasLength(10),
+          reason: 'GroupAction has 10 members');
+    });
+  });
+}

--- a/packages/account_actions/test/change_set_test.dart
+++ b/packages/account_actions/test/change_set_test.dart
@@ -1,0 +1,41 @@
+import 'package:account_actions/account_actions.dart';
+import 'package:test/test.dart';
+
+/// The two shapes a [FieldChange] comes in (#300).
+///
+/// A `ChangeSet` describes two different kinds of thing, and until #300 it had
+/// only one way to say either: a value moving from one thing to another, and a
+/// quantity the action acts on. Rendered through the one template the second
+/// read "leden toevoegen: ∅ → 21" — a field that used to be empty and is
+/// becoming 21, true of nothing that happens to a class group.
+void main() {
+  group('FieldChange (#300)', () {
+    test('a transition keeps both halves and reads as one', () {
+      const f = FieldChange('mail', after: 'GBS-3A@student.school.example');
+      expect(f.isCount, isFalse);
+      expect(f.before, isNull);
+      expect(
+        f.toString(),
+        'FieldChange(mail: ∅ → GBS-3A@student.school.example)',
+      );
+    });
+
+    test('a count states one number and has no before half', () {
+      final f = FieldChange.count('leden toevoegen', 21);
+      expect(f.field, 'leden toevoegen');
+      expect(f.isCount, isTrue);
+      expect(f.before, isNull);
+      expect(f.after, '21',
+          reason: 'the number rides in the value slot, so '
+              'every consumer that reads a field value keeps working');
+      expect(f.toString(), 'FieldChange(leden toevoegen: 21)');
+    });
+
+    test('a count with a before half is a contradiction and is refused', () {
+      expect(
+        () => FieldChange('leden', before: '17', after: '21', isCount: true),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+}

--- a/packages/account_actions/test/change_set_test.dart
+++ b/packages/account_actions/test/change_set_test.dart
@@ -1,18 +1,20 @@
 import 'package:account_actions/account_actions.dart';
 import 'package:test/test.dart';
 
-/// The two shapes a [FieldChange] comes in (#300).
+/// The three shapes a [FieldChange] comes in (#300, #305).
 ///
-/// A `ChangeSet` describes two different kinds of thing, and until #300 it had
-/// only one way to say either: a value moving from one thing to another, and a
-/// quantity the action acts on. Rendered through the one template the second
-/// read "leden toevoegen: ∅ → 21" — a field that used to be empty and is
-/// becoming 21, true of nothing that happens to a class group.
+/// A `ChangeSet` describes three different kinds of thing, and until #300 it
+/// had only one way to say any of them: a value moving from one thing to
+/// another, a quantity the action acts on, and a fact about the record an
+/// informational notice is describing. Rendered through the one template the
+/// second read "leden toevoegen: ∅ → 21" — a field that used to be empty and is
+/// becoming 21 — and the third "mail: GBS-9Z@… → ∅", an address being cleared
+/// by an action whose heading says it writes nothing at all.
 void main() {
-  group('FieldChange (#300)', () {
+  group('FieldChange (#300, #305)', () {
     test('a transition keeps both halves and reads as one', () {
       const f = FieldChange('mail', after: 'GBS-3A@student.school.example');
-      expect(f.isCount, isFalse);
+      expect(f.shape, FieldChangeShape.transition);
       expect(f.before, isNull);
       expect(
         f.toString(),
@@ -23,7 +25,7 @@ void main() {
     test('a count states one number and has no before half', () {
       final f = FieldChange.count('leden toevoegen', 21);
       expect(f.field, 'leden toevoegen');
-      expect(f.isCount, isTrue);
+      expect(f.shape, FieldChangeShape.count);
       expect(f.before, isNull);
       expect(f.after, '21',
           reason: 'the number rides in the value slot, so '
@@ -33,7 +35,30 @@ void main() {
 
     test('a count with a before half is a contradiction and is refused', () {
       expect(
-        () => FieldChange('leden', before: '17', after: '21', isCount: true),
+        () => FieldChange('leden',
+            before: '17', after: '21', shape: FieldChangeShape.count),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('a statement states what is, and has nothing it moves to (#305)', () {
+      const f = FieldChange.statement('mail', 'GBS-9Z@student.school.example');
+      expect(f.field, 'mail');
+      expect(f.shape, FieldChangeShape.statement);
+      expect(f.before, 'GBS-9Z@student.school.example',
+          reason: 'the value rides in the slot that has always meant '
+              '"what the record holds now"');
+      expect(f.after, isNull);
+      expect(f.toString(), 'FieldChange(mail: GBS-9Z@student.school.example)');
+    });
+
+    test('a statement with an after half is a contradiction and is refused',
+        () {
+      expect(
+        () => FieldChange('mail',
+            before: 'a@b.example',
+            after: 'c@d.example',
+            shape: FieldChangeShape.statement),
         throwsA(isA<AssertionError>()),
       );
     });

--- a/packages/account_actions/test/group_purity_test.dart
+++ b/packages/account_actions/test/group_purity_test.dart
@@ -121,6 +121,45 @@ void main() {
       );
     });
 
+    test(
+        'the namesake notice states the group\'s code instead of diffing it '
+        '(#306)', () {
+      // The last bare-`before` field left standing after #305. The notice tells
+      // the operator to repair a Smartschool group by hand, and names the code
+      // they will find it under. Through the transition template that read
+      //
+      //   code: G2G → ∅
+      //
+      // — the code being cleared, by an action that writes nothing at all
+      // (`canApply == false`). The two fields around it are genuine
+      // transitions: the rename and the make-it-official are what the operator
+      // is being asked to do.
+      final change = ClassExistsAsSmartschoolGroup(
+        linkedGroup(
+          wisa: wisaGroup(name: '2G'),
+          smartschoolNamesake: ssGroupNode(code: 'G2G', name: '2 G'),
+        ),
+      ).describeChanges();
+
+      expect(change.system, Origin.smartschool);
+      expect(change.fields.map((f) => f.field),
+          ['name', 'code', 'officiële klas']);
+
+      final code = change.fields[1];
+      expect(code.shape, FieldChangeShape.statement,
+          reason: 'the code is how the operator finds the group, not a value '
+              'this notice moves anywhere');
+      expect(code.before, 'G2G');
+      expect(code.after, isNull, reason: 'a statement has no half to move to');
+
+      // Its neighbours still diff, because they really are transitions.
+      expect(
+        [change.fields[0], change.fields[2]]
+            .map((f) => '${f.shape.name}:${f.before}>${f.after}'),
+        ['transition:2 G>2G', 'transition:nee>ja'],
+      );
+    });
+
     test('DoNotImportFromWisa describes the rule it would add', () {
       final change =
           DoNotImportFromWisa(linkedGroup(wisa: wisaGroup(name: '3A')))

--- a/packages/account_state/lib/src/materialize/materialized_state.dart
+++ b/packages/account_state/lib/src/materialize/materialized_state.dart
@@ -86,6 +86,10 @@ class CandidateAction {
                 'field': f.field,
                 if (f.before != null) 'before': f.before,
                 if (f.after != null) 'after': f.after,
+                // Which of the two shapes this is (#300). A count read back as
+                // a transition renders as "∅ → 21" again, so a passive session
+                // would show the very thing the live one no longer does.
+                if (f.isCount) 'count': true,
               },
           ],
         'canApply': canApply,
@@ -105,6 +109,9 @@ class CandidateAction {
               (f as Map<String, dynamic>)['field'] as String,
               before: f['before'] as String?,
               after: f['after'] as String?,
+              // Absent in documents written before #300, which read back as
+              // the transitions they were.
+              isCount: f['count'] as bool? ?? false,
             ),
         ],
         canApply: json['canApply'] as bool? ?? true,

--- a/packages/account_state/lib/src/materialize/materialized_state.dart
+++ b/packages/account_state/lib/src/materialize/materialized_state.dart
@@ -15,7 +15,7 @@
 library;
 
 import 'package:account_actions/account_actions.dart'
-    show Alternatives, FieldChange, collapseAlternatives;
+    show Alternatives, FieldChange, FieldChangeShape, collapseAlternatives;
 import 'package:account_core/account_core.dart' as core;
 
 /// One dispatched action, flattened for storage and display.
@@ -86,10 +86,13 @@ class CandidateAction {
                 'field': f.field,
                 if (f.before != null) 'before': f.before,
                 if (f.after != null) 'after': f.after,
-                // Which of the two shapes this is (#300). A count read back as
-                // a transition renders as "∅ → 21" again, so a passive session
-                // would show the very thing the live one no longer does.
-                if (f.isCount) 'count': true,
+                // Which of the three shapes this is (#300, #305). Read back as
+                // a transition, a count renders as "∅ → 21" again and a
+                // statement as "GBS-9Z@… → ∅" — so a passive session would show
+                // the very thing the live one no longer does. Omitted for the
+                // transition, which is what every field written before #300 is.
+                if (f.shape != FieldChangeShape.transition)
+                  'shape': f.shape.name,
               },
           ],
         'canApply': canApply,
@@ -109,9 +112,7 @@ class CandidateAction {
               (f as Map<String, dynamic>)['field'] as String,
               before: f['before'] as String?,
               after: f['after'] as String?,
-              // Absent in documents written before #300, which read back as
-              // the transitions they were.
-              isCount: f['count'] as bool? ?? false,
+              shape: _fieldShape(f['shape'] as String?),
             ),
         ],
         canApply: json['canApply'] as bool? ?? true,
@@ -119,6 +120,17 @@ class CandidateAction {
         isDefaultAlternative: json['isDefaultAlternative'] as bool? ?? false,
       );
 }
+
+/// The persisted [FieldChangeShape] of one stored field.
+///
+/// Absent in documents written before #300/#305 — and in every field that is a
+/// plain transition, which is exactly what those documents hold — so an unknown
+/// or missing name reads back as [FieldChangeShape.transition].
+FieldChangeShape _fieldShape(String? name) =>
+    FieldChangeShape.values.firstWhere(
+      (FieldChangeShape s) => s.name == name,
+      orElse: () => FieldChangeShape.transition,
+    );
 
 /// The decision points a candidate list represents (#251) — the persisted-view
 /// counterpart of the reconcile controller's `PendingChoice`, built by the one

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -792,14 +792,40 @@ void main() {
         ],
       );
       final restored = CandidateAction.fromJson(original.toJson());
-      expect(restored.fields.first.isCount, isTrue);
+      expect(restored.fields.first.shape, FieldChangeShape.count);
       expect(restored.fields.first.after, '21');
       expect(restored.fields.first.before, isNull);
-      expect(restored.fields.last.isCount, isFalse,
+      expect(restored.fields.last.shape, FieldChangeShape.transition,
           reason: 'an ordinary transition is unaffected');
     });
 
-    test('a field written before #300 reads back as a transition', () {
+    test('a statement field survives a candidate JSON round-trip (#305)', () {
+      // Same reasoning as the count above, for the other non-transition shape:
+      // dropped on the way through Cosmos, the "laat de groep staan" notice
+      // reads "mail: GBS-9Z@… → ∅" in a passive session — an address being
+      // cleared by the option that writes nothing.
+      const original = CandidateAction(
+        family: 'group',
+        kind: 'AzureClassGroupWithoutClass',
+        system: core.Origin.azure,
+        summary: 'Laat de Office 365-groep GBS-9Z staan',
+        canApply: false,
+        fields: [
+          FieldChange.statement('mail', 'GBS-9Z@student.school.example'),
+          FieldChange.statement('leden', '21'),
+        ],
+      );
+      final restored = CandidateAction.fromJson(original.toJson());
+      expect(
+        restored.fields.map((f) => f.shape),
+        everyElement(FieldChangeShape.statement),
+      );
+      expect(restored.fields.map((f) => f.before),
+          ['GBS-9Z@student.school.example', '21']);
+      expect(restored.fields.every((f) => f.after == null), isTrue);
+    });
+
+    test('a field written before #300/#305 reads back as a transition', () {
       final restored = CandidateAction.fromJson(<String, dynamic>{
         'family': 'group',
         'kind': 'SyncAzureClassGroupMembers',
@@ -809,7 +835,7 @@ void main() {
           {'field': 'leden toevoegen', 'after': '21'},
         ],
       });
-      expect(restored.fields.single.isCount, isFalse);
+      expect(restored.fields.single.shape, FieldChangeShape.transition);
     });
 
     test('buildRollups counts the choice once at every level', () {

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -777,6 +777,41 @@ void main() {
       expect(restored.isDefaultAlternative, isTrue);
     });
 
+    test('a count field survives a candidate JSON round-trip (#300)', () {
+      // A stored candidate is what a passive session renders. If the count
+      // shape is dropped on the way through Cosmos, that session shows
+      // "leden toevoegen: ∅ → 21" again while the live one no longer does.
+      final original = CandidateAction(
+        family: 'group',
+        kind: 'SyncAzureClassGroupMembers',
+        system: core.Origin.azure,
+        summary: 'Werk het ledenbestand van GBS-1A bij',
+        fields: [
+          FieldChange.count('leden toevoegen', 21),
+          const FieldChange('mail', after: 'GBS-1A@student.school.example'),
+        ],
+      );
+      final restored = CandidateAction.fromJson(original.toJson());
+      expect(restored.fields.first.isCount, isTrue);
+      expect(restored.fields.first.after, '21');
+      expect(restored.fields.first.before, isNull);
+      expect(restored.fields.last.isCount, isFalse,
+          reason: 'an ordinary transition is unaffected');
+    });
+
+    test('a field written before #300 reads back as a transition', () {
+      final restored = CandidateAction.fromJson(<String, dynamic>{
+        'family': 'group',
+        'kind': 'SyncAzureClassGroupMembers',
+        'system': core.Origin.azure.toJson(),
+        'summary': 'Werk het ledenbestand bij',
+        'fields': [
+          {'field': 'leden toevoegen', 'after': '21'},
+        ],
+      });
+      expect(restored.fields.single.isCount, isFalse);
+    });
+
     test('buildRollups counts the choice once at every level', () {
       final account = _account(candidates: [
         candidate('UnregisterStudentFromSmartschool',


### PR DESCRIPTION
The foundation half of epic #291 — everything that ships before the layout rework, plus two follow-ups filed inside this batch. The layout itself (#295 and what depends on it) follows in the next chunk.

## What changed

- **#292 — the decision, not the combination, is what a bulk apply acts on.** Grouping now keys on a single `PendingChoice.situationId` via new `SituationCohort` / `PendingDecision` types; `applyDecisions` / `dryRunDecisions` / `applyScopeForDecisions` run and scope one nominated decision per account, while `applyEntries` keeps the whole-card reading through the same `_run`. `situationKey` — the family plus the sorted set of every decision on the card — is gone, so students needing a class change and students needing a class change *plus* an email fix are no longer two disjoint subsets. Bulk headers moved to the top of the pending list, since a card can now belong to several cohorts and interleaving would duplicate it (the shape Klasgroepen already used). Intended knock-on: a namesake-class cohort now counts 0 and disables its button, because that decision writes nothing.
- **#293 — whether an action may go in bulk is a property of the action.** `canApplyToAll` (default `false`) added to the sealed `StudentAction` / `StaffAction` / `GroupAction` bases and granted to 9 student, 2 staff and 4 group actions, ported from legacy. Inert metadata for now — #296/#297 wire it. The test pins each family's exact granted set, the `canApply ⇒ canApplyToAll` invariant and the destructive-withheld rule, with exhaustive `switch` classifications so a new action fails to compile until it is classified. Two deliberate divergences from the issue's table, both read off `legacy-wpf/` (which the issue names as the authority): `ModifyAzureSchool` and `ModifyAzureStudentEmail` are granted, because legacy passes `true, true` to both and the table's `ChangeEmail` is a dead legacy class whose grant lands on `ModifyAzureStudentEmail` here; legacy's staff `AddToStaffGroup` grant has no Dart counterpart. The group family had no legacy flag, so its four grants are decided and documented in place.
- **#294 — the global apply-all is gone.** Removed the `actions-dry-run` / `actions-apply` buttons and the header's `actions-progress` bar, and deleted `ReconcileController.dryRun` / `applyAll` (no production callers left). The pending-count line stays. Every test that drove a pass from the header was retargeted onto the per-decision cohort header or the per-entry pair, which run the same `_run` path. No disabled shell left behind for #296.
- **#298 — a system indicator means "work you can do on this screen".** New `account_manager/lib/src/screens/system_indicator.dart` holds the shared vocabulary (`SystemIndicatorState` missing / needsWork / inOrder, derivation from presence plus applyable work, `SystemIndicatorCell`, `ActionLine`, and `systemLabel` moved out of `action_tiles.dart`, which re-exports it). Klasgroepen cells are keyed `class-cell-<klas>-<systeem>`, and every action line is led by the system it writes to. Acties gets the vocabulary and the tag but no indicator cells — those land with #295's flat list, per #291. **The #290 conflict is resolved in #298's favour** and documented in both doc comments; #290 is already closed and `AzureClassGroupMembership.canApply` is still `false`, so enacting it needed no code change.
- **#300 — a card no longer says its summary twice, and counts read as counts.** Two independent defects at the #281/#283 seam. The collapsed card previews each decision as a summary line and #281 made the expanded body lead every decision with the same sentence: a new shared `PendingCardTile` (used by both `PendingEntryTile` and the Klasgroepen `_ClassRow`) takes an `expanded` flag so the preview stands down while the card is open, and the decision heading picks up the `ActionLine` system tag the preview used to carry — keeping `entryDetail` self-sufficient for #295's details pane. Separately, `FieldChange` had only a transition shape, so a count rendered as `leden toevoegen: ∅ → 21`; added `FieldChange.count`, rendered by a new `fieldChangeLine` as `leden toevoegen: 21`, round-tripped through `CandidateAction` JSON so passive sessions match.
- **#305 — an informational notice states a fact instead of diffing it.** *(Follow-up filed by the #300 worker.)* A bare `before` went through the before → after template, so the "laat de groep staan" notice claimed it was clearing the group's mail and its 21 members. Replaced #300's `isCount` bool with a `FieldChangeShape` enum (transition / count / statement), added `FieldChange.statement` rendered arrow-free, used it for both stale-group actions, and persisted the shape through the JSON (an absent key still reads back as a transition).
- **#306 — the namesake notice names a group's code instead of clearing it.** *(Follow-up filed by the #305 worker.)* `ClassExistsAsSmartschoolGroup` described the group's code as a transition, so an action with `canApply == false` rendered `code: G2G → ∅`. One field moved onto #305's `FieldChange.statement`. A sweep confirms this was the last bare-`before` field in the action packages.

## Test plan

Run per commit, each green on its own; figures below are at the branch tip:

- `dart format --set-exit-if-changed .` — clean (317 files, 0 changed)
- `dart analyze --fatal-infos --fatal-warnings` — clean over the workspace, 0 issues
- `dart test packages/*/test` — **1416 pass / 11 skipped** (live opt-ins, self-skipping)
- `flutter test` (account_manager) — **536 pass / 0 fail** (from 512 at branch point)
- `flutter test integration_test/app_launch_test.dart -d windows` — **114 pass / 0 fail**

Every new test was verified failing on the unpatched code first. Notably: restoring #292's old combination key fails 7 of its 10 new cohort tests (the 3 that pass are the invariants #292 preserves) plus the new e2e; flipping `ModifySmartschoolData.canApplyToAll` to false fails 3 of #293's 8; stashing #294's change fails both its new widget assertion and the #154 e2e; #306's integration test fails on `Found 0 widgets with text "code: G2G"`.

New coverage: 10 cohort unit tests + 1 e2e (#292), 8 in a new `can_apply_to_all_test.dart` (#293), 1 widget + retargeted e2e (#294), 8 unit in a new `system_indicator_test.dart` + 3 widget + 1 e2e (#298), 3 regression tests (#300), 1 widget + 1 e2e (#305), 1 unit + 1 e2e (#306).

**#293 carries no integration test, deliberately** — `canApplyToAll` is inert domain metadata that no UI reads yet, so there is no user-visible level to test it at. #296/#297 in the next chunk are where it becomes visible, and they carry the e2e coverage for it.

Closes #292
Closes #293
Closes #294
Closes #298
Closes #300
Closes #305
Closes #306