### PR TITLE
Acties: one flat account list, with the decision as the unit of work

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -754,6 +754,100 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  // The complement of the run above, for the kinds #293 deliberately withholds
+  // a school-wide apply from (#297). The operator ticks the accounts by hand,
+  // names the one decision, and the pass covers exactly the ticked accounts it
+  // stands open on. Worth a full run for the same reason #296 is: the count on
+  // the button, the rows the checkboxes sit on and the writes the pass makes are
+  // resolved in three different places, and only the real app composes all
+  // three — over real fonts, the real navigation shell and the real Graph and
+  // SOAP write paths.
+  testWidgets(
+      'ticked accounts run one decision that gets no apply-all, and the pass '
+      'skips the ones it does not stand open on (#297)',
+      (WidgetTester tester) async {
+    useTallWindow(tester);
+    // The same rollover fixture: three students share the sanctioned class
+    // move, and Sam alone also carries the Office 365 rename — a judgement call
+    // the sanction refuses, and therefore exactly the kind this exists for.
+    final harness = rolloverHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    expect(harness.controller.error, isNull);
+
+    final String sam = accountId(harness, 'Sam Sels');
+    final String sara = accountId(harness, 'Sara Segers');
+    final String tom = accountId(harness, 'Tom Tas');
+    Finder check(String id) => find.byKey(ValueKey('account-check-$id'));
+
+    // The rename carries no school-wide affordance anywhere on Sam's card…
+    await selectAccount(tester, sam);
+    expect(
+      find.byKey(ValueKey('decision-apply-all-student-$sam-0')),
+      findsNothing,
+    );
+
+    // …so the bulk path is the ticks. Sam and Sara, by hand; Tom is left alone
+    // and stays that way.
+    for (final id in <String>[sam, sara]) {
+      await tester.ensureVisible(check(id));
+      await tester.tap(check(id));
+      await tester.pumpAndSettle();
+    }
+    expect(tester.widget<Checkbox>(check(tom)).value, isFalse);
+
+    final Finder rename =
+        find.byKey(const ValueKey('actions-decision-student|ModifyAzureName'));
+    await tester.ensureVisible(rename);
+    await tester.tap(rename);
+    await tester.pumpAndSettle();
+
+    // Sara raises the class move, not the rename. The bar says so rather than
+    // quietly passing over her.
+    expect(
+      tester
+          .widget<Text>(find.byKey(const ValueKey('actions-selection-scope')))
+          .data,
+      'Wordt toegepast op 1 van de 2 geselecteerde account(s) — 1 '
+      'overgeslagen, want daar staat deze beslissing niet open.',
+    );
+
+    await tester.tap(find.byKey(const ValueKey('actions-selection-apply')));
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Toepassen op 1 geselecteerd(e) account(s)?'),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.textContaining('1 wijziging naar Office 365'),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    // One real Graph PATCH, and not one class move — the pass is one decision
+    // deep whatever else the ticked cards carry (#292).
+    expect(
+      harness.graph.requests.where((r) => r.method == 'PATCH'),
+      hasLength(1),
+    );
+    expect(
+      harness.soap.soapActions.where((a) => a.endsWith('#saveUserToClass')),
+      isEmpty,
+    );
+    expect(harness.controller.applyResults, hasLength(1));
+    expect(tester.takeException(), isNull);
+  });
+
   /// Opens the Klasgroepen tab from the navigation rail (#227). The class
   /// inventory is a destination of its own now, not a node inside Acties.
   Future<void> openKlasgroepen(WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -848,6 +848,91 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets(
+      'an apply leaves the operator on the account they applied, reading its '
+      'verdict, and lets the row go when they move on end-to-end (#299)',
+      (WidgetTester tester) async {
+    // The complaint #299 is about is a *composition* one, which is why it gets
+    // a full run: the pass is the controller's, the refreshed rows and the
+    // details pane are the screen's, and the failure was the seam between them
+    // — an account settling its last decision fell out of the filtered list at
+    // the exact moment its verdict arrived, so the pane the operator applied
+    // from reverted to "kies een account" and a half-succeeded pass read like a
+    // clean one. Only the real app puts the pass, the list, the pane and the
+    // filters in one frame together.
+    //
+    // Three students each carry one stale Office 365 display name — work a real
+    // Graph write genuinely clears — so a pass really does empty an account's
+    // card, which is the whole precondition.
+    useTallWindow(tester);
+    final harness = crossClassSituationHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    expect(harness.controller.error, isNull);
+
+    final String sam = accountId(harness, 'Sam Sels');
+    final String sara = accountId(harness, 'Sara Segers');
+    final String tom = accountId(harness, 'Tom Tas');
+    Finder row(String id) => find.byKey(ValueKey('account-row-$id'));
+
+    // Apply Sam's one decision from his open details pane.
+    await selectAccount(tester, sam);
+    final Finder apply = find.byKey(ValueKey('entry-apply-$sam'));
+    await tester.ensureVisible(apply);
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    // One real Graph PATCH, and it settled his card.
+    expect(
+        harness.graph.requests.where((r) => r.method == 'PATCH'), hasLength(1));
+    expect(harness.controller.pendingEntries.where((e) => e.targetId == sam),
+        isEmpty);
+
+    // He is still on the list, under the work filter that no longer matches
+    // him, marked as what just happened rather than as an account that was
+    // always fine — and his two colleagues are untouched beside him.
+    await tester.ensureVisible(row(sam));
+    expect(row(sam), findsOneWidget);
+    expect(find.byKey(ValueKey('account-done-$sam')), findsOneWidget);
+    expect(find.byKey(ValueKey('account-done-$sara')), findsNothing);
+    expect(
+      tester
+          .widget<SystemIndicatorCell>(
+              find.byKey(ValueKey('account-cell-$sam-${Origin.azure.name}')))
+          .state,
+      SystemIndicatorState.inOrder,
+      reason: 'the row re-rendered in place off the view the pass relinked',
+    );
+
+    // The pane is still his, with the verdict on the card — no re-selection,
+    // no sync, and not merely the page-level section that reports the pass.
+    expect(find.byKey(ValueKey('actions-detail-$sam')), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-detail-empty')), findsNothing);
+    final Finder verdict = find.byKey(ValueKey('entry-outcomes-student-$sam'));
+    await tester.ensureVisible(verdict);
+    expect(
+      find.descendant(
+          of: verdict, matching: find.text('Wijzig de naam in Azure')),
+      findsOneWidget,
+    );
+
+    // Moving to an account the pass never touched is the operator done reading
+    // it, so the held row lets go and the list is the work list again.
+    await selectAccount(tester, sara);
+    expect(row(sam), findsNothing);
+    expect(row(sara), findsOneWidget);
+    expect(row(tom), findsOneWidget);
+    expect(find.byKey(ValueKey('actions-detail-$sara')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   /// Opens the Klasgroepen tab from the navigation rail (#227). The class
   /// inventory is a destination of its own now, not a node inside Acties.
   Future<void> openKlasgroepen(WidgetTester tester) async {
@@ -4000,9 +4085,9 @@ void main() {
   });
 
   testWidgets(
-      'applying an account\'s work takes it out of the Acties work list and '
-      'off the counts, without a re-sync end-to-end (#236/#295)',
-      (WidgetTester tester) async {
+      'applying an account\'s work takes it off the counts and, once the '
+      'operator moves on, out of the Acties work list, without a re-sync '
+      'end-to-end (#236/#295/#299)', (WidgetTester tester) async {
     // The real app, real fonts, real navigation. The counts are re-derived from
     // the materialized rollups, which only a sync used to rewrite, so work that
     // had just been applied kept being advertised — and the work-list filter
@@ -4046,9 +4131,20 @@ void main() {
       reason: 'the live list drops the work immediately — it always did',
     );
 
-    // The work list is empty now, with no sync between…
-    expect(find.byKey(ValueKey('account-row-$sam')), findsNothing,
+    // His badge is gone with the work behind it. The row itself is still on
+    // screen, and only because #299 holds a just-applied account there long
+    // enough for its verdict to be read — marked as what happened, not badged.
+    final Finder samRow = find.byKey(ValueKey('account-row-$sam'));
+    expect(samRow, findsOneWidget);
+    expect(find.byKey(ValueKey('account-done-$sam')), findsOneWidget);
+    expect(find.descendant(of: samRow, matching: find.text('1')), findsNothing,
         reason: 'the row used to come back still badged 1');
+
+    // Reshaping the list is the operator moving on, so the hold lets go — and
+    // the work list is empty, with no sync between.
+    await tester.tap(find.byKey(const ValueKey('actions-sort-klas')));
+    await tester.pumpAndSettle();
+    expect(samRow, findsNothing);
     expect(find.text('Geen openstaande acties — alles staat in orde.'),
         findsOneWidget);
     // …while the work nobody touched is untouched: a re-derivation of what
@@ -4061,7 +4157,6 @@ void main() {
     await tester.ensureVisible(toggle);
     await tester.tap(toggle);
     await tester.pumpAndSettle();
-    final Finder samRow = find.byKey(ValueKey('account-row-$sam'));
     await tester.ensureVisible(samRow);
     expect(find.descendant(of: samRow, matching: find.text('1')), findsNothing);
     expect(find.descendant(of: samRow, matching: find.byIcon(Icons.check)),

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -633,9 +633,126 @@ void main() {
   }
 
   // The bulk affordance that stood where the Acties header's global "Alles
-  // toepassen" used to (#294) now lives only on the Klasgroepen cohort headers,
-  // which the class-inventory scenarios below drive directly. Acties itself
-  // carries no bulk apply since #295; #296 gives it one, cohort-first.
+  // toepassen" used to (#294) comes in two shapes now: the Klasgroepen cohort
+  // headers, which the class-inventory scenarios below drive directly, and — on
+  // Acties since #296 — a per-decision "Toepassen op alle" that filters the flat
+  // list down to its cohort before offering a confirmation. The run below is
+  // that one, end to end.
+
+  testWidgets(
+      'a decision applied across the whole school shows its cohort first, and '
+      'writes that decision alone end-to-end (#296)',
+      (WidgetTester tester) async {
+    // The real app, real fonts, real navigation, over the real Smartschool and
+    // Graph write paths. The September rollover in miniature: three students
+    // moved up into `4A` while Smartschool still has all three in last year's
+    // `3C`, so every one of them needs the same class change — and Sam alone
+    // also has a stale Office 365 display name.
+    //
+    // Only a full run puts the two halves of #296 on screen in the order that
+    // matters. The count on the button is resolved school-wide by the
+    // controller, the rows it promises are rendered by the screen out of a
+    // *filtered* list, and the write is decided a third time by the pass. This
+    // walks it the way the operator does: narrow the list to one student, arm
+    // the cohort from their card, and check that the other two are now on
+    // screen — before anything is confirmed, let alone written.
+    useTallWindow(tester);
+    final harness = rolloverHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    expect(harness.controller.error, isNull);
+
+    final String sam = accountId(harness, 'Sam Sels');
+    final String sara = accountId(harness, 'Sara Segers');
+    final String tom = accountId(harness, 'Tom Tas');
+    Finder row(String id) => find.byKey(ValueKey('account-row-$id'));
+
+    // The operator is looking at Sam alone.
+    await tester.enterText(find.byKey(const ValueKey('actions-search')), 'Sam');
+    await tester.pumpAndSettle();
+    expect(row(sam), findsOneWidget);
+    expect(row(sara), findsNothing);
+
+    await selectAccount(tester, sam);
+
+    // His card carries two decisions. Only the class move is sanctioned for a
+    // school-wide pass (#293) — a rename is a judgement call — and the button
+    // counts the school, not the search box.
+    final Finder rename = find.byKey(ValueKey('decision-apply-all-student-'
+        '$sam-0'));
+    final Finder moveAll = find.byKey(ValueKey('decision-apply-all-student-'
+        '$sam-1'));
+    expect(rename, findsNothing);
+    await tester.ensureVisible(moveAll);
+    expect(
+      find.descendant(
+          of: moveAll, matching: find.text('Toepassen op alle (3)')),
+      findsOneWidget,
+    );
+
+    // Pressing it writes nothing. It shows the cohort: the list is now the
+    // three accounts the pass would touch, and the search box that was hiding
+    // two of them has stood down.
+    await tester.tap(moveAll);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('actions-cohort-banner')), findsOneWidget);
+    expect(
+      find.text('Wijzig de klas in Smartschool — 3 account(s) in de hele '
+          'school'),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('actions-search')), findsNothing);
+    for (final id in <String>[sam, sara, tom]) {
+      await tester.ensureVisible(row(id));
+      expect(row(id), findsOneWidget);
+    }
+    expect(
+        harness.soap.soapActions.where((a) => a.endsWith('#saveUserToClass')),
+        isEmpty);
+
+    // The confirmation names that one decision: three Smartschool writes, and
+    // no claim on Office 365. Scoped to the dialog, because the cards behind it
+    // lead each line with the system it writes to (#298).
+    await tester.tap(find.byKey(const ValueKey('actions-cohort-apply')));
+    await tester.pumpAndSettle();
+    final Finder confirmation = find.byType(AlertDialog);
+    expect(
+      find.descendant(
+          of: confirmation, matching: find.textContaining('3 wijzigingen')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: confirmation, matching: find.textContaining('Office 365')),
+      findsNothing,
+      reason: "summing every decision on every card would quote Sam's rename "
+          'and then not write it',
+    );
+
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    // Three class moves against the real SOAP transport, each with its own
+    // payload; not one Graph write, because the rename was never armed.
+    expect(
+      harness.soap.soapActions.where((a) => a.endsWith('#saveUserToClass')),
+      hasLength(3),
+    );
+    expect(harness.graph.requests.where((r) => r.method == 'PATCH'), isEmpty);
+    expect(harness.controller.applyResults, hasLength(3));
+    expect(find.text('Resultaat van het toepassen'), findsWidgets);
+
+    // The review is over — what it was built from has been written — so the
+    // list has its own controls back.
+    expect(find.byKey(const ValueKey('actions-cohort-banner')), findsNothing);
+    expect(find.byKey(const ValueKey('actions-search')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
 
   /// Opens the Klasgroepen tab from the navigation rail (#227). The class
   /// inventory is a destination of its own now, not a node inside Acties.

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -149,6 +149,23 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  /// The linker's id of the account the flat Acties list shows as [label] —
+  /// what its row, its cells and its details pane are keyed by (#295).
+  String accountId(ReconcileHarness harness, String label) =>
+      harness.controller.linkedAccounts
+          .firstWhere((a) => a.label == label)
+          .id
+          .value;
+
+  /// Selects one account in the flat Acties list, which is what puts its
+  /// decisions in the details pane beside it (#295).
+  Future<void> selectAccount(WidgetTester tester, String id) async {
+    final Finder row = find.byKey(ValueKey('account-row-$id'));
+    await tester.ensureVisible(row);
+    await tester.tap(row);
+    await tester.pumpAndSettle();
+  }
+
   testWidgets('the app launches into the Plink-themed Home shell',
       (WidgetTester tester) async {
     // The real main(): with no --dart-define config, AAD is not configured, so
@@ -315,8 +332,8 @@ void main() {
 
   testWidgets(
       'the reconcile flow runs end-to-end: sign-in → sync → overview on '
-      'Reconcile → actions via the Actions tab drill-down → dry-run → apply → '
-      'unchanged re-sync (#154)', (WidgetTester tester) async {
+      'Reconcile → actions via the Actions tab list → dry-run → apply → '
+      'unchanged re-sync (#154/#295)', (WidgetTester tester) async {
     // The real app composition — shell, navigation, theme — over the offline
     // reconcile harness (scripted syncers + recording transports), driven the
     // way the operator drives it.
@@ -359,20 +376,18 @@ void main() {
       reason: 'Reconcile no longer shows the flat pending-actions list',
     );
 
-    // Switch to the Actions tab: the actions are browsed by the year → class
-    // drill-down. Drill into 3C to build that class's action tile.
+    // Switch to the Actions tab: since #295 the actions are one flat,
+    // school-wide list of accounts — no jaar → klas tree to walk down.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.byType(ActionsScreen), findsOneWidget);
-    // Scoped to this screen: since #265 the Synchronisatie tab heads its own
-    // counts section "Overzicht" too, and the shell keeps a visited screen
-    // alive in the IndexedStack.
     expect(
       find.descendant(
         of: find.byType(ActionsScreen),
-        matching: find.text('Overzicht'),
+        matching: find.text('Jaar 3'),
       ),
-      findsOneWidget,
+      findsNothing,
+      reason: 'the drill-down it replaces is gone',
     );
     // The header states the workload and stops there (#294): the global
     // "Dry-run alles" / "Alles toepassen" pair that wrote every account in the
@@ -390,20 +405,21 @@ void main() {
     expect(find.text('Dry-run alles'), findsNothing);
     expect(find.text('Alles toepassen'), findsNothing);
 
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('3C'));
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
+    // The one account with work is a row of the list, carrying its class and
+    // its three system indicators; selecting it puts its decisions in the
+    // details pane beside it, and dry-running from there writes nothing.
+    final String id = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student')
+        .targetId;
+    expect(
+      find.descendant(
+        of: find.byKey(ValueKey('account-row-$id')),
+        matching: find.text('3C'),
+      ),
+      findsOneWidget,
+    );
+    await selectAccount(tester, id);
     expect(find.text('Wijzig de klas in Smartschool'), findsWidgets);
-
-    // Open the one account in 3C and dry-run it: the projected changes render,
-    // nothing writes.
-    final String id =
-        harness.controller.classroomPendingEntries.single.targetId;
-    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
-    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
-    await tester.pumpAndSettle();
     await tester.ensureVisible(find.byKey(ValueKey('entry-dry-run-$id')));
     await tester.tap(find.byKey(ValueKey('entry-dry-run-$id')));
     await tester.pumpAndSettle();
@@ -605,37 +621,6 @@ void main() {
     expect(harness.controller.busy, isFalse);
   });
 
-  /// Two departed Smartschool-only students with different names, each raising
-  /// the unregister/delete choice — a two-action pass whose steps are told
-  /// apart by the account they name. [gate] parks every action so the pass can
-  /// be observed frozen exactly where the operator waits (#243).
-  ReconcileHarness twoDepartedHarness(Future<void> Function() gate) =>
-      ReconcileHarness(
-        applyGate: gate,
-        wisa: wisaSnap(students: const []),
-        smartschool: ssSnap(
-          groups: const [],
-          accounts: [
-            ssAccount(
-              uid: 'user0',
-              accountId: '0',
-              mail: 'user0@student.school.example',
-              givenName: 'Jan',
-              surname: 'Peeters',
-            ),
-            ssAccount(
-              uid: 'user1',
-              accountId: '1',
-              mail: 'user1@student.school.example',
-              givenName: 'Sofie',
-              surname: 'Claes',
-            ),
-          ],
-          memberships: const [],
-        ),
-        azure: azSnap(users: const []),
-      );
-
   /// Syncs on Reconcile and lands on the Actions tab, the way the operator gets
   /// to the apply affordances.
   Future<void> syncThenOpenActions(WidgetTester tester) async {
@@ -647,29 +632,10 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  /// Drills the Actions overview into the leaver bucket, where the two departed
-  /// students of [twoDepartedHarness] sit as a single cohort.
-  Future<void> drillZonderKlas(WidgetTester tester) async {
-    await tester.tap(find.text('Niet toegewezen'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('Zonder klas'));
-    await tester.tap(find.text('Zonder klas'));
-    await tester.pumpAndSettle();
-  }
-
-  /// Presses the open classroom's one cohort header — the bulk apply that
-  /// stands where the header's global "Alles toepassen" used to (#294). The
-  /// cohort is on screen above the button, which is the whole difference.
-  Future<void> tapCohortApply(
-    WidgetTester tester,
-    ReconcileHarness harness,
-  ) async {
-    final String key = harness.controller.classroomPendingSituations.single.key;
-    final Finder bulk = find.byKey(ValueKey('situation-apply-$key'));
-    await tester.ensureVisible(bulk);
-    await tester.tap(bulk);
-    await tester.pumpAndSettle();
-  }
+  // The bulk affordance that stood where the Acties header's global "Alles
+  // toepassen" used to (#294) now lives only on the Klasgroepen cohort headers,
+  // which the class-inventory scenarios below drive directly. Acties itself
+  // carries no bulk apply since #295; #296 gives it one, cohort-first.
 
   /// Opens the Klasgroepen tab from the navigation rail (#227). The class
   /// inventory is a destination of its own now, not a node inside Acties.
@@ -696,18 +662,21 @@ void main() {
 
   testWidgets(
       'an apply pass holds the operator in a modal progress dialog naming the '
-      'account and action in flight, and clears when the pass ends (#243)',
+      'action in flight, and clears when the pass ends (#243)',
       (WidgetTester tester) async {
     // The real app over the offline harness, with the pass parked one action at
-    // a time. An "Apply to all" over a September situation group writes
-    // hundreds of accounts sequentially and runs for minutes; its only feedback
-    // used to be greyed-out buttons and an indeterminate bar in a page header
-    // the operator had scrolled past, and nothing stopped them navigating away
-    // mid-write. Composition is the point here: the dialog has to sit over the
-    // real shell, in the real font, above a page that is still scrollable.
+    // a time. A rollover pass writes hundreds of accounts sequentially and runs
+    // for minutes; its only feedback used to be greyed-out buttons and an
+    // indeterminate bar in a page header the operator had scrolled past, and
+    // nothing stopped them navigating away mid-write. Composition is the point
+    // here: the dialog has to sit over the real shell, in the real font.
+    //
+    // Driven from one account's two decisions, which since #295 is the longest
+    // pass Acties itself can start — the multi-account form lives on the
+    // Klasgroepen cohort header until #296 brings it back here.
     useTallWindow(tester);
     final gates = <Completer<void>>[];
-    final harness = twoDepartedHarness(() async {
+    final harness = ReconcileHarness(applyGate: () async {
       final gate = Completer<void>();
       gates.add(gate);
       await gate.future;
@@ -719,23 +688,33 @@ void main() {
     ));
     await tester.pumpAndSettle();
     await syncThenOpenActions(tester);
-    await drillZonderKlas(tester);
+
+    final entry = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student');
+    final steps = <String>[
+      for (final c in entry.choices)
+        '${entry.target} — ${c.selected.changes.summary}',
+    ];
+    expect(steps, hasLength(2));
+    await selectAccount(tester, entry.targetId);
 
     // Idle: no dialog.
     expect(progressDialog, findsNothing);
 
-    await tapCohortApply(tester, harness);
+    final Finder apply = find.byKey(ValueKey('entry-apply-${entry.targetId}'));
+    await tester.ensureVisible(apply);
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
     // Parked on the first action: the dialog names how far along the pass is
-    // and whose account is being written right now.
+    // and what is being written right now.
     expect(progressDialog, findsOneWidget);
     expect(gates, hasLength(1));
     expect(find.text('Acties toepassen…'), findsOneWidget);
     expect(progressLine(tester, 'actions-progress-count'), 'Actie 1 van 2');
-    expect(progressLine(tester, 'actions-progress-step'),
-        startsWith('Jan Peeters —'));
+    expect(progressLine(tester, 'actions-progress-step'), steps[0]);
     expect(
       tester
           .widget<LinearProgressIndicator>(
@@ -752,12 +731,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(progressDialog, findsOneWidget);
 
-    // The text follows the pass onto the second account.
+    // The text follows the pass onto the second decision.
     gates[0].complete();
     await tester.pumpAndSettle();
     expect(progressLine(tester, 'actions-progress-count'), 'Actie 2 van 2');
-    expect(progressLine(tester, 'actions-progress-step'),
-        startsWith('Sofie Claes —'));
+    expect(progressLine(tester, 'actions-progress-step'), steps[1]);
 
     // The pass finishes: the dialog closes by itself, leaving the results.
     gates[1].complete();
@@ -776,7 +754,7 @@ void main() {
     // future rather than to anything observed about the results.
     useTallWindow(tester);
     final gate = Completer<void>();
-    final harness = twoDepartedHarness(() async {
+    final harness = ReconcileHarness(applyGate: () async {
       await gate.future;
       throw StateError('Smartschool weigerde de schrijfactie');
     });
@@ -787,9 +765,14 @@ void main() {
     ));
     await tester.pumpAndSettle();
     await syncThenOpenActions(tester);
-    await drillZonderKlas(tester);
 
-    await tapCohortApply(tester, harness);
+    final String id = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student')
+        .targetId;
+    await selectAccount(tester, id);
+    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
     expect(progressDialog, findsOneWidget);
@@ -804,9 +787,8 @@ void main() {
       findsWidgets,
       reason: 'the failure is reported on the page, not behind a stuck modal',
     );
-    // The app is usable again: the affordances are live and reachable.
-    final String key = harness.controller.classroomPendingSituations.single.key;
-    await tester.ensureVisible(find.byKey(ValueKey('situation-apply-$key')));
+    // The app is usable again: the affordance is live and reachable.
+    await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
     expect(tester.takeException(), isNull);
   });
 
@@ -1320,15 +1302,9 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    // The departed account is browsed on the Actions tab, under the
-    // "Niet toegewezen" → "Zonder klas" bucket (#210 dropped the always-empty
-    // grade level between them).
+    // The departed account is one row of the flat Actions list, filed under the
+    // "Zonder klas" bucket a leaver falls into.
     await tester.tap(find.text('Acties'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Niet toegewezen'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('Zonder klas'));
-    await tester.tap(find.text('Zonder klas'));
     await tester.pumpAndSettle();
 
     // One entry for the departed account (not two independent rows).
@@ -1337,12 +1313,17 @@ void main() {
     final id = entry.targetId;
     expect(entry.choices.single.isChoice, isTrue,
         reason: 'unregister vs delete collapse into a single choice');
-    expect(find.byKey(ValueKey('entry-student-$id')), findsOneWidget);
+    expect(find.byKey(ValueKey('account-row-$id')), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(ValueKey('account-row-$id')),
+        matching: find.text('Zonder klas'),
+      ),
+      findsOneWidget,
+    );
 
-    // Expand the entry, choose delete (the non-default), apply just this row.
-    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
-    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
-    await tester.pumpAndSettle();
+    // Select it, choose delete (the non-default), apply just this row.
+    await selectAccount(tester, id);
     await tester
         .tap(find.byKey(ValueKey('alt-$id-DeleteStudentFromSmartschool')));
     await tester.pumpAndSettle();
@@ -1396,27 +1377,20 @@ void main() {
         reason: 'the account is still in the group ⇒ Azure is kept');
 
     // Browse it on the Actions tab: because school 2 is one we do NOT manage,
-    // its node is kept out of the drill-down (#178). The departed student is
-    // re-bucketed to "Niet toegewezen" so its Smartschool cleanup stays
-    // actionable — never surfacing a non-managed school node.
+    // the student has no class of ours, so the row files them under "Zonder
+    // klas" and their Smartschool cleanup stays actionable (#178).
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.text('School 2'), findsNothing,
         reason: 'a school we do not manage never appears in Actions (#178)');
-    await tester.tap(find.text('Niet toegewezen'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('Zonder klas'));
-    await tester.tap(find.text('Zonder klas'));
-    await tester.pumpAndSettle();
-    expect(find.byKey(ValueKey('entry-student-${entry.targetId}')),
+    final Finder row = find.byKey(ValueKey('account-row-${entry.targetId}'));
+    expect(row, findsOneWidget);
+    expect(find.descendant(of: row, matching: find.text('Zonder klas')),
         findsOneWidget);
 
     // Apply the row: the Smartschool departure writes against the recording
     // SOAP transport; Azure (Graph) is never called.
-    await tester
-        .ensureVisible(find.byKey(ValueKey('entry-student-${entry.targetId}')));
-    await tester.tap(find.byKey(ValueKey('entry-student-${entry.targetId}')));
-    await tester.pumpAndSettle();
+    await selectAccount(tester, entry.targetId);
     await tester
         .ensureVisible(find.byKey(ValueKey('entry-apply-${entry.targetId}')));
     await tester.tap(find.byKey(ValueKey('entry-apply-${entry.targetId}')));
@@ -1434,7 +1408,7 @@ void main() {
   });
 
   testWidgets(
-      'the Actions drill-down hides a school the operator does not manage in '
+      'the Actions list hides a school the operator does not manage in '
       'Settings, re-bucketing its student to the leaver group (#178)',
       (WidgetTester tester) async {
     // A student enrolled in school 2, fully present in our Smartschool + Azure.
@@ -1457,26 +1431,26 @@ void main() {
 
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    // Scoped to this screen — the Synchronisatie tab behind it has an
-    // "Overzicht" heading of its own since #265.
+    // The non-managed school is nowhere on the screen…
+    expect(find.text('School 2'), findsNothing,
+        reason: 'school 2 is not managed → its class never names a row');
+    // …but the departed student's cleanup stays actionable, filed under the
+    // leaver bucket rather than vanishing entirely.
+    final String leaver = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student')
+        .targetId;
     expect(
       find.descendant(
-        of: find.byType(ActionsScreen),
-        matching: find.text('Overzicht'),
+        of: find.byKey(ValueKey('account-row-$leaver')),
+        matching: find.text('Zonder klas'),
       ),
       findsOneWidget,
     );
-    // The non-managed school is not a node in the drill-down…
-    expect(find.text('School 2'), findsNothing,
-        reason: 'school 2 is not managed → no node in Actions');
-    // …but the departed student's cleanup stays actionable under the leaver
-    // bucket rather than vanishing entirely.
-    expect(find.text('Niet toegewezen'), findsOneWidget);
   });
 
   testWidgets(
       'marking that same school as managed in Settings surfaces its students in '
-      'the Actions drill-down end-to-end (#178)', (WidgetTester tester) async {
+      'the Actions list end-to-end (#178)', (WidgetTester tester) async {
     // The very same school-2 student, but now school 2 is one of ours: their
     // class must be browsable instead of sitting in the leaver bucket. Proves
     // the managed set from Settings drives which students show. The school
@@ -1497,13 +1471,16 @@ void main() {
 
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    expect(find.text('Niet toegewezen'), findsNothing,
+    final String id = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student')
+        .targetId;
+    final Finder row = find.byKey(ValueKey('account-row-$id'));
+    expect(find.descendant(of: row, matching: find.text('Zonder klas')),
+        findsNothing,
         reason: 'managing school 2 takes its student out of the leaver bucket');
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    expect(find.text('3C'), findsWidgets);
+    expect(find.descendant(of: row, matching: find.text('3C')), findsOneWidget);
     // The class the student reached still carries school 2's partition, which
-    // is what the per-class read targets.
+    // is what the stored documents are keyed by.
     expect(
       harness.controller
           .studentChildrenOf(harness.controller.studentRollups.single)
@@ -1515,7 +1492,7 @@ void main() {
 
   testWidgets(
       'the materialized view names a school by name and code end-to-end, never '
-      '"School <id>", while the drill-down shows no school at all (#204/#210)',
+      '"School <id>", while the list shows no school at all (#204/#210)',
       (WidgetTester tester) async {
     // The real app, real fonts, real navigation. This session's WISA snapshot
     // carries no schools at all, so the school's identity can only come from
@@ -1542,17 +1519,24 @@ void main() {
     expect(find.text('School 25'), findsNothing,
         reason: 'the numeric id is the last resort, not the rendering (#204)');
     expect(find.text('Instituut Sancta Maria-A (ISMAA)'), findsNothing,
-        reason: 'no school node survives in the student tree (#210)');
+        reason: 'the school level is nowhere in the Acties list (#210/#295)');
 
     // The stored school rollup — what the counters and the Cosmos documents are
     // keyed and labelled by — still carries the full identity.
     expect(harness.controller.schoolRollups.single.label,
         'Instituut Sancta Maria-A (ISMAA)');
 
-    // And the year drills straight to the student's class.
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    expect(find.text('3C'), findsWidgets);
+    // And the student's row names their class, straight away.
+    final String id = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student')
+        .targetId;
+    expect(
+      find.descendant(
+        of: find.byKey(ValueKey('account-row-$id')),
+        matching: find.text('3C'),
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets(
@@ -1605,7 +1589,7 @@ void main() {
         reason: 'the inverted rendering #208 fixed must not come back');
     expect(find.text('School 25'), findsNothing);
     expect(find.text('Instituut Sancta Maria-A (ISMAA)'), findsNothing,
-        reason: 'no school node survives in the student tree (#210)');
+        reason: 'the school level is nowhere in the Acties list (#210/#295)');
   });
 
   testWidgets(
@@ -1692,20 +1676,18 @@ void main() {
 
     // Over on Acties: the virtual school's student is still imported and still
     // sits in the class their own WISA record names — dropping the class-group
-    // records moved nobody.
+    // records moved nobody. The list spans every managed school (#210/#295), so
+    // the virtual school's 1V student is a row beside our own school's.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    // The merged first year spans both managed schools (#210), so the virtual
-    // school's 1V sits beside our own 1A under it.
-    final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
-    await tester.ensureVisible(yearNode);
-    await tester.tap(yearNode);
-    await tester.pumpAndSettle();
-    final classNode = find.byKey(const ValueKey('rollup-class-class|99|1|1V'));
-    await tester.ensureVisible(classNode);
-    await tester.tap(classNode);
-    await tester.pumpAndSettle();
-    expect(find.text('Jane Doe'), findsWidgets);
+    final String inVirtual = harness.controller.linkedAccounts
+        .firstWhere((a) => a.classroom == '1V')
+        .id
+        .value;
+    final Finder virtualRow = find.byKey(ValueKey('account-row-$inVirtual'));
+    expect(virtualRow, findsOneWidget);
+    expect(find.descendant(of: virtualRow, matching: find.text('Jane Doe')),
+        findsOneWidget);
   });
 
   testWidgets(
@@ -2164,16 +2146,16 @@ void main() {
     expect(harness.controller.groupRollup!.pendingCount, isNot(6),
         reason: 'the badge used to count both halves of both choices');
 
-    // Each student's own class carries one action and is badged once, so the
+    // Each student's own row carries one action and is badged once, so the
     // collapse did not simply deflate every count.
-    final jaar1 = find.byKey(const ValueKey('rollup-grade-grades|1'));
-    await tester.ensureVisible(jaar1);
-    await tester.tap(jaar1);
-    await tester.pumpAndSettle();
-    final klas1A = find.byKey(const ValueKey('rollup-class-class|1|1|1A'));
-    await tester.ensureVisible(klas1A);
+    final String inOneA = harness.controller.linkedAccounts
+        .firstWhere((a) => a.classroom == '1A')
+        .id
+        .value;
+    final Finder rowOneA = find.byKey(ValueKey('account-row-$inOneA'));
+    await tester.ensureVisible(rowOneA);
     expect(
-        find.descendant(of: klas1A, matching: find.text('1')), findsOneWidget);
+        find.descendant(of: rowOneA, matching: find.text('1')), findsOneWidget);
 
     // The number on the aggregate is exactly what a confirmed apply of the
     // Klasgroepen list would write — the claim the badge and the dialog used to
@@ -2203,10 +2185,6 @@ void main() {
     // The staff twin of the class case, and the crisp version of the count: two
     // freshly hired teachers, each raising the provision-or-ignore either/or of
     // #248 and nothing else. Two people, two decisions — the node read 4.
-    //
-    // The Personeel tree is the deeper one (school → jaar → klas), so this also
-    // proves the collapse survives every level of the aggregation rather than
-    // only the leaf the operator drills into.
     useTallWindow(tester);
     final harness = newStaffChoiceHarness();
     await tester.pumpWidget(AccountManagerApp(
@@ -2220,24 +2198,18 @@ void main() {
 
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
-    final staffSchool =
-        find.byKey(const ValueKey('rollup-school-school|staff'));
-    await tester.ensureVisible(staffSchool);
-    await tester.tap(staffSchool);
-    await tester.pumpAndSettle();
-    await tester
-        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
-    await tester.pumpAndSettle();
 
-    final staffClass = find
-        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
-    await tester.ensureVisible(staffClass);
-    expect(find.descendant(of: staffClass, matching: find.text('2')),
-        findsOneWidget,
-        reason: 'two hires, one either/or each');
-    expect(
-        find.descendant(of: staffClass, matching: find.text('4')), findsNothing,
-        reason: 'the opt-out is the alternative, never a second to-do');
+    // Each hire is one row, badged once — never twice for the two halves of the
+    // one either/or.
+    for (final e in harness.controller.pendingEntries
+        .where((e) => e.family == 'staff')) {
+      final Finder row = find.byKey(ValueKey('account-row-${e.targetId}'));
+      await tester.ensureVisible(row);
+      expect(find.descendant(of: row, matching: find.text('1')), findsOneWidget,
+          reason: 'one hire, one either/or');
+      expect(find.descendant(of: row, matching: find.text('2')), findsNothing,
+          reason: 'the opt-out is the alternative, never a second to-do');
+    }
 
     // The Personeel tab badge is derived the same way and agrees.
     expect(harness.controller.staffPendingCount, 2);
@@ -2975,11 +2947,12 @@ void main() {
     await tester.pumpAndSettle();
     expect(healthy, findsOneWidget);
 
-    // And the same list is not maintained in two places: the Klasgroepen node
-    // has left the Acties drill-down.
+    // And the same list is not maintained in two places: no class is a row of
+    // the Acties list, which holds accounts only.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('rollup-groups')), findsNothing);
+    expect(find.byKey(const ValueKey('class-row-1A')), findsNothing);
     expect(tester.takeException(), isNull);
   });
 
@@ -3306,45 +3279,28 @@ void main() {
     await tester.pumpAndSettle();
 
     // Nothing applyable hangs off either class's *students*, so the work list
-    // hides them — the switch is what turns the view into the inventory an
+    // holds neither — the switch is what turns the view into the inventory an
     // operator answering a phone call browses (#226).
-    expect(find.byKey(const ValueKey('rollup-grade-grades|1')), findsNothing);
+    final String samId = accountId(harness, 'Sam Sels');
+    final String janeId = accountId(harness, 'Jane Doe');
+    expect(find.byKey(ValueKey('account-row-$samId')), findsNothing);
     final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
     await tester.ensureVisible(toggle);
     await tester.tap(toggle);
     await tester.pumpAndSettle();
 
-    // The year is opened once and stays open across both drill-downs: since
-    // #235 pressing Overzicht comes back to the grade-year it was opened from.
-    final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
-    await tester.ensureVisible(yearNode);
-    await tester.tap(yearNode);
-    await tester.pumpAndSettle();
-
-    // Sam, in 1B: one line, naming both groups, and marked as a manual fix.
-    await tester
-        .ensureVisible(find.byKey(const ValueKey('rollup-class-class|1|1|1B')));
-    await tester.tap(find.byKey(const ValueKey('rollup-class-class|1|1|1B')));
-    await tester.pumpAndSettle();
-    expect(find.text('Sam Sels'), findsOneWidget);
+    // Sam: one line, naming both groups, in the details pane beside his row.
+    await selectAccount(tester, samId);
     expect(
       find.textContaining(
           'Zit in de verkeerde Office 365-klasgroep: GBS-1A in plaats van '
           'GBS-1B'),
       findsOneWidget,
     );
-    expect(find.textContaining('(manueel)'), findsWidgets,
-        reason: 'the class row performs the write, so this one diagnoses');
 
-    // Jane, in 1A: the plain "missing from her own group" reading. Overzicht
-    // lands back on the still-open year, with her class already listed.
-    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
-    await tester.pumpAndSettle();
-    await tester
-        .ensureVisible(find.byKey(const ValueKey('rollup-class-class|1|1|1A')));
-    await tester.tap(find.byKey(const ValueKey('rollup-class-class|1|1|1A')));
-    await tester.pumpAndSettle();
-    expect(find.text('Jane Doe'), findsOneWidget);
+    // Jane: the plain "missing from her own group" reading, one row away — no
+    // going back out to an overview in between.
+    await selectAccount(tester, janeId);
     expect(
       find.textContaining('Ontbreekt in de Office 365-klasgroep GBS-1A'),
       findsOneWidget,
@@ -3430,29 +3386,29 @@ void main() {
     );
 
     // The students the same fact is reported on are informational only, so
-    // nothing over on Acties turns orange for them: their cards still carry the
-    // diagnosis, marked "(manueel)", and raise no applyable work at all.
+    // nothing over on Acties turns orange for them: their rows still carry the
+    // diagnosis in the details pane, and colour no cell at all.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
     await tester.ensureVisible(toggle);
     await tester.tap(toggle);
     await tester.pumpAndSettle();
-    final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
-    await tester.ensureVisible(yearNode);
-    await tester.tap(yearNode);
-    await tester.pumpAndSettle();
-    final classNode = find.byKey(const ValueKey('rollup-class-class|1|1|1A'));
-    await tester.ensureVisible(classNode);
-    await tester.tap(classNode);
-    await tester.pumpAndSettle();
+    final String janeId = accountId(harness, 'Jane Doe');
+    await selectAccount(tester, janeId);
 
-    expect(find.text('Jane Doe'), findsOneWidget);
     expect(
       find.textContaining('Ontbreekt in de Office 365-klasgroep GBS-1A'),
       findsOneWidget,
     );
-    expect(find.textContaining('(manueel)'), findsWidgets);
+    expect(
+      tester
+          .widget<SystemIndicatorCell>(
+              find.byKey(ValueKey('account-cell-$janeId-azure')))
+          .state,
+      SystemIndicatorState.inOrder,
+      reason: 'an informational candidate colours no indicator',
+    );
     final studentWork = harness.controller.pendingEntries
         .where((e) => e.family == 'student')
         .expand(workSystemsOfEntry)
@@ -3468,20 +3424,18 @@ void main() {
   });
 
   testWidgets(
-      'a passive session marks the same informational candidate "(manueel)" on '
-      'the account card end-to-end (#255)', (WidgetTester tester) async {
-    // The same #245 fixture, read the way most operators meet it: session 1
-    // syncs and materializes the shared view, session 2 is the real app over
-    // those stores and never syncs, so Acties renders stored documents as static
-    // cards (#214) instead of interactive tiles.
+      'a session that cannot seed gets one blocking notice on Acties and no '
+      'list to browse end-to-end (#214/#287/#295)',
+      (WidgetTester tester) async {
+    // Session 1 syncs and materializes the shared view; session 2 is the real
+    // app over those stores holding no seeded snapshot, so it cannot link and
+    // has nothing to act on.
     //
-    // This is the layer that sees the bug. The two renderings are different
-    // widgets fed by different pipelines — the interactive tile reads live
-    // `PendingChoice`s, the passive card reads `CandidateAction`s round-tripped
-    // through the store's JSON — and only a full-app run puts an operator in
-    // front of the passive one. There Sam's line used to read as ordinary due
-    // work beside a badge counting it 0, with no way to tell "the app will do
-    // this" from "you must do this by hand".
+    // Acties used to answer that by rendering the stored documents as inert
+    // account cards under the same drill-down (#214). That was a second way to
+    // browse the same data, one the operator can do nothing with — so since
+    // #295 the notice is the whole screen, and its Synchroniseer is the one
+    // thing on it.
     useTallWindow(tester);
     final snapshots = InMemorySnapshotStore();
     final linkedStore = InMemoryLinkedStore();
@@ -3490,9 +3444,6 @@ void main() {
       linkedStore: linkedStore,
     ).controller.sync();
 
-    // Deliberately holding no seeded snapshot: since #287 a session that does
-    // adopts the shared state and gets the interactive tiles instead, and this
-    // scenario is about the passive card.
     final resumed = ReconcileHarness(linkedStore: linkedStore);
     await tester.pumpWidget(AccountManagerApp(
       session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
@@ -3504,50 +3455,38 @@ void main() {
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
 
-    // Nothing applyable hangs off the students, so the work list hides their
-    // classes until the inventory toggle is flipped (#226) — exactly the state
-    // in which the unmarked line was most misleading.
-    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
-    await tester.ensureVisible(toggle);
-    await tester.tap(toggle);
-    await tester.pumpAndSettle();
-
-    final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
-    await tester.ensureVisible(yearNode);
-    await tester.tap(yearNode);
-    await tester.pumpAndSettle();
-    final klas1B = find.byKey(const ValueKey('rollup-class-class|1|1|1B'));
-    await tester.ensureVisible(klas1B);
-    await tester.tap(klas1B);
-    await tester.pumpAndSettle();
-
-    // The card is the passive one — locked, no interactive entry tile — and
-    // Sam's one line now says the operator has to fix this by hand.
     expect(resumed.controller.linked, isNull,
-        reason: 'link() is never called in a passive session');
+        reason: 'link() is never called in a session with nothing to link');
     expect(find.byKey(const ValueKey('actions-read-only')), findsOneWidget);
-    expect(find.text('Sam Sels'), findsOneWidget);
+    expect(find.text('Alleen-lezen overzicht'), findsOneWidget);
     expect(
-      find.textContaining('Zit in de verkeerde Office 365-klasgroep: GBS-1A '
-          'in plaats van GBS-1B'),
-      findsOneWidget,
+      tester
+          .widget<FilledButton>(
+              find.byKey(const ValueKey('actions-read-only-sync')))
+          .onPressed,
+      isNotNull,
     );
-    expect(find.textContaining('(manueel)'), findsOneWidget,
-        reason: 'the class row performs the write, so this card diagnoses');
+
+    // One notice, and nothing behind it: no list, no controls, no inert cards.
+    expect(find.byKey(const ValueKey('actions-list')), findsNothing);
+    expect(
+        find.byKey(const ValueKey('actions-only-with-actions')), findsNothing);
+    expect(find.byKey(const ValueKey('actions-search')), findsNothing);
+    expect(find.text('Sam Sels'), findsNothing);
     expect(resumed.wisaSyncs, 0);
     expect(resumed.ssSyncs, 0);
     expect(resumed.azSyncs, 0);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets(
-      'the Acties drill-down opens on grade-years merged across the managed '
-      'schools end-to-end, with no school level to guess at (#210)',
-      (WidgetTester tester) async {
+      'the flat Acties list spans every managed school end-to-end, with no '
+      'school level to guess at (#210/#295)', (WidgetTester tester) async {
     // The real app, real fonts, real navigation. Two managed schools whose
     // years overlap: school 1 holds 1A and 3C, school 2 holds 1B and the
     // non-numeric OKAN. The WISA school split is administrative — operators
-    // treat both as one school — so the overview must open on the years, and a
-    // class must be findable by name without first guessing its school.
+    // treat both as one school — so every student is in one list, each row
+    // naming their own class, and no school appears anywhere.
     useTallWindow(tester);
     final harness = twoSchoolHarness();
     await tester.pumpWidget(AccountManagerApp(
@@ -3563,47 +3502,51 @@ void main() {
 
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    expect(find.text('Jaar 1'), findsOneWidget);
-    expect(find.text('Jaar 3'), findsOneWidget);
+    expect(find.text('Jaar 1'), findsNothing);
     expect(find.text('School 1'), findsNothing);
     expect(find.text('School 2'), findsNothing);
-    // The synthetic non-numeric bucket is renamed rather than read as the
-    // nonsensical "Jaar Overig" next to the real years.
-    expect(find.text('Overige klassen'), findsOneWidget);
-    expect(find.text('Jaar Overig'), findsNothing);
+    expect(find.text('Overige klassen'), findsNothing);
 
-    // The merged first year carries both schools' first-year classes and their
-    // combined account count.
+    // One row per student, whichever school they are enrolled in, each naming
+    // their own class. Sorted by class, the two schools interleave — which is
+    // the point: the operator never has to guess a school first.
+    await tester.tap(find.byKey(const ValueKey('actions-sort-klas')));
+    await tester.pumpAndSettle();
+    for (final klas in const <String>['1A', '1B', '3C', 'OKAN']) {
+      final String id = harness.controller.linkedAccounts
+          .firstWhere((a) => a.classroom == klas)
+          .id
+          .value;
+      final Finder row = find.byKey(ValueKey('account-row-$id'));
+      await tester.ensureVisible(row);
+      expect(
+          find.descendant(of: row, matching: find.text(klas)), findsOneWidget);
+    }
+
+    // The stored rollups keep their school partitions all the same — the
+    // flattening is presentation only.
     expect(harness.controller.studentRollups.first.accountCount, 2);
-    await tester.tap(find.text('Jaar 1'));
-    await tester.pumpAndSettle();
-    expect(find.text('1A'), findsOneWidget);
-    expect(find.text('1B'), findsOneWidget);
-
-    // Opening the school-2 class still targets school 2's own partition — the
-    // flattening is presentation only, the documents stay partitioned by school.
-    await tester.ensureVisible(find.text('1B'));
-    await tester.tap(find.text('1B'));
-    await tester.pumpAndSettle();
-    expect(harness.controller.selectedClassroom?.school, '2');
-    expect(harness.controller.classroomAccounts, hasLength(1));
     expect(
-        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+      harness.controller
+          .studentChildrenOf(harness.controller.studentRollups.first)
+          .map((r) => r.school),
+      <String>['1', '2'],
+    );
   });
 
   testWidgets(
-      'the Acties filter collapses the drill-down to the work list end-to-end: '
-      'ticked-off classes and whole ticked-off years are gone, the switch is '
-      'set once and survives a tab change (#226)', (WidgetTester tester) async {
+      'the Acties filter collapses the list to the work list end-to-end: the '
+      'accounts with nothing to do are gone, the switch is set once and '
+      'survives a tab change (#226/#295)', (WidgetTester tester) async {
     // The real app, real fonts, real navigation. Four students across three
     // classes of two managed schools; exactly one of them (Sam, in 3C) sits in
-    // the wrong Smartschool class, so exactly one class carries work.
+    // the wrong Smartschool class, so exactly one of them carries work.
     //
-    // This is the layer that sees it: the tree the operator browses is built
-    // from the stored rollups by two projections one tab apart, the switch
-    // lives above the family tab bar and has to outlive a tab change, and
-    // "which nodes render" is a whole-page composition question that a widget
-    // test of one section structurally cannot answer.
+    // This is the layer that sees it: the list is joined from the linked view
+    // and the derived account documents, the switch lives above the family tab
+    // bar and has to outlive a tab change, and "which rows render" is a
+    // whole-page composition question that a widget test of one section
+    // structurally cannot answer.
     useTallWindow(tester);
     final harness = ReconcileHarness(
       wisa: wisaSnap(
@@ -3663,8 +3606,8 @@ void main() {
       ),
       // Every Azure account already carries the WISA display name, so the only
       // student action the pass raises anywhere is Sam's class move. (The WISA
-      // fixture names every student "Jane Doe"; the tree is browsed by node,
-      // not by person, so only the class each of them sits in matters here.)
+      // fixture names every student "Jane Doe"; the rows are addressed by id,
+      // so only the class each of them sits in matters here.)
       azure: azSnap(users: [
         azUser(displayName: 'Jane Doe'),
         azUser(
@@ -3720,22 +3663,20 @@ void main() {
     expect(toggle, findsOneWidget);
     expect(tester.widget<Switch>(toggle).value, isTrue);
 
-    // Jaar 1's two classes are both done, so the whole year is gone; Jaar 3
-    // stays because one of its classes is not.
-    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
-    expect(find.byKey(const ValueKey('rollup-grade-grades|1')), findsNothing,
-        reason: 'both of Jaar 1\'s classes are done — the year goes with them');
-    // …and the operator is told why a year they expected is missing.
-    expect(find.byKey(const ValueKey('actions-filter-hidden')), findsOneWidget);
+    // The WISA fixture names every student "Jane Doe", so the rows are told
+    // apart by the class each of them sits in.
+    String rowOf(String klas) => harness.controller.linkedAccounts
+        .firstWhere((a) => a.classroom == klas)
+        .id
+        .value;
+    final String sam = rowOf('3C');
+    final String tom = rowOf('3D');
 
-    // Inside the surviving year, the ticked-off class is gone too.
-    await tester.tap(find.byKey(const ValueKey('rollup-grade-grades|3')));
-    await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-class-class|1|3|3C')),
-        findsOneWidget);
-    expect(
-        find.byKey(const ValueKey('rollup-class-class|1|3|3D')), findsNothing,
-        reason: 'a class with nothing to do is not rendered under the filter');
+    // The 3C student is the only account with work, so they are the whole list.
+    expect(find.byKey(ValueKey('account-row-$sam')), findsOneWidget);
+    expect(find.byKey(ValueKey('account-row-$tom')), findsNothing,
+        reason: 'an account with nothing to do is not in the work list');
+    expect(find.byKey(ValueKey('account-row-${rowOf('1C')}')), findsNothing);
 
     // The switch is a mode, not a per-list setting: it outlives a tab change.
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
@@ -3744,91 +3685,37 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('actions-tab-leerlingen')));
     await tester.pumpAndSettle();
     expect(tester.widget<Switch>(toggle).value, isTrue);
-    expect(find.byKey(const ValueKey('rollup-grade-grades|1')), findsNothing);
+    expect(find.byKey(ValueKey('account-row-$tom')), findsNothing);
 
-    // Switched off, the full inventory is back — every year, every class. Jaar
-    // 3 was left open above and, being visible under either filter setting,
-    // stays open across the switch (#235), so its ticked-off class simply
-    // reappears beside the one with work.
+    // Switched off, the whole school is back — every student, three green
+    // cells on the ones that need nothing.
     await tester.ensureVisible(toggle);
     await tester.tap(toggle);
     await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-grade-grades|1')), findsOneWidget);
-    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
-    expect(find.byKey(const ValueKey('actions-filter-hidden')), findsNothing);
-    expect(find.byKey(const ValueKey('rollup-class-class|1|3|3C')),
-        findsOneWidget);
-    expect(find.byKey(const ValueKey('rollup-class-class|1|3|3D')),
-        findsOneWidget);
+    for (final klas in const <String>['1C', '3C', '3D']) {
+      final Finder row = find.byKey(ValueKey('account-row-${rowOf(klas)}'));
+      await tester.ensureVisible(row);
+      expect(row, findsOneWidget);
+    }
+    expect(
+      tester
+          .widget<SystemIndicatorCell>(
+              find.byKey(ValueKey('account-cell-$tom-smartschool')))
+          .state,
+      SystemIndicatorState.inOrder,
+    );
   });
 
   testWidgets(
-      'the Acties tree is a single-open accordion whose grade-year survives a '
-      'drill into a class end-to-end (#235)', (WidgetTester tester) async {
-    // The real app, real fonts, real navigation. This bug is a composition one:
-    // while a class is open the drill-down is not built at all, so the
-    // expansion held inside the ExpansionTiles died with them and **Overzicht**
-    // came back to a fully collapsed tree. Only an end-to-end run navigates the
-    // way that breaks it — a widget test of the tree alone never leaves it.
-    useTallWindow(tester);
-    final harness = twoSchoolHarness();
-    await tester.pumpWidget(AccountManagerApp(
-      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
-      graph: graph,
-      reconcileBootstrap: harness.bootstrap,
-    ));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Synchronisatie'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Acties'));
-    await tester.pumpAndSettle();
-
-    final jaar1 = find.byKey(const ValueKey('rollup-grade-grades|1'));
-    final jaar3 = find.byKey(const ValueKey('rollup-grade-grades|3'));
-    final klas1A = find.byKey(const ValueKey('rollup-class-class|1|1|1A'));
-    final klas3C = find.byKey(const ValueKey('rollup-class-class|1|3|3C'));
-
-    // Open Jaar 1…
-    await tester.ensureVisible(jaar1);
-    await tester.tap(jaar1);
-    await tester.pumpAndSettle();
-    expect(klas1A, findsOneWidget);
-
-    // …then Jaar 3: one open node per level, so Jaar 1 shuts behind it.
-    await tester.ensureVisible(jaar3);
-    await tester.tap(jaar3);
-    await tester.pumpAndSettle();
-    expect(klas3C, findsOneWidget);
-    expect(klas1A, findsNothing,
-        reason: 'several years could stand open at once before #235');
-
-    // Drill into 3C and press Overzicht: the year the operator came from is
-    // still open, with its class in view rather than behind a re-expand.
-    await tester.ensureVisible(klas3C);
-    await tester.tap(klas3C);
-    await tester.pumpAndSettle();
-    expect(harness.controller.selectedClassroom?.classroom, '3C');
-    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
-    await tester.pumpAndSettle();
-    expect(klas3C, findsOneWidget,
-        reason: 'the tree used to come back fully collapsed');
-    expect(klas1A, findsNothing);
-    expect(harness.controller.expandedPath, <String>['rollup-grade-grades|3']);
-  });
-
-  testWidgets(
-      'a sync whose shared write fails still closes the open class, so the '
-      'drill-down never pairs the previous generation with the fresh view '
-      'end-to-end (#289)', (WidgetTester tester) async {
-    // The real app, real navigation. The bug is a composition one: the four
-    // derived caches were dropped on the far side of the store write, so a
-    // Cosmos write that timed out or threw left the class the operator had open
-    // — its documents read for the generation before — standing in front of the
-    // freshly linked view. Only an end-to-end run navigates the way that shows
-    // it: sync, drill in, sync again over a store that refuses the write, and
-    // look at what is still on screen.
+      'a sync whose shared write fails still leaves Acties showing the view it '
+      'just linked, never the previous generation end-to-end (#289/#295)',
+      (WidgetTester tester) async {
+    // The real app, real navigation. The bug is a composition one: the derived
+    // caches were dropped on the far side of the store write, so a Cosmos write
+    // that timed out or threw left the operator looking at documents read for
+    // the generation before, standing in front of the freshly linked view.
+    // Only an end-to-end run navigates the way that shows it: sync, look,
+    // sync again over a store that refuses the write, and look again.
     useTallWindow(tester);
     final inner = InMemoryLinkedStore();
     final harness = ReconcileHarness(
@@ -3852,17 +3739,19 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    // Drill into the class the shared view just materialized.
+    // The student the shared view just materialized, in the class it names.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('3C'));
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget,
-        reason: 'the drill-down is open on 3C');
-    expect(harness.controller.selectedClassroom?.classroom, '3C');
+    final String id = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student')
+        .targetId;
+    expect(
+      find.descendant(
+        of: find.byKey(ValueKey('account-row-$id')),
+        matching: find.text('3C'),
+      ),
+      findsOneWidget,
+    );
 
     // WISA moves the student out of 3C, and the operator re-syncs — but the
     // shared store refuses the write.
@@ -3881,32 +3770,37 @@ void main() {
       reason: 'the write really did fail',
     );
 
-    // Back on Acties: the class the operator had open is closed, because the
-    // view behind it was replaced. Before the fix the detail view was still
-    // there, joining the fresh entries to 3C's stale documents.
+    // Back on Acties: the row reads the class the fresh link gives it, not the
+    // one the generation before the failed write still says. Before the fix the
+    // screen was still joined to that previous generation's documents.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    expect(harness.controller.selectedClassroom, isNull);
-    expect(find.byKey(const ValueKey('actions-classroom-back')), findsNothing,
-        reason: 'a re-link closes the drill-down, write or no write');
-    expect(harness.controller.classroomPendingEntries, isEmpty);
+    final String moved = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student')
+        .targetId;
+    final Finder movedRow = find.byKey(ValueKey('account-row-$moved'));
+    await tester.ensureVisible(movedRow);
+    expect(find.descendant(of: movedRow, matching: find.text('3D')),
+        findsOneWidget);
+    expect(
+        find.descendant(of: movedRow, matching: find.text('3C')), findsNothing);
     // …and the session is still perfectly usable: it holds the view it linked.
     expect(harness.controller.linked, isNotNull);
   });
 
   testWidgets(
-      'applying a class\'s work updates its Acties badge on the way back to '
-      'the overview, without a re-sync end-to-end (#236)',
+      'applying an account\'s work takes it out of the Acties work list and '
+      'off the counts, without a re-sync end-to-end (#236/#295)',
       (WidgetTester tester) async {
-    // The real app, real fonts, real navigation. The badges are read from the
-    // materialized rollups, which only a sync used to rewrite, so a class whose
-    // work had just been applied kept advertising it — and since #226 that same
-    // stale count decides whether the class is in the tree at all.
+    // The real app, real fonts, real navigation. The counts are re-derived from
+    // the materialized rollups, which only a sync used to rewrite, so work that
+    // had just been applied kept being advertised — and the work-list filter
+    // reads that same count.
     //
-    // This is the layer that sees it: the overview and the drilled-in list are
-    // two projections composed by different halves of the screen, and the bug is
-    // precisely that they disagree. Only a run that syncs, drills in, applies,
-    // and comes back out puts both on screen in that order.
+    // This is the layer that sees it: the header count, the tab badges and the
+    // list are three projections composed by different halves of the screen,
+    // and the bug is precisely that they disagree. Only a run that syncs,
+    // applies and looks again puts them all on screen in that order.
     useTallWindow(tester);
     final harness = appliedClassWorkHarness();
     await tester.pumpWidget(AccountManagerApp(
@@ -3918,60 +3812,56 @@ void main() {
     await syncThenOpenActions(tester);
     expect(harness.controller.error, isNull);
 
-    final jaar3 = find.byKey(const ValueKey('rollup-grade-grades|3'));
-    final klas3C = find.byKey(const ValueKey('rollup-class-class|1|3|3C'));
-
-    // Sam's stale Office 365 name is the only student work: 3C carries it,
-    // badged 1, and the class groups carry four writes of their own.
-    await tester.ensureVisible(jaar3);
-    await tester.tap(jaar3);
-    await tester.pumpAndSettle();
-    expect(
-        find.descendant(of: klas3C, matching: find.text('1')), findsOneWidget);
+    // Sam's stale Office 365 name is the only student work: he is the whole
+    // work list, and the class groups carry four writes of their own.
+    final String sam = accountId(harness, 'Sam Sels');
+    final String tom = accountId(harness, 'Tom Tas');
+    expect(find.byKey(ValueKey('account-row-$sam')), findsOneWidget);
+    expect(find.byKey(ValueKey('account-row-$tom')), findsNothing);
     expect(harness.controller.groupRollup!.pendingCount, 4);
 
-    // Drill into 3C and apply that one entry, confirmation dialog and all.
-    await tester.ensureVisible(klas3C);
-    await tester.tap(klas3C);
-    await tester.pumpAndSettle();
-    final entry = harness.controller.classroomPendingEntries.single;
-    await tester.tap(find.byKey(ValueKey('entry-student-${entry.targetId}')));
-    await tester.pumpAndSettle();
-    final applyEntry = find.byKey(ValueKey('entry-apply-${entry.targetId}'));
+    // Select him and apply that one entry, confirmation dialog and all.
+    await selectAccount(tester, sam);
+    final applyEntry = find.byKey(ValueKey('entry-apply-$sam'));
     await tester.ensureVisible(applyEntry);
     await tester.tap(applyEntry);
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
     expect(find.text('Resultaat van het toepassen'), findsWidgets);
-    expect(harness.controller.classroomPendingEntries, isEmpty,
-        reason: 'the live list drops the work immediately — it always did');
+    expect(
+      harness.controller.pendingEntries.where((e) => e.family == 'student'),
+      isEmpty,
+      reason: 'the live list drops the work immediately — it always did',
+    );
 
-    // Overzicht: the class is done, so under the work-list filter it is gone,
-    // and with 3D already clean the whole year goes with it.
-    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
-    await tester.pumpAndSettle();
-    expect(klas3C, findsNothing,
-        reason: 'the class used to come back still badged 1');
-    expect(jaar3, findsNothing);
+    // The work list is empty now, with no sync between…
+    expect(find.byKey(ValueKey('account-row-$sam')), findsNothing,
+        reason: 'the row used to come back still badged 1');
+    expect(find.text('Geen openstaande acties — alles staat in orde.'),
+        findsOneWidget);
     // …while the work nobody touched is untouched: a re-derivation of what
     // changed, not a blanket reset.
     expect(harness.controller.groupRollup!.pendingCount, 4);
 
-    // Off the filter, the class is back in the inventory — now ticked off
-    // rather than badged, with no sync between.
+    // Off the filter, Sam is back in the inventory — ticked off rather than
+    // badged, and his Office 365 cell is green.
     final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
     await tester.ensureVisible(toggle);
     await tester.tap(toggle);
     await tester.pumpAndSettle();
-    await tester.ensureVisible(jaar3);
-    if (klas3C.evaluate().isEmpty) {
-      await tester.tap(jaar3);
-      await tester.pumpAndSettle();
-    }
-    expect(find.descendant(of: klas3C, matching: find.text('1')), findsNothing);
-    expect(find.descendant(of: klas3C, matching: find.byIcon(Icons.check)),
+    final Finder samRow = find.byKey(ValueKey('account-row-$sam'));
+    await tester.ensureVisible(samRow);
+    expect(find.descendant(of: samRow, matching: find.text('1')), findsNothing);
+    expect(find.descendant(of: samRow, matching: find.byIcon(Icons.check)),
         findsOneWidget);
+    expect(
+      tester
+          .widget<SystemIndicatorCell>(
+              find.byKey(ValueKey('account-cell-$sam-azure')))
+          .state,
+      SystemIndicatorState.inOrder,
+    );
     expect(tester.takeException(), isNull);
   });
 
@@ -3986,8 +3876,11 @@ void main() {
     // Only a two-session run can see that: one session applies, and the bug is
     // what the *other* one is still showing. So operator A is an offline
     // session over the shared stores, and operator B is the real app — real
-    // fonts, real navigation, real rollup tree — reading the same shared view
-    // over the same realtime fan-out, and never syncing or linking at all.
+    // fonts, real navigation — reading the same shared view over the same
+    // realtime fan-out, and never syncing or linking at all. B cannot link, so
+    // since #295 Acties offers it one blocking notice; what it *does* still
+    // read passively is the Synchronisatie overview, and that is where the
+    // stale offer showed.
     useTallWindow(tester);
     final hub = InMemorySignalHub();
     final snapshots = InMemorySnapshotStore();
@@ -4013,19 +3906,14 @@ void main() {
       reconcileBootstrap: operatorB.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Acties'));
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
 
-    final jaar3 = find.byKey(const ValueKey('rollup-grade-grades|3'));
-    final klas3C = find.byKey(const ValueKey('rollup-class-class|1|3|3C'));
-
-    // B is offered the work, badged 1 — read from the shared documents, with no
-    // pull and no link() of its own.
-    await tester.ensureVisible(jaar3);
-    await tester.tap(jaar3);
-    await tester.pumpAndSettle();
-    expect(
-        find.descendant(of: klas3C, matching: find.text('1')), findsOneWidget);
+    // B is offered the work — read from the shared documents, with no pull and
+    // no link() of its own.
+    expect(find.byKey(const ValueKey('reconcile-category-students')),
+        findsOneWidget);
+    expect(find.text('1 openstaande actie'), findsOneWidget);
 
     // A applies it. B is nudged over the realtime fan-out and refetches the one
     // shard that moved.
@@ -4035,247 +3923,39 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Under the work-list filter the finished class is gone, and with 3D already
-    // clean the whole year goes with it — the panel has stopped offering work
-    // that is already done.
-    expect(klas3C, findsNothing,
+    // B has stopped offering work that is already done.
+    expect(find.text('1 openstaande actie'), findsNothing,
         reason: 'B used to keep advertising it until someone re-synced');
-    expect(jaar3, findsNothing);
     expect(operatorB.wisaSyncs, 0, reason: 'the nudge never triggers a pull');
     expect(operatorB.controller.linked, isNull,
         reason: 'link() is never called in a passive session');
 
-    // Off the filter the class is back on the inventory, ticked off rather than
-    // badged — B's drill-down agrees with the store it just re-read.
-    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
-    await tester.ensureVisible(toggle);
-    await tester.tap(toggle);
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(jaar3);
-    if (klas3C.evaluate().isEmpty) {
-      await tester.tap(jaar3);
-      await tester.pumpAndSettle();
-    }
-    expect(find.descendant(of: klas3C, matching: find.text('1')), findsNothing);
-    expect(find.descendant(of: klas3C, matching: find.byIcon(Icons.check)),
-        findsOneWidget);
+    // The stored document itself moved with the rollup — the write-back
+    // patched both, so the next session to adopt the shared state links a view
+    // with the work already gone.
+    expect(
+      (await linkedStore.readClassroom(school: '1', classroom: '3C'))
+          .expand((a) => a.candidates),
+      isEmpty,
+    );
 
-    // …and drilling in shows the card with nothing left to do on it.
-    await tester.ensureVisible(klas3C);
-    await tester.tap(klas3C);
+    // …and Acties gives B the one blocking notice it owes a session that
+    // cannot link, rather than a second, inert way to browse the same rows.
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('actions-read-only')), findsOneWidget);
-    expect(find.text('Sam Sels'), findsOneWidget);
-    expect(
-      operatorB.controller.classroomAccounts!.expand((a) => a.candidates),
-      isEmpty,
-      reason: 'the stored document itself dropped the applied candidate',
-    );
+    expect(find.byKey(const ValueKey('actions-list')), findsNothing);
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets(
-      'a classroom\'s bulk "Alles toepassen" writes only that classroom, '
-      'leaving the identical situation in another class pending (#252)',
-      (WidgetTester tester) async {
-    // The real app, real fonts, real navigation. Three students share one
-    // situation — a stale Office 365 display name — but they are split across
-    // two classes: Sam and Sara in 3C, Tom in 3D.
-    //
-    // This is the layer that sees it. The bulk header is built over *one*
-    // class's entries and counts them, while the pass behind it re-resolved the
-    // situation key against the whole linked view — so the operator drilled
-    // into 3C, read "Alles toepassen (2)", and wrote three accounts including
-    // one in a class they never opened. Only a run that drills into a class,
-    // presses the class's own bulk button, and then comes back out to look at
-    // the other class puts both sides on screen in that order.
-    useTallWindow(tester);
-    final harness = crossClassSituationHarness();
-    await tester.pumpWidget(AccountManagerApp(
-      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
-      graph: graph,
-      reconcileBootstrap: harness.bootstrap,
-    ));
-    await tester.pumpAndSettle();
-    await syncThenOpenActions(tester);
-    expect(harness.controller.error, isNull);
-
-    final jaar3 = find.byKey(const ValueKey('rollup-grade-grades|3'));
-    final klas3C = find.byKey(const ValueKey('rollup-class-class|1|3|3C'));
-    final klas3D = find.byKey(const ValueKey('rollup-class-class|1|3|3D'));
-
-    // Two classes, both carrying the same student work: 3C badged 2, 3D 1.
-    await tester.ensureVisible(jaar3);
-    await tester.tap(jaar3);
-    await tester.pumpAndSettle();
-    expect(
-        find.descendant(of: klas3C, matching: find.text('2')), findsOneWidget);
-    expect(
-        find.descendant(of: klas3D, matching: find.text('1')), findsOneWidget);
-
-    // Drill into 3C. Its bulk header counts this class, and only this class.
-    await tester.ensureVisible(klas3C);
-    await tester.tap(klas3C);
-    await tester.pumpAndSettle();
-    expect(harness.controller.selectedClassroom?.classroom, '3C');
-    expect(find.text('Sam Sels'), findsWidgets);
-    expect(find.text('Sara Segers'), findsWidgets);
-    expect(find.text('Tom Tas'), findsNothing,
-        reason: 'the operator is looking at 3C — Tom is not on this page');
-
-    final key = harness.controller.classroomPendingSituations.single.key;
-    final bulk = find.byKey(ValueKey('situation-apply-$key'));
-    await tester.ensureVisible(bulk);
-    // The header line the count sits on is Dutch, like the rest of the screen
-    // (#253) — the operator-facing language everywhere in this app.
-    expect(
-        find.textContaining('2 accounts in dezelfde situatie'), findsOneWidget);
-    expect(
-        find.descendant(of: bulk, matching: find.text('Alles toepassen (2)')),
-        findsOneWidget);
-
-    // The confirmation quotes the same two writes the label counts (#234) —
-    // the mismatch that surfaced this said "3 wijzigingen" here.
-    await tester.tap(bulk);
-    await tester.pumpAndSettle();
-    expect(find.textContaining('2 wijzigingen'), findsOneWidget);
-    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Resultaat van het toepassen'), findsWidgets);
-    expect(harness.controller.applyResults, hasLength(2));
-    final patched = harness.graph.requests
-        .where((r) => r.method == 'PATCH')
-        .map((r) => r.url.path)
-        .toList();
-    expect(patched, hasLength(2),
-        reason: 'two accounts written, not every account group-wide');
-    expect(patched.any((p) => p.endsWith(kSam3C)), isTrue);
-    expect(patched.any((p) => p.endsWith(kSara3C)), isTrue);
-    expect(patched.any((p) => p.endsWith(kTom3D)), isFalse,
-        reason: "Tom's class was never opened, so it must not be written");
-
-    // Overzicht: 3C is done and drops out under the work filter, while 3D still
-    // stands there badged 1 — its identical situation is untouched, waiting for
-    // someone to open it.
-    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(jaar3);
-    if (klas3D.evaluate().isEmpty) {
-      await tester.tap(jaar3);
-      await tester.pumpAndSettle();
-    }
-    expect(klas3C, findsNothing, reason: 'the class the operator cleared');
-    expect(
-        find.descendant(of: klas3D, matching: find.text('1')), findsOneWidget);
-    expect(tester.takeException(), isNull);
-  });
-
-  testWidgets(
-      'a bulk apply covers one decision everywhere it occurs, and writes '
-      'nothing else on the cards it touches end-to-end (#292)',
-      (WidgetTester tester) async {
-    // The real app, real fonts, real navigation, over the real Smartschool and
-    // Graph write paths. The September rollover in miniature: three students
-    // moved up into `4A` while Smartschool still has all three in last year's
-    // `3C`, so every one of them needs the same class change — and one of them,
-    // Sam, also has a stale Office 365 display name.
-    //
-    // Both halves of the defect are only visible here. The header's cohort is
-    // built by the controller, rendered by the shared tile library and scoped by
-    // the drill-down, and what the button behind it writes is decided a fourth
-    // place again: the old grouping keyed on the family plus the sorted set of
-    // *every* decision on a card, so Sam fell into a subset of his own and the
-    // operator read "2 accounts in dezelfde situatie" for work that three
-    // students needed. Pressing the other header then wrote Sam's Office 365
-    // rename along with his class change, under a label that named neither.
-    useTallWindow(tester);
-    final harness = rolloverHarness();
-    await tester.pumpWidget(AccountManagerApp(
-      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
-      graph: graph,
-      reconcileBootstrap: harness.bootstrap,
-    ));
-    await tester.pumpAndSettle();
-    await syncThenOpenActions(tester);
-    expect(harness.controller.error, isNull);
-
-    // Drill into 4A, where all three students now belong.
-    final jaar4 = find.byKey(const ValueKey('rollup-grade-grades|4'));
-    await tester.ensureVisible(jaar4);
-    await tester.tap(jaar4);
-    await tester.pumpAndSettle();
-    final klas4A = find.byKey(const ValueKey('rollup-class-class|1|4|4A'));
-    await tester.ensureVisible(klas4A);
-    await tester.tap(klas4A);
-    await tester.pumpAndSettle();
-    expect(harness.controller.selectedClassroom?.classroom, '4A');
-
-    // One header for the class change, and it counts all three — Sam included,
-    // whatever else his card carries.
-    expect(
-      find.text('Wijzig de klas in Smartschool — 3 accounts in dezelfde '
-          'situatie'),
-      findsOneWidget,
-    );
-    final moveKey = harness.controller.classroomPendingSituations
-        .firstWhere((c) => c.label == 'Wijzig de klas in Smartschool')
-        .key;
-    final moveBulk = find.byKey(ValueKey('situation-apply-$moveKey'));
-    await tester.ensureVisible(moveBulk);
-    expect(
-      find.descendant(of: moveBulk, matching: find.text('Alles toepassen (3)')),
-      findsOneWidget,
-    );
-    // Sam's second decision is on his card, and gets no bulk header of its own:
-    // he is the only student who needs it.
-    expect(find.text('Wijzig de naam in Azure'), findsOneWidget);
-    expect(find.textContaining('Wijzig de naam in Azure — '), findsNothing);
-
-    // The confirmation names the one decision: three Smartschool writes, and no
-    // claim on Office 365.
-    await tester.tap(moveBulk);
-    await tester.pumpAndSettle();
-    // Scoped to the dialog: since #298 the cards behind it lead each line with
-    // the system it writes to, so Sam's rename puts "Office 365 ·" on screen —
-    // which is the point of that issue and says nothing about this pass.
-    final confirmation = find.byType(AlertDialog);
-    expect(
-      find.descendant(
-          of: confirmation, matching: find.textContaining('3 wijzigingen')),
-      findsOneWidget,
-    );
-    expect(
-      find.descendant(
-          of: confirmation, matching: find.textContaining('Office 365')),
-      findsNothing,
-      reason: "summing every decision on every card would quote Sam's "
-          'rename and then not write it',
-    );
-    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-    await tester.pumpAndSettle();
-
-    // Three class moves in Smartschool…
-    expect(
-      harness.soap.soapActions.where((a) => a.endsWith('#saveUserToClass')),
-      hasLength(3),
-      reason: 'one pass covered the whole class, Sam included',
-    );
-    expect(
-      harness.controller.applyResults!.map((r) => r.changes.summary),
-      everyElement('Wijzig de klas in Smartschool'),
-    );
-    // …and not a single Office 365 write. Sam's rename is a decision the
-    // operator never pressed.
-    expect(
-      harness.graph.requests.where((r) => r.method == 'PATCH'),
-      isEmpty,
-      reason: 'the bulk pass wrote the decision on the header and no other',
-    );
-    // It is still his to make, still on the screen.
-    expect(find.text('Wijzig de naam in Azure'), findsOneWidget);
-    expect(tester.takeException(), isNull);
-  });
+  // The Acties bulk-apply end-to-end runs of #252 (a classroom's "Alles
+  // toepassen" stops at that classroom) and #292 (a bulk apply covers one
+  // decision everywhere it occurs) went with the affordance they drove: #295
+  // took bulk apply off the Acties screen, which lands with per-decision apply
+  // only, and #296 gives it back school-wide with its cohort visible first.
+  // Both rules still run end-to-end over the Klasgroepen cohort headers above
+  // — see the namesake-class scenario, where two cohorts of one decision each
+  // prove that a header writes the decision it names and no other.
 
   testWidgets(
       'a single-group class whose name another school shares raises no class '
@@ -4325,36 +4005,30 @@ void main() {
       reason: 'the "no sub-groups" sentinel is never part of a class name',
     );
 
-    // Browse it the way the operator does: the merged first year holds both
-    // schools' `1C`, each still keyed to its own school partition. The year is
-    // opened once — since #235 Overzicht comes back to it still open.
+    // Browse it the way the operator does: both schools' students are rows of
+    // the one list, each naming the class their own WISA record does.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-
-    final yearNode = find.byKey(const ValueKey('rollup-grade-grades|1'));
-    await tester.ensureVisible(yearNode);
-    await tester.tap(yearNode);
+    // Nobody has work, so the list is the whole school with the filter off.
+    await tester.tap(find.byKey(const ValueKey('actions-only-with-actions')));
     await tester.pumpAndSettle();
     expect(find.text('1C 00'), findsNothing,
-        reason: 'the sentinel never names a class in the drill-down either');
+        reason: 'the sentinel never names a class in the list either');
 
-    // Each school's class in turn: opened, and carrying no class-change row.
+    // Each school's student in turn: on screen, in `1C`, with no class-change
+    // row in their details pane.
     for (final school in <String>['1', '2']) {
-      if (harness.controller.selectedClassroom != null) {
-        await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
-        await tester.pumpAndSettle();
-      }
-      final classNode = find.byKey(ValueKey('rollup-class-class|$school|1|1C'));
-      expect(classNode, findsOneWidget);
-      await tester.ensureVisible(classNode);
-      await tester.tap(classNode);
-      await tester.pumpAndSettle();
-
-      // The drill-down really opened (both the populated and the empty branch
-      // render this header), so the absence assertions below mean something.
+      final String id = harness.controller.linkedAccounts
+          .firstWhere((a) => a.school == school)
+          .id
+          .value;
+      final Finder row = find.byKey(ValueKey('account-row-$id'));
+      expect(row, findsOneWidget);
+      await tester.ensureVisible(row);
       expect(
-          find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
-      expect(harness.controller.selectedClassroom?.school, school);
+          find.descendant(of: row, matching: find.text('1C')), findsOneWidget);
+
+      await selectAccount(tester, id);
       expect(find.text('Wijzig de klas in Smartschool'), findsNothing,
           reason: 'school $school\'s 1C is single-group — no move is due');
       expect(find.textContaining('1C 00'), findsNothing);
@@ -4363,12 +4037,12 @@ void main() {
 
   testWidgets(
       'the Actions view splits Personeel and Leerlingen into tabs end-to-end: '
-      'staff drill in one tab, students in the other (#179)',
+      'staff in one tab, students in the other (#179/#295)',
       (WidgetTester tester) async {
     // The real app, real fonts, real window: one student plus one WISA staff
-    // member so both families have a rollup node. The Actions view must browse
-    // them as two separate workflows — a horizontal tab bar with a per-family
-    // drill-down — not one combined rollup.
+    // member so both families have a row. The Actions view must browse them as
+    // two separate workflows — a horizontal tab bar with a per-family list —
+    // not one combined list.
     useTallWindow(tester);
     final harness = ReconcileHarness(
       wisa: wisaSnap(students: [wisaStudent()], staff: [wisaStaff()]),
@@ -4392,37 +4066,27 @@ void main() {
         find.byKey(const ValueKey('actions-tab-leerlingen')), findsOneWidget);
     expect(find.byKey(const ValueKey('actions-tab-personeel')), findsOneWidget);
 
-    // Default Leerlingen tab: the merged grade-year node drills (#210); the
-    // staff node does not appear here.
-    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
-    expect(
-        find.byKey(const ValueKey('rollup-school-school|staff')), findsNothing);
+    // Default Leerlingen tab: the student is a row, the staff member is not.
+    final String student = accountId(harness, 'Jane Doe');
+    final String staff = accountId(harness, 'Anna Smit');
+    expect(find.byKey(ValueKey('account-row-$student')), findsOneWidget);
+    expect(find.byKey(ValueKey('account-row-$staff')), findsNothing);
 
-    // Switch to Personeel and drill down to the staff member — the drill-down
-    // is preserved within the tab, showing only staff.
+    // Switch to Personeel: only staff, and the class column names the
+    // synthetic Personeel bucket they sit in.
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsNothing);
-    final staffSchool =
-        find.byKey(const ValueKey('rollup-school-school|staff'));
-    expect(staffSchool, findsOneWidget);
+    expect(find.byKey(ValueKey('account-row-$student')), findsNothing);
+    final Finder staffRow = find.byKey(ValueKey('account-row-$staff'));
+    expect(staffRow, findsOneWidget);
+    expect(find.descendant(of: staffRow, matching: find.text('Anna Smit')),
+        findsOneWidget);
+    expect(find.descendant(of: staffRow, matching: find.text('Personeel')),
+        findsOneWidget);
 
-    await tester.ensureVisible(staffSchool);
-    await tester.tap(staffSchool);
-    await tester.pumpAndSettle();
-    await tester
-        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
-    await tester.pumpAndSettle();
-    final staffClass = find
-        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
-    await tester.ensureVisible(staffClass);
-    await tester.tap(staffClass);
-    await tester.pumpAndSettle();
-
-    // The staff member's account is browsed inside the Personeel tab.
-    expect(find.text('Anna Smit'), findsWidgets);
-    expect(
-        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+    // And their decisions open in the details pane beside the list.
+    await selectAccount(tester, staff);
+    expect(find.byKey(ValueKey('actions-detail-$staff')), findsOneWidget);
   });
 
   testWidgets(
@@ -4721,39 +4385,29 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    // Browse the student on the Actions tab, drilling into her class (3C).
+    // Browse the student on the Actions tab and select her row: the
+    // previously-hidden differing field shows in the details pane, and
+    // unchanged fields are not rendered as misleading "X → X" rows.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('3C'));
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
+    final entry = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student');
+    await selectAccount(tester, entry.targetId);
 
     // The address action is present (postalCode really drifted).
     expect(find.text('Wijzig het adres in Smartschool'), findsWidgets);
-
-    // Expand the student entry: the previously-hidden differing field shows,
-    // and unchanged fields are not rendered as misleading "X → X" rows.
-    final entry = harness.controller.pendingEntries
-        .firstWhere((e) => e.family == 'student');
-    final entryKey = ValueKey('entry-student-${entry.targetId}');
-    await tester.ensureVisible(find.byKey(entryKey));
-    await tester.tap(find.byKey(entryKey));
-    await tester.pumpAndSettle();
-
     expect(find.textContaining('postalCode: 3270 → 3271'), findsOneWidget);
     expect(find.textContaining('country'), findsNothing);
     expect(find.textContaining('street:'), findsNothing);
   });
 
   testWidgets(
-      "a large class's actions virtualize in the real app: only a bounded "
-      'number of entry tiles build, and scrolling loads more (#111/#154)',
+      'the flat Acties list virtualizes in the real app: only a bounded number '
+      'of rows build, and scrolling loads more (#111/#295)',
       (WidgetTester tester) async {
     // A September-changeover-scale pending set (a thousand WISA-departed
-    // accounts, all in one bucket) in the real, laid-out app. Drilling into the
-    // class builds only the on-screen tiles through the lazy sliver list.
+    // accounts) in the real, laid-out app. The drill-down existed partly to
+    // avoid rendering this; the flat list builds only the on-screen rows.
     useTallWindow(tester);
     final harness = manyDepartedHarness(count: 1000);
     await tester.pumpWidget(AccountManagerApp(
@@ -4768,38 +4422,40 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
-    // Browse them on the Actions tab: drill into their "Zonder klas" bucket.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Niet toegewezen'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('Zonder klas'));
-    await tester.tap(find.text('Zonder klas'));
-    await tester.pumpAndSettle();
 
-    // All 1000 accounts sit in this one class, but only a small window builds.
-    expect(harness.controller.classroomPendingEntries, hasLength(1000));
-    final entryTiles = find.byWidgetPredicate(
+    // All 1000 accounts are in this one school-wide list, but only a small
+    // window builds.
+    expect(harness.controller.pendingEntries, hasLength(1000));
+    final rows = find.byWidgetPredicate(
       (w) =>
           w.key is ValueKey<String> &&
-          (w.key! as ValueKey<String>).value.startsWith('entry-'),
+          (w.key! as ValueKey<String>).value.startsWith('account-row-'),
     );
-    final builtInitially = entryTiles.evaluate().length;
-    expect(builtInitially, greaterThan(0));
-    expect(builtInitially, lessThan(200),
-        reason: 'virtualized: on-screen tiles only, not all 1000');
+    List<String> built() => <String>[
+          for (final e in rows.evaluate())
+            (e.widget.key! as ValueKey<String>).value,
+        ];
+    final List<String> initial = built();
+    expect(initial, isNotEmpty);
+    expect(initial, hasLength(lessThan(200)),
+        reason: 'virtualized: on-screen rows only, not all 1000');
 
-    // A far-off entry is not built until scrolled to.
-    final entries = harness.controller.classroomPendingEntries;
-    final lastKey = ValueKey('entry-student-${entries.last.targetId}');
-    expect(find.byKey(lastKey), findsNothing);
-    await tester.scrollUntilVisible(
-      find.byKey(lastKey),
-      5000,
-      scrollable: find.byType(Scrollable).first,
-      maxScrolls: 200,
+    // Scrolling loads rows that were not built and unloads the ones that
+    // scrolled far off-screen.
+    await tester.drag(
+      find.byKey(const ValueKey('actions-list')),
+      const Offset(0, -20000),
     );
-    expect(find.byKey(lastKey), findsOneWidget);
+    await tester.pumpAndSettle();
+
+    final List<String> after = built();
+    expect(after, isNotEmpty);
+    expect(after, hasLength(lessThan(200)));
+    expect(after.toSet().intersection(initial.toSet()), isEmpty,
+        reason: 'a different window of the list is built now');
+    expect(find.byKey(ValueKey(initial.first)), findsNothing);
   });
 
   testWidgets(
@@ -4868,9 +4524,8 @@ void main() {
   });
 
   testWidgets(
-      'a passive session renders the materialized overview and drills into a '
-      'classroom with no pull and no link() (#115)',
-      (WidgetTester tester) async {
+      'a passive session renders the materialized overview with no pull and no '
+      'link() (#115/#295)', (WidgetTester tester) async {
     // Session 1 (offline harness) syncs and materializes the shared view into a
     // LinkedStore both sessions share.
     final snapshots = InMemorySnapshotStore();
@@ -4890,31 +4545,24 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    // The overview lives on the Actions tab now — rendered straight from the
-    // store, no Synchronise tapped.
-    await tester.tap(find.text('Acties'));
+    // The stored rollups render on Synchronisatie, straight from the store and
+    // with no Synchronise tapped.
+    await tester.tap(find.text('Synchronisatie'));
     await tester.pumpAndSettle();
-    expect(find.text('Overzicht'), findsOneWidget);
-    // The stored view projects to the same school-less tree a syncing session
-    // renders (#210).
-    expect(find.text('Jaar 3'), findsOneWidget);
-    expect(find.text('School 1'), findsNothing);
-    expect(resumed.wisaSyncs, 0);
-    expect(resumed.ssSyncs, 0);
-    expect(resumed.azSyncs, 0);
+    expect(find.byKey(const ValueKey('reconcile-category-students')),
+        findsOneWidget);
+    expect(find.textContaining('openstaande actie'), findsWidgets);
+    expect(resumed.controller.hasOverview, isTrue);
     expect(resumed.controller.linked, isNull,
         reason: 'link() is never called in a passive session');
 
-    // Drill down: grade-year → classroom.
-    await tester.tap(find.text('Jaar 3'));
+    // Acties has nothing to act on, so it is the one blocking notice (#295) —
+    // never a second, inert way to browse the same documents.
+    await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
-
-    // The classroom's account doc renders — still with no connector pull.
-    expect(find.text('Jane Doe'), findsOneWidget);
-    expect(
-        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-read-only')), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-list')), findsNothing);
+    expect(find.text('Jane Doe'), findsNothing);
     expect(resumed.wisaSyncs, 0);
     expect(resumed.ssSyncs, 0);
     expect(resumed.azSyncs, 0);
@@ -4966,7 +4614,7 @@ void main() {
   });
 
   testWidgets(
-      'a passive session surfaces pending group actions in the drill-down '
+      'a passive session surfaces pending group actions on Klasgroepen '
       'with no pull and no link() (#119)', (WidgetTester tester) async {
     // Session 1 (offline harness) syncs and materializes the shared view. The
     // fixture's two Smartschool-only classes (2B, 3C) raise the informational
@@ -4988,14 +4636,8 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Acties'));
-    await tester.pumpAndSettle();
-
-    // The account overview is there, straight from the store — no Synchronise
-    // tapped.
-    expect(find.text('Overzicht'), findsOneWidget);
-
-    // And so is the class inventory, on its own tab, listing the orphan
+    // The class inventory renders straight from the store — no Synchronise
+    // tapped — on its own tab, listing the orphan
     // Smartschool classes with their notice (#227).
     await openKlasgroepen(tester);
 
@@ -5011,15 +4653,15 @@ void main() {
   });
 
   testWidgets(
-      'a passive Acties drill-down says it is read-only in both trees, and its '
-      'Synchroniseer turns the very same class interactive end-to-end (#214)',
-      (WidgetTester tester) async {
+      'a passive session says it is read-only on both action screens, and its '
+      'Synchroniseer turns the very same accounts interactive end-to-end '
+      '(#214/#295)', (WidgetTester tester) async {
     // Session 1 syncs and materializes the shared view; session 2 is the real
     // app over the same stores and never syncs — the everyday passive session
-    // that opened Acties to look at the pending work. Both drill-downs used to
-    // swap their interactive tiles for static bullet text with no gesture
-    // handler and say nothing about it, which reads as an interactive screen
-    // whose taps stopped working rather than as a view of the shared state.
+    // that opened Acties to look at the pending work. Both screens used to swap
+    // their interactive tiles for static bullet text with no gesture handler
+    // and say nothing about it, which reads as an interactive screen whose taps
+    // stopped working rather than as a view of the shared state.
     useTallWindow(tester);
     final linkedStore = InMemoryLinkedStore();
     await ReconcileHarness(linkedStore: linkedStore).controller.sync();
@@ -5041,30 +4683,11 @@ void main() {
     expect(resumed.controller.linked, isNull);
 
     final readOnly = find.byKey(const ValueKey('actions-read-only'));
-    final pendingTiles = find.byWidgetPredicate((w) =>
+    final accountRows = find.byWidgetPredicate((w) =>
         w.key is ValueKey<String> &&
-        (w.key! as ValueKey<String>).value.startsWith('entry-'));
-    expect(readOnly, findsNothing,
-        reason: 'the browsable overview is not the read-only surface');
+        (w.key! as ValueKey<String>).value.startsWith('account-row-'));
 
-    // The Klasgroepen tab: static rows, and they say so — the same
-    // announcement, keyed per view since #227 put the two on different tabs.
-    await openKlasgroepen(tester);
-    final klasgroepenReadOnly =
-        find.byKey(const ValueKey('class-groups-read-only'));
-    expect(klasgroepenReadOnly, findsOneWidget);
-    expect(find.text('Alleen-lezen overzicht'), findsOneWidget);
-    expect(pendingTiles, findsNothing);
-    await tester.tap(find.text('Acties'));
-    await tester.pumpAndSettle();
-
-    // The classroom tree: the same announcement, and the cards themselves carry
-    // the muted lock rather than passing for tappable rows.
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('3C'));
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
+    // Acties: one blocking notice, and nothing behind it (#295).
     expect(readOnly, findsOneWidget);
     // Since #287 the notice names what is missing rather than reporting the
     // absence of a sync: there is no snapshot here to build a view from.
@@ -5072,30 +4695,38 @@ void main() {
       find.textContaining('Geen opgeslagen momentopname'),
       findsOneWidget,
     );
-    expect(find.byIcon(Icons.lock_outline), findsWidgets);
-    expect(pendingTiles, findsNothing,
-        reason: 'nothing in this class is actionable — that is the point');
+    expect(accountRows, findsNothing,
+        reason: 'nothing here is actionable — that is the point');
 
-    // Take the offered way out, from the banner itself: WISA is pulled, the
-    // session links, and the freshly persisted view closes the drill-down.
+    // The Klasgroepen tab: static rows, and they say so — the same
+    // announcement, keyed per view since #227 put the two on different tabs.
+    await openKlasgroepen(tester);
+    expect(
+        find.byKey(const ValueKey('class-groups-read-only')), findsOneWidget);
+    expect(find.text('Alleen-lezen overzicht'), findsOneWidget);
+    expect(find.byIcon(Icons.lock_outline), findsWidgets);
+    await tester.tap(find.text('Acties'));
+    await tester.pumpAndSettle();
+
+    // Take the offered way out, from the notice itself: WISA is pulled and the
+    // session links.
     final sync = find.byKey(const ValueKey('actions-read-only-sync'));
     await tester.ensureVisible(sync);
     await tester.tap(sync);
     await tester.pumpAndSettle();
     expect(resumed.wisaSyncs, 1);
     expect(resumed.controller.linked, isNotNull);
-    expect(readOnly, findsNothing);
 
-    // The very same class is interactive now: real entry tiles, no notice, no
+    // The very same accounts are interactive now: a real list, no notice, no
     // locks — which is what the operator expected the first time round.
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('3C'));
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
     expect(readOnly, findsNothing);
     expect(find.byIcon(Icons.lock_outline), findsNothing);
-    expect(pendingTiles, findsWidgets);
+    expect(accountRows, findsWidgets);
+    final String id = resumed.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student')
+        .targetId;
+    await selectAccount(tester, id);
+    expect(find.byKey(ValueKey('entry-apply-$id')), findsOneWidget);
   });
 
   testWidgets(
@@ -5152,23 +4783,19 @@ void main() {
         findsOneWidget);
     expect(find.text('Gedeelde synchronisatie'), findsOneWidget);
 
-    // Acties: drill into a class and the tiles are the interactive ones —
+    // Acties: the list is there and its rows are the interactive ones —
     // choices, dry-run, apply — with the same notice above them.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('3C'));
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
+    final String seeded = operatorB.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student')
+        .targetId;
+    await selectAccount(tester, seeded);
 
     expect(find.byKey(const ValueKey('actions-read-only')), findsNothing);
     expect(find.byKey(const ValueKey('actions-shared-state')), findsOneWidget);
     expect(find.byIcon(Icons.lock_outline), findsNothing);
-    final pendingTiles = find.byWidgetPredicate((w) =>
-        w.key is ValueKey<String> &&
-        (w.key! as ValueKey<String>).value.startsWith('entry-'));
-    expect(pendingTiles, findsWidgets);
+    expect(find.byKey(ValueKey('entry-apply-$seeded')), findsOneWidget);
 
     // The whole of it without one connector round-trip, and without touching
     // the shared view: no generation bump, so no client is asked to refetch.
@@ -5345,7 +4972,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // The overview rendered at generation 1 and the subscriber connected.
-    expect(find.text('Overzicht'), findsOneWidget);
+    expect(find.textContaining('Generatie 1'), findsOneWidget);
     expect(resumed.controller.syncState.generation, 1);
     final socket = connector.sockets.single;
     socket.serverSend('{}$signalRRecordSeparator'); // handshake ack
@@ -5372,10 +4999,10 @@ void main() {
 
     expect(resumed.controller.syncState.generation, 2,
         reason: 'the app caught up from the decoded wire signal alone');
-    // Drill down to prove the refreshed rollups reached the UI: 3D now exists.
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    expect(find.text('3D'), findsOneWidget);
+    // …and the refreshed shared state reached the UI: the freshness stamp above
+    // the list names the generation the nudge announced.
+    expect(find.textContaining('Generatie 2'), findsOneWidget);
+    expect(find.textContaining('Generatie 1'), findsNothing);
 
     await subscriber.close();
   });
@@ -5450,23 +5077,17 @@ void main() {
     await tester.pumpAndSettle();
     expect(await harness.passwordQueue.load(), isEmpty);
 
-    // Browse the create on the Actions tab, in the student's class.
+    // Browse the create on the Actions tab and select the student's row.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('3C'));
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
+    final String createId = harness.controller.pendingEntries
+        .firstWhere((e) => e.family == 'student')
+        .targetId;
+    await selectAccount(tester, createId);
     expect(find.text('Maak een nieuw Smartschool account'), findsWidgets);
 
     // Apply the row for real (against the recording SOAP transport): the create
     // runs and its minted password is captured into the shared queue.
-    final String createId =
-        harness.controller.classroomPendingEntries.single.targetId;
-    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$createId')));
-    await tester.tap(find.byKey(ValueKey('entry-student-$createId')));
-    await tester.pumpAndSettle();
     await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$createId')));
     await tester.tap(find.byKey(ValueKey('entry-apply-$createId')));
     await tester.pumpAndSettle();
@@ -6218,31 +5839,68 @@ void main() {
   });
 
   testWidgets(
-      'the Actions Personeel classroom filters by any part of the name in any '
-      'order and by the top-level only-with-actions switch end-to-end, '
-      'combining both (#187/#217/#226)', (WidgetTester tester) async {
-    // The real app, real fonts, real window over a passive session: three staff
-    // seeded into the one synthetic Personeel class — two share the surname
-    // "Smit" (one carrying an action, one not) and one has a distinct voornaam.
-    // The operator narrows the list by name and by the has-actions switch, and
-    // the two filters combine.
+      'the Actions list filters by any part of the name in any order and by the '
+      'only-with-actions switch end-to-end, combining both '
+      '(#187/#217/#226/#295)', (WidgetTester tester) async {
+    // The real app, real fonts, real window, real keyboard. Three staff: two
+    // share the surname "Smit" — Anna is a fresh hire with work, Clara is
+    // already in every system — and Bram has a distinct voornaam. The operator
+    // narrows the list by name and by the has-actions switch, and the two
+    // filters combine.
+    //
+    // The search box used to live inside an opened Personeel classroom; since
+    // #295 it is the flat list's own lookup, on both family tabs.
     useTallWindow(tester);
-    final store = await seededLinkedStore([
-      matStaff(id: 't1', label: 'Anna Smit', withAction: true),
-      matStaff(id: 't2', label: 'Bram Jansen', withAction: false),
-      matStaff(id: 't3', label: 'Clara Smit', withAction: false),
-    ]);
-    final harness = ReconcileHarness(linkedStore: store);
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(students: const [], staff: [
+        wisaStaff(
+            code: 'SMIT', wisaId: '42', firstName: 'Anna', lastName: 'Smit'),
+        wisaStaff(
+            code: 'JANS', wisaId: '43', firstName: 'Bram', lastName: 'Jansen'),
+        wisaStaff(
+            code: 'CSMI', wisaId: '44', firstName: 'Clara', lastName: 'Smit'),
+      ]),
+      // Clara alone is fully provisioned, so she is the account the work-list
+      // filter has to drop while the name search keeps her.
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: [
+          ssStaffAccount(
+            uid: 'clara.smit',
+            accountId: 'CSMI',
+            mail: 'clara.smit@school.example',
+            givenName: 'Clara',
+            surname: 'Smit',
+            fax: '0044',
+          ),
+        ],
+        memberships: const [],
+      ),
+      azure: azSnap(users: [
+        azStaffUser(
+          id: 'az-clara',
+          upn: 'clara.smit@school.example',
+          employeeId: '44',
+          displayName: 'Smit Clara',
+          givenName: 'Clara',
+          surname: 'Smit',
+        ),
+      ]),
+    );
     await tester.pumpWidget(AccountManagerApp(
       session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
       graph: graph,
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
 
-    // Open the Actions tab (passive overview from the store). The global filter
-    // is on by default since #226 and sits above the family tab bar; this test
-    // is about the name search, so start from the full inventory.
+    // Open the Actions tab. The work-list filter is on by default since #226
+    // and sits above the family tab bar; this test starts from the full list.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
@@ -6252,72 +5910,61 @@ void main() {
     await tester.tap(toggle);
     await tester.pumpAndSettle();
 
-    // Go to Personeel — the switch survives the tab change (#226) — and drill
-    // into the single staff class.
+    // Go to Personeel — the switch survives the tab change (#226).
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
     expect(tester.widget<Switch>(toggle).value, isFalse);
-    await tester.tap(find.byKey(const ValueKey('rollup-school-school|staff')));
-    await tester.pumpAndSettle();
-    await tester
-        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
-    await tester.pumpAndSettle();
-    final staffClass = find
-        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
-    await tester.ensureVisible(staffClass);
-    await tester.tap(staffClass);
-    await tester.pumpAndSettle();
 
-    // All three staff render, and the Personeel tab carries the name search.
-    expect(find.text('Anna Smit'), findsOneWidget);
-    expect(find.text('Bram Jansen'), findsOneWidget);
-    expect(find.text('Clara Smit'), findsOneWidget);
-    expect(find.byKey(const ValueKey('actions-search')), findsOneWidget);
+    final String anna = accountId(harness, 'Anna Smit');
+    final String bram = accountId(harness, 'Bram Jansen');
+    final String clara = accountId(harness, 'Clara Smit');
+    Finder rowOf(String id) => find.byKey(ValueKey('account-row-$id'));
+
+    // All three staff render, under the list's own search box.
+    expect(rowOf(anna), findsOneWidget);
+    expect(rowOf(bram), findsOneWidget);
+    expect(rowOf(clara), findsOneWidget);
+    final search = find.byKey(const ValueKey('actions-search'));
+    expect(search, findsOneWidget);
 
     // Search on the surname "Smit": both Smits match, Jansen drops out.
-    await tester.enterText(
-        find.byKey(const ValueKey('actions-search')), 'smit');
-    await tester.pump();
-    expect(find.text('Anna Smit'), findsOneWidget);
-    expect(find.text('Clara Smit'), findsOneWidget);
-    expect(find.text('Bram Jansen'), findsNothing);
+    await tester.enterText(search, 'smit');
+    await tester.pumpAndSettle();
+    expect(rowOf(anna), findsOneWidget);
+    expect(rowOf(clara), findsOneWidget);
+    expect(rowOf(bram), findsNothing);
 
     // Both halves of one name, typed in the stored order and reversed (#217).
     // Reversed is the half of the time the operator misremembers which way
     // round the name is stored; it used to return an empty list, because the
     // needle was matched as one contiguous substring of "Voornaam Naam".
-    await tester.enterText(
-        find.byKey(const ValueKey('actions-search')), 'anna smit');
-    await tester.pump();
-    expect(find.text('Anna Smit'), findsOneWidget);
-    expect(find.text('Clara Smit'), findsNothing);
-    await tester.enterText(
-        find.byKey(const ValueKey('actions-search')), 'smit anna');
-    await tester.pump();
-    expect(find.text('Anna Smit'), findsOneWidget);
-    expect(find.text('Clara Smit'), findsNothing);
-    expect(find.text('Bram Jansen'), findsNothing);
+    await tester.enterText(search, 'anna smit');
+    await tester.pumpAndSettle();
+    expect(rowOf(anna), findsOneWidget);
+    expect(rowOf(clara), findsNothing);
+    await tester.enterText(search, 'smit anna');
+    await tester.pumpAndSettle();
+    expect(rowOf(anna), findsOneWidget);
+    expect(rowOf(clara), findsNothing);
+    expect(rowOf(bram), findsNothing);
 
     // Every part must occur, so parts taken from two different people match
     // neither — the operator sees the filter-empty line, not both of them.
-    await tester.enterText(
-        find.byKey(const ValueKey('actions-search')), 'anna jansen');
-    await tester.pump();
+    await tester.enterText(search, 'anna jansen');
+    await tester.pumpAndSettle();
     expect(
         find.text('Geen accounts die aan de filter voldoen.'), findsOneWidget);
 
-    // Back to "Smit", then combine with the global only-with-actions switch
-    // back on: only Anna keeps an action, so Clara (name-matched but
-    // action-free) drops too.
-    await tester.enterText(
-        find.byKey(const ValueKey('actions-search')), 'smit');
-    await tester.pump();
+    // Back to "Smit", then combine with the work-list switch back on: only
+    // Anna keeps an action, so Clara (name-matched but action-free) drops too.
+    await tester.enterText(search, 'smit');
+    await tester.pumpAndSettle();
     await tester.ensureVisible(toggle);
     await tester.tap(toggle);
     await tester.pumpAndSettle();
-    expect(find.text('Anna Smit'), findsOneWidget);
-    expect(find.text('Clara Smit'), findsNothing);
-    expect(find.text('Bram Jansen'), findsNothing);
+    expect(rowOf(anna), findsOneWidget);
+    expect(rowOf(clara), findsNothing);
+    expect(rowOf(bram), findsNothing);
   });
 
   testWidgets(
@@ -6778,11 +6425,18 @@ void main() {
     await tester.pumpAndSettle();
 
     // School 2 is not ours yet, so its student is re-bucketed as a leaver and
-    // their class is nowhere in the tree.
+    // their row names no class of ours.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    expect(find.text('Niet toegewezen'), findsOneWidget);
-    expect(find.text('Jaar 3'), findsNothing);
+    String studentRowKey() =>
+        'account-row-${harness.controller.pendingEntries.firstWhere((e) => e.family == 'student').targetId}';
+    expect(
+      find.descendant(
+        of: find.byKey(ValueKey(studentRowKey())),
+        matching: find.text('Zonder klas'),
+      ),
+      findsOneWidget,
+    );
 
     // Instellingen → Wisa → tick "beheerd" for Sint-Pieter → Opslaan.
     await tester.tap(find.text('Instellingen'));
@@ -6809,14 +6463,16 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
     await tester.pumpAndSettle();
 
-    // …and the student is out of the leaver bucket and browsable under their
-    // own class, with no relaunch anywhere in this test.
+    // …and the student is out of the leaver bucket, their row naming their own
+    // class, with no relaunch anywhere in this test.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    expect(find.text('Niet toegewezen'), findsNothing);
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    expect(find.text('3C'), findsWidgets);
+    final Finder studentRow = find.byKey(ValueKey(studentRowKey()));
+    await tester.ensureVisible(studentRow);
+    expect(find.descendant(of: studentRow, matching: find.text('Zonder klas')),
+        findsNothing);
+    expect(find.descendant(of: studentRow, matching: find.text('3C')),
+        findsOneWidget);
   });
 
   testWidgets(
@@ -7663,22 +7319,17 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    /// Opens Acties → Jaar 3 → 3C and expands the student's pending row, which
-    /// is where the proposed `userPrincipalName` is written out.
+    /// Opens Acties and selects the student's row, which puts the proposed
+    /// `userPrincipalName` in the details pane beside it.
     Future<void> openStudentRow() async {
       await tester.tap(find.text('Acties'));
       await tester.pumpAndSettle();
-      await tester.tap(find.text('Jaar 3'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('3C'));
-      await tester.pumpAndSettle();
-      final id = harness.controller.pendingEntries
-          .firstWhere((e) => e.family == 'student')
-          .targetId;
-      final row = find.byKey(ValueKey('entry-student-$id'));
-      await tester.ensureVisible(row);
-      await tester.tap(row);
-      await tester.pumpAndSettle();
+      await selectAccount(
+        tester,
+        harness.controller.pendingEntries
+            .firstWhere((e) => e.family == 'student')
+            .targetId,
+      );
     }
 
     // A first Synchroniseer, on the domain as it stands.
@@ -8194,12 +7845,12 @@ void main() {
     // they did when they reported this.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
-    expect(
-        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+    await selectAccount(
+      tester,
+      harness.controller.pendingEntries
+          .firstWhere((e) => e.family == 'student')
+          .targetId,
+    );
 
     expect(find.text('Maak een nieuw Office 365 account'), findsNothing,
         reason: 'the account already exists — creating one duplicates it');
@@ -8286,29 +7937,20 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
-    final staffSchool =
-        find.byKey(const ValueKey('rollup-school-school|staff'));
-    await tester.ensureVisible(staffSchool);
-    await tester.tap(staffSchool);
-    await tester.pumpAndSettle();
-    await tester
-        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
-    await tester.pumpAndSettle();
-    final staffClass = find
-        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
-    await tester.ensureVisible(staffClass);
-    await tester.tap(staffClass);
-    await tester.pumpAndSettle();
-    expect(
-        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+    await selectAccount(
+      tester,
+      harness.controller.pendingEntries
+          .firstWhere((e) => e.family == 'staff')
+          .targetId,
+    );
 
     expect(find.text('Maak een nieuw Office 365 account'), findsNothing,
         reason: 'the account already exists — creating one duplicates it');
     // The record is now WISA + Azure, so the only thing left to build is the
     // Smartschool side — the proposal the adoption unlocks, reading as the
     // create side of the #248 choice it shares with the WISA opt-out.
-    expect(find.text('Maak een nieuw Smartschool account (keuze)'),
-        findsOneWidget);
+    expect(find.text('Kies één oplossing:'), findsOneWidget);
+    expect(find.text('Maak een nieuw Smartschool account'), findsOneWidget);
   });
 
   testWidgets(
@@ -8479,19 +8121,12 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
-    final staffSchool =
-        find.byKey(const ValueKey('rollup-school-school|staff'));
-    await tester.ensureVisible(staffSchool);
-    await tester.tap(staffSchool);
-    await tester.pumpAndSettle();
-    await tester
-        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
-    await tester.pumpAndSettle();
-    final staffClass = find
-        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
-    await tester.ensureVisible(staffClass);
-    await tester.tap(staffClass);
-    await tester.pumpAndSettle();
+    await selectAccount(
+      tester,
+      harness.controller.pendingEntries
+          .firstWhere((e) => e.family == 'staff')
+          .targetId,
+    );
     expect(find.text('Wijzig het e-mailadres in Smartschool'), findsOneWidget);
   });
 
@@ -8598,11 +8233,7 @@ void main() {
       entry.choices.map((c) => c.selected.changes.summary),
       <String>['Wijzig de naam in Azure'],
     );
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('3C'));
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
+    await selectAccount(tester, entry.targetId);
     expect(find.text('Wijzig de naam in Azure'), findsOneWidget);
   });
 
@@ -8689,25 +8320,18 @@ void main() {
     expect(linked.smartschool, isNull);
     expect(linked.azure?.id, 'az-staff');
 
-    // And that is what the operator sees: Acties → Personeel, drilled the way
-    // they would.
+    // And that is what the operator sees: Acties → Personeel, the way they
+    // would look.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
-    final staffSchool =
-        find.byKey(const ValueKey('rollup-school-school|staff'));
-    await tester.ensureVisible(staffSchool);
-    await tester.tap(staffSchool);
-    await tester.pumpAndSettle();
-    await tester
-        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
-    await tester.pumpAndSettle();
-    final staffClass = find
-        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
-    await tester.ensureVisible(staffClass);
-    await tester.tap(staffClass);
-    await tester.pumpAndSettle();
+    await selectAccount(
+      tester,
+      harness.controller.pendingEntries
+          .firstWhere((e) => e.family == 'staff')
+          .targetId,
+    );
     expect(find.text('Verwijder Azure account'), findsOneWidget);
   });
 
@@ -8755,23 +8379,16 @@ void main() {
 
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.text('3C'));
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
 
     final entry = harness.controller.pendingEntries
         .firstWhere((e) => e.family == 'student');
     expect(
       entry.choices.map((c) => c.selected.changes.summary),
       <String>['Wijzig de naam in Azure'],
-      reason: 'the class holds exactly the action the report names',
+      reason: 'the account holds exactly the action the report names',
     );
     final id = entry.targetId;
-    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
-    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
-    await tester.pumpAndSettle();
+    await selectAccount(tester, id);
     await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
     await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
     await tester.pumpAndSettle();
@@ -8853,26 +8470,22 @@ void main() {
     expect(harness.controller.error, isNull);
 
     // Browse Acties → Leerlingen the way the operator did when they reported
-    // this: the student is under their own year and class.
+    // this: the student's row names their own class.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
-    expect(
-        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
-    expect(find.text('Jane Doe'), findsWidgets,
-        reason: 'a student with no downstream account is still listed');
-    expect(find.text('Maak een nieuw Office 365 account'), findsOneWidget);
-
-    // Apply that one row.
     final entry = harness.controller.pendingEntries
         .firstWhere((e) => e.family == 'student');
     final id = entry.targetId;
-    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
-    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
-    await tester.pumpAndSettle();
+    final Finder row = find.byKey(ValueKey('account-row-$id'));
+    expect(find.descendant(of: row, matching: find.text('Jane Doe')),
+        findsOneWidget,
+        reason: 'a student with no downstream account is still listed');
+    expect(find.descendant(of: row, matching: find.text('3C')), findsOneWidget,
+        reason: 'under their own class — not "Zonder klas", not nowhere');
+
+    // Apply that one row.
+    await selectAccount(tester, id);
+    expect(find.text('Maak een nieuw Office 365 account'), findsOneWidget);
     await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
     await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
     await tester.pumpAndSettle();
@@ -8964,43 +8577,27 @@ void main() {
     await tester.pumpAndSettle();
     expect(harness.controller.error, isNull);
 
-    // Browse Acties → Personeel: the staff member is under the synthetic staff
-    // school, with the first link of the chain offered and only that one.
+    // Browse Acties → Personeel: the staff member is a row of that tab's list,
+    // with the first link of the chain offered and only that one.
     await tester.tap(find.text('Acties'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
-    final staffSchool =
-        find.byKey(const ValueKey('rollup-school-school|staff'));
-    await tester.ensureVisible(staffSchool);
-    await tester.tap(staffSchool);
-    await tester.pumpAndSettle();
-    await tester
-        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
-    await tester.pumpAndSettle();
-    final staffClass = find
-        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
-    await tester.ensureVisible(staffClass);
-    await tester.tap(staffClass);
-    await tester.pumpAndSettle();
-    expect(
-        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
-    expect(find.text('Anna Smit'), findsWidgets,
-        reason: 'a staff member with no downstream account is still listed');
-    // …reading as the create side of the either/or choice of #248: the WISA
-    // opt-out this family also raises is its alternative, not a second to-do.
-    expect(
-        find.text('Maak een nieuw Office 365 account (keuze)'), findsOneWidget);
-    expect(find.text('Maak een nieuw Smartschool account'), findsNothing,
-        reason: 'the dispatch can only see the first link of the chain');
-
-    // Apply that one row.
     final entry = harness.controller.pendingEntries
         .firstWhere((e) => e.family == 'staff');
     final id = entry.targetId;
-    await tester.ensureVisible(find.byKey(ValueKey('entry-staff-$id')));
-    await tester.tap(find.byKey(ValueKey('entry-staff-$id')));
-    await tester.pumpAndSettle();
+    final Finder row = find.byKey(ValueKey('account-row-$id'));
+    expect(find.descendant(of: row, matching: find.text('Anna Smit')),
+        findsOneWidget,
+        reason: 'a staff member with no downstream account is still listed');
+
+    // Apply that one row. Its decision reads as the either/or of #248: the WISA
+    // opt-out this family also raises is its alternative, not a second to-do.
+    await selectAccount(tester, id);
+    expect(find.text('Kies één oplossing:'), findsOneWidget);
+    expect(find.text('Maak een nieuw Office 365 account'), findsOneWidget);
+    expect(find.text('Maak een nieuw Smartschool account'), findsNothing,
+        reason: 'the dispatch can only see the first link of the chain');
     await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
     await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
     await tester.pumpAndSettle();
@@ -9042,7 +8639,7 @@ void main() {
   });
 
   testWidgets(
-      'a new staff member offers one either/or choice, and "apply to all" '
+      'a new staff member offers one either/or choice, and applying it '
       'provisions every hire without blacklisting any end-to-end (#248)',
       (WidgetTester tester) async {
     // The real app, real fonts, real navigation, over the real Graph and
@@ -9078,70 +8675,53 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
-    final staffSchool =
-        find.byKey(const ValueKey('rollup-school-school|staff'));
-    await tester.ensureVisible(staffSchool);
-    await tester.tap(staffSchool);
-    await tester.pumpAndSettle();
-    await tester
-        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
-    await tester.pumpAndSettle();
-    final staffClass = find
-        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
-    await tester.ensureVisible(staffClass);
-    await tester.tap(staffClass);
-    await tester.pumpAndSettle();
-    expect(
-        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
 
-    // Both new hires are on the list, each reading as *one* choice…
-    expect(find.text('Anna Smit'), findsWidgets);
-    expect(find.text('Bram Jansen'), findsWidgets);
-    expect(find.text('Maak een nieuw Office 365 account (keuze)'),
-        findsNWidgets(2));
-    // …and no row carries the opt-out as a line of its own: it is the
-    // alternative the operator can switch to, not a second thing that also
-    // runs. (The bulk header below names both sides of the one choice.)
-    expect(find.text('Negeer dit account bij het importeren uit WISA'),
-        findsNothing);
-
-    // Expanding one offers both readings as radios, the create pre-selected.
+    // Both new hires are rows, each badged once — the either/or is one
+    // decision, never two independent to-dos.
     final entries = harness.controller.pendingEntries
         .where((e) => e.family == 'staff')
         .toList();
     expect(entries, hasLength(2));
-    final first = find.byKey(ValueKey('entry-staff-${entries.first.targetId}'));
-    await tester.ensureVisible(first);
-    await tester.tap(first);
-    await tester.pumpAndSettle();
+    for (final e in entries) {
+      final Finder row = find.byKey(ValueKey('account-row-${e.targetId}'));
+      await tester.ensureVisible(row);
+      expect(
+          find.descendant(of: row, matching: find.text('1')), findsOneWidget);
+    }
+
+    // Selecting one offers both readings as radios, the create pre-selected —
+    // and the opt-out is only ever the alternative, never a line of its own.
+    await selectAccount(tester, entries.first.targetId);
     expect(find.text('Kies één oplossing:'), findsOneWidget);
+    expect(find.text('Maak een nieuw Office 365 account'), findsOneWidget);
     expect(find.text('Negeer dit account bij het importeren uit WISA'),
         findsOneWidget);
-    await tester.tap(first);
-    await tester.pumpAndSettle();
 
-    // The bulk header offers the one resolution for both hires.
-    final key = harness.controller.classroomPendingSituations.single.key;
-    final bulk = find.byKey(ValueKey('situation-apply-$key'));
-    await tester.ensureVisible(bulk);
-    expect(
-      find.textContaining('Maak een nieuw Office 365 account / Negeer dit '
-          'account bij het importeren uit WISA'),
-      findsOneWidget,
-      reason: 'the header names one either/or, not two independent to-dos',
-    );
-
+    // Provision both, one deliberate apply each — since #295 Acties applies per
+    // decision and nothing else, and #296 is what brings the school-wide bulk
+    // pass back with its cohort visible first.
     final pulls = harness.wisaSyncs;
-    await tester.tap(bulk);
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-    await tester.pumpAndSettle();
+    final summaries = <String>[];
+    final outcomes = <String>[];
+    for (final e in entries) {
+      await selectAccount(tester, e.targetId);
+      final Finder apply = find.byKey(ValueKey('entry-apply-${e.targetId}'));
+      await tester.ensureVisible(apply);
+      await tester.tap(apply);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      await tester.pumpAndSettle();
+      // Each pass clears the previous one's results, so the verdicts are
+      // collected as they land.
+      summaries.addAll(
+          harness.controller.applyResults!.map((r) => r.changes.summary));
+      outcomes
+          .addAll(harness.controller.applyResults!.map((r) => r.outcome.name));
+    }
 
     // Both teachers were provisioned end to end — Office 365 and, off the #240
     // chain, Smartschool…
     expect(harness.graph.createdUsers, hasLength(2));
-    final summaries =
-        harness.controller.applyResults!.map((r) => r.changes.summary).toList();
     expect(summaries.where((s) => s == 'Maak een nieuw Office 365 account'),
         hasLength(2));
     expect(summaries.where((s) => s == 'Maak een nieuw Smartschool account'),
@@ -9155,10 +8735,7 @@ void main() {
       reason: 'the rule would drop the hires this same pass just provisioned',
     );
     expect(harness.wisaSyncs, pulls);
-    expect(
-      harness.controller.applyResults!.map((r) => r.outcome.name),
-      everyElement('applied'),
-    );
+    expect(outcomes, everyElement('applied'));
   });
 }
 

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3253,6 +3253,76 @@ void main() {
   });
 
   testWidgets(
+      'each action tab says what the other one is holding, and following the '
+      'line lands there end-to-end (#301)', (WidgetTester tester) async {
+    // The real app, real rail, real navigation — which is the whole of this
+    // issue. Acties covers people and Klasgroepen covers classes, so "is
+    // everything as expected?" is only answerable by visiting both, and nothing
+    // prompted the operator to. The rollover is where that bites: the
+    // Smartschool class change is per student here while the Office 365 roster
+    // write is one action per class there, so a clean Acties list can sit above
+    // a pile of stale rosters.
+    //
+    // Only a full run can show it. The two counts are derived on the shared
+    // controller, rendered by two screens that never see each other, and the
+    // link has to reach across the shell that keeps both alive — three halves a
+    // widget test of either screen structurally cannot put together.
+    //
+    // The fixture in miniature: `3C` and `3D` both lack their Office 365 group
+    // (two classes), and of the two students only Sam's Office 365 display name
+    // is stale (one account).
+    useTallWindow(tester);
+    final harness = appliedClassWorkHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    expect(harness.controller.error, isNull);
+    expect(find.byType(ActionsScreen), findsOneWidget);
+
+    // Acties names what the other tab is holding, on the first visit — it reads
+    // the inventory itself rather than waiting for the operator to go to the
+    // very tab the line exists to send them to.
+    final Finder toClasses =
+        find.byKey(const ValueKey('actions-class-attention'));
+    expect(toClasses, findsOneWidget);
+    expect(find.text('2 klas(sen) vragen ook aandacht op Klasgroepen.'),
+        findsOneWidget);
+
+    // Following it lands on Klasgroepen, where the count is the one that tab
+    // states for itself — one derivation, so the pointer cannot contradict the
+    // list it points at.
+    await tester.ensureVisible(toClasses);
+    await tester.tap(toClasses);
+    await tester.pumpAndSettle();
+    expect(find.byType(ClassGroupsScreen), findsOneWidget);
+    expect(find.textContaining('2 klas(sen), waarvan 2 aandacht vragen'),
+        findsOneWidget);
+
+    // And the mirror of it, back the other way.
+    final Finder toAccounts =
+        find.byKey(const ValueKey('class-groups-account-attention'));
+    expect(toAccounts, findsOneWidget);
+    expect(find.text('1 account(s) vragen ook aandacht op Acties.'),
+        findsOneWidget);
+    await tester.ensureVisible(toAccounts);
+    await tester.tap(toAccounts);
+    await tester.pumpAndSettle();
+    expect(find.byType(ActionsScreen), findsOneWidget);
+
+    // The one account it counted is the list Acties comes back to, still under
+    // its own work filter.
+    final String sam = accountId(harness, 'Sam Sels');
+    final String tom = accountId(harness, 'Tom Tas');
+    expect(find.byKey(ValueKey('account-row-$sam')), findsOneWidget);
+    expect(find.byKey(ValueKey('account-row-$tom')), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'the Klasgroepen inventory is searchable by class name and description, '
       'composing with the attention switch end-to-end (#262)',
       (WidgetTester tester) async {

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -654,10 +654,6 @@ class ReconcileController extends ChangeNotifier {
 
   SyncState _syncState = SyncState.initial;
   List<Rollup> _rollups = const [];
-  Rollup? _selectedClassroom;
-  List<String> _expandedPath = const <String>[];
-  List<MaterializedAccount>? _classroomAccounts;
-  bool _loadingClassroom = false;
   List<MaterializedGroup>? _groupDocs;
   bool _loadingGroups = false;
   SyncLease? _lock;
@@ -682,6 +678,13 @@ class ReconcileController extends ChangeNotifier {
   LinkedState? _pendingCacheKey;
   int _choicesVersion = 0;
   int _pendingCacheChoicesVersion = -1;
+
+  /// Memoized [linkedAccounts] (#295), keyed on the identity of the linked view
+  /// exactly as [_pendingEntriesCache] is. The operator's alternative picks do
+  /// **not** enter into it: a document says where an account lives and which
+  /// systems hold it, never which resolution was chosen for it.
+  List<MaterializedAccount>? _accountDocsCache;
+  LinkedState? _accountDocsKey;
 
   /// The persisted operator decisions loaded from the shared store (#109/#110),
   /// used to tell which duplicate-mail collisions have been accepted. Refreshed
@@ -1014,24 +1017,43 @@ class ReconcileController extends ChangeNotifier {
           for (final c in e.choices) PendingDecision(entry: e, choice: c),
       ];
 
-  /// The live pending entries for the accounts of the currently-open classroom
-  /// (#154): the interactive tiles the Actions drill-down builds for one class,
-  /// joined to the lazily-loaded classroom docs by account id. Empty before a
-  /// classroom is opened, or in a passive session with no live view to act on.
-  List<PendingAccountEntry> get classroomPendingEntries {
-    final accounts = _classroomAccounts;
-    if (accounts == null || _linked == null) return const [];
-    final ids = <String>{for (final a in accounts) a.id.value};
-    return [
-      for (final e in pendingEntries)
-        if (ids.contains(e.targetId)) e,
-    ];
+  /// Every account and staff member of the linked view as a document, derived
+  /// school-wide from the view in hand (#295) — the inventory the flat Acties
+  /// list renders its rows from, joined to [pendingEntries] by id.
+  ///
+  /// Derived rather than read: the store's own per-account documents are made by
+  /// exactly this [materialize] call, but [LinkedStore] only offers them one
+  /// classroom partition at a time — which is what the jaar → klas drill-down
+  /// was shaped around. Since #287 every session holds the linked view itself,
+  /// so the whole roster is already in memory and the school-wide list needs no
+  /// read at all. Deriving it here also keeps Acties, Klasgroepen and the
+  /// Synchronisatie overview reading one set of facts rather than three.
+  ///
+  /// Memoized on the identity of the linked view, for the reason
+  /// [pendingEntries] is: the screen reads it several times per frame, and a
+  /// September roster is ~9.6k accounts. A failed derivation answers empty and
+  /// says so once — the list is then simply not offered, which is honest.
+  List<MaterializedAccount> get linkedAccounts {
+    final linked = _linked;
+    if (linked == null) return const [];
+    if (identical(_accountDocsKey, linked) && _accountDocsCache != null) {
+      return _accountDocsCache!;
+    }
+    List<MaterializedAccount> docs;
+    try {
+      docs = materialize(
+        linked,
+        generation: _syncState.generation,
+        schoolLabels: _schoolLabels(),
+      ).accounts;
+    } on Object catch (e) {
+      log.addError(core.Origin.all, 'Kon de accountlijst niet opbouwen: $e');
+      docs = const <MaterializedAccount>[];
+    }
+    _accountDocsKey = linked;
+    _accountDocsCache = docs;
+    return docs;
   }
-
-  /// [classroomPendingEntries] grouped into same-situation cohorts, so the
-  /// per-class list keeps the bulk-apply affordance of the old flat list (#154).
-  List<SituationCohort> get classroomPendingSituations =>
-      situationCohorts(classroomPendingEntries);
 
   /// The live group ("Klasgroepen") pending entries (#154): the interactive
   /// tiles the group drill-down builds. Empty in a passive session.
@@ -1577,20 +1599,24 @@ class ReconcileController extends ChangeNotifier {
     return null;
   }
 
-  /// The top-level nodes of the **student** drill-down (#210): one merged
-  /// grade-year node per year across *every* managed school, then the
-  /// "Niet toegewezen" bucket.
+  /// The **student** grade-year aggregates (#210): one merged node per year
+  /// across *every* managed school, then the "Niet toegewezen" bucket.
   ///
   /// The WISA school split is administrative, not operational — everyone running
   /// this software treats the managed schools as one school — so the school level
   /// carries no decision and is flattened away here. This is a **view**
   /// projection: the stored rollups keep their school → grade-year → classroom
   /// shape, which matters twice over. `school` is the Cosmos partition key of the
-  /// per-account documents, so a classroom node must keep its real school for
-  /// [openClassroom] to read exactly one partition; and [totalPendingCount],
+  /// per-account documents, so a classroom node keeps its real school and one
+  /// partition can still be read on its own; and [totalPendingCount],
   /// [staffPendingCount], [studentPendingCount], [schoolRollups] and the
   /// per-category summaries all aggregate over [RollupLevel.school], so a passive
   /// session's badges keep reading from data that is still there.
+  ///
+  /// Since #295 Acties no longer *browses* these: the flat account list renders
+  /// straight off the linked view. They stay as the counts every passive surface
+  /// reads, and as the per-class tallies #301 answers "how many other classes
+  /// need attention?" from.
   ///
   /// Ordering is pinned: Jaar 1 … Jaar 7 numerically, then the non-numeric years
   /// ([gradeNodeLabel] renders those as "Overige klassen" — `OKAN` and friends
@@ -1632,8 +1658,8 @@ class ReconcileController extends ChangeNotifier {
   /// A merged grade-year node collects that year's classrooms from **every**
   /// managed school; "Niet toegewezen" skips its always-synthetic grade level and
   /// lists its classrooms ("Zonder klas") directly. Every node returned is a real
-  /// stored classroom rollup, so it still carries the [Rollup.school] partition
-  /// [openClassroom] reads.
+  /// stored classroom rollup, so it still carries its own [Rollup.school]
+  /// partition.
   List<Rollup> studentChildrenOf(Rollup node) {
     final bool unassigned = node.school == unassignedPartition;
     final children = <Rollup>[
@@ -1674,9 +1700,8 @@ class ReconcileController extends ChangeNotifier {
   }
 
   /// The rollup nodes directly under [parentKey] (grade-years of a school, or
-  /// classrooms of a grade-year), alphabetical. The stored parent/child shape —
-  /// what the Personeel tab drills; the student tree flattens it away through
-  /// [studentRollups] / [studentChildrenOf] (#210).
+  /// classrooms of a grade-year), alphabetical — the stored parent/child shape
+  /// the per-class tallies are read from.
   List<Rollup> childrenOf(String parentKey) {
     final children = [
       for (final r in _rollups)
@@ -1685,47 +1710,16 @@ class ReconcileController extends ChangeNotifier {
     return children;
   }
 
-  /// The classroom whose accounts are currently open in the drill-down, or
-  /// `null` when none is selected.
-  Rollup? get selectedClassroom => _selectedClassroom;
-
-  /// The per-account docs of [selectedClassroom], lazily loaded from the store;
-  /// `null` until a classroom is opened.
-  List<MaterializedAccount>? get classroomAccounts => _classroomAccounts;
-
-  /// Whether a classroom drill-down read is in flight.
-  bool get loadingClassroom => _loadingClassroom;
-
-  /// Which accordion nodes the Acties drill-down has open, outermost first
-  /// (#235) — `['rollup-grade-grades|3']` on the flat Leerlingen tree, and
-  /// `['rollup-school-school|staff', 'rollup-grade-grade|staff|Personeel']` on
-  /// the nested Personeel one. Empty means a fully collapsed tree.
-  ///
-  /// It lives up here beside [selectedClassroom] for the reason the bug existed:
-  /// while a class is open the tree is not built at all, so expansion kept
-  /// inside the `ExpansionTile`s themselves died with them and **Overzicht**
-  /// came back fully collapsed. Held one level above the widgets it survives the
-  /// detail view — and a family tab change, which closes the drill-down but
-  /// leaves the other tab's path untouched, the two trees sharing no node key.
-  ///
-  /// One entry **per depth** is what makes it an accordion without breaking the
-  /// nested staff tree: opening a node replaces whichever sibling sat at its
-  /// depth and drops everything below, while its ancestors stay open.
-  List<String> get expandedPath => _expandedPath;
-
-  set expandedPath(List<String> path) {
-    if (_samePath(_expandedPath, path)) return;
-    _expandedPath = List<String>.unmodifiable(path);
-    notifyListeners();
-  }
-
-  static bool _samePath(List<String> a, List<String> b) {
-    if (a.length != b.length) return false;
-    for (var i = 0; i < a.length; i++) {
-      if (a[i] != b[i]) return false;
-    }
-    return true;
-  }
+  // There is deliberately no open-classroom state here any more (#295). The
+  // Acties panel browsed jaar → klas → account because `LinkedStore` offers
+  // `readRollups()` and `readClassroom()` and nothing else, so a session could
+  // only hold one classroom partition at a time. Since #287 every session adopts
+  // the shared linked view at startup, so the whole roster is in `_linked`, and
+  // [linkedAccounts] + [pendingEntries] are both school-wide. `openClassroom`,
+  // `classroomAccounts`, `classroomPendingEntries`, `classroomPendingSituations`
+  // and the accordion's `expandedPath` went with the tree they existed for.
+  // `LinkedStore.readClassroom` itself stays: the store is shared, and the
+  // Synchronisatie overview still reads rollups.
 
   /// The three category summaries the Reconcile overview renders (#163), summed
   /// from the stored rollups so they read in a passive session too: students are
@@ -2277,38 +2271,26 @@ class ReconcileController extends ChangeNotifier {
     }
   }
 
-  /// Re-reads the shared overview (sync state, rollups, lease) and any open
-  /// drill-down from the store — the refetch [onStoreChanged] and
+  /// Re-reads the shared overview (sync state, rollups, lease) and the class
+  /// inventory from the store — the refetch [onStoreChanged] and
   /// [resyncFromStore] share (no pull, no `link()`).
   ///
   /// The overview itself is always re-read: the rollups are the counts the nudge
-  /// was about, and they are small. The *drill-downs* are what [shard] narrows
-  /// (#254) — a one-classroom apply elsewhere in the school has nothing to say
-  /// about the class this session has open, or about the Klasgroepen inventory,
-  /// so those reads are skipped rather than paid for. A null shard (a sync's
+  /// was about, and they are small. The Klasgroepen inventory is what [shard]
+  /// narrows (#254) — an apply elsewhere in the school has nothing to say about
+  /// it, so the read is skipped rather than paid for. A null shard (a sync's
   /// whole-view rewrite, or a reconnect that cannot know what it missed) re-reads
   /// everything, exactly as before.
+  ///
+  /// The Acties list is **not** re-read here and has nothing to re-read (#295):
+  /// it renders off this session's linked view rather than off classroom
+  /// partitions, so the shared store moving under it changes the counts above it
+  /// and not the rows.
   Future<void> _refetchFromStore({ShardRef? shard}) async {
     _syncState = await store.readSyncState();
     _rollups = await store.readRollups();
     _decisions = await store.readDecisions();
     await _refreshLock();
-    final open = _selectedClassroom;
-    if (open != null &&
-        (shard == null ||
-            shard.touchesClassroom(
-              school: open.school,
-              classroom: open.classroom,
-            ))) {
-      try {
-        _classroomAccounts = await store.readClassroom(
-          school: open.school,
-          classroom: open.classroom,
-        );
-      } on Object catch (e) {
-        log.addError(core.Origin.all, 'Kon ${open.label} niet vernieuwen: $e');
-      }
-    }
     if (_groupDocs != null &&
         (shard == null || shard.touchesPartition(groupsPartition))) {
       try {
@@ -2320,44 +2302,15 @@ class ReconcileController extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Opens a classroom in the drill-down, lazily reading its per-account docs
-  /// from the store (no pull, no `link()`).
-  Future<void> openClassroom(Rollup classroom) async {
-    _selectedClassroom = classroom;
-    _classroomAccounts = null;
-    _loadingClassroom = true;
-    notifyListeners();
-    try {
-      _classroomAccounts = await store.readClassroom(
-        school: classroom.school,
-        classroom: classroom.classroom,
-      );
-    } on Object catch (e) {
-      log.addError(core.Origin.all, 'Kon ${classroom.label} niet openen: $e');
-      _classroomAccounts = const [];
-    } finally {
-      _loadingClassroom = false;
-      notifyListeners();
-    }
-  }
-
-  /// Closes the classroom drill-down, back to the overview.
-  void closeClassroom() {
-    _selectedClassroom = null;
-    _classroomAccounts = null;
-    notifyListeners();
-  }
-
   /// Reads the **class inventory** — every stored class document — from the
   /// store (no pull, no `link()`). One partition read; there are a few hundred
   /// classes at most.
   ///
-  /// The group-family counterpart of [openClassroom], except that it is not a
-  /// drill-down any more: since #227 Klasgroepen is a top-level tab that lists
-  /// every class rather than a node listing the ones with work, so the read is
-  /// "load the inventory" and there is nothing to close. A second call while a
-  /// read is in flight is a no-op; a sync drops [groupDocs] so the tab re-reads
-  /// the generation it just wrote.
+  /// Since #227 Klasgroepen is a top-level tab that lists every class rather
+  /// than a node listing the ones with work, so the read is "load the inventory"
+  /// and there is nothing to close. A second call while a read is in flight is a
+  /// no-op; a sync drops [groupDocs] so the tab re-reads the generation it just
+  /// wrote.
   Future<void> loadGroups() async {
     if (_loadingGroups) return;
     _loadingGroups = true;
@@ -2685,23 +2638,19 @@ class ReconcileController extends ChangeNotifier {
     // This pass pulled and linked for itself, so the view is no longer somebody
     // else's to attribute (#287).
     _adoptedFrom = null;
-    // A re-link invalidates any open drill-down: the documents behind it were
-    // read for the view [_link] just replaced, and the live entries the screens
-    // join them against are the new one's. The remembered accordion path goes
-    // with them (#235), so it can never point at a node the fresh view no longer
-    // has, and the class inventory goes too — the Klasgroepen tab re-reads
-    // (#227).
+    // A re-link invalidates the cached class inventory: those documents were
+    // read for the view [_link] just replaced, and the live entries the
+    // Klasgroepen rows join them against are the new one's, so the tab re-reads
+    // (#227). The Acties list needs no such line since #295 — it holds no store
+    // documents of its own, and [linkedAccounts] is keyed on the identity of the
+    // linked view that has just been swapped out.
     //
     // Sits here, before [_persist], and not on the far side of the store write
-    // it used to (#289). These are invalidations of *this session's* derived
-    // caches; whether the shared write lands has nothing to do with them, and a
-    // write that timed out or threw used to skip them entirely — leaving the
-    // open classroom joining fresh entries against the previous generation's
-    // documents. Written straight to the fields: the pass notifies once when it
-    // finishes.
-    _selectedClassroom = null;
-    _expandedPath = const <String>[];
-    _classroomAccounts = null;
+    // it used to (#289). This is an invalidation of *this session's* derived
+    // cache; whether the shared write lands has nothing to do with it, and a
+    // write that timed out or threw used to skip it entirely — leaving the rows
+    // joining fresh entries against the previous generation's documents. Written
+    // straight to the field: the pass notifies once when it finishes.
     _groupDocs = null;
     _setProgress(0.9);
     await _persist(_linked!);

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -1933,6 +1933,55 @@ class ReconcileController extends ChangeNotifier {
   /// Whether a class-inventory read is in flight.
   bool get loadingGroups => _loadingGroups;
 
+  /// How many classes the **Klasgroepen** tab is holding work on (#301).
+  ///
+  /// Derived here rather than on the screen that shows it, because two screens
+  /// now quote it: Klasgroepen's own header, and the pointer Acties carries at
+  /// it. A pointer that counts differently from the list it points at is worse
+  /// than no pointer, so there is one derivation and both read it.
+  ///
+  /// Exactly the predicate that tab highlights a row on: a live entry in an
+  /// active session, [MaterializedGroup.needsAttention] in a passive one.
+  /// Informational notices therefore count — a class Smartschool already holds
+  /// is real work the operator does *there* (#225/#250), which is precisely why
+  /// it is not an Acties row and why this pointer has to exist at all.
+  ///
+  /// Zero until [loadGroups] has answered: a count the store has not been asked
+  /// for is not a count, and a header says nothing rather than guess.
+  int get classesNeedingAttention {
+    final docs = _groupDocs;
+    if (docs == null) return 0;
+    if (_linked == null) {
+      return docs.where((d) => d.needsAttention).length;
+    }
+    // The group family's entries are keyed by the class name, which is the
+    // document label — both come from the linker's cross-system match key.
+    final targets = <String>{for (final e in groupPendingEntries) e.targetId};
+    return docs.where((d) => targets.contains(d.label)).length;
+  }
+
+  /// How many accounts the **Acties** list is holding work on (#301) — the
+  /// mirror of [classesNeedingAttention], for the line Klasgroepen carries.
+  ///
+  /// Accounts rather than actions, so the two pointers are one sentence in two
+  /// nouns, and [totalPendingCount] is the wrong number for it twice over: it
+  /// counts cards of every family, class groups included, and an account with
+  /// three decisions on it is still one row of the list.
+  ///
+  /// Applyable rather than merely pending, which is the same predicate the flat
+  /// list filters on and the same one its indicators colour by (#245/#255/#298):
+  /// an informational candidate on an account diagnoses work that happens on
+  /// Klasgroepen, and counting it here would put it on the wrong side of this
+  /// very pointer.
+  int get accountsNeedingAttention {
+    if (_linked == null) return 0;
+    var total = 0;
+    for (final e in pendingEntries) {
+      if (e.family != 'group' && e.canApply) total++;
+    }
+    return total;
+  }
+
   /// How many pending actions an apply pass would actually write — the
   /// **selected** applyable option of each choice (#110). A departed student
   /// counts once (the chosen resolution), not twice, and the informational group

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -131,6 +131,7 @@ class PendingActionOption {
     required this.target,
     required this.changes,
     required this.canApply,
+    this.canApplyToAll = false,
     this.unlockedSystems = const {},
   });
 
@@ -162,6 +163,19 @@ class PendingActionOption {
 
   /// Whether an apply pass would actually write this option.
   final bool canApply;
+
+  /// Whether this action is sanctioned for a **school-wide** apply (#293/#296)
+  /// — `StudentAction.canApplyToAll` et al., read off the action rather than
+  /// decided here.
+  ///
+  /// A different question from [canApply], which asks whether the action has an
+  /// automated write at all. This asks whether writing it to every record that
+  /// needs it, off one confirmation, is a thing the operator may do without
+  /// looking at each record: true for the rollover class move, false for the
+  /// destructive and judgement-call actions. The sanction presupposes the
+  /// mechanism — the action classes pin `canApplyToAll ⇒ canApply` — so nothing
+  /// here has to re-check it.
+  final bool canApplyToAll;
 
   /// The systems only a **chained follow-up** of this option would write to
   /// (`StudentAction.unlockedSystems` et al., #234) — never the option's own
@@ -282,6 +296,16 @@ class PendingChoice {
   /// routes a pass's verdict back to the decision it is the verdict of.
   String get situationId => alternatives.first.situationId;
 
+  /// Whether the resolution the operator has **picked here** is sanctioned for
+  /// a school-wide apply (#296).
+  ///
+  /// Read off the selected alternative rather than off the decision, because an
+  /// either/or can mix the two: the staff import decision offers "create in
+  /// Office 365" (sanctioned), "create in Smartschool" and "never import this
+  /// person" (both withheld). So the answer is a property of what this account
+  /// is set to do, which is also what a bulk pass would run for it.
+  bool get canApplyToAll => selected.canApplyToAll;
+
   /// A short human description of *this* decision (#292): both sides of an
   /// either/or, or the lone action's summary. What a [SituationCohort] leads
   /// with, so the header names the one decision it applies and nothing else.
@@ -343,6 +367,11 @@ class PendingDecision {
   /// applyable Office 365 group decision beside it, and a cohort of the former
   /// must not count itself as work.
   bool get canApply => choice.selected.canApply;
+
+  /// Whether this account's stake in the decision may be written by a
+  /// school-wide pass (#296) — [PendingChoice.canApplyToAll] of the resolution
+  /// it is set to.
+  bool get canApplyToAll => choice.canApplyToAll;
 }
 
 /// Every account that raises one and the same decision (#292) — the subset a
@@ -686,6 +715,18 @@ class ReconcileController extends ChangeNotifier {
   List<MaterializedAccount>? _accountDocsCache;
   LinkedState? _accountDocsKey;
 
+  /// Memoized school-wide cohorts by [SituationCohort.key] (#296), keyed on the
+  /// identity of the [pendingEntries] list they were grouped from — which is
+  /// itself invalidated by a relink and by every [chooseAlternative], so this
+  /// inherits both.
+  ///
+  /// A per-decision "Toepassen op alle" has to answer *how many accounts in the
+  /// school need this* while a details pane is being built, and a details pane
+  /// is rebuilt on every controller notification. Regrouping ~9.6k accounts'
+  /// decisions per block per frame is what that costs without a cache.
+  Map<String, SituationCohort>? _cohortIndexCache;
+  List<PendingAccountEntry>? _cohortIndexKey;
+
   /// The persisted operator decisions loaded from the shared store (#109/#110),
   /// used to tell which duplicate-mail collisions have been accepted. Refreshed
   /// on every overview read and after each accept/revoke.
@@ -930,6 +971,9 @@ class ReconcileController extends ChangeNotifier {
       // (`AzureClassGroupMembership`), so the apply affordance is gated on the
       // action rather than assumed, exactly as the group family's is.
       canApply: (a) => a.canApply,
+      // The school-wide sanction of #293, carried here so #296's per-decision
+      // "Toepassen op alle" can read it off the pending list.
+      canApplyToAll: (a) => a.canApplyToAll,
       unlockedSystems: (a) => a.unlockedSystems,
     ));
     entries.addAll(_entriesFor(
@@ -943,6 +987,7 @@ class ReconcileController extends ChangeNotifier {
       // Read off the action like the other two families since #240: every staff
       // action is applyable today, but nothing here should assume it.
       canApply: (a) => a.canApply,
+      canApplyToAll: (a) => a.canApplyToAll,
       unlockedSystems: (a) => a.unlockedSystems,
     ));
     entries.addAll(_entriesFor(
@@ -954,6 +999,7 @@ class ReconcileController extends ChangeNotifier {
       isDefault: (a) => a.isDefaultAlternative,
       changes: (a) => a.describeChanges(),
       canApply: (a) => a.canApply,
+      canApplyToAll: (a) => a.canApplyToAll,
       unlockedSystems: (a) => a.unlockedSystems,
     ));
     _pendingCacheKey = l;
@@ -968,6 +1014,75 @@ class ReconcileController extends ChangeNotifier {
   /// while each account keeps its own chosen alternative.
   List<SituationCohort> get pendingSituations =>
       situationCohorts(pendingEntries);
+
+  /// The whole school's cohort for one decision, narrowed to the members a
+  /// **school-wide** apply may write (#296) — or `null` when this decision gets
+  /// no apply-all at all.
+  ///
+  /// Three narrowings, and each is load-bearing:
+  ///
+  /// - **The action must be sanctioned.** `null` unless the resolution
+  ///   [decision] is set to declares [PendingActionOption.canApplyToAll] (#293).
+  ///   That is what keeps the destructive and judgement-call actions — a delete,
+  ///   a rename, a blacklist — off this path entirely; they get checkbox
+  ///   multi-select instead (#297).
+  /// - **Every member must be sanctioned too**, not merely the one the operator
+  ///   is looking at. The staff import decision mixes the two in one either/or,
+  ///   so a colleague set to "never import" is not swept along by a cohort
+  ///   armed from a colleague set to "create in Office 365".
+  /// - **Non-applyable members are out**, exactly as they are everywhere else.
+  ///
+  /// So the returned cohort's members are precisely the actions the pass will
+  /// run: its length is the N on the button, the list the screen filters to, and
+  /// the change count the confirmation quotes, all from one resolution.
+  ///
+  /// This is the one cohort in the app that is deliberately **not** grouped from
+  /// the rows on screen (#252). It is school-wide by definition — that is the
+  /// September rollover it exists for — so the safety comes from the other
+  /// direction: the screen filters its list down to this cohort and makes the
+  /// operator look at it before the confirmation is offered.
+  SituationCohort? applyToAllCohort(PendingDecision decision) => decision
+          .canApplyToAll
+      ? applyToAllCohortFor('${decision.entry.family}|${decision.situationId}')
+      : null;
+
+  /// [applyToAllCohort] by [SituationCohort.key] — what a screen holding an
+  /// armed cohort re-reads it as on every build.
+  ///
+  /// The key rather than the members, deliberately. A cohort under review is
+  /// live: the operator can still switch an account's alternative while looking
+  /// at it, and a captured list would then apply the resolution they changed
+  /// their mind about. Re-reading means the rows on screen, the N on the button,
+  /// the confirmation's change count and the write are all one resolution of the
+  /// same key — which is the #252 guarantee, arrived at from the other side.
+  ///
+  /// `null` once the cohort has emptied — every member applied, or the last one
+  /// switched to a resolution that is not sanctioned — which is a screen's cue
+  /// to drop out of its review mode.
+  SituationCohort? applyToAllCohortFor(String key) {
+    final all = _cohortIndex[key];
+    if (all == null) return null;
+    final members = <PendingDecision>[
+      for (final d in all.decisions)
+        if (d.canApply && d.canApplyToAll) d,
+    ];
+    if (members.isEmpty) return null;
+    return SituationCohort(key: all.key, decisions: members);
+  }
+
+  /// [pendingSituations] as a lookup by [SituationCohort.key], memoized on the
+  /// entry list it was grouped from.
+  Map<String, SituationCohort> get _cohortIndex {
+    final entries = pendingEntries;
+    final cached = _cohortIndexCache;
+    if (cached != null && identical(_cohortIndexKey, entries)) return cached;
+    final index = <String, SituationCohort>{
+      for (final c in situationCohorts(entries)) c.key: c,
+    };
+    _cohortIndexKey = entries;
+    _cohortIndexCache = index;
+    return index;
+  }
 
   /// Groups the decisions of [entries] into cohorts in first-seen order — the
   /// shared grouping the global list and the per-classroom / per-group
@@ -1124,6 +1239,7 @@ class ReconcileController extends ChangeNotifier {
     required bool Function(T) isDefault,
     required actions.ChangeSet Function(T) changes,
     required bool Function(T) canApply,
+    required bool Function(T) canApplyToAll,
     required Set<core.Origin> Function(T) unlockedSystems,
   }) {
     final order = <String>[];
@@ -1156,6 +1272,7 @@ class ReconcileController extends ChangeNotifier {
                   target: labels[id]!,
                   changes: changes(a),
                   canApply: canApply(a),
+                  canApplyToAll: canApplyToAll(a),
                   unlockedSystems: unlockedSystems(a),
                 ),
             ],
@@ -2332,6 +2449,11 @@ class ReconcileController extends ChangeNotifier {
   // scoped selection ([applyEntries]). A method that took "everything pending"
   // existed only to serve a header button that wrote every account in the
   // school on the strength of a dialog nobody could verify.
+  //
+  // #296's school-wide apply-all is not a return of it: it is
+  // [applyDecisions] over an [applyToAllCohort], which is one action the
+  // operator has read, over a list the screen has just filtered itself down to.
+  // The pass still receives the members themselves, never a key to re-resolve.
 
   /// Dry-runs one entry's chosen resolution (#110): the per-row preview.
   Future<void> dryRunEntry(PendingAccountEntry entry) =>

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -702,7 +702,8 @@ class ReconcileController extends ChangeNotifier {
   /// several times per frame — recomputing it each time is what janks a large
   /// pending set. The cache is keyed on the identity of the linked view (a fresh
   /// `link()` / apply-refresh replaces it) and a version bumped on every
-  /// [chooseAlternative], so a stale entry can never be served.
+  /// [chooseAlternative], so a stale entry can never be served — except for the
+  /// span of a running apply pass, which pins it deliberately ([_holdDerived]).
   List<PendingAccountEntry>? _pendingEntriesCache;
   LinkedState? _pendingCacheKey;
   int _choicesVersion = 0;
@@ -726,6 +727,26 @@ class ReconcileController extends ChangeNotifier {
   /// decisions per block per frame is what that costs without a cache.
   Map<String, SituationCohort>? _cohortIndexCache;
   List<PendingAccountEntry>? _cohortIndexKey;
+
+  /// Whether the three caches above are pinned to the view the running apply
+  /// pass started from, rather than following [_linked] (#299).
+  ///
+  /// [_applyOne] swaps a freshly relinked view in after **every** write, and the
+  /// pass emits a notification per action to drive the progress dialog (#243).
+  /// Left to itself that means one full rebuild of the derived state per write:
+  /// `describeChanges()` over every pending action, and [materialize] over a
+  /// ~9.6k-account roster. A September rollover writes thousands of accounts in
+  /// one pass, so the screen behind the modal would spend the whole run
+  /// re-deriving a list nobody can read — quadratic in the size of the very
+  /// operation this app exists to do.
+  ///
+  /// So a pass answers from the view it began with and the screens refresh
+  /// **once**, when it ends and [_releaseDerived] drops the pinned lists. The
+  /// live [_linked] is never held back — [_refreshRollups], [_shareApplied] and
+  /// the applier itself all read it directly — and nothing the operator can
+  /// reach is interactive mid-pass anyway: every affordance is gated on [busy]
+  /// behind a modal dialog.
+  bool _holdDerived = false;
 
   /// The persisted operator decisions loaded from the shared store (#109/#110),
   /// used to tell which duplicate-mail collisions have been accepted. Refreshed
@@ -832,14 +853,28 @@ class ReconcileController extends ChangeNotifier {
   /// [applyOutcomesForChoice] gives the part that answers one decision, and
   /// [unroutedApplyOutcomesFor] the part no decision on the card can claim
   /// (#283).
-  List<ActionOutcomeEntry> applyOutcomesFor(PendingAccountEntry entry) {
+  List<ActionOutcomeEntry> applyOutcomesFor(PendingAccountEntry entry) =>
+      applyOutcomesForTarget(family: entry.family, targetId: entry.targetId);
+
+  /// [applyOutcomesFor] addressed by the identity the rows are stamped with,
+  /// for a target that no longer raises an entry at all (#299).
+  ///
+  /// An apply that lands settles the decision it wrote, so an account whose
+  /// last piece of work the pass finished raises nothing on the relink behind
+  /// it — and the details pane the operator applied from has no
+  /// [PendingAccountEntry] left to ask for the verdict. That verdict is the one
+  /// thing they were waiting for, so the pane reads it by `family` +
+  /// `targetId`: precisely what [ActionOutcomeEntry] carries, and all an entry
+  /// ever supplied here.
+  List<ActionOutcomeEntry> applyOutcomesForTarget({
+    required String family,
+    required String targetId,
+  }) {
     final results = _applyResults ?? _dryRunResults;
     if (results == null) return const <ActionOutcomeEntry>[];
     return <ActionOutcomeEntry>[
       for (final r in results)
-        if (r.identifiesEntry &&
-            r.family == entry.family &&
-            r.targetId == entry.targetId)
+        if (r.identifiesEntry && r.family == family && r.targetId == targetId)
           r,
     ];
   }
@@ -953,9 +988,10 @@ class ReconcileController extends ChangeNotifier {
   List<PendingAccountEntry> get pendingEntries {
     final l = _linked;
     if (l == null) return const [];
-    if (identical(_pendingCacheKey, l) &&
-        _pendingCacheChoicesVersion == _choicesVersion &&
-        _pendingEntriesCache != null) {
+    if (_pendingEntriesCache != null &&
+        (_holdDerived ||
+            (identical(_pendingCacheKey, l) &&
+                _pendingCacheChoicesVersion == _choicesVersion))) {
       return _pendingEntriesCache!;
     }
     final entries = <PendingAccountEntry>[];
@@ -1151,7 +1187,8 @@ class ReconcileController extends ChangeNotifier {
   List<MaterializedAccount> get linkedAccounts {
     final linked = _linked;
     if (linked == null) return const [];
-    if (identical(_accountDocsKey, linked) && _accountDocsCache != null) {
+    if (_accountDocsCache != null &&
+        (_holdDerived || identical(_accountDocsKey, linked))) {
       return _accountDocsCache!;
     }
     List<MaterializedAccount> docs;
@@ -2540,6 +2577,11 @@ class ReconcileController extends ChangeNotifier {
         touched.add(d.entry);
       }
     }
+    // Pin the derived lists to the view this pass starts from (#299). A real
+    // pass relinks after every write and notifies once per action, so without
+    // this the screens re-derive the whole school between one write and the
+    // next; a dry run patches nothing, so there is nothing for it to pin.
+    _holdDerived = !dry;
     _begin(ReconcilePhase.applying);
 
     final options =
@@ -2599,6 +2641,7 @@ class ReconcileController extends ChangeNotifier {
         await _shareApplied(_refreshRollups(), touched);
       }
       _applyStep = null;
+      _releaseDerived();
       _finish(ReconcilePhase.ready);
     } on Object catch (e) {
       // _applyOne swallows per-action failures; reaching here means the pass
@@ -2614,8 +2657,11 @@ class ReconcileController extends ChangeNotifier {
         await _persistEarnedWisaRules(earnedRules);
         await _shareApplied(_refreshRollups(), touched);
       }
-      // Nothing is in flight any more, however the pass ended (#243).
+      // Nothing is in flight any more, however the pass ended (#243), and the
+      // half of it that did run is as real as a whole one — so the screens get
+      // the view it left behind rather than the one it started from (#299).
       _applyStep = null;
+      _releaseDerived();
       _fail(e);
     }
   }
@@ -3256,6 +3302,25 @@ class ReconcileController extends ChangeNotifier {
         'Kon de WISA-importregel(s) niet opslaan in de instellingen: $e',
       );
     }
+  }
+
+  /// Unpins the derived caches after a pass and drops what they were pinned to
+  /// (#299), so the very next read rebuilds — once — from the settled view.
+  ///
+  /// Dropped rather than merely unpinned: the last write of the pass may well
+  /// have left [_linked] identical to the view a pinned list was keyed on, and
+  /// an identity check would then serve that list forever. Called before the
+  /// pass's closing notification, so the frame that learns the pass is over is
+  /// already the refreshed one — the same reason #289 moved the sibling
+  /// invalidation in [_relink] to the near side of the store write.
+  void _releaseDerived() {
+    _holdDerived = false;
+    _pendingEntriesCache = null;
+    _pendingCacheKey = null;
+    _accountDocsCache = null;
+    _accountDocsKey = null;
+    _cohortIndexCache = null;
+    _cohortIndexKey = null;
   }
 
   void _begin(ReconcilePhase phase) {

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -40,49 +40,38 @@ import 'system_indicator.dart';
 export 'system_indicator.dart';
 
 // ---------------------------------------------------------------------------
-// Rows.
+// Ordering.
 // ---------------------------------------------------------------------------
 
-/// One row of a per-classroom (or per-group) pending list: a same-situation
-/// bulk header or a single account entry. Flattening the cohorts → entries tree
-/// into a linear list lets a lazy [SliverList] build only the on-screen rows
-/// (#111/#154).
-sealed class PendingRow {
-  const PendingRow();
-}
-
-class SituationHeaderRow extends PendingRow {
-  const SituationHeaderRow(this.cohort);
-
-  final SituationCohort cohort;
-}
-
-class EntryRow extends PendingRow {
-  const EntryRow(this.entry);
-
-  final PendingAccountEntry entry;
-}
-
-/// Flattens [cohorts] and [entries] into the linear [PendingRow] list a lazy
-/// sliver builds from: the bulk headers, then one tile per account.
+/// Orders class names the way an operator reads a class list: by year first and
+/// numerically (`2A` before `10A`), then alphabetically, so `2F` sorts beside
+/// its sub-groups rather than between `20A` and `21B`.
 ///
-/// The headers lead rather than each sitting above its own run of rows, and
-/// since #292 they have to. A cohort is one decision, so an account with three
-/// decisions belongs to three of them; interleaving would mean rendering its
-/// card three times, once under each. Klasgroepen already collects its bulk
-/// affordances above the inventory for the same reason (its rows are sorted by
-/// class name, so a cohort was never contiguous there either), and this is that
-/// shape. Both lists therefore read the same way: what can be done in bulk on
-/// top, the accounts themselves below, each exactly once.
-List<PendingRow> pendingRows(
-  List<SituationCohort> cohorts,
-  List<PendingAccountEntry> entries,
-) =>
-    <PendingRow>[
-      for (final cohort in cohorts)
-        if (cohort.length > 1) SituationHeaderRow(cohort),
-      for (final entry in entries) EntryRow(entry),
-    ];
+/// Shared since #295: the Klasgroepen inventory is class-ordered, and the flat
+/// Acties list orders by class too. Two screens listing the same classes in two
+/// different orders is the kind of difference an operator reads as a bug.
+int compareClassNames(String a, String b) {
+  final ya = _leadingYear(a);
+  final yb = _leadingYear(b);
+  if (ya != yb) {
+    // A non-numeric class (`OKAN`) sorts after every numbered year.
+    if (ya == null) return 1;
+    if (yb == null) return -1;
+    return ya - yb;
+  }
+  return a.toLowerCase().compareTo(b.toLowerCase());
+}
+
+int? _leadingYear(String name) {
+  final match = RegExp(r'^\s*(\d+)').firstMatch(name);
+  return match == null ? null : int.tryParse(match.group(1)!);
+}
+
+// The `PendingRow` / `pendingRows` flattening that interleaved a classroom's
+// bulk headers with its entry tiles is gone with the drill-down it served
+// (#295). Klasgroepen collects its [SituationHeader]s above the inventory
+// directly, and the flat Acties list has no cohort headers at all until #296
+// gives school-wide bulk apply its own cohort-first affordance.
 
 // ---------------------------------------------------------------------------
 // Wording.
@@ -805,8 +794,9 @@ String pendingChoiceLine(PendingChoice c) {
   return c.selected.canApply ? summary : '$summary (manueel)';
 }
 
-/// The expandable card both action screens build a record with pending work on
-/// — the Acties [PendingEntryTile] and the Klasgroepen class row.
+/// The expandable card the Klasgroepen inventory builds a class with pending
+/// work on. (Acties built one too until #295 moved its decisions into a details
+/// pane of their own; the rule below is what made that move possible.)
 ///
 /// It exists for one rule neither screen can hold on its own (#300). A
 /// collapsed card previews its decisions as summary lines; since #281 the
@@ -819,9 +809,9 @@ String pendingChoiceLine(PendingChoice c) {
 /// > **Werk het ledenbestand van SSM-1A bij (21 toevoegen, 17 verwijderen)**
 ///
 /// The heading is the one that has to stay: it groups the block under it, it is
-/// uniform across every decision (#281), and it is what #295's details pane —
-/// which has no collapsed row at all — will read [entryDetail] for. So the
-/// *preview* gives way instead. [subtitle] is therefore built with whether the
+/// uniform across every decision (#281), and it is what the Acties details pane
+/// — which has no collapsed row at all — reads [entryDetail] for since #295. So
+/// the *preview* gives way instead. [subtitle] is therefore built with whether the
 /// card is open, which is the one thing an [ExpansionTile] does not hand its
 /// own subtitle.
 class PendingCardTile extends StatefulWidget {
@@ -834,10 +824,9 @@ class PendingCardTile extends StatefulWidget {
     required this.children,
   });
 
-  /// Names the tile itself (`entry-<family>-<targetId>`). Deliberately not this
-  /// widget's own [key]: the screens' tests and #295's row builder address the
-  /// [ExpansionTile], and two widgets answering to one key would make
-  /// `find.byKey` ambiguous.
+  /// Names the tile itself (`entry-group-<klas>`). Deliberately not this
+  /// widget's own [key]: the screen's tests address the [ExpansionTile], and two
+  /// widgets answering to one key would make `find.byKey` ambiguous.
   final Key tileKey;
 
   final Widget? leading;
@@ -886,57 +875,13 @@ class _PendingCardTileState extends State<PendingCardTile> {
       );
 }
 
-/// One account's pending resolution (#110): a single expandable row showing the
-/// selected summary, the mutually-exclusive choice (as radios) when there is
-/// one, the per-field diff, and per-entry dry-run / apply.
-class PendingEntryTile extends StatelessWidget {
-  const PendingEntryTile({
-    super.key,
-    required this.controller,
-    required this.entry,
-  });
-
-  final ReconcileController controller;
-  final PendingAccountEntry entry;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final Color hairline = Theme.of(context).dividerColor;
-
-    return Container(
-      margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
-      decoration: BoxDecoration(
-        border: Border.all(color: hairline),
-        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
-      ),
-      child: PendingCardTile(
-        tileKey: ValueKey('entry-${entry.family}-${entry.targetId}'),
-        leading: PlinkBadge(entry.family),
-        title: Text(entry.target, style: text.bodyLarge),
-        // The whole subtitle here is the preview, so an open card has none:
-        // every line it holds is repeated as a heading below (#300).
-        subtitle: (context, expanded) => expanded
-            ? null
-            : Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  // Each line led by the system it writes to (#298): one card
-                  // can raise work in two systems and the summaries do not
-                  // always say where they land.
-                  for (final c in entry.choices)
-                    ActionLine(
-                      system: c.selected.changes.system,
-                      line: pendingChoiceLine(c),
-                    ),
-                ],
-              ),
-        children: entryDetail(context, controller: controller, entry: entry),
-      ),
-    );
-  }
-}
+// `PendingEntryTile` — the expandable Acties card that previewed its decisions
+// collapsed and rendered [entryDetail] open — retired with the drill-down that
+// listed it (#295). An Acties row is now a selectable line in a flat list and
+// its decisions live in the details pane beside it, which is exactly the
+// standing-on-its-own [entryDetail] #300 prepared. Klasgroepen still builds its
+// own card from [PendingCardTile] + [entryDetail], because there a row *is* the
+// class inventory and there is no second pane to put the detail in.
 
 /// The expanded body of one pending entry: one block per decision, each with
 /// its own verdict (#281/#283), then the verdicts of the last pass that no
@@ -1034,9 +979,9 @@ String choiceHeading(PendingChoice choice) =>
 /// That heading is also why an open card drops its collapsed preview (#300):
 /// the two say the same sentence, and on a card carrying one decision the
 /// operator read it twice in a row. The heading is the half that stays — it
-/// groups the block under it, and [entryDetail] has to stand on its own in
-/// #295's details pane, where there is no collapsed row to have previewed
-/// anything.
+/// groups the block under it, and [entryDetail] has to stand on its own in the
+/// Acties details pane (#295), where there is no collapsed row to have
+/// previewed anything.
 ///
 /// The verdict lines pooled the same way and for the same reason (#283): one
 /// apply on that card produces two of them, and below both decisions they said

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -30,6 +30,11 @@ import 'package:wisa_api/wisa_api.dart' as wapi show formatWerkdatum;
 
 import '../format/timestamps.dart';
 import '../reconcile/reconcile_controller.dart';
+// The tab names and the seam that selects one (#301) — the pointer each action
+// screen carries at the other has to be able to follow itself. Deliberately the
+// small `shell_navigation.dart` and not `app_shell.dart`, which imports the very
+// screens that import this library.
+import '../shell/shell_navigation.dart';
 import 'system_indicator.dart';
 
 // The system vocabulary both action screens speak (#298) — what a coloured
@@ -634,6 +639,80 @@ class SharedStateNotice extends StatelessWidget {
             ),
           ],
         ],
+      ),
+    );
+  }
+}
+
+/// The pointer one action screen carries at the other (#301).
+///
+/// Acties covers people and Klasgroepen covers classes, and since #227 the split
+/// is right — but it means "is everything as expected?" is only answerable by
+/// visiting both, and nothing on either screen said so. The gap has teeth at a
+/// rollover, where the two halves of one operation live on opposite sides of it:
+/// the Smartschool class change is per student in Acties, while the Office 365
+/// roster write is one `SyncAzureClassGroupMembers` per class in Klasgroepen. An
+/// operator can work Acties to a clean list and leave 150 stale rosters behind.
+///
+/// So each header states what the other screen is holding, and following the
+/// line lands there.
+///
+/// Three things it is careful about:
+///
+/// - **One derivation per count.** Both numbers come from the controller
+///   ([ReconcileController.classesNeedingAttention] /
+///   [ReconcileController.accountsNeedingAttention]) rather than from the screen
+///   that renders the line, so the pointer and the header it points at cannot
+///   drift apart. A pointer quoting a number the destination then contradicts
+///   is worse than no pointer at all.
+/// - **Silence when there is nothing.** A line reading "0 klas(sen)" is noise in
+///   the one case where the operator is actually done, so a zero count renders
+///   nothing whatsoever.
+/// - **It still reads outside the shell.** [ShellNavigation] is absent in a
+///   widget test and in any embedding that is not the rail, and the sentence is
+///   true either way — so it degrades to plain prose rather than vanishing.
+class OtherTabAttentionLine extends StatelessWidget {
+  /// The line **Acties** carries: how many classes Klasgroepen is holding.
+  const OtherTabAttentionLine.classes({required this.count})
+      : _noun = 'klas(sen)',
+        _screen = 'Klasgroepen',
+        _tab = ShellTab.klasgroepen,
+        super(key: const ValueKey('actions-class-attention'));
+
+  /// The line **Klasgroepen** carries: how many accounts Acties is holding.
+  const OtherTabAttentionLine.accounts({required this.count})
+      : _noun = 'account(s)',
+        _screen = 'Acties',
+        _tab = ShellTab.acties,
+        super(key: const ValueKey('class-groups-account-attention'));
+
+  /// How many rows the *other* screen has that ask something of the operator.
+  final int count;
+
+  final String _noun;
+  final String _screen;
+  final ShellTab _tab;
+
+  @override
+  Widget build(BuildContext context) {
+    if (count <= 0) return const SizedBox.shrink();
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final ShellNavigation? shell = ShellNavigation.maybeOf(context);
+    // "vragen" stays invariant beside the "(s)" plural, exactly as the
+    // Klasgroepen header's own "waarvan N aandacht vragen" does.
+    final String sentence = '$count $_noun vragen ook aandacht op $_screen.';
+
+    if (shell == null) return Text(sentence, style: text.bodySmall);
+    return InkWell(
+      onTap: () => shell.go(_tab),
+      child: Text(
+        sentence,
+        style: text.bodySmall?.copyWith(
+          color: colors.primary,
+          decoration: TextDecoration.underline,
+          decorationColor: colors.primary,
+        ),
       ),
     );
   }

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -205,7 +205,12 @@ String readOnlyCandidateLine(actions.Alternatives<CandidateAction> choice) {
 ///
 /// [scope] is what that particular confirmation covers (#234) — the systems the
 /// pass will really reach, not a fixed pair.
-Future<void> confirmAndApply(
+///
+/// Answers whether the pass actually ran, so a caller can tell "the operator
+/// said no" from "the writes are done" (#296): a cancelled confirmation must
+/// leave the screen exactly as the operator left it, while a finished pass has
+/// invalidated everything the affordance was built from.
+Future<bool> confirmAndApply(
   BuildContext context, {
   required ReconcileController controller,
   required String title,
@@ -230,14 +235,15 @@ Future<void> confirmAndApply(
       ],
     ),
   );
-  if (!(confirmed ?? false)) return;
-  if (!context.mounted) return;
+  if (!(confirmed ?? false)) return false;
+  if (!context.mounted) return false;
   await runWithProgress(
     context,
     controller: controller,
     dry: false,
     run: apply,
   );
+  return true;
 }
 
 /// Runs one dry-run/apply pass behind a **modal** progress dialog (#243).
@@ -897,10 +903,19 @@ class _PendingCardTileState extends State<PendingCardTile> {
 /// two targets that share a display label share an entry, so a kind is not
 /// guaranteed unique within one card — and a duplicate key among a [Column]'s
 /// children is a build-time crash, not a cosmetic clash.
+///
+/// [onApplyToAll] is the school-wide apply-all seam (#296). Passed in rather
+/// than reached for, because only Acties can honour it: pressing it filters
+/// *that* screen's flat list down to the cohort so the operator can read it
+/// before confirming, and a screen with no such list has no honest way to show
+/// what the button would write. Klasgroepen therefore leaves it `null` and its
+/// blocks carry no apply-all — its own per-cohort headers already sit above the
+/// rows they cover.
 List<Widget> entryDetail(
   BuildContext context, {
   required ReconcileController controller,
   required PendingAccountEntry entry,
+  void Function(PendingDecision decision)? onApplyToAll,
 }) =>
     <Widget>[
       for (final (index, choice) in entry.choices.indexed)
@@ -911,6 +926,7 @@ List<Widget> entryDetail(
           entry: entry,
           choice: choice,
           index: index,
+          onApplyToAll: onApplyToAll,
         ),
       EntryOutcomes(
         keyValue: 'entry-outcomes-${entry.family}-${entry.targetId}',
@@ -996,6 +1012,7 @@ class EntryChoiceBlock extends StatelessWidget {
     required this.entry,
     required this.choice,
     required this.index,
+    this.onApplyToAll,
   });
 
   final ReconcileController controller;
@@ -1007,6 +1024,10 @@ class EntryChoiceBlock extends StatelessWidget {
   /// the block's verdict, which is keyed by position for the reason
   /// [entryDetail] keys the blocks themselves that way.
   final int index;
+
+  /// What the block's "Toepassen op alle (N)" hands back (#296), or `null` on a
+  /// screen that offers no school-wide apply. See [entryDetail].
+  final void Function(PendingDecision decision)? onApplyToAll;
 
   @override
   Widget build(BuildContext context) {
@@ -1036,12 +1057,45 @@ class EntryChoiceBlock extends StatelessWidget {
           ChoiceControl(controller: controller, entry: entry, choice: choice)
         else
           OptionDetail(option: choice.selected),
+        ..._applyToAll(context),
         EntryOutcomes(
           keyValue: 'entry-outcomes-${entry.family}-${entry.targetId}-$index',
           outcomes: controller.applyOutcomesForChoice(entry, choice),
         ),
       ],
     );
+  }
+
+  /// The block's school-wide affordance (#296), or nothing.
+  ///
+  /// Nothing in three cases, and they are different statements. The screen may
+  /// offer no apply-all at all ([onApplyToAll] is `null`); the action may not be
+  /// sanctioned for one (`canApplyToAll`, #293), which is the majority and
+  /// includes every destructive action; or this account may be the only one in
+  /// the school that needs the decision, where "op alle (1)" says nothing the
+  /// **Toepassen** button below does not already say.
+  List<Widget> _applyToAll(BuildContext context) {
+    final onApplyToAll = this.onApplyToAll;
+    if (onApplyToAll == null) return const <Widget>[];
+    final decision = PendingDecision(entry: entry, choice: choice);
+    final cohort = controller.applyToAllCohort(decision);
+    if (cohort == null || cohort.length < 2) return const <Widget>[];
+
+    return <Widget>[
+      const SizedBox(height: PlinkSpacing.s2),
+      Align(
+        alignment: Alignment.centerLeft,
+        child: OutlinedButton.icon(
+          key: ValueKey(
+              'decision-apply-all-${entry.family}-${entry.targetId}-$index'),
+          // Never disabled on the count — a cohort this short does not render
+          // — but a pass already running owns the connectors.
+          onPressed: controller.busy ? null : () => onApplyToAll(decision),
+          icon: const Icon(Icons.done_all, size: 16),
+          label: Text('Toepassen op alle (${cohort.length})'),
+        ),
+      ),
+    ];
   }
 }
 

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -87,13 +87,41 @@ export 'action_tiles.dart' show applyConfirmationMessage, systemLabel;
 /// blocks inside its expandable rows, and two screens wording one decision two
 /// ways is how an operator stops trusting either.
 ///
+/// ## School-wide apply-all, cohort first (#296)
+///
+/// At the September rollover every student in the school needs the same
+/// Smartschool class change. Doing that one account at a time is not a workflow
+/// anyone will follow, so a decision block in the details pane offers
+/// **Toepassen op alle (N)** — but only for the actions #293 sanctions for it,
+/// which excludes every destructive one.
+///
+/// Pressing it does **not** write. It arms a review: the list drops its own
+/// controls and filters down to exactly the N accounts the pass would touch, and
+/// a banner above it names the one decision and offers **Dry-run alles**,
+/// **Alles toepassen (N)** and **Annuleer**. So the operator scrolls the real
+/// cohort — the same rows, the same indicators, each still selectable to read
+/// its diff — before any confirmation is offered.
+///
+/// That is exactly what the global "Alles toepassen" of #294 could not do, and
+/// the difference is not the dialog: it is that the button names *one* action
+/// whose description and field diff the operator is looking at, over a list they
+/// can see. The cohort is re-read from the controller by key on every build
+/// rather than captured, so switching an account's alternative mid-review moves
+/// it out of the cohort instead of being written as the resolution the operator
+/// changed their mind about.
+///
 /// ## What it deliberately does not do
 ///
 /// Nothing here applies an action the operator has not seen. The header's global
 /// "Dry-run alles" / "Alles toepassen" pair went in #294 for exactly that
-/// reason, and the flat list adds no replacement: the only apply is the per-card
-/// pair inside the open details pane. School-wide bulk apply with its cohort
-/// visible first is #296, and checkbox multi-select is #297.
+/// reason, and it is not coming back: every apply is started from a list that is
+/// on screen. Checkbox multi-select, for the kinds that get no apply-all, is
+/// #297.
+///
+/// A running pass cannot be cancelled and is never concurrent — a rollover over
+/// ~3000 accounts takes a long time, and is resumable in practice because every
+/// applied decision settles out of the refreshed view, so re-arming picks up
+/// what is left.
 ///
 /// A session that #287 refuses to seed gets one blocking [ReadOnlyNotice] and no
 /// list at all. The old screen offered a read-only browse of the stored
@@ -338,6 +366,15 @@ class _ActionsBodyState extends State<_ActionsBody>
   /// running pass emits.
   String? _selectedId;
 
+  /// The [SituationCohort.key] of the decision under school-wide review (#296),
+  /// or `null` when the list is the ordinary one.
+  ///
+  /// The key, never the members. A cohort under review is live — the operator
+  /// can switch an account's alternative while looking at it — so it is
+  /// re-resolved from the controller on every build; see
+  /// [ReconcileController.applyToAllCohortFor].
+  String? _cohortKey;
+
   ReconcileController get controller => widget.controller;
 
   @override
@@ -364,12 +401,15 @@ class _ActionsBodyState extends State<_ActionsBody>
   }
 
   /// Rebuilds for the newly-selected family and — when the family actually
-  /// changed — drops the selection, which belongs to the list being left behind.
+  /// changed — drops the selection and any armed cohort, both of which belong
+  /// to the list being left behind. A cohort is single-family by construction
+  /// (its key leads with the family), so it would review an empty list here.
   void _onTabChanged() {
     final index = _tabs.index;
     if (index != _shownIndex) {
       _shownIndex = index;
       _selectedId = null;
+      _cohortKey = null;
     }
     if (mounted) setState(() {});
   }
@@ -422,7 +462,26 @@ class _ActionsBodyState extends State<_ActionsBody>
   /// one another: the switch keeps the accounts with work, the search keeps the
   /// names asked for, the system filter keeps the rows that system has something
   /// to say about.
-  List<_AccountRow> _visibleRows(List<_AccountRow> rows) {
+  ///
+  /// A cohort under review (#296) replaces all three instead of composing with
+  /// them — that is what "the list shows you the cohort" means. The N on the
+  /// button counts the school, so a search or a system chip left over from a
+  /// moment ago must not quietly hide members of the very list the operator is
+  /// being asked to confirm. The controls are off screen while it is armed, so
+  /// there is nothing to look inert.
+  List<_AccountRow> _visibleRows(
+    List<_AccountRow> rows,
+    SituationCohort? cohort,
+  ) {
+    if (cohort != null) {
+      final members = <String>{
+        for (final d in cohort.decisions) d.entry.targetId,
+      };
+      return <_AccountRow>[
+        for (final r in rows)
+          if (members.contains(r.id)) r,
+      ];
+    }
     final NameQuery query = _query;
     final core.Origin? origin = _system.origin;
     return <_AccountRow>[
@@ -433,6 +492,23 @@ class _ActionsBodyState extends State<_ActionsBody>
                 r.stateFor(origin) != SystemIndicatorState.inOrder))
           r,
     ];
+  }
+
+  /// The cohort the screen is reviewing, re-read by key from the controller on
+  /// every build (#296) — `null` when nothing is armed, and also when the armed
+  /// cohort has emptied out from under the review.
+  SituationCohort? _armedCohort() {
+    final key = _cohortKey;
+    if (key == null) return null;
+    return controller.applyToAllCohortFor(key);
+  }
+
+  /// Arms the school-wide review of [decision]: the list narrows to its cohort
+  /// and the banner takes over from the list controls. Nothing is written.
+  void _armCohort(PendingDecision decision) {
+    final cohort = controller.applyToAllCohort(decision);
+    if (cohort == null) return;
+    setState(() => _cohortKey = cohort.key);
   }
 
   @override
@@ -454,8 +530,9 @@ class _ActionsBodyState extends State<_ActionsBody>
   Widget _body(BuildContext context, BoxConstraints constraints) {
     final bool wide = constraints.maxWidth >= _splitBreakpoint;
     final bool active = controller.linked != null;
+    final SituationCohort? cohort = active ? _armedCohort() : null;
     final rows = active ? _rows() : const <_AccountRow>[];
-    final visible = _visibleRows(rows);
+    final visible = _visibleRows(rows, cohort);
     // A selection the current filters have hidden is not a selection any more:
     // the operator cannot see what they would be acting on.
     final _AccountRow? selected = _selectedRow(visible);
@@ -472,6 +549,7 @@ class _ActionsBodyState extends State<_ActionsBody>
           child: _ActionsHeader(
             controller: controller,
             onlyWithActions: _onlyWithActions,
+            reviewingCohort: cohort != null,
           ),
         ),
         const SizedBox(height: PlinkSpacing.s4),
@@ -499,16 +577,25 @@ class _ActionsBodyState extends State<_ActionsBody>
               head,
               Padding(
                 padding: _hPad,
-                child: _ListControls(
-                  searchController: _search,
-                  onlyWithActions: _onlyWithActions,
-                  onOnlyWithActionsChanged: (v) =>
-                      setState(() => _onlyWithActions = v),
-                  sort: _sort,
-                  onSortChanged: (v) => setState(() => _sort = v),
-                  system: _system,
-                  onSystemChanged: (v) => setState(() => _system = v),
-                ),
+                // The two are exclusive: while a cohort is under review the
+                // list is *that cohort*, so controls that would narrow it
+                // further would either lie about N or do nothing.
+                child: cohort == null
+                    ? _ListControls(
+                        searchController: _search,
+                        onlyWithActions: _onlyWithActions,
+                        onOnlyWithActionsChanged: (v) =>
+                            setState(() => _onlyWithActions = v),
+                        sort: _sort,
+                        onSortChanged: (v) => setState(() => _sort = v),
+                        system: _system,
+                        onSystemChanged: (v) => setState(() => _system = v),
+                      )
+                    : _CohortReviewBanner(
+                        controller: controller,
+                        cohort: cohort,
+                        onDisarm: () => setState(() => _cohortKey = null),
+                      ),
               ),
               const SizedBox(height: PlinkSpacing.s3),
               Padding(
@@ -669,7 +756,11 @@ class _ActionsBodyState extends State<_ActionsBody>
               style: text.bodyMedium,
             )
           else
-            _AccountDetail(controller: controller, row: selected),
+            _AccountDetail(
+              controller: controller,
+              row: selected,
+              onApplyToAll: _armCohort,
+            ),
           ..._resultSections(),
           const SizedBox(height: PlinkSpacing.s6),
         ],
@@ -712,14 +803,17 @@ class _ActionsBodyState extends State<_ActionsBody>
 /// safe reading of that: the operator had seen none of the changes, and at a
 /// September changeover the count behind the button is in the thousands. Its
 /// confirmation named systems and a number, which is not the same as having
-/// looked. Bulk itself is not gone for good — #296 gives it back with the cohort
-/// on screen first — but the affordance that applied what nobody had read is.
+/// looked. Bulk itself is not gone — #296 put it back on the decision block,
+/// where pressing it filters the list to the cohort and shows the operator the
+/// accounts before offering a confirmation — but the affordance that applied
+/// what nobody had read is.
 ///
 /// The count line stays. It states how much work exists; it is not a button.
 class _ActionsHeader extends StatelessWidget {
   const _ActionsHeader({
     required this.controller,
     required this.onlyWithActions,
+    this.reviewingCohort = false,
   });
 
   final ReconcileController controller;
@@ -727,6 +821,11 @@ class _ActionsHeader extends StatelessWidget {
   /// Whether the work-list filter is on, so the sub-line describes the list the
   /// operator is actually looking at.
   final bool onlyWithActions;
+
+  /// Whether a school-wide cohort is under review (#296), in which case neither
+  /// reading of [onlyWithActions] describes the list: it is one decision's
+  /// cohort, and the banner right below says so.
+  final bool reviewingCohort;
 
   @override
   Widget build(BuildContext context) {
@@ -745,11 +844,14 @@ class _ActionsHeader extends StatelessWidget {
         Text('Acties', style: text.headlineMedium),
         const SizedBox(height: PlinkSpacing.s2),
         Text(
-          switch ((count, onlyWithActions)) {
-            (0, _) => 'Geen openstaande acties.',
-            (_, true) => '$count openstaande actie(s) — de lijst toont enkel '
-                'accounts met werk.',
-            (_, false) => '$count openstaande actie(s) — de lijst toont elk '
+          switch ((count, reviewingCohort, onlyWithActions)) {
+            (0, _, _) => 'Geen openstaande acties.',
+            (_, true, _) => '$count openstaande actie(s) — de lijst toont de '
+                'accounts van één beslissing.',
+            (_, _, true) =>
+              '$count openstaande actie(s) — de lijst toont enkel '
+                  'accounts met werk.',
+            (_, _, false) => '$count openstaande actie(s) — de lijst toont elk '
                 'account. Drie groene vinkjes betekent dat het account overal '
                 'juist staat.',
           },
@@ -860,6 +962,122 @@ class _ListControls extends StatelessWidget {
         ),
       ],
     );
+  }
+}
+
+/// The cohort under school-wide review (#296): what the one armed decision is,
+/// how many accounts in the school raise it, and the two passes that cover
+/// exactly them — plus the way out.
+///
+/// It stands where [_ListControls] normally stands, and that placement is the
+/// design. The list below it *is* the cohort, so this reads as a caption of the
+/// rows the operator is scrolling rather than as a floating button whose scope
+/// has to be taken on trust. It is the answer to the "Alles toepassen" of #294:
+/// the same power, but the list is filtered to what will be written and the
+/// operator is standing in front of it before a dialog is ever offered.
+///
+/// Both passes run over the very cohort this banner counted — the standing rule
+/// since #252 — and that cohort is re-read from the controller on every build,
+/// so an alternative switched mid-review moves the account out of the list, out
+/// of N, out of the confirmation's change count and out of the write together.
+class _CohortReviewBanner extends StatelessWidget {
+  const _CohortReviewBanner({
+    required this.controller,
+    required this.cohort,
+    required this.onDisarm,
+  });
+
+  final ReconcileController controller;
+  final SituationCohort cohort;
+
+  /// Leaves the review and gives the list its own controls back.
+  final VoidCallback onDisarm;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final int count = cohort.length;
+
+    return Container(
+      key: const ValueKey('actions-cohort-banner'),
+      padding: const EdgeInsets.all(PlinkSpacing.s4),
+      decoration: BoxDecoration(
+        color: colors.primary.withValues(alpha: 0.06),
+        border: Border.all(color: colors.primary),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            '${cohort.label} — $count account(s) in de hele school',
+            style: text.titleSmall,
+          ),
+          const SizedBox(height: PlinkSpacing.s1),
+          Text(
+            'De lijst toont enkel deze accounts. Bekijk ze en bevestig '
+            'hieronder; elk account krijgt zijn eigen gekozen oplossing.',
+            style: text.bodySmall,
+          ),
+          const SizedBox(height: PlinkSpacing.s3),
+          Wrap(
+            spacing: PlinkSpacing.s2,
+            runSpacing: PlinkSpacing.s2,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: <Widget>[
+              TextButton(
+                key: const ValueKey('actions-cohort-cancel'),
+                onPressed: controller.busy ? null : onDisarm,
+                child: const Text('Annuleer'),
+              ),
+              OutlinedButton(
+                key: const ValueKey('actions-cohort-dry-run'),
+                onPressed: controller.busy
+                    ? null
+                    : () => runWithProgress(
+                          context,
+                          controller: controller,
+                          dry: true,
+                          // Nothing is written, so the review survives it: the
+                          // dry-run is what the operator reads before pressing
+                          // the one beside it.
+                          run: () =>
+                              controller.dryRunDecisions(cohort.decisions),
+                        ),
+                child: const Text('Dry-run alles'),
+              ),
+              FilledButton(
+                key: const ValueKey('actions-cohort-apply'),
+                onPressed: controller.busy ? null : () => _apply(context),
+                child: Text('Alles toepassen ($count)'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Confirms, runs, and — only when the pass really ran — leaves the review.
+  ///
+  /// A cancelled confirmation must put the operator back exactly where they
+  /// were, still looking at the cohort. A finished pass has invalidated it:
+  /// every decision it wrote settles out of the refreshed view, so what is left
+  /// is the failures, and re-arming from a card is how they are picked up.
+  Future<void> _apply(BuildContext context) async {
+    final ran = await confirmAndApply(
+      context,
+      controller: controller,
+      // The count and the noun the banner just showed, so the dialog is
+      // recognisably about the list behind it.
+      title: 'Toepassen op ${cohort.length} account(s)?',
+      // Scoped to this one decision across the cohort (#292): summing every
+      // decision on every card would quote writes this pass will not make.
+      scope: controller.applyScopeForDecisions(cohort.decisions),
+      apply: () => controller.applyDecisions(cohort.decisions),
+    );
+    if (ran) onDisarm();
   }
 }
 
@@ -1027,10 +1245,17 @@ class _SystemRow extends StatelessWidget {
 /// made those blocks stand on their own precisely so this pane could reuse them
 /// with no collapsed row above to have previewed anything.
 class _AccountDetail extends StatelessWidget {
-  const _AccountDetail({required this.controller, required this.row});
+  const _AccountDetail({
+    required this.controller,
+    required this.row,
+    required this.onApplyToAll,
+  });
 
   final ReconcileController controller;
   final _AccountRow row;
+
+  /// What a decision block's "Toepassen op alle (N)" arms (#296).
+  final void Function(PendingDecision decision) onApplyToAll;
 
   @override
   Widget build(BuildContext context) {
@@ -1066,7 +1291,12 @@ class _AccountDetail extends StatelessWidget {
             style: text.bodyMedium,
           )
         else
-          ...entryDetail(context, controller: controller, entry: entry),
+          ...entryDetail(
+            context,
+            controller: controller,
+            entry: entry,
+            onApplyToAll: onApplyToAll,
+          ),
       ],
     );
   }

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -156,6 +156,43 @@ export 'action_tiles.dart' show applyConfirmationMessage, systemLabel;
 /// settled them — and when the family tab changes, because both make the set
 /// name accounts that are no longer the list.
 ///
+/// ## Where an apply leaves the operator (#299)
+///
+/// Standing exactly where they were, reading what the pass did. That takes two
+/// things, and the screen owns only the second.
+///
+/// The **refresh** is the controller's: `_applyOne` swaps in the view relinked
+/// after every write and the derived lists are keyed on its identity, so a row's
+/// indicators, its badge and the details pane's decisions all re-render in place
+/// from the settled state, with no re-selection and no sync. What #299 added
+/// there is that a pass pins those lists for its duration and drops them once at
+/// the end — a rollover writes thousands of accounts and notifies per write, and
+/// re-deriving the school between two writes is time spent on a list nobody can
+/// read behind the modal.
+///
+/// The **list** is this screen's. An apply settles what it lands, so the account
+/// just applied stops matching "toon enkel accounts met acties" and would drop
+/// out the instant the pass ends — taking the selection, the open pane and the
+/// verdict with it. So the pass's targets are held through the state filters
+/// until the operator looks away, marked **Toegepast** when nothing is left on
+/// them, and the pane keeps rendering the account's own verdict even once its
+/// entry is gone.
+///
+/// That hold is not a filter and must never behave like one, so every control
+/// that reshapes the list drops it: the sort, the work switch, the system chips,
+/// the search box, a family tab change, and selecting an account the pass did
+/// not touch. Selecting one it *did* keeps it — a bulk pass settles many
+/// accounts and reading the second must not delete the first out from under the
+/// tap. A sync drops it on its own, the pass that replaces the view being the
+/// same one that clears the results the hold is read from.
+///
+/// The case that decides all of it is the half-succeeded pass, which is where
+/// #272 came from: Smartschool takes the write, Graph refuses the other half.
+/// The account keeps the refused decision, so it stays on the list under its own
+/// steam, its card shows the refusal under the question it answers (#283) and
+/// the landed half at card level. Nothing about that reads as a clean success,
+/// which is the whole point.
+///
 /// ## What it deliberately does not do
 ///
 /// Nothing here applies an action the operator has not seen. The header's global
@@ -446,6 +483,30 @@ class _ActionsBodyState extends State<_ActionsBody>
   /// frame is already building.
   LinkedState? _tickedView;
 
+  /// The accounts the last apply pass wrote to, by id — the rows the list holds
+  /// on screen for a moment longer than the filter would (#299).
+  ///
+  /// An apply settles what it lands, so an account whose work is finished stops
+  /// matching "toon enkel accounts met acties" and would drop out of the list
+  /// the instant the pass ends — taking the selection, the open details pane
+  /// and the verdict the operator was waiting for with it. Worse when the pass
+  /// half-succeeds: the reported case behind #272 is a class whose Smartschool
+  /// write landed and whose Office 365 write was refused, and a row that
+  /// vanishes on the strength of the half that worked makes a refusal read as a
+  /// clean success.
+  ///
+  /// So the pass's targets are held through the filters until the operator
+  /// looks away — see [_forgetSettled] for exactly when that is. Ids, for the
+  /// reason [_selectedId] and [_ticked] are ids: the rows are rebuilt from the
+  /// refreshed view underneath them.
+  final Set<String> _settled = <String>{};
+
+  /// The results list [_settled] was taken from, so it is re-read exactly once
+  /// per pass. `_begin` nulls the results when any pass starts and the tail of
+  /// the pass installs the new list, so an identity check covers both halves:
+  /// the hold is dropped when a pass begins and re-armed from what it wrote.
+  List<ActionOutcomeEntry>? _settledFrom;
+
   ReconcileController get controller => widget.controller;
 
   @override
@@ -468,7 +529,9 @@ class _ActionsBodyState extends State<_ActionsBody>
   }
 
   void _onSearchChanged() {
-    if (mounted) setState(() {});
+    // Typing a name is the operator moving on, so the rows the last pass is
+    // holding on screen let go (#299).
+    if (mounted) setState(_forgetSettled);
   }
 
   /// Rebuilds for the newly-selected family and — when the family actually
@@ -484,6 +547,8 @@ class _ActionsBodyState extends State<_ActionsBody>
       // The ticks name accounts of the family being left behind, and a pass is
       // single-family anyway (#297).
       _clearTicks();
+      // …as do the rows the last pass is holding on screen (#299).
+      _forgetSettled();
     }
     if (mounted) setState(() {});
   }
@@ -507,6 +572,43 @@ class _ActionsBodyState extends State<_ActionsBody>
     if (identical(_tickedView, view)) return;
     _tickedView = view;
     _clearTicks();
+  }
+
+  /// Re-reads [_settled] off the last pass's results (#299), at the top of
+  /// [_body] and for the same reasons [_retireStaleTicks] sits there.
+  ///
+  /// The whole pass, not only the accounts that came out clean: one that failed
+  /// still has work and stays visible on its own, and one whose card now shows
+  /// a refusal beside a success is exactly the row that must not move.
+  ///
+  /// Group results are dropped — a class is a Klasgroepen row, and its id is a
+  /// display label rather than an account id, so keeping it could only ever
+  /// collide with one.
+  void _holdSettled() {
+    final List<ActionOutcomeEntry>? results = controller.applyResults;
+    if (identical(_settledFrom, results)) return;
+    _settledFrom = results;
+    _settled.clear();
+    if (results == null) return;
+    for (final r in results) {
+      if (r.family != 'group' && r.targetId.isNotEmpty) {
+        _settled.add(r.targetId);
+      }
+    }
+  }
+
+  /// Lets the held rows go (#299) — they are a courtesy to the operator reading
+  /// a verdict, not a second filter, so they must clear reliably or a long
+  /// session accumulates settled rows in a list that claims to show work.
+  ///
+  /// Called from every control that says the operator has moved on: a sort, the
+  /// work switch, the system chips, the search box, a family tab change, and
+  /// selecting an account that is not itself one of the held ones. A sync
+  /// clears it too, through [_holdSettled] — the pass that replaces the view
+  /// nulls the results the hold is read from.
+  void _forgetSettled() {
+    if (_settled.isEmpty) return;
+    _settled.clear();
   }
 
   /// Ticks or unticks one account (#297).
@@ -609,10 +711,17 @@ class _ActionsBodyState extends State<_ActionsBody>
     final core.Origin? origin = _system.origin;
     return <_AccountRow>[
       for (final r in rows)
-        if ((!_onlyWithActions || r.hasWork) &&
-            query.matches(r.searchText) &&
-            (origin == null ||
-                r.stateFor(origin) != SystemIndicatorState.inOrder))
+        // A row the last pass just settled is exempt from both *state* filters
+        // — the work switch and the system chip, which are two readings of
+        // "does this need doing?" and are exactly what an apply has just
+        // answered (#299). Never from the search: that one is about who the
+        // account is, and a needle that no longer matches was typed after the
+        // pass, which drops the hold anyway.
+        if ((_settled.contains(r.id) ||
+                ((!_onlyWithActions || r.hasWork) &&
+                    (origin == null ||
+                        r.stateFor(origin) != SystemIndicatorState.inOrder))) &&
+            query.matches(r.searchText))
           r,
     ];
   }
@@ -661,6 +770,7 @@ class _ActionsBodyState extends State<_ActionsBody>
 
   Widget _body(BuildContext context, BoxConstraints constraints) {
     _retireStaleTicks();
+    _holdSettled();
     final bool wide = constraints.maxWidth >= _splitBreakpoint;
     final bool active = controller.linked != null;
     final SituationCohort? cohort = active ? _armedCohort() : null;
@@ -726,12 +836,23 @@ class _ActionsBodyState extends State<_ActionsBody>
                     ? _ListControls(
                         searchController: _search,
                         onlyWithActions: _onlyWithActions,
-                        onOnlyWithActionsChanged: (v) =>
-                            setState(() => _onlyWithActions = v),
+                        // Every one of the three reshapes the list, which is
+                        // the operator saying they are done reading the last
+                        // pass — so each lets the held rows go (#299).
+                        onOnlyWithActionsChanged: (v) => setState(() {
+                          _onlyWithActions = v;
+                          _forgetSettled();
+                        }),
                         sort: _sort,
-                        onSortChanged: (v) => setState(() => _sort = v),
+                        onSortChanged: (v) => setState(() {
+                          _sort = v;
+                          _forgetSettled();
+                        }),
                         system: _system,
-                        onSystemChanged: (v) => setState(() => _system = v),
+                        onSystemChanged: (v) => setState(() {
+                          _system = v;
+                          _forgetSettled();
+                        }),
                       )
                     : _CohortReviewBanner(
                         controller: controller,
@@ -883,9 +1004,18 @@ class _ActionsBodyState extends State<_ActionsBody>
         return _AccountListRow(
           row: row,
           selected: identical(row, selected),
-          onTap: () => setState(() => _selectedId = row.id),
+          onTap: () => setState(() {
+            // Moving to an account the last pass did not touch is the operator
+            // done with its results, so the held rows go (#299). Moving to one
+            // it *did* keeps them: a bulk pass settles many accounts at once
+            // and reading the second must not delete the first from under the
+            // tap that opened it.
+            if (!_settled.contains(row.id)) _forgetSettled();
+            _selectedId = row.id;
+          }),
           ticked: _ticked.contains(row.id),
           onTicked: ticking ? (v) => _setTicked(row.id, v) : null,
+          justApplied: _settled.contains(row.id),
         );
       },
     );
@@ -1573,6 +1703,7 @@ class _AccountListRow extends StatelessWidget {
     required this.onTap,
     this.ticked = false,
     this.onTicked,
+    this.justApplied = false,
   });
 
   final _AccountRow row;
@@ -1581,6 +1712,15 @@ class _AccountListRow extends StatelessWidget {
 
   /// Whether this row is in the multi-select (#297).
   final bool ticked;
+
+  /// Whether the last apply pass wrote to this account (#299) — which is why
+  /// the row may be here at all with nothing left to do.
+  ///
+  /// It gets a marker rather than being left to the badge's muted tick, because
+  /// that tick is also what an account that was in order all along shows, and
+  /// the difference between "nothing to do here" and "this is what you just
+  /// did" is the whole reason the row is being held.
+  final bool justApplied;
 
   /// Ticks/unticks the row, or `null` when this list offers no ticking at all —
   /// which is what a cohort under review is, its list being the review's own.
@@ -1648,6 +1788,25 @@ class _AccountListRow extends StatelessWidget {
                   ),
                   const SizedBox(width: PlinkSpacing.s2),
                   Text(row.account.classroom, style: text.bodySmall),
+                  // Only once the work is gone: a pass that half-failed leaves
+                  // the row with its remaining decisions, and calling that
+                  // "toegepast" is the misreading #299 is written against.
+                  if (justApplied && !row.hasWork) ...<Widget>[
+                    const SizedBox(width: PlinkSpacing.s2),
+                    Row(
+                      key: ValueKey('account-done-${row.id}'),
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        Icon(Icons.task_alt, size: 14, color: colors.primary),
+                        const SizedBox(width: PlinkSpacing.s1),
+                        Text(
+                          'Toegepast',
+                          style:
+                              text.bodySmall?.copyWith(color: colors.primary),
+                        ),
+                      ],
+                    ),
+                  ],
                   const SizedBox(width: PlinkSpacing.s2),
                   PendingBadge(count: row.pendingCount),
                 ],
@@ -1749,12 +1908,13 @@ class _AccountDetail extends StatelessWidget {
           Text(w, style: text.bodySmall),
         ],
         const SizedBox(height: PlinkSpacing.s3),
-        if (entry == null)
+        if (entry == null) ...<Widget>[
           Text(
             'Geen openstaande beslissingen voor dit account.',
             style: text.bodyMedium,
-          )
-        else
+          ),
+          ..._settledVerdict(),
+        ] else
           ...entryDetail(
             context,
             controller: controller,
@@ -1763,6 +1923,32 @@ class _AccountDetail extends StatelessWidget {
           ),
       ],
     );
+  }
+
+  /// What the last pass did to an account it left with nothing to decide
+  /// (#299) — the verdict block [entryDetail] would have shown at card level,
+  /// for the card that no longer exists.
+  ///
+  /// The ordinary end of a successful apply, and the moment the operator most
+  /// wants to read: their work settled every decision, so the entry that
+  /// carried them is gone and with it every route to the verdict except the
+  /// page-level results section — which reports the whole *pass*, and in a
+  /// rollover is hundreds of rows deep. Keyed exactly as the card-level block
+  /// is, because it is the same block about the same account.
+  List<Widget> _settledVerdict() {
+    final String family = row.account.isStaff ? 'staff' : 'student';
+    final outcomes = controller.applyOutcomesForTarget(
+      family: family,
+      targetId: row.id,
+    );
+    if (outcomes.isEmpty) return const <Widget>[];
+    return <Widget>[
+      EntryOutcomes(
+        keyValue: 'entry-outcomes-$family-${row.id}',
+        outcomes: outcomes,
+        settled: true,
+      ),
+    ];
   }
 }
 

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -1,13 +1,8 @@
 import 'dart:async';
 
 import 'package:account_actions/account_actions.dart' as actions;
-import 'package:account_state/account_state.dart'
-    show
-        MaterializedAccount,
-        Rollup,
-        RollupLevel,
-        candidateChoices,
-        pendingDecisionCount;
+import 'package:account_core/account_core.dart' as core;
+import 'package:account_state/account_state.dart' show MaterializedAccount;
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
@@ -20,67 +15,99 @@ import 'action_tiles.dart';
 // a screen of its own (#227); re-exported so they stay importable from here.
 export 'action_tiles.dart' show applyConfirmationMessage, systemLabel;
 
-/// The Actions view (#154): the pending-actions browser, split off the
-/// Reconcile screen so a September changeover's hundreds/thousands of tiles no
-/// longer render inline on one very long page.
+/// The Actions view (#154/#295): one flat, sortable list of accounts on the
+/// left and the selected account's decisions on the right.
 ///
-/// Instead of one flat list, actions are browsed through the rollup drill-down
-/// (#119) — grade-year → classroom for students since #210 dropped the
-/// administrative school level, school → grade-year → classroom for staff: the
-/// tree loads only the aggregate counts, and one classroom's actions are lazily
-/// loaded (via `LinkedStore.readClassroom`) and built only when the operator
-/// drills into it.
-/// The per-class list itself renders through a lazy [SliverList] so only the
-/// on-screen tiles build. Every apply starts from something the operator has
-/// opened — one card, or one decision across the cohort shown above it; the
-/// header's global "Dry-run alles" / "Alles toepassen" pair was removed in #294
-/// precisely because it did not.
+/// ## Why it is flat
 ///
-/// One view-wide switch above the family tab bar — "toon enkel accounts met
-/// acties", on by default — collapses all of that to the work list (#226):
-/// grade-years and classrooms with nothing pending are not rendered, and an
-/// opened classroom lists only accounts with a pending action. What it holds
-/// back is counted and named, so a year the operator expected is explained
-/// rather than merely absent.
+/// It used to browse jaar → klas → account (#119/#210), for two reasons, and
+/// neither survives. The first was rendering cost — a September changeover
+/// produces thousands of tiles — which a lazy [ListView] answers just as well as
+/// a tree does. The second was the read strategy: `LinkedStore` offers
+/// `readRollups()` and `readClassroom()` and nothing else, so a session that had
+/// not synced genuinely could only hold one classroom partition at a time.
+/// Since #287 every session adopts the shared linked view at startup, so the
+/// whole roster is in memory and `pendingEntries` / `linkedAccounts` are both
+/// school-wide.
 ///
-/// The tree is a single-open accordion whose open path outlives the detail view
-/// (#235): drilling into a class and pressing **Overzicht** comes back to the
-/// grade-year it was opened from, and opening another year closes the one that
-/// was open. The path is held on the [ReconcileController], because while a
-/// class is open the tree is not built at all.
+/// What was left was a browsing structure costing two clicks per class to answer
+/// questions that are not per-class: *who is leaving?*, *who is missing from
+/// Office 365?*, *who needs the class change?* Sorting and filtering answer
+/// those; a tree does not.
 ///
-/// Class groups are **not** here. The "Klasgroepen" node used to hang under the
-/// Leerlingen tree and open the classes that raised something; since #227 that
-/// is a top-level tab listing every class, which is a superset of what this node
-/// showed — so it left rather than being maintained in two places.
+/// ## The two questions #295 left open, and how they were settled
 ///
-/// A session with no linked view — passive, or one whose pass failed before it
-/// linked — can only show the stored documents, so both drill-downs say so out
-/// loud rather than quietly swapping in static cards (#214).
+/// **"Sort by system" is a filter, not a sort.** A tri-state indicator has no
+/// meaningful order — green before orange before red is one arbitrary ranking of
+/// six, and sorting by it buries the rows the operator was looking for among the
+/// ones they were not. What they actually mean is *show me everyone with
+/// Smartschool work*, so that is what [_SystemFilter] does: it keeps the rows
+/// whose cell for that one system is **not** green, which answers "who is
+/// missing from Office 365?" and "who has Smartschool work?" with the same
+/// control. Sorting is therefore by name or by class ([_ActionSort]) — the two
+/// orders that really do order — and both the sort and the filter outlive a
+/// selection, because they describe the list and not the row.
 ///
-/// Every action line names the system it writes to (#298): one card can raise
-/// work in two systems and the summaries do not always say where they land. The
-/// three-way system indicator that reads *needs work* rather than *exists*
-/// arrives with the flat list of #295; its vocabulary — and the principle it
-/// shares with Klasgroepen — already lives in `system_indicator.dart`.
+/// **The split folds at [_splitBreakpoint].** Above it the list and the details
+/// sit side by side, which is the layout the screen is for. Below it there is
+/// not enough width for two readable columns — the details pane carries field
+/// diffs and radio labels, so squeezing it wraps every line — so the panes
+/// become one: the list fills the width, selecting a row replaces it with the
+/// details, and **Overzicht** comes back. Measured off the pane's own
+/// constraints rather than the window's, so the navigation rail is already
+/// accounted for.
+///
+/// ## What a row says
+///
+/// The display name, the class, a pending badge, and the three system
+/// indicators — WISA · Smartschool · Office 365 — in the shared vocabulary of
+/// #298: red missing, orange work pending, green in order. That vocabulary lives
+/// in `system_indicator.dart` and is the same one Klasgroepen's rows speak, so a
+/// coloured cell means one thing across the app.
 ///
 /// **Colour by work that can be done on this screen.** Klasgroepen highlights a
 /// row on `MaterializedGroup.needsAttention`, informational notices included
-/// (#225/#250), because there the manual notice *is* the work the operator
-/// does on that screen. Here an informational candidate is a diagnosis of work
-/// that happens elsewhere, so it colours nothing, raises no badge and puts no
-/// row in the work list — `pendingDecisionCount` has counted it zero since
-/// #245/#255, and the indicators apply that same predicate. The case that
-/// forces the rule is `AzureClassGroupMembership`: Office 365 class membership
-/// is a property of the group, so the write is one `SyncAzureClassGroupMembers`
-/// per class on Klasgroepen. Colouring it here would paint ~3000 student rows
-/// orange at the rollover for work this screen structurally cannot do. (#290
-/// proposed the opposite and was closed; the action still declares
-/// `canApply => false`.)
+/// (#225/#250), because there the manual notice *is* the work the operator does
+/// on that screen. Here an informational candidate is a diagnosis of work that
+/// happens elsewhere, so it colours nothing, raises no badge and puts no row in
+/// the work list — `pendingDecisionCount` has counted it zero since #245/#255,
+/// and the indicators apply that same predicate. The case that forces the rule
+/// is `AzureClassGroupMembership`: Office 365 class membership is a property of
+/// the group, so the write is one `SyncAzureClassGroupMembers` per class on
+/// Klasgroepen. Colouring it here would paint ~3000 student rows orange at the
+/// rollover for work this screen structurally cannot do. (#290 proposed the
+/// opposite and was closed; the action still declares `canApply => false`.)
+///
+/// ## What the details pane shows
+///
+/// [entryDetail] — the very blocks #281/#283 built and #300 made self-sufficient
+/// — so every decision on the account leads with its own heading, then its field
+/// diff (or radios), then the verdict of the last pass that answers *that*
+/// decision. Reused rather than reinvented: Klasgroepen renders the identical
+/// blocks inside its expandable rows, and two screens wording one decision two
+/// ways is how an operator stops trusting either.
+///
+/// ## What it deliberately does not do
+///
+/// Nothing here applies an action the operator has not seen. The header's global
+/// "Dry-run alles" / "Alles toepassen" pair went in #294 for exactly that
+/// reason, and the flat list adds no replacement: the only apply is the per-card
+/// pair inside the open details pane. School-wide bulk apply with its cohort
+/// visible first is #296, and checkbox multi-select is #297.
+///
+/// A session that #287 refuses to seed gets one blocking [ReadOnlyNotice] and no
+/// list at all. The old screen offered a read-only browse of the stored
+/// documents instead (#214); that was a second, inert way to browse the same
+/// data, and the whole point of the notice is that there is one thing to do
+/// about it.
+///
+/// Class groups are **not** here. They are a top-level Klasgroepen tab since
+/// #227 — a full class inventory, which is a superset of what an Acties node
+/// could show.
 ///
 /// Shares the one memoized [ReconcileServices] (and so the one
-/// [ReconcileController]) with the Reconcile and Passwords screens, so a sync
-/// run on Reconcile populates the actions shown here.
+/// [ReconcileController]) with the Reconcile, Klasgroepen and Passwords screens,
+/// so a sync run on Reconcile populates the actions shown here.
 class ActionsScreen extends StatefulWidget {
   const ActionsScreen({super.key, required this.bootstrap});
 
@@ -167,50 +194,96 @@ class _ActionsScreenState extends State<ActionsScreen> {
 
 /// The two family tabs (#179): staff and student actions are reviewed as
 /// separate workflows, so the Actions view splits them across a horizontal tab
-/// bar rather than one combined rollup. Index order matches the Reconcile
+/// bar rather than one combined list. Index order matches the Reconcile
 /// overview's category order (Leerlingen, then Personeel).
 enum _ActionFamilyTab { leerlingen, personeel }
 
-/// One family tab's drill-down after the global "toon enkel accounts met acties"
-/// filter has been applied (#226): the nodes that survive, plus a count of what
-/// it removed so the tree can say why a year is missing rather than silently
-/// shrinking.
-class _FilteredTree {
-  const _FilteredTree({
-    required this.roots,
-    required this.hidden,
-  });
+/// How the flat list is ordered (#295).
+///
+/// Two orders, because two things about an account order meaningfully: who they
+/// are, and where they sit. "By system" is not a third — see the class doc of
+/// [ActionsScreen] and [_SystemFilter].
+enum _ActionSort {
+  naam('Naam'),
+  klas('Klas');
 
-  /// The top-level accordion nodes still worth rendering.
-  final List<Rollup> roots;
+  const _ActionSort(this.label);
 
-  /// How many nodes disappeared from what the tree would otherwise show —
-  /// counted as the operator would browse it, so a hidden year counts once
-  /// rather than once per classroom inside it.
-  final int hidden;
+  final String label;
 }
 
-/// The seam the drill-down's expandable nodes are driven through (#235): where
-/// a node's persistent [ExpansibleController] comes from, whether it is the open
-/// one at its depth, and where a tap on it is recorded.
+/// Which system's trouble the list is narrowed to (#295) — the half of "sort by
+/// system" that is actually useful, expressed as what it is.
 ///
-/// Passed down rather than reached for, so [_DrillDownSection] and [_GradeNode]
-/// stay the stateless projections of the rollups they already were — the open
-/// path itself lives on the [ReconcileController], one level above the tree.
-class _Accordion {
-  const _Accordion({
-    required this.controllerFor,
-    required this.isOpen,
-    required this.onToggled,
-  });
+/// A row survives when its cell for that system is not green: it is missing
+/// there, or this screen has applyable work against it. That is one control for
+/// both of the questions the drill-down could not answer — *who is missing from
+/// Office 365?* and *who has Smartschool work?*
+enum _SystemFilter {
+  alle('Alle', null),
+  wisa('WISA', core.Origin.wisa),
+  smartschool('Smartschool', core.Origin.smartschool),
+  azure('Office 365', core.Origin.azure);
 
-  final ExpansibleController Function(String node) controllerFor;
+  const _SystemFilter(this.label, this.origin);
 
-  /// Whether [node] is the open node at that depth of the tree — 0 for a
-  /// top-level node, 1 for a grade-year nested under the staff school.
-  final bool Function(String node, int depth) isOpen;
+  final String label;
 
-  final void Function(String node, int depth, bool open) onToggled;
+  /// The system this filter is about, or `null` for "narrow nothing".
+  final core.Origin? origin;
+}
+
+/// One row of the flat list: the account as a document, plus the live pending
+/// entry for it when it has one.
+///
+/// Both halves, and each answers something the other cannot. The document says
+/// who the account is, which class it sits in and which systems hold it — facts
+/// that are true of an account with nothing to do, which is most of them. The
+/// entry is the work, and is `null` for exactly those.
+class _AccountRow {
+  const _AccountRow({required this.account, this.entry});
+
+  final MaterializedAccount account;
+
+  /// The interactive entry for this account, or `null` when nothing is pending.
+  final PendingAccountEntry? entry;
+
+  String get id => account.id.value;
+
+  /// Whether an apply pass would write anything here — the predicate the
+  /// "toon enkel accounts met acties" switch keeps rows on, and the same one the
+  /// badge counts and the indicators colour by (#245/#255/#298). An entry that
+  /// carries only an informational diagnosis is not work this screen can do.
+  bool get hasWork => entry?.canApply ?? false;
+
+  /// How many applyable decisions the badge quotes.
+  int get pendingCount => entry == null
+      ? 0
+      : entry!.choices.where((c) => c.selected.canApply).length;
+
+  /// The systems this row has applyable work in (#298) — what turns a cell
+  /// orange. Read off the live dispatch, which drops a decision the moment it
+  /// is applied.
+  Set<core.Origin> get workSystems =>
+      entry == null ? const <core.Origin>{} : workSystemsOfEntry(entry!);
+
+  bool presentIn(core.Origin system) => switch (system) {
+        core.Origin.wisa => account.inWisa,
+        core.Origin.smartschool => account.inSmartschool,
+        core.Origin.azure => account.inAzure,
+        _ => true,
+      };
+
+  /// What this row's cell for [system] reads as.
+  SystemIndicatorState stateFor(core.Origin system) => systemIndicatorState(
+        present: presentIn(system),
+        hasWork: workSystems.contains(system),
+      );
+
+  /// What the name search matches against — the display name alone. The class
+  /// has its own control (the sort) and its own column, so folding it into the
+  /// haystack would make "3" match every third-year student.
+  String get searchText => account.label;
 }
 
 class _ActionsBody extends StatefulWidget {
@@ -224,40 +297,46 @@ class _ActionsBody extends StatefulWidget {
 
 class _ActionsBodyState extends State<_ActionsBody>
     with SingleTickerProviderStateMixin {
+  /// Below this many logical pixels of pane width the list and the details stop
+  /// fitting side by side and become one pane with a back button.
+  static const double _splitBreakpoint = 900.0;
+
   late final TabController _tabs;
   int _shownIndex = 0;
 
-  /// The **global** Acties filter (#226), promoted out of the per-classroom bar
-  /// it was born in (#187): with the switch on, everything below it shows only
-  /// what carries an applyable action — grade-year and classroom nodes with a
-  /// zero pending count are not rendered, a grade-year left with no visible
-  /// classroom goes with them, and an opened classroom lists only accounts with
-  /// a pending action.
+  /// The **global** Acties filter (#226): with the switch on, the list holds
+  /// only the accounts carrying an applyable action.
   ///
-  /// One decision per session rather than one per class, so it is deliberately
-  /// **not** reset by a family tab change ([_onTabChanged]): the operator's mode
-  /// outlives whichever tab they happen to be on. Defaults on — the Acties view
-  /// exists to answer "what needs doing?", and the full inventory is the
-  /// exception, not the starting point.
+  /// Defaults on — the Acties view exists to answer "what needs doing?", and the
+  /// full inventory is the exception, not the starting point. Deliberately not
+  /// reset by a family tab change: since #226 it is the view-wide mode, and the
+  /// operator's mode outlives whichever tab they happen to be on.
+  ///
+  /// Since #295 turning it **off** means something it never could before: the
+  /// list then holds every account of the school, in order, three green cells
+  /// each. The drill-down could only ever show the classes and accounts that had
+  /// raised something, because that is all a rollup knew.
   bool _onlyWithActions = true;
 
-  /// The Personeel name search (#187/#217). Unlike [_onlyWithActions] this is a
-  /// per-list lookup, not a mode, so it stays inside the opened classroom and is
-  /// cleared on every family tab change.
+  /// The name search (#187/#217), promoted out of the Personeel classroom list
+  /// it was born in.
+  ///
+  /// It is the list's own lookup now rather than one class's, so — unlike its
+  /// ancestor — it is **not** cleared on a family tab change: the box stays on
+  /// screen across the change, and text vanishing out of a visible box reads as
+  /// a bug rather than as a fresh start.
   final TextEditingController _search = TextEditingController();
 
-  /// One [ExpansibleController] per accordion node the operator has met this
-  /// session, keyed by [_rollupNodeKey] (#235).
+  _ActionSort _sort = _ActionSort.naam;
+  _SystemFilter _system = _SystemFilter.alle;
+
+  /// The selected account's id, or `null` when nothing is selected.
   ///
-  /// An `ExpansionTile` reads [ExpansionTile.initiallyExpanded] once, in its
-  /// `initState`, and thereafter owns its own open/closed state — so nothing
-  /// declarative can close the year that was open when another is tapped, and
-  /// nothing survives the tile being disposed. Both halves of #235 need a handle
-  /// that outlives the tile, which is exactly what an injected controller is:
-  /// held here, it carries a node's expansion across the detail view, and it is
-  /// the one thing that can collapse a sibling on demand.
-  final Map<String, ExpansibleController> _tiles =
-      <String, ExpansibleController>{};
+  /// Held here rather than on the controller — where the drill-down's open
+  /// classroom used to live — because nothing outside this screen needs to know
+  /// it, and because a selection must survive every controller notification a
+  /// running pass emits.
+  String? _selectedId;
 
   ReconcileController get controller => widget.controller;
 
@@ -267,18 +346,10 @@ class _ActionsBodyState extends State<_ActionsBody>
     _tabs = TabController(length: _ActionFamilyTab.values.length, vsync: this)
       ..addListener(_onTabChanged);
     _search.addListener(_onSearchChanged);
-    // Anything that moves the open path without going through a tap — a re-sync
-    // clearing it (#235) — is picked up here and pushed into the tiles.
-    controller.addListener(_syncExpansion);
   }
 
   @override
   void dispose() {
-    controller.removeListener(_syncExpansion);
-    for (final ExpansibleController tile in _tiles.values) {
-      tile.dispose();
-    }
-    _tiles.clear();
     _tabs
       ..removeListener(_onTabChanged)
       ..dispose();
@@ -292,480 +363,345 @@ class _ActionsBodyState extends State<_ActionsBody>
     if (mounted) setState(() {});
   }
 
-  /// The drill-down tree's accordion seam (#235), handed to the widgets that
-  /// build the expandable nodes.
-  _Accordion get _accordion => _Accordion(
-        controllerFor: _tileFor,
-        isOpen: _isNodeOpen,
-        onToggled: _onNodeToggled,
-      );
-
-  /// The persistent controller of one accordion node, created on first render.
-  /// Safe to call from `build`: a controller nobody is listening to yet cannot
-  /// schedule a rebuild.
-  ExpansibleController _tileFor(String node) => _tiles.putIfAbsent(node, () {
-        final ExpansibleController tile = ExpansibleController();
-        if (_isNodeOpenKey(node)) tile.expand();
-        return tile;
-      });
-
-  /// Whether [node] is the open node at [depth] of
-  /// [ReconcileController.expandedPath].
-  bool _isNodeOpen(String node, int depth) {
-    final List<String> path = controller.expandedPath;
-    return path.length > depth && path[depth] == node;
-  }
-
-  bool _isNodeOpenKey(String node) => controller.expandedPath.contains(node);
-
-  /// Records the operator opening or closing one accordion node.
-  ///
-  /// Opening replaces whatever sat at that depth — which is what makes the tree
-  /// single-open — and truncates everything below it, since a node's children
-  /// go away with it. Closing truncates from that depth. The path setter
-  /// notifies, so [_syncExpansion] does the actual collapsing of the sibling
-  /// that just lost its place.
-  void _onNodeToggled(String node, int depth, bool open) {
-    final List<String> path = controller.expandedPath;
-    if (open) {
-      controller.expandedPath = <String>[...path.take(depth), node];
-    } else if (_isNodeOpen(node, depth)) {
-      controller.expandedPath = path.take(depth).toList();
-    }
-  }
-
-  /// Brings every tile controller back in line with the open path. Idempotent —
-  /// [ExpansibleController.expand] / [ExpansibleController.collapse] are no-ops
-  /// on a controller that already agrees — so it is safe to run on every
-  /// controller notification.
-  void _syncExpansion() {
-    if (!mounted) return;
-    final Set<String> open = controller.expandedPath.toSet();
-    for (final MapEntry<String, ExpansibleController> tile in _tiles.entries) {
-      if (open.contains(tile.key)) {
-        tile.value.expand();
-      } else {
-        tile.value.collapse();
-      }
-    }
-  }
-
-  /// Forgets the tail of the open path the global filter has just stopped
-  /// rendering (#226/#235).
-  ///
-  /// Without this, a year the operator opened with the filter off would come
-  /// back open — and, having been invisible in between, unexpectedly so — the
-  /// next time they switched the filter off again.
-  void _pruneExpansion() {
-    final List<String> path = controller.expandedPath;
-    if (path.isEmpty) return;
-    final Set<String> visible = _visibleNodeKeys();
-    var keep = 0;
-    while (keep < path.length && visible.contains(path[keep])) {
-      keep++;
-    }
-    if (keep < path.length) controller.expandedPath = path.take(keep).toList();
-  }
-
-  /// The keys of every accordion node either family tree would render under the
-  /// current filter — both tabs, because the open path outlives a tab change.
-  Set<String> _visibleNodeKeys() {
-    final keys = <String>{
-      for (final root in _studentTree().roots) _rollupNodeKey(root),
-    };
-    for (final root in _staffTree().roots) {
-      keys.add(_rollupNodeKey(root));
-      for (final grade in controller.childrenOf(root.key)) {
-        if (_keepGrade(grade)) keys.add(_rollupNodeKey(grade));
-      }
-    }
-    return keys;
-  }
-
-  /// Whether the Personeel family tab is the selected one — the only tab that
-  /// carries a name search (#187).
-  bool get _staffTab => _tabs.index == _ActionFamilyTab.personeel.index;
-
-  /// The active name search, parsed (empty on any non-Personeel tab, which
-  /// carries no search box).
-  ///
-  /// A single searchbox matches the person's display name ("Voornaam Naam"),
-  /// and since #217 the needle is split on whitespace with every part required
-  /// — the same [NameQuery] the Wachtwoorden → Personeel box uses (#215), so
-  /// the two Personeel searches one tab apart behave identically. Per-part
-  /// matching is what makes either name order work: "peeters jan" finds
-  /// "Jan Peeters", which as one contiguous substring found nobody.
-  NameQuery get _query => NameQuery(_staffTab ? _search.text : '');
-
-  /// The passive-session classroom accounts narrowed by the active filters: the
-  /// "only with actions" toggle keeps just the accounts with an applyable
-  /// candidate (the same `hasPending` predicate the rollup pending counts and
-  /// the tile badge use), and the name search keeps matching display names.
-  List<MaterializedAccount> _filterAccounts(
-      List<MaterializedAccount> accounts) {
-    final query = _query;
-    return [
-      for (final a in accounts)
-        if ((!_onlyWithActions || a.hasPending) && query.matches(a.label)) a,
-    ];
-  }
-
-  /// The active-session pending entries narrowed by the name search. The "only
-  /// with actions" toggle is a no-op here — every pending entry already carries
-  /// an action — so only the search filters (#187).
-  ///
-  /// The cohorts are grouped *from this result* rather than filtered afterwards
-  /// (#292), so a bulk header can only ever cover accounts the search left on
-  /// screen: label, confirmation scope and write come from one list, which is
-  /// the standing rule since #252.
-  List<PendingAccountEntry> _filterEntries(
-    List<PendingAccountEntry> entries,
-  ) {
-    final query = _query;
-    if (query.isEmpty) return entries;
-    return <PendingAccountEntry>[
-      for (final e in entries)
-        if (query.matches(e.target)) e,
-    ];
-  }
-
-  /// Rebuilds the sliver content for the newly-selected family, and — when the
-  /// selected family actually changed — closes any open drill-down so each tab
-  /// opens at its own overview rather than showing the other family's detail.
-  ///
-  /// The name search is cleared, because it is a lookup inside the list that is
-  /// being left behind. [_onlyWithActions] is **not**: since #226 it is the
-  /// view-wide mode, set once above the tab bar, and resetting it here would put
-  /// the switch and the tree it governs out of step on every tab change.
+  /// Rebuilds for the newly-selected family and — when the family actually
+  /// changed — drops the selection, which belongs to the list being left behind.
   void _onTabChanged() {
     final index = _tabs.index;
     if (index != _shownIndex) {
       _shownIndex = index;
-      _search.clear();
-      if (controller.selectedClassroom != null) controller.closeClassroom();
+      _selectedId = null;
     }
     if (mounted) setState(() {});
+  }
+
+  /// Whether the Personeel family tab is the selected one.
+  bool get _staffTab => _tabs.index == _ActionFamilyTab.personeel.index;
+
+  /// The typed needle, parsed. Matching is per whitespace-separated part and
+  /// order-independent — the same [NameQuery] the Wachtwoorden and Klasgroepen
+  /// boxes use (#215/#217/#262), so every search in this app behaves the same.
+  /// Per-part matching is what makes either name order work: "peeters jan"
+  /// finds "Jan Peeters", which as one contiguous substring found nobody.
+  NameQuery get _query => NameQuery(_search.text);
+
+  /// Every account of the selected family, with its live entry joined on — the
+  /// unfiltered list, in the chosen order.
+  List<_AccountRow> _rows() {
+    final byTarget = <String, PendingAccountEntry>{
+      for (final e in controller.pendingEntries)
+        if (e.family != 'group') e.targetId: e,
+    };
+    final rows = <_AccountRow>[
+      for (final doc in controller.linkedAccounts)
+        if (doc.isStaff == _staffTab)
+          _AccountRow(account: doc, entry: byTarget[doc.id.value]),
+    ];
+    rows.sort(_compare);
+    return rows;
+  }
+
+  /// The chosen order, with the name as the tie-break under either and the
+  /// account's own id under that.
+  ///
+  /// Both tie-breaks earn their place: a class of twenty must not reshuffle
+  /// between rebuilds, and `List.sort` is **not** stable — two namesakes (or a
+  /// September intake still carrying a placeholder name) would otherwise come
+  /// back in a different order every build.
+  int _compare(_AccountRow a, _AccountRow b) {
+    if (_sort == _ActionSort.klas) {
+      final byClass =
+          compareClassNames(a.account.classroom, b.account.classroom);
+      if (byClass != 0) return byClass;
+    }
+    final byName =
+        a.account.label.toLowerCase().compareTo(b.account.label.toLowerCase());
+    return byName != 0 ? byName : a.id.compareTo(b.id);
+  }
+
+  /// [_rows] narrowed by the three controls, which compose rather than replace
+  /// one another: the switch keeps the accounts with work, the search keeps the
+  /// names asked for, the system filter keeps the rows that system has something
+  /// to say about.
+  List<_AccountRow> _visibleRows(List<_AccountRow> rows) {
+    final NameQuery query = _query;
+    final core.Origin? origin = _system.origin;
+    return <_AccountRow>[
+      for (final r in rows)
+        if ((!_onlyWithActions || r.hasWork) &&
+            query.matches(r.searchText) &&
+            (origin == null ||
+                r.stateFor(origin) != SystemIndicatorState.inOrder))
+          r,
+    ];
   }
 
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
       listenable: controller,
-      builder: (context, _) {
-        return Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 960),
-            child: CustomScrollView(slivers: _slivers(context)),
-          ),
-        );
-      },
+      builder: (context, _) => Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 1400),
+          child: LayoutBuilder(builder: _body),
+        ),
+      ),
     );
   }
 
   static const EdgeInsets _hPad =
       EdgeInsets.symmetric(horizontal: PlinkSpacing.s6);
 
-  static Widget _section(Widget child) => SliverPadding(
-        padding: _hPad,
-        sliver: SliverToBoxAdapter(child: child),
-      );
+  Widget _body(BuildContext context, BoxConstraints constraints) {
+    final bool wide = constraints.maxWidth >= _splitBreakpoint;
+    final bool active = controller.linked != null;
+    final rows = active ? _rows() : const <_AccountRow>[];
+    final visible = _visibleRows(rows);
+    // A selection the current filters have hidden is not a selection any more:
+    // the operator cannot see what they would be acting on.
+    final _AccountRow? selected = _selectedRow(visible);
+    // In one pane the details take the whole width, so the list stands down.
+    final bool showList = wide || selected == null;
 
-  static SliverToBoxAdapter _gap(double height) =>
-      SliverToBoxAdapter(child: SizedBox(height: height));
+    final Widget head = Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        const SizedBox(height: PlinkSpacing.s6),
+        Padding(
+          padding: _hPad,
+          child: _ActionsHeader(
+            controller: controller,
+            onlyWithActions: _onlyWithActions,
+          ),
+        ),
+        const SizedBox(height: PlinkSpacing.s4),
+        Padding(padding: _hPad, child: _stateNotice()),
+      ],
+    );
 
-  /// Whether a grade-year or classroom node survives the global filter (#226).
-  ///
-  /// [Rollup.pendingCount] is already "how many applyable actions sit under this
-  /// node", so hiding is a pure render-time projection of the stored overview —
-  /// no store or materializer change is involved.
-  bool _keepNode(Rollup r) => !_onlyWithActions || r.pendingCount > 0;
+    // A refused session is the header and one blocking notice, and nothing
+    // else. It scrolls as a whole rather than being pinned above a pane that is
+    // not there: on a short window the notice — which carries the sync button
+    // the operator needs — would otherwise be the part that overflows.
+    if (!active) return SingleChildScrollView(child: head);
 
-  /// Whether a nested grade-year node (the Personeel tab's middle level) keeps
-  /// at least one visible classroom. A grade that would open onto nothing is
-  /// hidden as a whole rather than left as an empty accordion.
-  bool _keepGrade(Rollup grade) =>
-      !_onlyWithActions || controller.childrenOf(grade.key).any(_keepNode);
-
-  /// The Leerlingen drill-down after the global filter (#226): the merged
-  /// grade-years that still hold a visible classroom, and how many nodes went
-  /// missing so the tree can say so.
-  ///
-  /// The "Klasgroepen" node used to hang below these roots and open a list of
-  /// the classes with work. It is a top-level tab of its own since #227 — a full
-  /// class inventory, not just the ones that raised something — so it is not
-  /// rendered here any more: the same list must not be maintained in two places,
-  /// and the tab is the superset.
-  _FilteredTree _studentTree() {
-    final roots = <Rollup>[];
-    var hidden = 0;
-    for (final root in controller.studentRollups) {
-      final classrooms = controller.studentChildrenOf(root);
-      final kept = classrooms.where(_keepNode).length;
-      if (_onlyWithActions && kept == 0) {
-        // The year itself disappears rather than opening onto an empty list.
-        hidden++;
-        continue;
-      }
-      roots.add(root);
-      hidden += classrooms.length - kept;
-    }
-    return _FilteredTree(roots: roots, hidden: hidden);
-  }
-
-  /// The Personeel drill-down after the global filter (#226): the staff school
-  /// node, kept only while some grade below it still holds a visible classroom.
-  _FilteredTree _staffTree() {
-    final root = controller.staffSchoolRollup;
-    if (root == null) return const _FilteredTree(roots: <Rollup>[], hidden: 0);
-    var hidden = 0;
-    var keptGrades = 0;
-    for (final grade in controller.childrenOf(root.key)) {
-      final classrooms = controller.childrenOf(grade.key);
-      final kept = classrooms.where(_keepNode).length;
-      if (_onlyWithActions && kept == 0) {
-        hidden++;
-        continue;
-      }
-      keptGrades++;
-      hidden += classrooms.length - kept;
-    }
-    if (_onlyWithActions && keptGrades == 0) {
-      return const _FilteredTree(roots: <Rollup>[], hidden: 1);
-    }
-    return _FilteredTree(roots: <Rollup>[root], hidden: hidden);
-  }
-
-  List<Widget> _slivers(BuildContext context) {
-    final slivers = <Widget>[
-      _gap(PlinkSpacing.s6),
-      _section(_ActionsHeader(
-        controller: controller,
-        onlyWithActions: _onlyWithActions,
-      )),
-      _gap(PlinkSpacing.s4),
-      // The one place the filter is set (#226): above the family tab bar, so it
-      // governs both tabs, the drill-down, and every classroom opened from it.
-      _section(_ActionsFilterBar(
-        onlyWithActions: _onlyWithActions,
-        onChanged: (v) {
-          setState(() => _onlyWithActions = v);
-          // Pruned after the flag has flipped, against the tree the operator is
-          // about to see (#235).
-          _pruneExpansion();
-        },
-      )),
-      _gap(PlinkSpacing.s4),
-      _section(_FamilyTabBar(controller: controller, tabs: _tabs)),
-      _gap(PlinkSpacing.s4),
-    ];
-    final staffTab = _tabs.index == _ActionFamilyTab.personeel.index;
-    if (controller.selectedClassroom != null) {
-      slivers.addAll(_classroomSlivers(context));
-    } else if (controller.hasOverview) {
-      // Partition the drill-down by family: the Personeel tab shows only the
-      // synthetic staff school node (school → grade → classroom, unchanged); the
-      // Leerlingen tab opens straight on the merged grade-years. Class groups
-      // are a tab of their own since #227.
-      final tree = staffTab ? _staffTree() : _studentTree();
-      slivers.add(_section(staffTab
-          ? _DrillDownSection(
-              controller: controller,
-              accordion: _accordion,
-              roots: tree.roots,
-              hidden: tree.hidden,
-              filtering: _onlyWithActions,
-              emptyLabel: 'Geen openstaande personeelsacties.',
-              childrenOf: (root) => <Widget>[
-                for (final grade in controller.childrenOf(root.key))
-                  if (_keepGrade(grade))
-                    _GradeNode(
-                      controller: controller,
-                      accordion: _accordion,
-                      grade: grade,
-                      onlyWithActions: _onlyWithActions,
-                    ),
-              ],
-            )
-          : _DrillDownSection(
-              controller: controller,
-              accordion: _accordion,
-              roots: tree.roots,
-              hidden: tree.hidden,
-              filtering: _onlyWithActions,
-              emptyLabel: 'Nog geen gematerialiseerd overzicht.',
-              childrenOf: (root) => <Widget>[
-                for (final classroom in controller.studentChildrenOf(root))
-                  if (_keepNode(classroom))
-                    _ClassroomTile(
-                      controller: controller,
-                      classroom: classroom,
-                      indent: PlinkSpacing.s5,
-                    ),
-              ],
-            )));
-    } else {
-      slivers.add(_section(_EmptyState(controller: controller)));
-    }
-    slivers
-      ..addAll(_resultsSlivers())
-      ..add(_gap(PlinkSpacing.s6));
-    return slivers;
-  }
-
-  /// The drilled-into classroom: a back header, then either the live
-  /// interactive entry tiles for that class (active session) or the read-only
-  /// materialized account docs (passive session) — both through a lazy
-  /// [SliverList] so only the on-screen tiles build (#154).
-  ///
-  /// The read-only half announces itself (#214): without a linked view there is
-  /// nothing to choose, dry-run or apply, and the static account cards are
-  /// otherwise indistinguishable from an interactive list whose taps stopped
-  /// working.
-  List<Widget> _classroomSlivers(BuildContext context) {
-    final classroom = controller.selectedClassroom;
-    final slivers = <Widget>[
-      _section(_DetailHeader(
-        backKey: const ValueKey('actions-classroom-back'),
-        title: classroom?.label ?? '',
-        onBack: controller.closeClassroom,
-      )),
-      _gap(PlinkSpacing.s3),
-    ];
-    if (controller.loadingClassroom) {
-      return slivers..add(_section(const LinearProgressIndicator()));
-    }
-    slivers.addAll(_stateNoticeSlivers());
-
-    // Only the Personeel tab carries a per-list lookup; the mode switch that
-    // used to sit beside it now lives once, at the top of the view (#226).
-    final searchSlivers = _staffTab
-        ? <Widget>[
-            _section(_ClassroomSearchBar(searchController: _search)),
-            _gap(PlinkSpacing.s3),
-          ]
-        : const <Widget>[];
-
-    if (controller.linked != null) {
-      final all = controller.classroomPendingEntries;
-      if (all.isEmpty) {
-        return slivers
-          ..add(_section(const EmptyLine('Geen openstaande acties in deze '
-              'klas.')));
-      }
-      final shown = _filterEntries(all);
-      final rows =
-          pendingRows(ReconcileController.situationCohorts(shown), shown);
-      slivers
-        ..addAll(searchSlivers)
-        ..add(rows.isEmpty
-            ? _section(const EmptyLine(_noMatchLabel))
-            : _rowsSliver(rows));
-    } else {
-      final accounts = controller.classroomAccounts;
-      if (accounts == null || accounts.isEmpty) {
-        return slivers
-          ..add(_section(const EmptyLine('Geen accounts in deze klas.')));
-      }
-      final filtered = _filterAccounts(accounts);
-      slivers
-        ..addAll(searchSlivers)
-        ..add(filtered.isEmpty
-            ? _section(const EmptyLine(_noMatchLabel))
-            : SliverPadding(
+    return Column(
+      // Stretch, not start: the panes below have to fill the measured width
+      // rather than shrink to their content.
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _capped(
+          constraints,
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              head,
+              Padding(
                 padding: _hPad,
-                sliver: SliverList.builder(
-                  itemCount: filtered.length,
-                  itemBuilder: (context, index) =>
-                      _AccountTile(account: filtered[index]),
+                child: _ListControls(
+                  searchController: _search,
+                  onlyWithActions: _onlyWithActions,
+                  onOnlyWithActionsChanged: (v) =>
+                      setState(() => _onlyWithActions = v),
+                  sort: _sort,
+                  onSortChanged: (v) => setState(() => _sort = v),
+                  system: _system,
+                  onSystemChanged: (v) => setState(() => _system = v),
                 ),
-              ));
-    }
-    return slivers;
+              ),
+              const SizedBox(height: PlinkSpacing.s3),
+              Padding(
+                padding: _hPad,
+                child: _FamilyTabBar(controller: controller, tabs: _tabs),
+              ),
+              const SizedBox(height: PlinkSpacing.s3),
+            ],
+          ),
+        ),
+        Expanded(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              if (showList)
+                Expanded(
+                  flex: 5,
+                  child: _listPane(
+                    rows: rows,
+                    visible: visible,
+                    selected: selected,
+                  ),
+                ),
+              if (wide) const VerticalDivider(width: 1, thickness: 1),
+              if (wide || !showList)
+                Expanded(
+                  flex: 6,
+                  child: _detailPane(selected: selected, wide: wide),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
   }
 
-  /// The line shown when the active filters (toggle and/or search) hide every
-  /// account in the open classroom (#187) — distinct from the "no accounts at
-  /// all" empty state so the operator knows to relax the filter.
-  static const String _noMatchLabel =
-      'Geen accounts die aan de filter voldoen.';
+  /// How much of a short window the fixed block above the panes may take before
+  /// it starts scrolling inside itself.
+  static const double _headShare = 0.65;
 
-  /// The announcement shown above either drill-down about where this session's
-  /// view comes from.
+  /// Bounds the block above the panes so it can never overflow a short window.
+  ///
+  /// It is a fixed header at any ordinary window height — the content is well
+  /// under [_headShare] of it, so the [SingleChildScrollView] simply sizes to
+  /// its child and the panes below take the rest. Squeeze the window and the
+  /// header scrolls within its share instead of pushing the list off the bottom,
+  /// which is what a plain [Column] would do: the panes' [Expanded] can only
+  /// give back space that is left, and here there is none.
+  Widget _capped(BoxConstraints constraints, Widget child) {
+    if (!constraints.hasBoundedHeight) return child;
+    return ConstrainedBox(
+      constraints:
+          BoxConstraints(maxHeight: constraints.maxHeight * _headShare),
+      child: SingleChildScrollView(child: child),
+    );
+  }
+
+  /// The row the selection names, or `null` — including when the filters have
+  /// taken it off the screen.
+  _AccountRow? _selectedRow(List<_AccountRow> visible) {
+    final id = _selectedId;
+    if (id == null) return null;
+    for (final r in visible) {
+      if (r.id == id) return r;
+    }
+    return null;
+  }
+
+  /// The announcement above the list about where this session's view comes
+  /// from.
   ///
   /// Two of them, and never both: [ReadOnlyNotice] when there is no linked view
-  /// to act on (#214) — a session refused the shared seed, or one whose
-  /// sync/drift pass failed before it could link — and [SharedStateNotice] when
-  /// the tiles below *are* interactive but were built from the cold seed a
-  /// colleague's sync left behind (#287). Empty only in a session that pulled
-  /// for itself.
-  List<Widget> _stateNoticeSlivers() {
+  /// at all — a session refused the shared seed (#287), or one whose sync/drift
+  /// pass failed before it could link (#214) — and [SharedStateNotice] when the
+  /// list below *is* interactive but was built from the cold seed a colleague's
+  /// sync left behind (#287). Nothing at all in a session that pulled for
+  /// itself.
+  ///
+  /// A refused session gets the notice and no list: since #295 there is no
+  /// read-only browse of the stored documents to fall back on, because a second
+  /// inert way to browse the same data is not what a blocking notice is for.
+  Widget _stateNotice() {
     final Widget? notice = controller.linked == null
         ? ReadOnlyNotice(controller: controller)
         : controller.adoptedFrom == null
             ? null
             : SharedStateNotice(controller: controller);
-    if (notice == null) return const <Widget>[];
-    return <Widget>[_section(notice), _gap(PlinkSpacing.s3)];
+    if (notice == null) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(bottom: PlinkSpacing.s4),
+      child: notice,
+    );
   }
 
-  /// A lazy sliver over pending [rows] (situation headers + entry tiles) — the
-  /// carried-over virtualized list from the old flat pending section (#111).
-  Widget _rowsSliver(List<PendingRow> rows) => SliverPadding(
+  /// The left pane: the flat list itself, lazily built so a September roster of
+  /// thousands costs only the rows on screen (#111/#154).
+  Widget _listPane({
+    required List<_AccountRow> rows,
+    required List<_AccountRow> visible,
+    required _AccountRow? selected,
+  }) {
+    if (rows.isEmpty) {
+      return Padding(
         padding: _hPad,
-        sliver: SliverList.builder(
-          itemCount: rows.length,
-          itemBuilder: (context, index) {
-            final row = rows[index];
-            return switch (row) {
-              SituationHeaderRow(:final cohort) =>
-                SituationHeader(controller: controller, cohort: cohort),
-              EntryRow(:final entry) =>
-                PendingEntryTile(controller: controller, entry: entry),
-            };
-          },
-        ),
+        child: EmptyLine(_staffTab
+            ? 'Geen personeelsleden in het gedeelde overzicht.'
+            : 'Geen leerlingen in het gedeelde overzicht.'),
       );
+    }
+    if (visible.isEmpty) {
+      return Padding(
+        padding: _hPad,
+        child: EmptyLine(
+            _onlyWithActions && _query.isEmpty && _system == _SystemFilter.alle
+                ? 'Geen openstaande acties — alles staat in orde.'
+                : _noMatchLabel),
+      );
+    }
+    return ListView.builder(
+      key: const ValueKey('actions-list'),
+      padding: _hPad,
+      itemCount: visible.length,
+      itemBuilder: (context, index) {
+        final row = visible[index];
+        return _AccountListRow(
+          row: row,
+          selected: identical(row, selected),
+          onTap: () => setState(() => _selectedId = row.id),
+        );
+      },
+    );
+  }
 
-  List<Widget> _resultsSlivers() {
+  /// The line shown when the active controls hide every account of a non-empty
+  /// list — distinct from the "nothing pending at all" line, which is a
+  /// statement about the school rather than about the filters.
+  static const String _noMatchLabel =
+      'Geen accounts die aan de filter voldoen.';
+
+  /// The right pane (or, on a narrow window, the only one): the selected
+  /// account's decisions, and below them what the last pass did.
+  Widget _detailPane({required _AccountRow? selected, required bool wide}) {
+    final TextTheme text = Theme.of(context).textTheme;
+    return SingleChildScrollView(
+      padding: _hPad,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          if (!wide && selected != null) ...<Widget>[
+            _DetailBackHeader(onBack: () => setState(() => _selectedId = null)),
+            const SizedBox(height: PlinkSpacing.s3),
+          ],
+          if (selected == null)
+            Text(
+              key: const ValueKey('actions-detail-empty'),
+              'Kies een account in de lijst om de openstaande beslissingen te '
+              'zien.',
+              style: text.bodyMedium,
+            )
+          else
+            _AccountDetail(controller: controller, row: selected),
+          ..._resultSections(),
+          const SizedBox(height: PlinkSpacing.s6),
+        ],
+      ),
+    );
+  }
+
+  /// The page-level verdict of the last pass, rendered in the details pane.
+  ///
+  /// It reports the *pass*, which is a different thing from the per-decision
+  /// verdicts [entryDetail] renders on the card that raised the work (#272/
+  /// #283). It sits here rather than under the list because every apply on this
+  /// screen is started from an open details pane, so this is where the operator
+  /// already is when the pass ends.
+  List<Widget> _resultSections() {
     final dry = controller.dryRunResults;
     final applied = controller.applyResults;
-    final slivers = <Widget>[];
-    if (dry != null) {
-      slivers
-        ..add(_gap(PlinkSpacing.s5))
-        ..addAll(_resultSectionSlivers(
+    return <Widget>[
+      if (dry != null)
+        _ResultSection(
           title: 'Resultaat van de dry-run',
           subtitle: 'Er is niets geschreven. Dit is wat toepassen zou doen.',
           results: dry,
-        ));
-    }
-    if (applied != null) {
-      slivers
-        ..add(_gap(PlinkSpacing.s5))
-        ..addAll(_resultSectionSlivers(
+        ),
+      if (applied != null)
+        _ResultSection(
           title: 'Resultaat van het toepassen',
           subtitle: applyResultsSubtitle(applied),
           results: applied,
-        ));
-    }
-    return slivers;
-  }
-
-  List<Widget> _resultSectionSlivers({
-    required String title,
-    required String subtitle,
-    required List<ActionOutcomeEntry> results,
-  }) =>
-      <Widget>[
-        _section(_ResultsHeader(title: title, subtitle: subtitle)),
-        SliverPadding(
-          padding: _hPad,
-          sliver: SliverList.builder(
-            itemCount: results.length,
-            itemBuilder: (context, index) => _ResultRow(result: results[index]),
-          ),
         ),
-      ];
+    ];
+  }
 }
 
 /// The Actions title and how much work is pending — and, since #294, nothing
@@ -773,12 +709,11 @@ class _ActionsBodyState extends State<_ActionsBody>
 ///
 /// It used to carry a global "Dry-run alles" / "Alles toepassen" pair that ran
 /// every pending action of every family in every class in one pass. There is no
-/// safe reading of that: the drill-down below is collapsed, so the operator had
-/// seen none of the changes, and at a September changeover the count behind the
-/// button is in the thousands. Its confirmation named systems and a number,
-/// which is not the same as having looked. Bulk itself is not gone — it lives on
-/// the per-decision cohort header, where the cohort is on screen and one action
-/// deep — but the affordance that applied what nobody had read is.
+/// safe reading of that: the operator had seen none of the changes, and at a
+/// September changeover the count behind the button is in the thousands. Its
+/// confirmation named systems and a number, which is not the same as having
+/// looked. Bulk itself is not gone for good — #296 gives it back with the cohort
+/// on screen first — but the affordance that applied what nobody had read is.
 ///
 /// The count line stays. It states how much work exists; it is not a button.
 class _ActionsHeader extends StatelessWidget {
@@ -789,9 +724,8 @@ class _ActionsHeader extends StatelessWidget {
 
   final ReconcileController controller;
 
-  /// Whether the global filter is on, so the sub-line describes the tree the
-  /// operator is actually looking at (#226) — with the filter on there are no
-  /// ticked-off classes left to explain.
+  /// Whether the work-list filter is on, so the sub-line describes the list the
+  /// operator is actually looking at.
   final bool onlyWithActions;
 
   @override
@@ -799,6 +733,9 @@ class _ActionsHeader extends StatelessWidget {
     final TextTheme text = Theme.of(context).textTheme;
     final bool ink = Theme.of(context).brightness == Brightness.dark;
     final count = controller.totalPendingCount;
+    // The shared stamp both action views carry (#247), so Acties and
+    // Klasgroepen name the same generation the same way.
+    final freshness = sharedViewFreshness(controller);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -810,59 +747,127 @@ class _ActionsHeader extends StatelessWidget {
         Text(
           switch ((count, onlyWithActions)) {
             (0, _) => 'Geen openstaande acties.',
-            (_, true) =>
-              '$count openstaande actie(s) — enkel jaren en klassen met '
-                  'acties worden getoond.',
-            (_, false) => '$count openstaande actie(s) — blader per jaar en '
-                'klas. Klassen zonder acties tonen een vinkje.',
+            (_, true) => '$count openstaande actie(s) — de lijst toont enkel '
+                'accounts met werk.',
+            (_, false) => '$count openstaande actie(s) — de lijst toont elk '
+                'account. Drie groene vinkjes betekent dat het account overal '
+                'juist staat.',
           },
           style: text.bodyMedium,
         ),
+        if (freshness != null) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s1),
+          Text(freshness, style: text.bodySmall),
+        ],
       ],
     );
   }
 }
 
-/// The one, view-wide "toon enkel accounts met acties" switch (#226).
+/// Everything that shapes the list: the name search, the work-list switch, the
+/// sort and the system filter.
 ///
-/// It sits above the family tab bar, so the single decision it records governs
-/// both families, the whole jaar → klas drill-down, and every classroom opened
-/// from it. Its per-classroom ancestor (#187) had to be re-flipped in every
-/// class the operator opened and was reset on every tab change, which is why it
-/// never actually collapsed the tree to the work list.
-class _ActionsFilterBar extends StatelessWidget {
-  const _ActionsFilterBar({
+/// Collected in one block above the family tabs, because each of them governs
+/// both families and every one of them is a property of *the list* rather than
+/// of a row. The switch in particular is set in exactly one place (#226); its
+/// per-classroom ancestor had to be re-flipped in every class the operator
+/// opened, which is why it never actually collapsed anything to the work list.
+class _ListControls extends StatelessWidget {
+  const _ListControls({
+    required this.searchController,
     required this.onlyWithActions,
-    required this.onChanged,
+    required this.onOnlyWithActionsChanged,
+    required this.sort,
+    required this.onSortChanged,
+    required this.system,
+    required this.onSystemChanged,
   });
 
+  final TextEditingController searchController;
   final bool onlyWithActions;
-  final ValueChanged<bool> onChanged;
+  final ValueChanged<bool> onOnlyWithActionsChanged;
+  final _ActionSort sort;
+  final ValueChanged<_ActionSort> onSortChanged;
+  final _SystemFilter system;
+  final ValueChanged<_SystemFilter> onSystemChanged;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
-    return Row(
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Switch(
-          key: const ValueKey('actions-only-with-actions'),
-          value: onlyWithActions,
-          onChanged: onChanged,
+        TextField(
+          key: const ValueKey('actions-search'),
+          controller: searchController,
+          decoration: InputDecoration(
+            isDense: true,
+            prefixIcon: const Icon(Icons.search, size: 18),
+            // Same wording as the Wachtwoorden → Personeel box, which matches
+            // the same way (#217): any part of the name, in any order.
+            hintText: 'Zoek op naam…',
+            border: const OutlineInputBorder(),
+            suffixIcon: searchController.text.isEmpty
+                ? null
+                : IconButton(
+                    key: const ValueKey('actions-search-clear'),
+                    icon: const Icon(Icons.close, size: 18),
+                    tooltip: 'Wis zoekopdracht',
+                    onPressed: searchController.clear,
+                  ),
+          ),
         ),
-        const SizedBox(width: PlinkSpacing.s2),
-        Expanded(
-          child: Text('Toon enkel accounts met acties', style: text.bodyMedium),
+        const SizedBox(height: PlinkSpacing.s2),
+        Row(
+          children: <Widget>[
+            Switch(
+              key: const ValueKey('actions-only-with-actions'),
+              value: onlyWithActions,
+              onChanged: onOnlyWithActionsChanged,
+            ),
+            const SizedBox(width: PlinkSpacing.s2),
+            Expanded(
+              child: Text('Toon enkel accounts met acties',
+                  style: text.bodyMedium),
+            ),
+          ],
+        ),
+        const SizedBox(height: PlinkSpacing.s2),
+        Wrap(
+          spacing: PlinkSpacing.s2,
+          runSpacing: PlinkSpacing.s2,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: <Widget>[
+            Text('Sorteer op', style: text.bodySmall),
+            for (final option in _ActionSort.values)
+              ChoiceChip(
+                key: ValueKey('actions-sort-${option.name}'),
+                label: Text(option.label),
+                selected: sort == option,
+                onSelected: (_) => onSortChanged(option),
+              ),
+            const SizedBox(width: PlinkSpacing.s3),
+            Text('Systeem', style: text.bodySmall),
+            for (final option in _SystemFilter.values)
+              ChoiceChip(
+                key: ValueKey('actions-system-${option.name}'),
+                label: Text(option.label),
+                selected: system == option,
+                onSelected: (_) => onSystemChanged(option),
+              ),
+          ],
         ),
       ],
     );
   }
 }
 
-/// The horizontal family tab bar (#179): switches the drill-down below between
-/// the Leerlingen (student + class-group) and Personeel (staff) action
-/// families, each carrying a pending-count badge so the operator sees where the
-/// work sits without opening both. Staff and student actions are reviewed as
-/// separate workflows, mirroring the legacy WPF app.
+/// The horizontal family tab bar (#179): switches the list below between the
+/// Leerlingen (student) and Personeel (staff) action families, each carrying a
+/// pending-count badge so the operator sees where the work sits without opening
+/// both. Staff and student actions are reviewed as separate workflows,
+/// mirroring the legacy WPF app.
 class _FamilyTabBar extends StatelessWidget {
   const _FamilyTabBar({required this.controller, required this.tabs});
 
@@ -910,412 +915,216 @@ class _FamilyTabBar extends StatelessWidget {
       );
 }
 
-/// The empty state before any sync/overview exists: nothing to browse yet.
-class _EmptyState extends StatelessWidget {
-  const _EmptyState({required this.controller});
+/// One account in the flat list: who they are, where they sit, and what each of
+/// the three systems says about them.
+///
+/// A line rather than an expandable card, which is the whole shape change of
+/// #295: the decisions live in the details pane beside it, so a row stays one
+/// scannable height whatever it is carrying, and a list of three thousand is a
+/// list of three thousand rows rather than of three thousand collapsed cards.
+class _AccountListRow extends StatelessWidget {
+  const _AccountListRow({
+    required this.row,
+    required this.selected,
+    required this.onTap,
+  });
 
-  final ReconcileController controller;
+  final _AccountRow row;
+  final bool selected;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
-    return Text(
-      'Nog geen gematerialiseerd overzicht. Synchroniseer op het tabblad '
-      'Synchronisatie om openstaande acties per klas te zien.',
-      style: text.bodyMedium,
-    );
-  }
-}
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final Color hairline = Theme.of(context).dividerColor;
 
-/// The stable widget key of one rollup node, by level — so a test (and the
-/// element tree) names a node the same way wherever it is rendered.
-String _rollupNodeKey(Rollup r) => switch (r.level) {
-      RollupLevel.school => 'rollup-school-${r.key}',
-      RollupLevel.gradeYear => 'rollup-grade-${r.key}',
-      RollupLevel.classroom => 'rollup-class-${r.key}',
-      RollupLevel.groups => 'rollup-groups',
-    };
-
-/// The materialized overview (#115/#119): the drill-down driven by the stored
-/// rollups, so it renders from the shared state even in a passive session that
-/// never pulled or re-linked. Tapping a classroom lazily loads just that node's
-/// actions (#154).
-///
-/// The "Klasgroepen" node used to sit below the student roots and open the
-/// classes with work. It became a top-level tab of its own in #227 — the full
-/// class inventory rather than a list of changes — so it is gone from here: the
-/// same list must not be maintained in two places.
-///
-/// The tree is two levels deep on the Leerlingen tab (#210): merged grade-year →
-/// classroom, with no school node — the WISA school split is administrative, so
-/// drilling through it never presented a choice. The Personeel tab keeps its
-/// stored school → grade-year → classroom shape; both are driven from the very
-/// same rollups, only projected differently by [childrenOf].
-class _DrillDownSection extends StatelessWidget {
-  const _DrillDownSection({
-    required this.controller,
-    required this.accordion,
-    required this.roots,
-    required this.emptyLabel,
-    required this.childrenOf,
-    required this.hidden,
-    required this.filtering,
-  });
-
-  final ReconcileController controller;
-
-  /// Drives the top-level nodes as a single-open accordion whose open node
-  /// outlives a drill-down (#235).
-  final _Accordion accordion;
-
-  /// The top-level accordion nodes: the merged grade-years plus
-  /// "Niet toegewezen" on the Leerlingen tab, the single staff school node on
-  /// the Personeel tab (#179/#210).
-  final List<Rollup> roots;
-
-  /// Builds the expanded children of one root — classroom tiles under a merged
-  /// grade-year, the nested grade nodes under the staff school.
-  final List<Widget> Function(Rollup root) childrenOf;
-
-  /// The message shown when this tab has nothing to browse.
-  final String emptyLabel;
-
-  /// How many nodes the global filter removed from this tab's tree (#226).
-  final int hidden;
-
-  /// Whether the global filter is on — the difference between "there is nothing
-  /// here" and "the filter is holding it back", which is what tells an operator
-  /// why a year they expected is missing.
-  final bool filtering;
-
-  /// The footnote under a tree the filter has thinned out, so a missing year is
-  /// explained rather than merely absent.
-  String get _hiddenNote =>
-      'Verborgen door de filter: $hidden zonder openstaande acties.';
-
-  /// The stand-in for the tree when the filter hid every last node — distinct
-  /// from [emptyLabel], which means the shared view holds nothing at all.
-  String get _allHiddenNote =>
-      'Alles is verborgen door de filter: $hidden zonder openstaande acties. '
-      'Zet de filter af voor het volledige overzicht.';
-
-  /// One top-level accordion node (depth 0), driven by [accordion] rather than
-  /// by the `ExpansionTile`'s own state (#235) — so the year the operator drilled
-  /// a class out of is still open when they come back, and opening another one
-  /// closes it.
-  Widget _rootTile(BuildContext context, Rollup root, Color hairline) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final String node = _rollupNodeKey(root);
     return Container(
+      key: ValueKey('account-row-${row.id}'),
       margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
       decoration: BoxDecoration(
-        border: Border.all(color: hairline),
+        color: selected ? colors.primary.withValues(alpha: 0.06) : null,
+        border: Border.all(color: selected ? colors.primary : hairline),
         borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
       ),
-      child: ExpansionTile(
-        key: ValueKey(node),
-        controller: accordion.controllerFor(node),
-        initiallyExpanded: accordion.isOpen(node, 0),
-        onExpansionChanged: (open) => accordion.onToggled(node, 0, open),
-        shape: const Border(),
-        collapsedShape: const Border(),
-        title: Text(root.label, style: text.bodyLarge),
-        trailing: PendingBadge(count: root.pendingCount),
-        children: childrenOf(root),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+        child: Padding(
+          padding: const EdgeInsets.all(PlinkSpacing.s4),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  Expanded(
+                    child: Text(
+                      row.account.label,
+                      style: text.bodyLarge,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  const SizedBox(width: PlinkSpacing.s2),
+                  Text(row.account.classroom, style: text.bodySmall),
+                  const SizedBox(width: PlinkSpacing.s2),
+                  PendingBadge(count: row.pendingCount),
+                ],
+              ),
+              const SizedBox(height: PlinkSpacing.s2),
+              _SystemRow(row: row),
+            ],
+          ),
+        ),
       ),
     );
   }
+}
+
+/// The three system cells of one account: WISA · Smartschool · Office 365, in
+/// the shared vocabulary of #298 — red missing, orange work pending, green in
+/// order.
+class _SystemRow extends StatelessWidget {
+  const _SystemRow({required this.row, this.keyPrefix = 'account-cell'});
+
+  final _AccountRow row;
+
+  /// What names these three cells. The details pane repeats the row's cells, so
+  /// the two sets must not answer to one key: `find.byKey` would be ambiguous
+  /// exactly when a row is selected, which is every interesting case.
+  final String keyPrefix;
 
   @override
   Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final Color hairline = Theme.of(context).dividerColor;
-    // The shared stamp both views carry (#247), so Acties and Klasgroepen name
-    // the same generation the same way.
-    final freshness = sharedViewFreshness(controller);
+    // Each cell is addressable on its own — `account-cell-<id>-<systeem>` —
+    // exactly as a Klasgroepen row's cells are (`class-cell-<klas>-<systeem>`),
+    // so a test can ask one row what it says about one system rather than
+    // counting icons across three.
+    Widget cell(core.Origin system) => Expanded(
+          child: SystemIndicatorCell(
+            key: ValueKey('$keyPrefix-${row.id}-${system.name}'),
+            system: system,
+            state: row.stateFor(system),
+          ),
+        );
 
-    return Column(
+    return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Overzicht', style: text.titleMedium),
-        if (freshness != null) ...<Widget>[
-          const SizedBox(height: PlinkSpacing.s1),
-          Text(freshness, style: text.bodySmall),
+        cell(core.Origin.wisa),
+        cell(core.Origin.smartschool),
+        cell(core.Origin.azure),
+      ],
+    );
+  }
+}
+
+/// The details pane's content for one account: who it is, what each system says
+/// about it, and every decision it raises.
+///
+/// The decisions are [entryDetail] verbatim — one block per decision, each led
+/// by its own heading and its system, then the radios or the field diff, then
+/// the verdict of the last pass that answers *that* decision (#281/#283). #300
+/// made those blocks stand on their own precisely so this pane could reuse them
+/// with no collapsed row above to have previewed anything.
+class _AccountDetail extends StatelessWidget {
+  const _AccountDetail({required this.controller, required this.row});
+
+  final ReconcileController controller;
+  final _AccountRow row;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final PendingAccountEntry? entry = row.entry;
+
+    return Column(
+      key: ValueKey('actions-detail-${row.id}'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Expanded(child: Text(row.account.label, style: text.titleMedium)),
+            const SizedBox(width: PlinkSpacing.s2),
+            PendingBadge(count: row.pendingCount),
+          ],
+        ),
+        const SizedBox(height: PlinkSpacing.s1),
+        Text(row.account.classroom, style: text.bodySmall),
+        const SizedBox(height: PlinkSpacing.s3),
+        // Repeated from the row on purpose: on a narrow window the list is not
+        // on screen at all, so the pane has to be able to say what the account's
+        // three systems look like.
+        _SystemRow(row: row, keyPrefix: 'account-detail-cell'),
+        for (final w in row.account.warnings) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s2),
+          Text(w, style: text.bodySmall),
         ],
         const SizedBox(height: PlinkSpacing.s3),
-        if (roots.isEmpty)
-          filtering && hidden > 0
-              ? Text(
-                  _allHiddenNote,
-                  key: const ValueKey('actions-filter-all-hidden'),
-                  style: text.bodyMedium,
-                )
-              : Text(emptyLabel, style: text.bodyMedium)
-        else ...<Widget>[
-          for (final root in roots) _rootTile(context, root, hairline),
-          if (filtering && hidden > 0) ...<Widget>[
-            const SizedBox(height: PlinkSpacing.s1),
-            Text(
-              _hiddenNote,
-              key: const ValueKey('actions-filter-hidden'),
-              style: text.bodySmall,
-            ),
-          ],
-        ],
+        if (entry == null)
+          Text(
+            'Geen openstaande beslissingen voor dit account.',
+            style: text.bodyMedium,
+          )
+        else
+          ...entryDetail(context, controller: controller, entry: entry),
       ],
     );
   }
 }
 
-/// A nested grade-year node inside a school node — the middle level of the
-/// Personeel tab's stored tree, which #210 left as it was. The student tree has
-/// no school to nest under, so its grade-years are [_DrillDownSection] roots and
-/// carry their "Jaar N" label from [ReconcileController.gradeNodeLabel] instead.
-class _GradeNode extends StatelessWidget {
-  const _GradeNode({
-    required this.controller,
-    required this.accordion,
-    required this.grade,
-    required this.onlyWithActions,
-  });
+/// The back affordance of the one-pane layout: on a window too narrow for two
+/// columns the details replace the list, so there has to be a way back to it.
+class _DetailBackHeader extends StatelessWidget {
+  const _DetailBackHeader({required this.onBack});
 
-  final ReconcileController controller;
-
-  /// Drives this node at depth 1 (#235). The depth is what keeps the staff tree
-  /// usable: opening a grade-year replaces its *sibling* year, never the school
-  /// node above it — which single-open on one flat key would have collapsed out
-  /// from under the year the operator just opened.
-  final _Accordion accordion;
-
-  final Rollup grade;
-
-  /// Whether the global filter is on, in which case only the classrooms of this
-  /// year that carry an applyable action are listed (#226).
-  final bool onlyWithActions;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final String node = _rollupNodeKey(grade);
-    return ExpansionTile(
-      key: ValueKey(node),
-      controller: accordion.controllerFor(node),
-      initiallyExpanded: accordion.isOpen(node, 1),
-      onExpansionChanged: (open) => accordion.onToggled(node, 1, open),
-      shape: const Border(),
-      collapsedShape: const Border(),
-      tilePadding: const EdgeInsets.only(left: PlinkSpacing.s5, right: 16),
-      title: Text('Jaar ${grade.label}', style: text.bodyMedium),
-      trailing: PendingBadge(count: grade.pendingCount),
-      children: <Widget>[
-        for (final classroom in controller.childrenOf(grade.key))
-          if (!onlyWithActions || classroom.pendingCount > 0)
-            _ClassroomTile(
-              controller: controller,
-              classroom: classroom,
-              indent: PlinkSpacing.s6,
-            ),
-      ],
-    );
-  }
-}
-
-/// A leaf classroom node: tapping it opens that class's accounts, which reads
-/// exactly one Cosmos partition ([Rollup.school]). Indented to whatever depth the
-/// enclosing tree puts it at — one level under a merged grade-year on the
-/// Leerlingen tab, two under school → grade-year on the Personeel tab.
-class _ClassroomTile extends StatelessWidget {
-  const _ClassroomTile({
-    required this.controller,
-    required this.classroom,
-    required this.indent,
-  });
-
-  final ReconcileController controller;
-  final Rollup classroom;
-  final double indent;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    return ListTile(
-      key: ValueKey(_rollupNodeKey(classroom)),
-      contentPadding: EdgeInsets.only(left: indent, right: 16),
-      title: Text(classroom.label, style: text.bodyMedium),
-      subtitle:
-          Text('${classroom.accountCount} account(s)', style: text.bodySmall),
-      trailing: PendingBadge(count: classroom.pendingCount),
-      onTap: () => controller.openClassroom(classroom),
-    );
-  }
-}
-
-/// The back-to-overview header of a drilled-into classroom / group node.
-class _DetailHeader extends StatelessWidget {
-  const _DetailHeader({
-    required this.backKey,
-    required this.title,
-    required this.onBack,
-  });
-
-  final Key backKey;
-  final String title;
   final VoidCallback onBack;
 
   @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    return Row(
-      children: <Widget>[
-        TextButton.icon(
-          key: backKey,
+  Widget build(BuildContext context) => Align(
+        alignment: Alignment.centerLeft,
+        child: TextButton.icon(
+          key: const ValueKey('actions-detail-back'),
           onPressed: onBack,
           icon: const Icon(Icons.arrow_back, size: 16),
           label: const Text('Overzicht'),
         ),
-        const SizedBox(width: PlinkSpacing.s2),
-        Text(title, style: text.titleMedium),
-      ],
-    );
-  }
+      );
 }
 
-/// The name search above a drilled-into classroom's account list, on the
-/// Personeel tab only (#187/#217).
-///
-/// The "toon enkel accounts met acties" toggle that used to sit beside it moved
-/// to the top of the view in #226 — it is a mode, and the filter must not be
-/// settable in two places. A name search is the opposite: a lookup inside *this*
-/// list, so it stays here.
-class _ClassroomSearchBar extends StatelessWidget {
-  const _ClassroomSearchBar({required this.searchController});
-
-  final TextEditingController searchController;
-
-  @override
-  Widget build(BuildContext context) {
-    return TextField(
-      key: const ValueKey('actions-search'),
-      controller: searchController,
-      decoration: InputDecoration(
-        isDense: true,
-        prefixIcon: const Icon(Icons.search, size: 18),
-        // Same wording as the Wachtwoorden → Personeel box, which matches the
-        // same way (#217): any part of the name, in any order.
-        hintText: 'Zoek op naam…',
-        border: const OutlineInputBorder(),
-        suffixIcon: searchController.text.isEmpty
-            ? null
-            : IconButton(
-                key: const ValueKey('actions-search-clear'),
-                icon: const Icon(Icons.close, size: 18),
-                tooltip: 'Wis zoekopdracht',
-                onPressed: searchController.clear,
-              ),
-      ),
-    );
-  }
-}
-
-/// One account's read-only summary in a passive-session classroom drill-down:
-/// the systems it lives in and its candidate action summaries (no live actions
-/// to apply without a sync this session).
-///
-/// Styled as the inert card it is (#214): a muted lock beside the pending
-/// badge, and the candidate lines in the disabled colour, so a card that offers
-/// no choice, dry-run or apply does not sit next to the interactive
-/// [PendingEntryTile] looking identical to it. [ReadOnlyNotice] above the
-/// list carries the explanation.
-class _AccountTile extends StatelessWidget {
-  const _AccountTile({required this.account});
-
-  final MaterializedAccount account;
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final Color hairline = Theme.of(context).dividerColor;
-    final Color muted = Theme.of(context).disabledColor;
-    final systems = <String>[
-      if (account.inWisa) 'WISA',
-      if (account.inSmartschool) 'Smartschool',
-      if (account.inAzure) 'Azure',
-    ];
-
-    return Container(
-      margin: const EdgeInsets.only(bottom: PlinkSpacing.s2),
-      padding: const EdgeInsets.all(PlinkSpacing.s4),
-      decoration: BoxDecoration(
-        border: Border.all(color: hairline),
-        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Row(
-            children: <Widget>[
-              Expanded(child: Text(account.label, style: text.bodyLarge)),
-              const ReadOnlyLock(),
-              const SizedBox(width: PlinkSpacing.s2),
-              PendingBadge(count: pendingDecisionCount(account.candidates)),
-            ],
-          ),
-          const SizedBox(height: PlinkSpacing.s2),
-          Wrap(
-            spacing: PlinkSpacing.s2,
-            children: <Widget>[for (final s in systems) PlinkBadge(s)],
-          ),
-          for (final w in account.warnings)
-            Padding(
-              padding: const EdgeInsets.only(top: PlinkSpacing.s1),
-              child: Text(w, style: text.bodySmall),
-            ),
-          // One line per *decision* (#251), worded exactly as the interactive
-          // tile words it: a departed student's unregister / delete pair is one
-          // either/or, so it reads as the single choice the interactive tile
-          // shows — never as two bullets that both look due — and an
-          // informational candidate is marked "(manueel)" (#255).
-          for (final c in candidateChoices(account.candidates))
-            Padding(
-              padding: const EdgeInsets.only(top: PlinkSpacing.s1),
-              child: ActionLine(
-                system: c.selected.system,
-                line: readOnlyCandidateLine(c),
-                style: text.bodySmall?.copyWith(color: muted),
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-}
-
-/// The header of a dry-run/apply result set: its title and subtitle, above the
-/// lazy list of outcome rows.
-class _ResultsHeader extends StatelessWidget {
-  const _ResultsHeader({required this.title, required this.subtitle});
+/// One dry-run/apply results block: its title, its subtitle, and one row per
+/// outcome.
+class _ResultSection extends StatelessWidget {
+  const _ResultSection({
+    required this.title,
+    required this.subtitle,
+    required this.results,
+  });
 
   final String title;
   final String subtitle;
+  final List<ActionOutcomeEntry> results;
 
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Text(title, style: text.titleMedium),
-        const SizedBox(height: PlinkSpacing.s1),
-        Text(subtitle, style: text.bodySmall),
-        const SizedBox(height: PlinkSpacing.s3),
-      ],
+    return Padding(
+      padding: const EdgeInsets.only(top: PlinkSpacing.s5),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(title, style: text.titleMedium),
+          const SizedBox(height: PlinkSpacing.s1),
+          Text(subtitle, style: text.bodySmall),
+          const SizedBox(height: PlinkSpacing.s3),
+          for (final result in results) _ResultRow(result: result),
+        ],
+      ),
     );
   }
 }
 
 /// One outcome row of a dry-run/apply pass: the check/cross plus the target and
-/// its change summary (or the failure cause). Built lazily by the results
-/// [SliverList].
+/// its change summary (or the failure cause).
 class _ResultRow extends StatelessWidget {
   const _ResultRow({required this.result});
 

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 
 import 'package:account_actions/account_actions.dart' as actions;
 import 'package:account_core/account_core.dart' as core;
-import 'package:account_state/account_state.dart' show MaterializedAccount;
+import 'package:account_state/account_state.dart'
+    show LinkedState, MaterializedAccount;
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
@@ -110,13 +111,58 @@ export 'action_tiles.dart' show applyConfirmationMessage, systemLabel;
 /// it out of the cohort instead of being written as the resolution the operator
 /// changed their mind about.
 ///
+/// ## Ticking the accounts a risky action runs on (#297)
+///
+/// The complement of the above, for the actions the sanction deliberately
+/// withholds. The September leavers sweep is the case: filter to "rood in WISA",
+/// read down the list, and the accounts resolve to unregister / delete / remove
+/// — a judgement call per person, but dozens of them in one sitting. There is no
+/// apply-all for those and there should not be; without a selection the operator
+/// opens each account and presses **Toepassen**, which is slow enough that it
+/// does not get done.
+///
+/// So a row with applyable work carries a checkbox, and a ticked selection gets
+/// [_SelectionBar]: it names **one** decision the ticked accounts raise, says how
+/// many of them raise it and how many are skipped, and offers a dry-run and an
+/// apply over exactly those. The pass behind it is the same per-decision
+/// [ReconcileController.applyDecisions] the cohort review and the Klasgroepen
+/// cohort headers run, so a bulk write is one decision deep wherever it starts
+/// (#292).
+///
+/// Where it and #296 are the same, and where they must not be:
+///
+/// - **Same.** Both are "one decision, over a set of accounts". Both group with
+///   [ReconcileController.situationCohorts], scope their confirmation with
+///   [ReconcileController.applyScopeForDecisions] and write with
+///   [ReconcileController.applyDecisions]. Neither shows the operator a number
+///   whose members are off screen.
+/// - **Not the same.** #296's cohort is *computed* — the whole school, resolved
+///   by the controller, which is why the action must be sanctioned for it. This
+///   set is *chosen*, account by account, precisely because the action is one
+///   that must never sweep. The ticking is the consent, so this is offered
+///   whatever `canApplyToAll` says (#293): withholding it here would leave the
+///   risky kinds with no bulk path at all, which is the whole of #297.
+///
+/// Two rules keep "tick everything" from quietly becoming a school-wide apply.
+/// Select-all is scoped to the **visible** rows, and the effective selection is
+/// re-intersected with them on every build — the same rule the details pane's
+/// selection already follows, because an account the filters have hidden is one
+/// the operator cannot see themselves acting on. And the confirmation quotes the
+/// count of that intersection, so the number in the dialog is the number of rows
+/// on the screen behind it.
+///
+/// Ticks are keyed by account id, so they survive a sort change and a rebuild;
+/// they are dropped when the linked view is replaced — a sync, or an apply that
+/// settled them — and when the family tab changes, because both make the set
+/// name accounts that are no longer the list.
+///
 /// ## What it deliberately does not do
 ///
 /// Nothing here applies an action the operator has not seen. The header's global
 /// "Dry-run alles" / "Alles toepassen" pair went in #294 for exactly that
 /// reason, and it is not coming back: every apply is started from a list that is
-/// on screen. Checkbox multi-select, for the kinds that get no apply-all, is
-/// #297.
+/// on screen — a cohort the screen filtered itself down to (#296), or a set the
+/// operator ticked row by row (#297).
 ///
 /// A running pass cannot be cancelled and is never concurrent — a rollover over
 /// ~3000 accounts takes a long time, and is resumable in practice because every
@@ -375,6 +421,31 @@ class _ActionsBodyState extends State<_ActionsBody>
   /// [ReconcileController.applyToAllCohortFor].
   String? _cohortKey;
 
+  /// The ticked accounts (#297), by id — the set one decision may be applied to
+  /// when there is no apply-all for it.
+  ///
+  /// Ids rather than rows, for the reason [_selectedId] is an id: a row is
+  /// rebuilt from the live view on every notification, and a captured one would
+  /// carry the resolution the operator has since changed their mind about. It
+  /// also makes the set survive a sort and a filter change untouched, while what
+  /// the buttons act on is re-intersected with the visible rows every build.
+  final Set<String> _ticked = <String>{};
+
+  /// The [SituationCohort.key] of the decision the selection bar is set to, or
+  /// `null` to take whichever decision the most ticked accounts raise. Re-checked
+  /// against the live candidates on every build, so unticking the last account
+  /// that raised the chosen decision falls back rather than going inert.
+  String? _decisionKey;
+
+  /// The linked view the ticks were made against, so a replaced one retires them
+  /// — a sync, or an apply whose writes settled the very decisions they named.
+  ///
+  /// Reconciled in [_body] rather than from a controller listener: the build is
+  /// where the cleared set is needed, the comparison is an identity check, and a
+  /// listener that calls `setState` would have to defend against firing while a
+  /// frame is already building.
+  LinkedState? _tickedView;
+
   ReconcileController get controller => widget.controller;
 
   @override
@@ -410,9 +481,61 @@ class _ActionsBodyState extends State<_ActionsBody>
       _shownIndex = index;
       _selectedId = null;
       _cohortKey = null;
+      // The ticks name accounts of the family being left behind, and a pass is
+      // single-family anyway (#297).
+      _clearTicks();
     }
     if (mounted) setState(() {});
   }
+
+  /// Drops the multi-select (#297) — the ticks and the decision they were
+  /// pointed at, which means nothing without them.
+  void _clearTicks() {
+    _ticked.clear();
+    _decisionKey = null;
+  }
+
+  /// Retires the ticks when the linked view underneath them has been replaced
+  /// (#297) — a sync, or an apply whose writes settled the decisions they named.
+  ///
+  /// Called at the top of [_body] rather than from a controller listener: this
+  /// is a reconciliation of state against what the build is about to read, it is
+  /// idempotent, and the frame that follows renders the cleared set — so there is
+  /// no `setState` to schedule and no chance of scheduling one mid-frame.
+  void _retireStaleTicks() {
+    final LinkedState? view = controller.linked;
+    if (identical(_tickedView, view)) return;
+    _tickedView = view;
+    _clearTicks();
+  }
+
+  /// Ticks or unticks one account (#297).
+  void _setTicked(String id, bool ticked) => setState(() {
+        if (ticked) {
+          _ticked.add(id);
+        } else {
+          _ticked.remove(id);
+        }
+      });
+
+  /// Select-all / clear, scoped to [tickable] — the rows on screen that carry
+  /// applyable work, and nothing else (#297).
+  ///
+  /// The scoping is the safety: an operator who ticks everything after filtering
+  /// to "rood in WISA" has selected the leavers, not the school. Ticks made
+  /// against another filter are left alone rather than cleared, because they are
+  /// still the operator's — what the buttons act on is the intersection with the
+  /// visible rows, which [_SelectionBar] recomputes every build.
+  void _selectAll(List<_AccountRow> tickable, bool ticked) => setState(() {
+        for (final row in tickable) {
+          if (ticked) {
+            _ticked.add(row.id);
+          } else {
+            _ticked.remove(row.id);
+          }
+        }
+        if (_ticked.isEmpty) _decisionKey = null;
+      });
 
   /// Whether the Personeel family tab is the selected one.
   bool get _staffTab => _tabs.index == _ActionFamilyTab.personeel.index;
@@ -505,10 +628,19 @@ class _ActionsBodyState extends State<_ActionsBody>
 
   /// Arms the school-wide review of [decision]: the list narrows to its cohort
   /// and the banner takes over from the list controls. Nothing is written.
+  ///
+  /// The two bulk modes are exclusive, so this drops the multi-select (#297).
+  /// A review's list *is* its cohort, resolved school-wide — ticks made against
+  /// the list before it would name a different set of accounts than the rows
+  /// now on screen, which is precisely the mismatch both affordances exist to
+  /// avoid.
   void _armCohort(PendingDecision decision) {
     final cohort = controller.applyToAllCohort(decision);
     if (cohort == null) return;
-    setState(() => _cohortKey = cohort.key);
+    setState(() {
+      _cohortKey = cohort.key;
+      _clearTicks();
+    });
   }
 
   @override
@@ -528,6 +660,7 @@ class _ActionsBodyState extends State<_ActionsBody>
       EdgeInsets.symmetric(horizontal: PlinkSpacing.s6);
 
   Widget _body(BuildContext context, BoxConstraints constraints) {
+    _retireStaleTicks();
     final bool wide = constraints.maxWidth >= _splitBreakpoint;
     final bool active = controller.linked != null;
     final SituationCohort? cohort = active ? _armedCohort() : null;
@@ -538,6 +671,15 @@ class _ActionsBodyState extends State<_ActionsBody>
     final _AccountRow? selected = _selectedRow(visible);
     // In one pane the details take the whole width, so the list stands down.
     final bool showList = wide || selected == null;
+    // What may be ticked right now (#297): the visible rows carrying applyable
+    // work, which is also what select-all covers. None while a cohort is under
+    // review — that list is the review's own, and the two modes are exclusive.
+    final List<_AccountRow> tickable = cohort != null
+        ? const <_AccountRow>[]
+        : <_AccountRow>[
+            for (final r in visible)
+              if (r.hasWork) r,
+          ];
 
     final Widget head = Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -597,6 +739,22 @@ class _ActionsBodyState extends State<_ActionsBody>
                         onDisarm: () => setState(() => _cohortKey = null),
                       ),
               ),
+              if (tickable.isNotEmpty) ...<Widget>[
+                const SizedBox(height: PlinkSpacing.s3),
+                Padding(
+                  padding: _hPad,
+                  child: _SelectionBar(
+                    controller: controller,
+                    tickable: tickable,
+                    ticked: _ticked,
+                    decisionKey: _decisionKey,
+                    onSelectAll: (v) => _selectAll(tickable, v),
+                    onClear: () => setState(_clearTicks),
+                    onDecisionChanged: (key) =>
+                        setState(() => _decisionKey = key),
+                  ),
+                ),
+              ],
               const SizedBox(height: PlinkSpacing.s3),
               Padding(
                 padding: _hPad,
@@ -617,6 +775,7 @@ class _ActionsBodyState extends State<_ActionsBody>
                     rows: rows,
                     visible: visible,
                     selected: selected,
+                    ticking: cohort == null,
                   ),
                 ),
               if (wide) const VerticalDivider(width: 1, thickness: 1),
@@ -696,6 +855,7 @@ class _ActionsBodyState extends State<_ActionsBody>
     required List<_AccountRow> rows,
     required List<_AccountRow> visible,
     required _AccountRow? selected,
+    required bool ticking,
   }) {
     if (rows.isEmpty) {
       return Padding(
@@ -724,6 +884,8 @@ class _ActionsBodyState extends State<_ActionsBody>
           row: row,
           selected: identical(row, selected),
           onTap: () => setState(() => _selectedId = row.id),
+          ticked: _ticked.contains(row.id),
+          onTicked: ticking ? (v) => _setTicked(row.id, v) : null,
         );
       },
     );
@@ -1081,6 +1243,270 @@ class _CohortReviewBanner extends StatelessWidget {
   }
 }
 
+/// The multi-select bar (#297): tick the accounts, name the one decision, run it
+/// over exactly them.
+///
+/// The affordance for the actions #293 refuses a school-wide apply — the
+/// deletes, the unregisters, the renames. The refusal is right: nobody should
+/// press one button that deletes every account the app believes has left. But
+/// the *work* is still bulk work, and the September leavers sweep is dozens of
+/// those judgement calls in one sitting. Ticking is what keeps the judgement and
+/// drops the repetition: the operator has looked at every row they ticked, and
+/// the ticking is the consent.
+///
+/// So, unlike [_CohortReviewBanner], this is offered whatever `canApplyToAll`
+/// says. The two are otherwise deliberately the same machine — one decision,
+/// grouped with [ReconcileController.situationCohorts], confirmed through
+/// [ReconcileController.applyScopeForDecisions], written by
+/// [ReconcileController.applyDecisions] — because a bulk write that resolved its
+/// work a second way is exactly how a button comes to mean something other than
+/// what it says (#252).
+///
+/// Three things it is careful to state:
+///
+/// - **Which decision.** A ticked set is not "everything on those cards": the
+///   pass is one decision deep (#292), so the decision is picked explicitly from
+///   the ones the selection actually raises, defaulting to whichever the most of
+///   them share.
+/// - **How many it skips.** Ticking twenty leavers and applying the Smartschool
+///   unregister must not silently pass over the three who are Azure-only. The
+///   line under the chips says how many of the ticked accounts the decision does
+///   not stand open on.
+/// - **That the count is the rows on screen.** [tickable] is the *visible* work
+///   rows, the effective selection is its intersection with [ticked], and the
+///   confirmation quotes that number — so select-all under a filter is a
+///   selection of what the filter shows, never of the school.
+class _SelectionBar extends StatelessWidget {
+  const _SelectionBar({
+    required this.controller,
+    required this.tickable,
+    required this.ticked,
+    required this.decisionKey,
+    required this.onSelectAll,
+    required this.onClear,
+    required this.onDecisionChanged,
+  });
+
+  final ReconcileController controller;
+
+  /// The rows that may be ticked right now: visible, and carrying applyable
+  /// work. Select-all covers exactly these.
+  final List<_AccountRow> tickable;
+
+  /// Every ticked id the screen is holding — including ones the current filter
+  /// has taken off screen, which is why this is intersected with [tickable]
+  /// rather than counted.
+  final Set<String> ticked;
+
+  /// The [SituationCohort.key] the operator picked, or `null` for the default.
+  final String? decisionKey;
+
+  final ValueChanged<bool> onSelectAll;
+  final VoidCallback onClear;
+  final ValueChanged<String> onDecisionChanged;
+
+  /// The decisions a selection raises that a pass could actually write, most
+  /// widely shared first — the chips, in the order they are offered.
+  ///
+  /// Grouped from the rows on screen with the same public
+  /// [ReconcileController.situationCohorts] the Klasgroepen headers use, which
+  /// is the point of it being public (#252): a bulk button's cohort is resolved
+  /// from the very list it was built over, never re-derived from the whole view.
+  ///
+  /// A cohort with no applyable member is dropped — an informational notice is a
+  /// diagnosis, not work this screen can do — so every chip offered leads to a
+  /// pass that writes something.
+  static List<SituationCohort> candidateDecisions(
+    List<_AccountRow> selection,
+  ) {
+    final entries = <PendingAccountEntry>[
+      for (final r in selection)
+        if (r.entry != null) r.entry!,
+    ];
+    final cohorts = <SituationCohort>[
+      for (final c in ReconcileController.situationCohorts(entries))
+        if (c.applyableCount > 0) c,
+    ];
+    // Widest first, so the decision the selection was probably made for is the
+    // default. Keyed tie-break because `List.sort` is not stable and the chips
+    // must not reshuffle between builds.
+    cohorts.sort((a, b) {
+      final byCount = b.applyableCount - a.applyableCount;
+      return byCount != 0 ? byCount : a.key.compareTo(b.key);
+    });
+    return cohorts;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    final List<_AccountRow> selection = <_AccountRow>[
+      for (final r in tickable)
+        if (ticked.contains(r.id)) r,
+    ];
+    final List<SituationCohort> candidates = candidateDecisions(selection);
+    final SituationCohort? decision = candidates.isEmpty
+        ? null
+        : candidates.firstWhere(
+            (c) => c.key == decisionKey,
+            orElse: () => candidates.first,
+          );
+    // What the pass runs: this one decision, for the ticked accounts it stands
+    // open on. Non-applyable members are out for the same reason they are out of
+    // every other cohort — they write nothing.
+    final List<PendingDecision> members = decision == null
+        ? const <PendingDecision>[]
+        : <PendingDecision>[
+            for (final d in decision.decisions)
+              if (d.canApply) d,
+          ];
+    final Set<String> covered = <String>{
+      for (final d in members) d.entry.targetId,
+    };
+    final int skipped = selection.length - covered.length;
+    final bool? allValue = selection.isEmpty
+        ? false
+        : selection.length == tickable.length
+            ? true
+            : null;
+
+    return Container(
+      key: const ValueKey('actions-selection-bar'),
+      padding: const EdgeInsets.all(PlinkSpacing.s4),
+      decoration: BoxDecoration(
+        border: Border.all(color: Theme.of(context).dividerColor),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Checkbox(
+                key: const ValueKey('actions-select-all'),
+                // Tristate for the reading, not for the cycle: a partial
+                // selection has to look partial. The press itself is decided
+                // here — everything ticked clears, anything else selects — so it
+                // never lands the operator on the dash.
+                tristate: true,
+                value: allValue,
+                onChanged: (_) => onSelectAll(allValue != true),
+              ),
+              const SizedBox(width: PlinkSpacing.s2),
+              Expanded(
+                child: Text(
+                  'Selecteer alle zichtbare (${tickable.length})',
+                  style: text.bodyMedium,
+                ),
+              ),
+              if (selection.isNotEmpty)
+                TextButton(
+                  key: const ValueKey('actions-selection-clear'),
+                  onPressed: controller.busy ? null : onClear,
+                  child: const Text('Wis selectie'),
+                ),
+            ],
+          ),
+          if (selection.isEmpty)
+            Text(
+              'Vink accounts aan om één beslissing op meerdere tegelijk toe te '
+              'passen — ook de beslissingen die geen "toepassen op alle" '
+              'krijgen.',
+              style: text.bodySmall,
+            )
+          else ...<Widget>[
+            const SizedBox(height: PlinkSpacing.s2),
+            Text(
+              '${selection.length} account(s) geselecteerd. Kies de beslissing '
+              'die je toepast:',
+              style: text.bodySmall,
+            ),
+            const SizedBox(height: PlinkSpacing.s2),
+            if (decision == null)
+              Text(
+                'Geen van de geselecteerde accounts heeft een beslissing die '
+                'automatisch geschreven kan worden.',
+                key: const ValueKey('actions-selection-no-decision'),
+                style: text.bodySmall,
+              )
+            else ...<Widget>[
+              Wrap(
+                spacing: PlinkSpacing.s2,
+                runSpacing: PlinkSpacing.s2,
+                children: <Widget>[
+                  for (final c in candidates)
+                    ChoiceChip(
+                      key: ValueKey('actions-decision-${c.key}'),
+                      label: Text('${c.label} (${c.applyableCount})'),
+                      selected: c.key == decision.key,
+                      onSelected: controller.busy
+                          ? null
+                          : (_) => onDecisionChanged(c.key),
+                    ),
+                ],
+              ),
+              const SizedBox(height: PlinkSpacing.s2),
+              Text(
+                key: const ValueKey('actions-selection-scope'),
+                skipped == 0
+                    ? 'Wordt toegepast op alle ${covered.length} '
+                        'geselecteerde account(s).'
+                    : 'Wordt toegepast op ${covered.length} van de '
+                        '${selection.length} geselecteerde account(s) — '
+                        '$skipped overgeslagen, want daar staat deze '
+                        'beslissing niet open.',
+                style: text.bodySmall?.copyWith(color: colors.primary),
+              ),
+              const SizedBox(height: PlinkSpacing.s3),
+              Wrap(
+                spacing: PlinkSpacing.s2,
+                runSpacing: PlinkSpacing.s2,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: <Widget>[
+                  OutlinedButton(
+                    key: const ValueKey('actions-selection-dry-run'),
+                    onPressed: controller.busy || members.isEmpty
+                        ? null
+                        : () => runWithProgress(
+                              context,
+                              controller: controller,
+                              dry: true,
+                              run: () => controller.dryRunDecisions(members),
+                            ),
+                    child: const Text('Dry-run selectie'),
+                  ),
+                  FilledButton(
+                    key: const ValueKey('actions-selection-apply'),
+                    onPressed: controller.busy || members.isEmpty
+                        ? null
+                        : () => confirmAndApply(
+                              context,
+                              controller: controller,
+                              // The count of the rows on screen behind the
+                              // dialog, so "alles aanvinken" can never read as a
+                              // school-wide apply.
+                              title: 'Toepassen op ${covered.length} '
+                                  'geselecteerd(e) account(s)?',
+                              // One decision deep (#292), over exactly the
+                              // ticked members — the same list the button counts
+                              // and the pass writes.
+                              scope: controller.applyScopeForDecisions(members),
+                              apply: () => controller.applyDecisions(members),
+                            ),
+                    child: Text('Toepassen op selectie (${covered.length})'),
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ],
+      ),
+    );
+  }
+}
+
 /// The horizontal family tab bar (#179): switches the list below between the
 /// Leerlingen (student) and Personeel (staff) action families, each carrying a
 /// pending-count badge so the operator sees where the work sits without opening
@@ -1145,11 +1571,29 @@ class _AccountListRow extends StatelessWidget {
     required this.row,
     required this.selected,
     required this.onTap,
+    this.ticked = false,
+    this.onTicked,
   });
 
   final _AccountRow row;
   final bool selected;
   final VoidCallback onTap;
+
+  /// Whether this row is in the multi-select (#297).
+  final bool ticked;
+
+  /// Ticks/unticks the row, or `null` when this list offers no ticking at all —
+  /// which is what a cohort under review is, its list being the review's own.
+  final ValueChanged<bool>? onTicked;
+
+  /// The width the tick column reserves, so a row without a checkbox still
+  /// lines its name up with the rows that have one.
+  ///
+  /// The measure a [Checkbox] takes at [VisualDensity.compact] with a
+  /// shrink-wrapped tap target — pinned rather than left to the theme, because
+  /// the blank has to match it exactly or every settled row's name sits a few
+  /// pixels off the ones above it.
+  static const double _checkboxColumn = 32.0;
 
   @override
   Widget build(BuildContext context) {
@@ -1175,6 +1619,26 @@ class _AccountListRow extends StatelessWidget {
             children: <Widget>[
               Row(
                 children: <Widget>[
+                  // Only a row with applyable work can be ticked — ticking a
+                  // settled account would add nothing to a pass and inflate the
+                  // "overgeslagen" count with accounts that were never work. The
+                  // blank keeps the names in one column either way.
+                  if (onTicked != null) ...<Widget>[
+                    SizedBox(
+                      width: _checkboxColumn,
+                      child: row.hasWork
+                          ? Checkbox(
+                              key: ValueKey('account-check-${row.id}'),
+                              value: ticked,
+                              visualDensity: VisualDensity.compact,
+                              materialTapTargetSize:
+                                  MaterialTapTargetSize.shrinkWrap,
+                              onChanged: (v) => onTicked!(v ?? false),
+                            )
+                          : null,
+                    ),
+                    const SizedBox(width: PlinkSpacing.s3),
+                  ],
                   Expanded(
                     child: Text(
                       row.account.label,

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -611,6 +611,37 @@ class _ActionsBodyState extends State<_ActionsBody>
     _settled.clear();
   }
 
+  /// Whether an inventory read is already queued, so a burst of notifications
+  /// schedules one.
+  bool _scheduledGroups = false;
+
+  /// Reads the class inventory when this session does not have it, so the
+  /// header can say how many classes are waiting on Klasgroepen (#301).
+  ///
+  /// The very read Klasgroepen does, through the same controller and the same
+  /// guard, so opening either tab first costs one partition read and the other
+  /// finds it already there. Without it the pointer would only appear once the
+  /// operator had visited the tab it is meant to send them to, which is the one
+  /// case it is not needed.
+  ///
+  /// Always **deferred to a microtask**, never run inline: this is reached from
+  /// a build, and the read's own first act is to publish its loading state — so
+  /// calling it inline would notify the other screens' listeners mid-frame.
+  /// A failed read answers `const []`, so it is attempted once and not retried
+  /// into a loop.
+  void _ensureGroupsLoaded() {
+    if (!mounted || _scheduledGroups) return;
+    if (controller.groupDocs != null || controller.loadingGroups) return;
+    _scheduledGroups = true;
+    scheduleMicrotask(() {
+      _scheduledGroups = false;
+      if (!mounted) return;
+      if (controller.groupDocs == null && !controller.loadingGroups) {
+        unawaited(controller.loadGroups());
+      }
+    });
+  }
+
   /// Ticks or unticks one account (#297).
   void _setTicked(String id, bool ticked) => setState(() {
         if (ticked) {
@@ -771,6 +802,7 @@ class _ActionsBodyState extends State<_ActionsBody>
   Widget _body(BuildContext context, BoxConstraints constraints) {
     _retireStaleTicks();
     _holdSettled();
+    _ensureGroupsLoaded();
     final bool wide = constraints.maxWidth >= _splitBreakpoint;
     final bool active = controller.linked != null;
     final SituationCohort? cohort = active ? _armedCohort() : null;
@@ -802,6 +834,7 @@ class _ActionsBodyState extends State<_ActionsBody>
             controller: controller,
             onlyWithActions: _onlyWithActions,
             reviewingCohort: cohort != null,
+            classesNeedingAttention: controller.classesNeedingAttention,
           ),
         ),
         const SizedBox(height: PlinkSpacing.s4),
@@ -1106,6 +1139,7 @@ class _ActionsHeader extends StatelessWidget {
     required this.controller,
     required this.onlyWithActions,
     this.reviewingCohort = false,
+    this.classesNeedingAttention = 0,
   });
 
   final ReconcileController controller;
@@ -1118,6 +1152,10 @@ class _ActionsHeader extends StatelessWidget {
   /// reading of [onlyWithActions] describes the list: it is one decision's
   /// cohort, and the banner right below says so.
   final bool reviewingCohort;
+
+  /// How many classes are waiting on the Klasgroepen tab (#301) — the one thing
+  /// in this header that is not about the list below it.
+  final int classesNeedingAttention;
 
   @override
   Widget build(BuildContext context) {
@@ -1149,6 +1187,14 @@ class _ActionsHeader extends StatelessWidget {
           },
           style: text.bodyMedium,
         ),
+        // The other half of "is everything as expected?" (#301). It sits under
+        // the count line and above the freshness stamp because it is a
+        // statement about the work, not about the view — and it says nothing at
+        // all when Klasgroepen is holding nothing.
+        if (classesNeedingAttention > 0) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s1),
+          OtherTabAttentionLine.classes(count: classesNeedingAttention),
+        ],
         if (freshness != null) ...<Widget>[
           const SizedBox(height: PlinkSpacing.s1),
           Text(freshness, style: text.bodySmall),

--- a/account_manager/lib/src/screens/class_groups_screen.dart
+++ b/account_manager/lib/src/screens/class_groups_screen.dart
@@ -308,8 +308,11 @@ class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
   List<Widget> _slivers(BuildContext context) {
     final bool active = controller.linked != null;
     final rows = _rows();
-    final int attention =
-        rows.where((r) => r.attentionIn(active: active)).length;
+    // The same predicate the rows below key their highlight on, but derived on
+    // the controller since #301 — Acties quotes this number too, and a pointer
+    // that counted differently from the list it points at would be worse than
+    // none.
+    final int attention = controller.classesNeedingAttention;
     // The two filters compose rather than replace one another (#262): the
     // search narrows the inventory to the classes the operator is looking for,
     // and the switch — if they turned it on — keeps the ones asking something.
@@ -333,6 +336,7 @@ class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
         controller: controller,
         total: rows.length,
         attention: attention,
+        accountsNeedingAttention: controller.accountsNeedingAttention,
       )),
       _gap(PlinkSpacing.s4),
       _section(_ClassSearchBar(searchController: _search)),
@@ -520,11 +524,16 @@ class _ClassGroupsHeader extends StatelessWidget {
     required this.controller,
     required this.total,
     required this.attention,
+    this.accountsNeedingAttention = 0,
   });
 
   final ReconcileController controller;
   final int total;
   final int attention;
+
+  /// How many accounts are waiting on the Acties tab (#301) — the mirror of the
+  /// line Acties carries about this one.
+  final int accountsNeedingAttention;
 
   @override
   Widget build(BuildContext context) {
@@ -549,6 +558,13 @@ class _ClassGroupsHeader extends StatelessWidget {
           },
           style: text.bodyMedium,
         ),
+        // The other half of "is everything as expected?" (#301) — the mirror of
+        // the pointer Acties carries at this tab, in the same place under the
+        // count line, and silent when Acties is holding nothing.
+        if (accountsNeedingAttention > 0) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s1),
+          OtherTabAttentionLine.accounts(count: accountsNeedingAttention),
+        ],
         if (freshness != null) ...<Widget>[
           const SizedBox(height: PlinkSpacing.s1),
           Text(freshness, style: text.bodySmall),

--- a/account_manager/lib/src/screens/class_groups_screen.dart
+++ b/account_manager/lib/src/screens/class_groups_screen.dart
@@ -12,6 +12,12 @@ import '../reconcile/reconcile_controller.dart';
 import '../search/name_query.dart';
 import 'action_tiles.dart';
 
+// The class-name ordering moved to the shared tile library when the flat Acties
+// list grew a "sorteer op klas" of its own (#295) — both screens order a class
+// list the same way or neither is scannable. Re-exported so it stays importable
+// from here, exactly as it was before it moved.
+export 'action_tiles.dart' show compareClassNames;
+
 /// The **Klasgroepen** tab (#227): the full class inventory.
 ///
 /// Every class the last sync linked is a row here — not only the ones that
@@ -506,26 +512,6 @@ class _ClassGroupsBodyState extends State<_ClassGroupsBody> {
           ),
         ),
       ];
-}
-
-/// Orders class names the way an operator reads a class list: by year first and
-/// numerically (`2A` before `10A`), then alphabetically, so `2F` sorts beside
-/// its sub-groups rather than between `20A` and `21B`.
-int compareClassNames(String a, String b) {
-  final ya = _leadingYear(a);
-  final yb = _leadingYear(b);
-  if (ya != yb) {
-    // A non-numeric class (`OKAN`) sorts after every numbered year.
-    if (ya == null) return 1;
-    if (yb == null) return -1;
-    return ya - yb;
-  }
-  return a.toLowerCase().compareTo(b.toLowerCase());
-}
-
-int? _leadingYear(String name) {
-  final match = RegExp(r'^\s*(\d+)').firstMatch(name);
-  return match == null ? null : int.tryParse(match.group(1)!);
 }
 
 /// The tab title plus the one-line state of the inventory.

--- a/account_manager/lib/src/screens/system_indicator.dart
+++ b/account_manager/lib/src/screens/system_indicator.dart
@@ -168,9 +168,10 @@ String systemIndicatorTooltip(core.Origin system, SystemIndicatorState state) =>
 /// One system cell of a row: the icon in its state's colour, the system's Dutch
 /// name, and optionally the thing that is (or is not) there.
 ///
-/// Shared so Klasgroepen's inventory rows and the flat Acties list of #295 mean
+/// Shared so Klasgroepen's inventory rows and the flat Acties list (#295) mean
 /// the same thing by a coloured cell — the point of #298. Callers give it a
-/// [key] so a test (and #295's row builder) can address one cell of one row.
+/// [key] — `class-cell-<klas>-<systeem>`, `account-cell-<id>-<systeem>` — so a
+/// test can address one cell of one row.
 class SystemIndicatorCell extends StatelessWidget {
   const SystemIndicatorCell({
     super.key,

--- a/account_manager/lib/src/shell/app_shell.dart
+++ b/account_manager/lib/src/shell/app_shell.dart
@@ -9,14 +9,21 @@ import '../screens/passwords_screen.dart';
 import '../screens/reconcile_screen.dart';
 import '../screens/settings_screen.dart';
 import '../settings/settings_bootstrap.dart';
+import 'shell_navigation.dart';
+
+export 'shell_navigation.dart';
 
 /// One navigable destination in the [AppShell].
 class ShellDestination {
   const ShellDestination({
+    required this.tab,
     required this.label,
     required this.icon,
     required this.builder,
   });
+
+  /// Which destination this is, so a screen can ask for it by name (#301).
+  final ShellTab tab;
 
   final String label;
   final IconData icon;
@@ -54,16 +61,19 @@ class _AppShellState extends State<AppShell> {
     // it (#257): the rail is read together with the heading it leads to, so a
     // rail saying "Actions" over a page titled "Acties" reads as two apps.
     ShellDestination(
+      tab: ShellTab.start,
       label: 'Start',
       icon: Icons.home_outlined,
       builder: (_) => const HomeScreen(),
     ),
     ShellDestination(
+      tab: ShellTab.synchronisatie,
       label: 'Synchronisatie',
       icon: Icons.sync_alt_outlined,
       builder: (_) => ReconcileScreen(bootstrap: widget.reconcileBootstrap),
     ),
     ShellDestination(
+      tab: ShellTab.acties,
       label: 'Acties',
       icon: Icons.checklist_outlined,
       builder: (_) => ActionsScreen(bootstrap: widget.reconcileBootstrap),
@@ -72,16 +82,19 @@ class _AppShellState extends State<AppShell> {
     // inside Acties: it lists *every* class, so it answers "is this right?",
     // which the action list structurally cannot.
     ShellDestination(
+      tab: ShellTab.klasgroepen,
       label: 'Klasgroepen',
       icon: Icons.groups_outlined,
       builder: (_) => ClassGroupsScreen(bootstrap: widget.reconcileBootstrap),
     ),
     ShellDestination(
+      tab: ShellTab.wachtwoorden,
       label: 'Wachtwoorden',
       icon: Icons.password_outlined,
       builder: (_) => PasswordsScreen(bootstrap: widget.reconcileBootstrap),
     ),
     ShellDestination(
+      tab: ShellTab.instellingen,
       label: 'Instellingen',
       icon: Icons.settings_outlined,
       builder: (_) => SettingsScreen(bootstrap: widget.settingsBootstrap),
@@ -89,6 +102,20 @@ class _AppShellState extends State<AppShell> {
   ];
 
   int _selected = 0;
+
+  /// Selects the destination named [tab] (#301) — how a screen follows its own
+  /// pointer at another one, rather than asking the operator to find the rail
+  /// entry themselves.
+  ///
+  /// Exactly what tapping the rail entry does, and nothing more: a destination
+  /// the operator has been to before is kept alive by the [IndexedStack] and
+  /// comes back as they left it; one they have not is built on the next frame,
+  /// as it would be either way.
+  void _go(ShellTab tab) {
+    final int index = _destinations.indexWhere((d) => d.tab == tab);
+    if (index < 0 || index == _selected) return;
+    setState(() => _selected = index);
+  }
 
   /// The reconcile stack is assembled once and kept across tab switches, so
   /// the screens are kept alive rather than rebuilt per selection.
@@ -100,6 +127,15 @@ class _AppShellState extends State<AppShell> {
   @override
   Widget build(BuildContext context) {
     _built[_selected] ??= _destinations[_selected].builder(context);
+    // Above the rail *and* the views, so a screen can follow its own pointer at
+    // another tab (#301).
+    return ShellNavigation(
+      go: _go,
+      child: _scaffold(),
+    );
+  }
+
+  Widget _scaffold() {
     return Scaffold(
       // The per-product identity rule spans the top of the whole shell (its
       // intended placement — a full-width accent bar), with the navigation

--- a/account_manager/lib/src/shell/shell_navigation.dart
+++ b/account_manager/lib/src/shell/shell_navigation.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/widgets.dart';
+
+/// The shell's destinations, by name (#301).
+///
+/// A screen that points at another tab — "12 klas(sen) vragen ook aandacht" on
+/// Acties, its mirror on Klasgroepen — names the destination rather than the
+/// index the navigation rail happens to give it, so reordering the rail cannot
+/// silently re-aim a link.
+enum ShellTab {
+  start,
+  synchronisatie,
+  acties,
+  klasgroepen,
+  wachtwoorden,
+  instellingen,
+}
+
+/// Lets a screen inside the shell send the operator to another tab (#301).
+///
+/// It lives in a file of its own rather than in `app_shell.dart` so the shared
+/// tile library can reach it: the shell imports the screens and the screens
+/// import the tiles, so a tile importing the shell would close the ring.
+///
+/// [maybeOf] is deliberately nullable and every caller has to cope with `null`.
+/// A screen is pumped on its own in every widget test, and a pointer that
+/// cannot be followed is still worth stating — so outside the shell the line
+/// renders as plain prose instead of throwing or disappearing.
+class ShellNavigation extends InheritedWidget {
+  const ShellNavigation({
+    super.key,
+    required this.go,
+    required super.child,
+  });
+
+  /// Selects [tab] in the shell.
+  final void Function(ShellTab tab) go;
+
+  static ShellNavigation? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<ShellNavigation>();
+
+  /// [go] is a bound method of the shell's state, so it is the very same
+  /// function on every rebuild and no dependent ever has to be told about a new
+  /// one.
+  @override
+  bool updateShouldNotify(ShellNavigation oldWidget) => false;
+}

--- a/account_manager/test/reconcile/reconcile_apply_to_all_test.dart
+++ b/account_manager/test/reconcile/reconcile_apply_to_all_test.dart
@@ -1,0 +1,242 @@
+import 'package:account_actions/account_actions.dart' as actions;
+import 'package:account_core/account_core.dart' show Origin;
+import 'package:account_manager/src/reconcile/reconcile_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'reconcile_fakes.dart';
+
+/// #296 — one action, applied across the **whole school**, with the cohort
+/// resolvable before anything is written.
+///
+/// At the September rollover every student changes class group, so
+/// `MoveToSmartschoolClassGroup` fires for the entire roster; doing that one
+/// account at a time is not a workflow anyone follows. What makes it safe where
+/// the global "Alles toepassen" of #294 was not is that the cohort is one
+/// *decision* (#292) whose action carries the bulk sanction (#293) — so the
+/// operator can read one description and know what the pass does to everyone in
+/// it.
+///
+/// These pin the resolution the screen builds its affordance from: which
+/// decisions get one at all, who is in the cohort, and that arming it writes
+/// nothing.
+void main() {
+  const String move = 'Wijzig de klas in Smartschool';
+  const String moveKey = 'student|MoveToSmartschoolClassGroup';
+  const String renameKey = 'student|ModifyAzureName';
+
+  PendingDecision decisionOf(
+    ReconcileHarness h, {
+    required String target,
+    required String situationId,
+  }) {
+    final entry =
+        h.controller.pendingEntries.firstWhere((e) => e.target == target);
+    return PendingDecision(
+      entry: entry,
+      choice: entry.choices.singleWhere((c) => c.situationId == situationId),
+    );
+  }
+
+  List<String> summariesOf(ReconcileHarness h) =>
+      h.controller.applyResults!.map((r) => r.changes.summary).toList();
+
+  group('the sanction reaches the pending list (#293/#296)', () {
+    test("an option carries its action's canApplyToAll", () async {
+      final h = rolloverHarness();
+      await h.controller.sync();
+
+      final sam =
+          h.controller.pendingEntries.firstWhere((e) => e.target == 'Sam Sels');
+      final flags = <String, bool>{
+        for (final c in sam.choices) c.situationId: c.canApplyToAll,
+      };
+
+      expect(flags, <String, bool>{
+        // Legacy granted the rollover move `canBeAppliedToAll`; this is the
+        // action #296 exists for.
+        'MoveToSmartschoolClassGroup': true,
+        // A rename is a judgement call — the operator is meant to look at the
+        // record.
+        'ModifyAzureName': false,
+      });
+    });
+
+    test('a destructive either/or is sanctioned on neither side', () async {
+      // Unregister *vs* delete: #293 withholds both, so the decision gets no
+      // school-wide affordance whichever way the operator resolves it.
+      final h = ReconcileHarness(
+        wisa: wisaSnap(students: const []),
+        smartschool: ssSnap(
+          groups: const [],
+          accounts: [
+            ssAccount(uid: 'jane', accountId: '1'),
+            ssAccount(uid: 'john', accountId: '2'),
+          ],
+          memberships: const [],
+        ),
+        azure: azSnap(users: const []),
+      );
+      await h.controller.sync();
+
+      final entry = h.controller.pendingEntries.first;
+      final choice = entry.choices.single;
+      expect(choice.alternatives.map((a) => a.canApplyToAll),
+          everyElement(isFalse));
+      expect(
+        h.controller
+            .applyToAllCohort(PendingDecision(entry: entry, choice: choice)),
+        isNull,
+        reason: 'a delete over the whole school off one dialog is exactly what '
+            'the sanction exists to refuse',
+      );
+    });
+  });
+
+  group('the cohort is the school, not the class (#296)', () {
+    test('every student needing the move is in it', () async {
+      final h = rolloverHarness();
+      await h.controller.sync();
+
+      final cohort = h.controller.applyToAllCohort(
+        decisionOf(h,
+            target: 'Sam Sels', situationId: 'MoveToSmartschoolClassGroup'),
+      )!;
+
+      expect(cohort.key, moveKey);
+      expect(cohort.label, move);
+      expect(
+        cohort.decisions.map((d) => d.entry.target),
+        <String>['Sam Sels', 'Sara Segers', 'Tom Tas'],
+        reason: 'armed from one card, resolved over the whole roster',
+      );
+    });
+
+    test('a decision the action withholds gets no cohort at all', () async {
+      final h = rolloverHarness();
+      await h.controller.sync();
+
+      expect(
+        h.controller.applyToAllCohort(
+          decisionOf(h, target: 'Sam Sels', situationId: 'ModifyAzureName'),
+        ),
+        isNull,
+      );
+      expect(h.controller.applyToAllCohortFor(renameKey), isNull,
+          reason: 'and not by the back door either — the members are what is '
+              'checked, so the key cannot smuggle one in');
+    });
+
+    test('the cohort is exactly what the pass will write', () async {
+      final h = rolloverHarness();
+      await h.controller.sync();
+      final cohort = h.controller.applyToAllCohortFor(moveKey)!;
+
+      // Length, applyable count and the confirmation's change count are one
+      // resolution — so the N on the button cannot over-claim.
+      expect(cohort.length, 3);
+      expect(cohort.applyableCount, 3);
+      final scope = h.controller.applyScopeForDecisions(cohort.decisions);
+      expect(scope.systems,
+          <Origin>[Origin.smartschool, Origin.smartschool, Origin.smartschool]);
+      expect(scope.chained, isEmpty);
+    });
+
+    test('resolving the cohort writes that decision and no other', () async {
+      final h = rolloverHarness();
+      await h.controller.sync();
+
+      await h.controller
+          .applyDecisions(h.controller.applyToAllCohortFor(moveKey)!.decisions);
+
+      expect(summariesOf(h), <String>[move, move, move]);
+      expect(
+        h.graph.requests.where((r) => r.method == 'PATCH'),
+        isEmpty,
+        reason: "Sam's Office 365 rename shares his card and was never armed",
+      );
+    });
+  });
+
+  group('a member is in on its own selected alternative (#296)', () {
+    test('only the sanctioned pick of a mixed either/or joins', () async {
+      // The staff import decision mixes the two: "create in Office 365" is
+      // sanctioned, "never import this person" is a blacklist and is withheld.
+      // So a colleague set to the blacklist must not be swept along by a cohort
+      // armed from a colleague set to the create.
+      final h = newStaffChoiceHarness();
+      await h.controller.sync();
+      final key = 'staff|${actions.staffImportAlternative}';
+      expect(h.controller.applyToAllCohortFor(key)!.length, 2);
+
+      final second = h.controller.pendingEntries
+          .where((e) => e.family == 'staff')
+          .toList()[1];
+      h.controller.chooseAlternative(
+        entry: second,
+        group: actions.staffImportAlternative,
+        kind: 'DontImportStaffFromWisa',
+      );
+
+      final narrowed = h.controller.applyToAllCohortFor(key)!;
+      expect(narrowed.length, 1);
+      expect(narrowed.decisions.single.entry.targetId, isNot(second.targetId));
+    });
+
+    test('re-reading by key is what keeps a live review honest', () async {
+      // The screen holds the key, never the members, precisely so a pick
+      // changed mid-review moves the account out of the list, out of N and out
+      // of the write together. Captured members would have applied the
+      // resolution the operator changed their mind about.
+      final h = newStaffChoiceHarness();
+      await h.controller.sync();
+      final key = 'staff|${actions.staffImportAlternative}';
+      final armed = h.controller.applyToAllCohortFor(key)!;
+
+      for (final entry
+          in h.controller.pendingEntries.where((e) => e.family == 'staff')) {
+        h.controller.chooseAlternative(
+          entry: entry,
+          group: actions.staffImportAlternative,
+          kind: 'DontImportStaffFromWisa',
+        );
+      }
+
+      expect(armed.length, 2, reason: 'the captured list is now stale…');
+      expect(h.controller.applyToAllCohortFor(key), isNull,
+          reason: '…and re-reading is what notices');
+    });
+  });
+
+  group('arming resolves, it does not write (#296)', () {
+    test('resolving the cohort touches no connector', () async {
+      final h = rolloverHarness();
+      await h.controller.sync();
+      final soap = h.soap.soapActions.length;
+      final graph = h.graph.requests.length;
+
+      h.controller.applyToAllCohort(
+        decisionOf(h,
+            target: 'Sam Sels', situationId: 'MoveToSmartschoolClassGroup'),
+      );
+
+      expect(h.soap.soapActions, hasLength(soap));
+      expect(h.graph.requests, hasLength(graph));
+      expect(h.controller.applyResults, isNull);
+    });
+
+    test('a dry-run over the cohort leaves it standing', () async {
+      // The pass the operator reads *before* pressing the one beside it, so it
+      // must not dissolve the review it was started from.
+      final h = rolloverHarness();
+      await h.controller.sync();
+
+      await h.controller.dryRunDecisions(
+          h.controller.applyToAllCohortFor(moveKey)!.decisions);
+
+      expect(h.controller.dryRunResults, hasLength(3));
+      expect(h.soap.soapActions.where((a) => a.endsWith('#saveUserToClass')),
+          isEmpty);
+      expect(h.controller.applyToAllCohortFor(moveKey)!.length, 3);
+    });
+  });
+}

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -1992,6 +1992,44 @@ void main() {
       await h.controller.loadGroups();
       expect(h.controller.groupDocs, isNotEmpty);
     });
+
+    test(
+        'the two attention counts are one derivation each, so the pointer one '
+        'action screen carries matches the list it points at (#301)', () async {
+      // `3C` and `3D` are both missing their Office 365 group; of the two
+      // students only Sam's Office 365 display name is stale.
+      final h = appliedClassWorkHarness();
+      await h.controller.sync();
+
+      // Nothing to count until the inventory has been read: a count the store
+      // was never asked for is not a count.
+      expect(h.controller.groupDocs, isNull);
+      expect(h.controller.classesNeedingAttention, 0);
+
+      await h.controller.loadGroups();
+      expect(h.controller.classesNeedingAttention, 2);
+
+      // Accounts, not actions. The view holds three pending cards — Sam plus
+      // the two classes — so neither the total nor the class half is the
+      // number the Klasgroepen pointer wants.
+      expect(h.controller.totalPendingCount, 3);
+      expect(h.controller.accountsNeedingAttention, 1);
+      expect(h.controller.groupPendingEntries, hasLength(2));
+    });
+
+    test(
+        'an informational candidate is class work, so it counts on Klasgroepen '
+        'and not against the accounts (#301)', () async {
+      // `2F` has no Office 365 group, which leaves each of its students with an
+      // `AzureClassGroupMembership` diagnosis of work that is done per class on
+      // the other tab. It must not turn them into accounts that need attention.
+      final h = azureClassGroupHarness();
+      await h.controller.sync();
+      await h.controller.loadGroups();
+
+      expect(h.controller.classesNeedingAttention, greaterThan(0));
+      expect(h.controller.accountsNeedingAttention, 0);
+    });
   });
 
   group('passive session reads the store (#115)', () {

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -366,8 +366,8 @@ void main() {
       final s1 = ReconcileHarness(store: snapshots, linkedStore: linkedStore);
       await s1.controller.sync();
 
-      // Session 2 reads that view, opens a class and the Klasgroepen
-      // inventory — and its own writes fail.
+      // Session 2 reads that view and the Klasgroepen inventory — and its own
+      // writes fail.
       final s2 = await ReconcileHarness.resume(
         store: snapshots,
         linkedStore: linkedStore,
@@ -377,14 +377,7 @@ void main() {
         ),
       );
       await s2.controller.loadOverview();
-      final classroom = s2.controller.schoolRollups
-          .expand((s) => s2.controller.childrenOf(s.key))
-          .expand((g) => s2.controller.childrenOf(g.key))
-          .single;
-      await s2.controller.openClassroom(classroom);
       await s2.controller.loadGroups();
-      s2.controller.expandedPath = <String>[classroom.key];
-      expect(s2.controller.classroomAccounts, isNotEmpty);
       expect(s2.controller.groupDocs, isNotEmpty);
 
       await s2.controller.sync();
@@ -396,15 +389,10 @@ void main() {
       );
       // …and the session still holds the view it just linked.
       expect(s2.controller.linked, isNotNull);
-      // The caches derived from the *previous* generation went with the
-      // re-link, whether or not the shared write landed.
-      expect(s2.controller.selectedClassroom, isNull,
-          reason: 'the open class was read for the view that was replaced');
-      expect(s2.controller.classroomAccounts, isNull);
+      // The cache derived from the *previous* generation went with the re-link,
+      // whether or not the shared write landed. (The Acties list has no such
+      // cache since #295: it renders off the linked view itself.)
       expect(s2.controller.groupDocs, isNull);
-      expect(s2.controller.expandedPath, isEmpty);
-      // With nothing open, no live entry can be joined to a stale document.
-      expect(s2.controller.classroomPendingEntries, isEmpty);
     });
 
     test(
@@ -423,13 +411,8 @@ void main() {
         persistTimeout: const Duration(milliseconds: 50),
       );
       await s2.controller.loadOverview();
-      final classroom = s2.controller.schoolRollups
-          .expand((s) => s2.controller.childrenOf(s.key))
-          .expand((g) => s2.controller.childrenOf(g.key))
-          .single;
-      await s2.controller.openClassroom(classroom);
       await s2.controller.loadGroups();
-      expect(s2.controller.classroomAccounts, isNotEmpty);
+      expect(s2.controller.groupDocs, isNotEmpty);
 
       await s2.controller.checkDrift();
 
@@ -439,8 +422,6 @@ void main() {
           'Het opslaan van het gedeelde overzicht duurde langer dan',
         )),
       );
-      expect(s2.controller.selectedClassroom, isNull);
-      expect(s2.controller.classroomAccounts, isNull);
       expect(s2.controller.groupDocs, isNull);
     });
   });
@@ -1857,7 +1838,7 @@ void main() {
 
     test(
         'a merged year lists both schools\' classrooms, each keeping its own '
-        'partition so the drill-down still reads one partition', () async {
+        'partition', () async {
       final h = twoSchoolHarness();
       await h.controller.sync();
 
@@ -1866,13 +1847,14 @@ void main() {
       final classes = h.controller.studentChildrenOf(jaar1);
       expect(classes.map((r) => r.label), <String>['1A', '1B']);
       // The partition key of each class is its real school — what
-      // `readClassroom(partitionKey: school)` targets.
+      // `readClassroom(partitionKey: school)` targets. Acties stopped reading
+      // classroom partitions in #295, but the store still holds them that way
+      // and the counts are still summed per school.
       expect(classes.map((r) => r.school), <String>['1', '2']);
-
-      // Opening one reads exactly that school's partition.
-      await h.controller.openClassroom(classes.last);
-      expect(h.controller.classroomAccounts, hasLength(1));
-      expect(h.controller.classroomAccounts!.single.school, '2');
+      expect(
+        await h.linkedStore.readClassroom(school: '2', classroom: '1B'),
+        hasLength(1),
+      );
     });
 
     test('a non-numeric class group is never labelled "Jaar Overig"', () async {
@@ -2043,11 +2025,8 @@ void main() {
           .expand((s) => s2.controller.childrenOf(s.key))
           .expand((g) => s2.controller.childrenOf(g.key))
           .single;
+      expect(classroom.accountCount, 1);
 
-      await s2.controller.openClassroom(classroom);
-
-      expect(s2.controller.selectedClassroom, classroom);
-      expect(s2.controller.classroomAccounts, hasLength(1));
       // Still no pull.
       expect(s2.wisaSyncs, 0);
       expect(s2.ssSyncs, 0);
@@ -2252,8 +2231,7 @@ void main() {
       expect(passive.controller.linked, isNotNull);
     });
 
-    test('onStoreChanged refetches the overview and the open classroom',
-        () async {
+    test('onStoreChanged refetches the overview', () async {
       final linkedStore = InMemoryLinkedStore();
       final snapshots = InMemorySnapshotStore();
 
@@ -2261,18 +2239,19 @@ void main() {
       final s1 = ReconcileHarness(store: snapshots, linkedStore: linkedStore);
       await s1.controller.sync();
 
-      // Session 2 renders the shared overview and drills into 3C.
+      // Session 2 renders the shared overview.
       final s2 = await ReconcileHarness.resume(
         store: snapshots,
         linkedStore: linkedStore,
       );
       await s2.controller.loadOverview();
-      final classroom3c = s2.controller.schoolRollups
-          .expand((s) => s2.controller.childrenOf(s.key))
-          .expand((g) => s2.controller.childrenOf(g.key))
-          .singleWhere((c) => c.classroom == '3C');
-      await s2.controller.openClassroom(classroom3c);
-      expect(s2.controller.classroomAccounts, hasLength(1));
+      expect(
+        s2.controller.schoolRollups
+            .expand((s) => s2.controller.childrenOf(s.key))
+            .expand((g) => s2.controller.childrenOf(g.key))
+            .map((c) => c.classroom),
+        contains('3C'),
+      );
 
       // Session 1 moves the student to 3D and re-syncs → generation 2.
       s1.wisaResult = wisaSnap(
@@ -2286,15 +2265,13 @@ void main() {
       await s2.controller.onStoreChanged(2);
 
       expect(s2.controller.syncState.generation, 2);
-      // The open 3C shard was refetched — the student has left it.
-      expect(s2.controller.classroomAccounts, isEmpty);
-      // …and 3D now exists in the refreshed rollups.
+      // 3D now exists in the refreshed rollups, and 3C is gone with it.
       expect(
         s2.controller.schoolRollups
             .expand((s) => s2.controller.childrenOf(s.key))
             .expand((g) => s2.controller.childrenOf(g.key))
             .map((c) => c.classroom),
-        contains('3D'),
+        <String>['3D'],
       );
     });
 
@@ -2318,18 +2295,19 @@ void main() {
       final s1 = ReconcileHarness(store: snapshots, linkedStore: linkedStore);
       await s1.controller.sync();
 
-      // Session 2 renders the shared overview and drills into 3C.
+      // Session 2 renders the shared overview.
       final s2 = await ReconcileHarness.resume(
         store: snapshots,
         linkedStore: linkedStore,
       );
       await s2.controller.loadOverview();
-      final classroom3c = s2.controller.schoolRollups
-          .expand((s) => s2.controller.childrenOf(s.key))
-          .expand((g) => s2.controller.childrenOf(g.key))
-          .singleWhere((c) => c.classroom == '3C');
-      await s2.controller.openClassroom(classroom3c);
-      expect(s2.controller.classroomAccounts, hasLength(1));
+      expect(
+        s2.controller.schoolRollups
+            .expand((s) => s2.controller.childrenOf(s.key))
+            .expand((g) => s2.controller.childrenOf(g.key))
+            .map((c) => c.classroom),
+        contains('3C'),
+      );
 
       // Session 1 moves the student to 3D → generation 2. Session 2 was
       // "disconnected" and never saw the nudge.
@@ -2340,10 +2318,9 @@ void main() {
       await s1.controller.sync();
 
       // A reconnect drives the catch-up with no generation argument — it
-      // re-reads unconditionally and the open 3C shard refreshes to empty.
+      // re-reads unconditionally.
       await s2.controller.resyncFromStore();
       expect(s2.controller.syncState.generation, 2);
-      expect(s2.controller.classroomAccounts, isEmpty);
       expect(
         s2.controller.schoolRollups
             .expand((s) => s2.controller.childrenOf(s.key))
@@ -2411,14 +2388,20 @@ void main() {
 
       await s2.controller.openSession();
 
-      // The same pending work the syncing session derived — without an open
-      // classroom, which is what a flat school-wide list needs (#295).
-      expect(s2.controller.selectedClassroom, isNull);
+      // The same pending work the syncing session derived — with no classroom
+      // to open, which is what the flat school-wide list needs (#295).
       expect(
         s2.controller.pendingEntries.map((e) => e.targetId),
         s1.controller.pendingEntries.map((e) => e.targetId),
       );
       expect(s2.controller.pendingEntries, isNotEmpty);
+      // And the account documents behind the rows are derived school-wide from
+      // that same view, with no per-classroom read at all (#295).
+      expect(
+        s2.controller.linkedAccounts.map((a) => a.label),
+        s1.controller.linkedAccounts.map((a) => a.label),
+      );
+      expect(s2.controller.linkedAccounts, isNotEmpty);
     });
 
     test('adoption runs once however many screens open the session', () async {
@@ -2754,30 +2737,20 @@ void main() {
       expect(b.azSyncs, 0);
     });
 
-    test("a passive session's open classroom drops the applied entry",
+    test('the applied entry is dropped from the stored account document too',
         () async {
-      // The drill-down is read from the per-account documents, not the rollups,
-      // so the write-back has to move both or B opens 3C and still sees the
-      // work on the card.
-      final hub = InMemorySignalHub();
+      // The rollups are aggregates; the per-account documents are what a
+      // session adopting the shared state links from. The write-back has to
+      // move both, or the next session to open reads the work as still due.
       final snapshots = InMemorySnapshotStore();
       final linkedStore = InMemoryLinkedStore();
       final a = appliedClassWorkHarness(
         store: snapshots,
         linkedStore: linkedStore,
-        hub: hub,
       );
       await a.controller.sync();
-
-      final b = await ReconcileHarness.resume(
-        store: snapshots,
-        linkedStore: linkedStore,
-        hub: hub,
-      );
-      await b.controller.loadOverview();
-      await b.controller.openClassroom(klas3C(b.controller)!);
       expect(
-        b.controller.classroomAccounts!
+        (await linkedStore.readClassroom(school: '1', classroom: '3C'))
             .expand((acc) => acc.candidates)
             .where((c) => c.canApply),
         hasLength(1),
@@ -2788,9 +2761,10 @@ void main() {
       await pumpEventQueue();
 
       expect(
-        b.controller.classroomAccounts!.expand((acc) => acc.candidates),
+        (await linkedStore.readClassroom(school: '1', classroom: '3C'))
+            .expand((acc) => acc.candidates),
         isEmpty,
-        reason: 'the open drill-down followed the shard it was told about',
+        reason: 'the write-back patched the document, not only the rollup',
       );
     });
 
@@ -2816,10 +2790,10 @@ void main() {
           reason: 'a one-row apply can name the very account it wrote');
     });
 
-    test('a shard rules an unrelated open classroom out of the refetch',
-        () async {
-      // What the shard is for: a session with 3D open is told about a change in
-      // 3C, and does not pay for a drill-down read it can prove is pointless.
+    test('a shard rules the class inventory out of the refetch', () async {
+      // What the shard is for: a session holding the Klasgroepen inventory is
+      // told about a change in one classroom, and does not pay for an inventory
+      // read it can prove is pointless.
       final snapshots = InMemorySnapshotStore();
       final linkedStore = InMemoryLinkedStore();
       await appliedClassWorkHarness(store: snapshots, linkedStore: linkedStore)
@@ -2831,11 +2805,9 @@ void main() {
         linkedStore: linkedStore,
       );
       await b.controller.loadOverview();
-      final threeD = b.controller.studentRollups
-          .expand(b.controller.studentChildrenOf)
-          .singleWhere((r) => r.classroom == '3D');
-      await b.controller.openClassroom(threeD);
-      final opened = b.controller.classroomAccounts;
+      await b.controller.loadGroups();
+      final loaded = b.controller.groupDocs;
+      expect(loaded, isNotEmpty);
 
       await b.controller.onStoreChanged(
         99,
@@ -2844,15 +2816,15 @@ void main() {
 
       expect(b.controller.syncState.generation, 1,
           reason: 'the overview itself is always re-read');
-      expect(identical(b.controller.classroomAccounts, opened), isTrue,
-          reason: '3D was never re-read — the shard ruled it out');
+      expect(identical(b.controller.groupDocs, loaded), isTrue,
+          reason: 'the inventory was never re-read — the shard ruled it out');
 
       // …while a shard that cannot rule it out does re-read it.
       await b.controller.onStoreChanged(
         100,
-        shard: const ShardRef(school: '1'),
+        shard: const ShardRef(school: groupsPartition),
       );
-      expect(identical(b.controller.classroomAccounts, opened), isFalse);
+      expect(identical(b.controller.groupDocs, loaded), isFalse);
     });
 
     test('a class-group apply reaches the stored group document', () async {

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1637,7 +1637,13 @@ const String kTom3D = 'az-tom-3d';
 /// at once, alongside whatever else drifted on their record over the summer, so
 /// the operation the app most needs to do in one pass is the one the old
 /// grouping fragmented hardest.
-ReconcileHarness rolloverHarness() => ReconcileHarness(
+///
+/// [applyGate] is awaited before every action, as in [appliedClassWorkHarness]
+/// — a test that needs one write of a two-decision pass refused throws from it
+/// on the call it picks (#299).
+ReconcileHarness rolloverHarness({Future<void> Function()? applyGate}) =>
+    ReconcileHarness(
+      applyGate: applyGate,
       wisa: wisaSnap(
         students: [
           wisaStudent(

--- a/account_manager/test/reconcile/reconcile_pending_choice_test.dart
+++ b/account_manager/test/reconcile/reconcile_pending_choice_test.dart
@@ -209,6 +209,63 @@ void main() {
       expect(identical(before, after), isFalse,
           reason: 'a fresh linked view must not serve a stale cached list');
     });
+
+    test(
+        'an apply pass refreshes the derived lists once, not once per write '
+        '(#299)', () async {
+      // A pass relinks after every write and notifies once per action to drive
+      // the progress dialog (#243), so a screen listening to it re-derives the
+      // whole school between one write and the next: `describeChanges()` over
+      // every pending action, plus a materialize of every account. At the
+      // September rollover that is thousands of writes, and the list being
+      // re-derived is behind a modal nobody can read.
+      // Three students in one situation — a rename each, which a real write
+      // genuinely settles — so the pass makes three writes, three relinks and
+      // a settled view to land on.
+      final h = crossClassSituationHarness();
+      await h.controller.sync();
+
+      // Exactly what a rebuild reads, on exactly the notifications it rebuilds
+      // on — so this counts the refreshes the screen would really have paid
+      // for, not the cache misses in the abstract.
+      final accountLists = <Object>[];
+      final entryLists = <Object>[];
+      void record() {
+        final Object accounts = h.controller.linkedAccounts;
+        if (!accountLists.any((o) => identical(o, accounts))) {
+          accountLists.add(accounts);
+        }
+        final Object entries = h.controller.pendingEntries;
+        if (!entryLists.any((o) => identical(o, entries))) {
+          entryLists.add(entries);
+        }
+      }
+
+      final cohort = h.controller.pendingSituations
+          .firstWhere((c) => c.key == 'student|ModifyAzureName');
+      expect(cohort.decisions, hasLength(3),
+          reason: 'three students share the rename');
+
+      h.controller.addListener(record);
+      await h.controller.applyDecisions(cohort.decisions);
+      h.controller.removeListener(record);
+
+      const reason = 'the view the pass started from, then the settled one — '
+          'the three intermediate relinks are the ones nobody can read';
+      expect(accountLists, hasLength(2), reason: reason);
+      expect(entryLists, hasLength(2), reason: reason);
+
+      // …and the second of each really is the settled view: the pass released
+      // the pinned lists before it announced it was over.
+      expect(
+        h.controller.pendingSituations
+            .where((c) => c.key == 'student|ModifyAzureName'),
+        isEmpty,
+        reason: 'the three renames were written, so nothing raises them again',
+      );
+      expect(identical(h.controller.pendingEntries, entryLists.last), isTrue);
+      expect(identical(h.controller.linkedAccounts, accountLists.last), isTrue);
+    });
   });
 
   group('a new class is one choice, not two to-dos (#244)', () {

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -2256,4 +2256,60 @@ void main() {
       );
     });
   });
+
+  // --- The pointer at Klasgroepen (#301) ------------------------------------
+
+  testWidgets(
+      'the Acties header says how many classes are waiting on Klasgroepen '
+      '(#301)', (WidgetTester tester) async {
+    // Acties covers people and Klasgroepen covers classes, and nothing on this
+    // screen said the second half existed. The fixture is the rollover shape in
+    // miniature: `3C` and `3D` are both missing their Office 365 group, which is
+    // work that can only be done on the other tab.
+    _useWideWindow(tester);
+    final harness = appliedClassWorkHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The screen reads the inventory itself, so the line is there on the first
+    // visit rather than only after the operator has been to the tab it points
+    // at — which is the one case it is not needed.
+    expect(harness.controller.groupDocs, isNotNull);
+    expect(harness.controller.classesNeedingAttention, 2);
+    expect(
+      find.text('2 klas(sen) vragen ook aandacht op Klasgroepen.'),
+      findsOneWidget,
+    );
+    // Pumped outside the shell there is no tab to switch to, and the sentence is
+    // true anyway — so it degrades to prose instead of vanishing.
+    expect(
+      find.byKey(const ValueKey('actions-class-attention')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('actions-class-attention')),
+        matching: find.byType(InkWell),
+      ),
+      findsNothing,
+      reason: 'no shell above it, so there is nothing to follow the line to',
+    );
+  });
+
+  testWidgets('…and says nothing at all when no class needs anything (#301)',
+      (WidgetTester tester) async {
+    // A line reading "0 klas(sen)" is noise in the one case where the operator
+    // is done. This fixture has departed Smartschool accounts and no class at
+    // all, so Acties has work and Klasgroepen has none.
+    _useWideWindow(tester);
+    final harness = departedHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(harness.controller.classesNeedingAttention, 0);
+    expect(find.byKey(const ValueKey('actions-class-attention')), findsNothing);
+    expect(find.textContaining('aandacht op Klasgroepen'), findsNothing);
+  });
 }

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -878,6 +878,228 @@ void main() {
     });
   });
 
+  // --- What an apply leaves on the screen (#299) ---------------------------
+
+  group('an apply updates the list and the pane in place (#299)', () {
+    /// Applies every decision on the card the details pane is open on, through
+    /// the confirmation the operator sees.
+    Future<void> applyCard(WidgetTester tester, String id) async {
+      final Finder apply = find.byKey(ValueKey('entry-apply-$id'));
+      await tester.ensureVisible(apply);
+      await tester.tap(apply);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      await tester.pumpAndSettle();
+    }
+
+    /// The "Toegepast" marker a held row carries once nothing is left on it.
+    Finder done(String id) => find.byKey(ValueKey('account-done-$id'));
+
+    /// Opens Acties over [harness] with the flat list on screen.
+    Future<void> open(WidgetTester tester, ReconcileHarness harness) async {
+      _useWideWindow(tester);
+      await harness.controller.sync();
+      await tester
+          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+        'the account the pass settled stays in the filtered list, marked done, '
+        'with the pane still on it', (WidgetTester tester) async {
+      // Sam's stale Office 365 display name is his only work, and a real write
+      // genuinely clears it — so the instant the pass ends he stops matching
+      // "toon enkel accounts met acties" and the list would drop him, taking
+      // the open pane and the verdict he was waiting for with him.
+      final harness = appliedClassWorkHarness();
+      await open(tester, harness);
+
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      await _select(tester, sam);
+      await applyCard(tester, sam);
+
+      expect(harness.graph.requests.where((r) => r.method == 'PATCH'),
+          hasLength(1));
+      expect(
+        harness.controller.pendingEntries.where((e) => e.targetId == sam),
+        isEmpty,
+        reason: 'the write settled his one decision',
+      );
+
+      // The filter never moved, and he is still on the list — marked as what
+      // just happened to him, not as an account that was always in order.
+      expect(
+        tester
+            .widget<Switch>(
+                find.byKey(const ValueKey('actions-only-with-actions')))
+            .value,
+        isTrue,
+      );
+      expect(_row(sam), findsOneWidget,
+          reason: 'a row that vanishes on the strength of its own success '
+              'takes the verdict off the screen with it');
+      expect(done(sam), findsOneWidget);
+      expect(
+          _cellState(tester, sam, Origin.azure), SystemIndicatorState.inOrder,
+          reason: 'the indicators re-rendered in place off the refreshed view');
+
+      // The pane never let go of him, and it says what the pass did — with no
+      // re-selection, and no sync.
+      expect(find.byKey(ValueKey('actions-detail-$sam')), findsOneWidget);
+      expect(find.byKey(const ValueKey('actions-detail-empty')), findsNothing);
+      final Finder verdict =
+          find.byKey(ValueKey('entry-outcomes-student-$sam'));
+      await tester.ensureVisible(verdict);
+      expect(
+        find.descendant(
+            of: verdict, matching: find.text('Wijzig de naam in Azure')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'a pass where one write lands and another is refused keeps the row and '
+        'shows both verdicts (#272/#283)', (WidgetTester tester) async {
+      // The reported shape behind #272, on an account rather than a class: one
+      // half of the card lands and the other is refused. A row that dropped out
+      // on the strength of the half that worked would make the refusal
+      // unreadable anywhere but the log panel on another screen.
+      var calls = 0;
+      final harness = rolloverHarness(applyGate: () async {
+        if (++calls == 2) throw StateError('Smartschool weigerde de opdracht');
+      });
+      await open(tester, harness);
+
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      await _select(tester, sam);
+      await applyCard(tester, sam);
+
+      // He keeps the decision that was refused, so the row stands on its own
+      // work — and is emphatically not marked done.
+      expect(_row(sam), findsOneWidget);
+      expect(done(sam), findsNothing);
+      expect(_cellState(tester, sam, Origin.smartschool),
+          SystemIndicatorState.needsWork);
+      expect(
+          _cellState(tester, sam, Origin.azure), SystemIndicatorState.inOrder,
+          reason: 'the rename landed, and the cell re-rendered in place');
+
+      // The refusal sits under the question it answers (#283)…
+      final Finder refused =
+          find.byKey(ValueKey('entry-outcomes-student-$sam-0'));
+      await tester.ensureVisible(refused);
+      expect(
+        find.descendant(
+          of: refused,
+          matching: find.textContaining('Smartschool weigerde de opdracht'),
+        ),
+        findsOneWidget,
+      );
+      // …and the half that landed keeps its own at card level, a settled
+      // decision having no block left to sit in.
+      final Finder settled =
+          find.byKey(ValueKey('entry-outcomes-student-$sam'));
+      await tester.ensureVisible(settled);
+      expect(
+        find.descendant(
+            of: settled, matching: find.text('Wijzig de naam in Azure')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('moving to an account the pass did not touch lets the row go',
+        (WidgetTester tester) async {
+      // Three students in one situation; applying Sam settles Sam alone. The
+      // hold is a courtesy to somebody reading a verdict, not a second filter,
+      // so it has to clear or the list accumulates finished rows.
+      final harness = crossClassSituationHarness();
+      await open(tester, harness);
+
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      final sara = _idOf(harness.controller, 'Sara Segers');
+      await _select(tester, sam);
+      await applyCard(tester, sam);
+      expect(_row(sam), findsOneWidget);
+
+      await _select(tester, sara);
+      expect(_row(sam), findsNothing);
+      expect(find.byKey(ValueKey('actions-detail-$sara')), findsOneWidget);
+    });
+
+    testWidgets('a sort or a search lets the held rows go',
+        (WidgetTester tester) async {
+      // Both reshape the list, which is the operator saying they are done
+      // reading the last pass — and the issue's own rule for when the hold must
+      // clear, alongside the sync that clears it anyway.
+      final harness = crossClassSituationHarness();
+      await open(tester, harness);
+
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      final sara = _idOf(harness.controller, 'Sara Segers');
+
+      await _select(tester, sam);
+      await applyCard(tester, sam);
+      expect(_row(sam), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('actions-sort-klas')));
+      await tester.pumpAndSettle();
+      expect(_row(sam), findsNothing);
+
+      await _select(tester, sara);
+      await applyCard(tester, sara);
+      expect(_row(sara), findsOneWidget);
+      await tester.enterText(
+          find.byKey(const ValueKey('actions-search')), 'Sara');
+      await tester.pumpAndSettle();
+      expect(_row(sara), findsNothing,
+          reason: 'she matches the needle and has no work left, so only the '
+              'hold was keeping her on screen');
+    });
+
+    testWidgets(
+        'a bulk pass holds every account it settled, and reading one does not '
+        'drop the rest', (WidgetTester tester) async {
+      // The pass a rollover really runs: one decision over a set of accounts,
+      // all of them settling at once. Opening the second of them must not
+      // delete the first out from under the tap that opened it.
+      final harness = crossClassSituationHarness();
+      await open(tester, harness);
+
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      final sara = _idOf(harness.controller, 'Sara Segers');
+      final tom = _idOf(harness.controller, 'Tom Tas');
+
+      await tester.tap(find.byKey(const ValueKey('actions-select-all')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('actions-selection-apply')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(harness.controller.applyResults, hasLength(3));
+      for (final String id in <String>[sam, sara, tom]) {
+        await tester.ensureVisible(_row(id));
+        expect(_row(id), findsOneWidget);
+        expect(done(id), findsOneWidget);
+      }
+
+      await _select(tester, sara);
+      expect(_row(sam), findsOneWidget);
+      expect(_row(tom), findsOneWidget);
+
+      // Her own verdict is on her card, though she raises nothing any more.
+      expect(find.text('Geen openstaande beslissingen voor dit account.'),
+          findsOneWidget);
+      final Finder verdict =
+          find.byKey(ValueKey('entry-outcomes-student-$sara'));
+      await tester.ensureVisible(verdict);
+      expect(
+        find.descendant(
+            of: verdict, matching: find.text('Wijzig de naam in Azure')),
+        findsOneWidget,
+      );
+    });
+  });
+
   testWidgets('cancelling the apply dialog writes nothing (#154)',
       (WidgetTester tester) async {
     _useWideWindow(tester);

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -363,6 +363,217 @@ void main() {
     expect(find.textContaining('in dezelfde situatie'), findsNothing);
   });
 
+  // --- School-wide apply-all, cohort first (#296) ---------------------------
+
+  group('a decision can be applied across the whole school (#296)', () {
+    /// The block-level "Toepassen op alle (N)" of the [index]-th decision on
+    /// [id]'s card.
+    Finder applyAll(String id, int index) =>
+        find.byKey(ValueKey('decision-apply-all-student-$id-$index'));
+
+    /// Which rows the flat list is showing right now, by account id.
+    Set<String> listedRows(WidgetTester tester) => tester
+        .widgetList<SystemIndicatorCell>(find.descendant(
+          of: find.byKey(const ValueKey('actions-list')),
+          matching: find.byWidgetPredicate(
+              (w) => w is SystemIndicatorCell && w.system == Origin.wisa),
+        ))
+        .map((c) => (c.key! as ValueKey<String>)
+            .value
+            .replaceFirst('account-cell-', '')
+            .replaceFirst('-wisa', ''))
+        .toSet();
+
+    int classMoves(ReconcileHarness harness) => harness.soap.soapActions
+        .where((a) => a.endsWith('#saveUserToClass'))
+        .length;
+
+    /// The September rollover in miniature: three students moved up into `4A`
+    /// while Smartschool still has all three in last year's `3C`, so every one
+    /// of them needs the same class change — and Sam alone also carries a stale
+    /// Office 365 display name, which is a decision #293 withholds from bulk.
+    Future<ReconcileHarness> openRollover(WidgetTester tester) async {
+      _useWideWindow(tester);
+      final harness = rolloverHarness();
+      await harness.controller.sync();
+      await tester
+          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+      return harness;
+    }
+
+    testWidgets(
+        'only the sanctioned decision offers it, and only when more than one '
+        'account needs it (#293)', (WidgetTester tester) async {
+      final harness = await openRollover(tester);
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      await _select(tester, sam);
+
+      // Sam's card, in dispatch order: the Office 365 rename, then the class
+      // move. The move is the rollover action legacy granted
+      // `canBeAppliedToAll`; the rename is a judgement call and is withheld.
+      expect(
+        harness.controller.pendingEntries
+            .firstWhere((e) => e.target == 'Sam Sels')
+            .choices
+            .map((c) => c.situationId),
+        <String>['ModifyAzureName', 'MoveToSmartschoolClassGroup'],
+      );
+      expect(applyAll(sam, 0), findsNothing,
+          reason: 'a rename over the whole school is exactly what the sanction '
+              'refuses');
+      expect(applyAll(sam, 1), findsOneWidget);
+      expect(
+        find.descendant(
+            of: applyAll(sam, 1), matching: find.text('Toepassen op alle (3)')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('an account alone in its situation gets no apply-all',
+        (WidgetTester tester) async {
+      // Jane needs the very same class move, but she is the only one — and
+      // "op alle (1)" says nothing the Toepassen button below it does not.
+      _useWideWindow(tester);
+      final harness = ReconcileHarness();
+      await harness.controller.sync();
+      await tester
+          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+
+      final id = _studentEntry(harness.controller).targetId;
+      await _select(tester, id);
+
+      expect(find.textContaining('Toepassen op alle'), findsNothing);
+      expect(find.byKey(ValueKey('entry-apply-$id')), findsOneWidget);
+    });
+
+    testWidgets(
+        'pressing it shows the cohort instead of writing it, whatever the '
+        'search box was set to', (WidgetTester tester) async {
+      final harness = await openRollover(tester);
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      final sara = _idOf(harness.controller, 'Sara Segers');
+      final tom = _idOf(harness.controller, 'Tom Tas');
+
+      // The operator has been looking at Sam alone.
+      await tester.enterText(
+          find.byKey(const ValueKey('actions-search')), 'Sam');
+      await tester.pumpAndSettle();
+      expect(listedRows(tester), <String>{sam});
+
+      await _select(tester, sam);
+      await tester.ensureVisible(applyAll(sam, 1));
+      await tester.tap(applyAll(sam, 1));
+      await tester.pumpAndSettle();
+
+      // The whole cohort is on screen — the count is school-wide, so the list
+      // it is confirmed against has to be too.
+      expect(listedRows(tester), <String>{sam, sara, tom});
+      expect(
+          find.byKey(const ValueKey('actions-cohort-banner')), findsOneWidget);
+      expect(
+        find.text('Wijzig de klas in Smartschool — 3 account(s) in de hele '
+            'school'),
+        findsOneWidget,
+      );
+      // The list's own controls stand down: they would either narrow the very
+      // list the operator is being asked to confirm, or do nothing.
+      expect(find.byKey(const ValueKey('actions-search')), findsNothing);
+      expect(find.byKey(const ValueKey('actions-only-with-actions')),
+          findsNothing);
+      // …and the header stops describing the list as the work list, which it
+      // no longer is.
+      expect(
+        find.textContaining('de lijst toont de accounts van één beslissing'),
+        findsOneWidget,
+      );
+
+      // And nothing has been written.
+      expect(
+          harness.soap.soapActions.where((a) => a.contains('save')), isEmpty);
+      expect(find.text('Resultaat van het toepassen'), findsNothing);
+    });
+
+    testWidgets('Annuleer gives the list and its controls back',
+        (WidgetTester tester) async {
+      final harness = await openRollover(tester);
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      await _select(tester, sam);
+      await tester.ensureVisible(applyAll(sam, 1));
+      await tester.tap(applyAll(sam, 1));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('actions-cohort-cancel')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('actions-cohort-banner')), findsNothing);
+      expect(find.byKey(const ValueKey('actions-search')), findsOneWidget);
+      expect(classMoves(harness), 0);
+    });
+
+    testWidgets(
+        'the confirmation names that one decision, and the pass writes it for '
+        'the whole cohort (#292/#234)', (WidgetTester tester) async {
+      final harness = await openRollover(tester);
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      await _select(tester, sam);
+      await tester.ensureVisible(applyAll(sam, 1));
+      await tester.tap(applyAll(sam, 1));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('actions-cohort-apply')));
+      await tester.pumpAndSettle();
+
+      final Finder dialog = find.byType(AlertDialog);
+      expect(find.text('Toepassen op 3 account(s)?'), findsOneWidget);
+      expect(
+        find.descendant(
+            of: dialog, matching: find.textContaining('3 wijzigingen')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+            of: dialog, matching: find.textContaining('Office 365')),
+        findsNothing,
+        reason: "summing every decision on every card would quote Sam's rename "
+            'and then not write it',
+      );
+
+      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(classMoves(harness), 3);
+      expect(harness.graph.requests.where((r) => r.method == 'PATCH'), isEmpty,
+          reason: 'the rename was never armed');
+      expect(harness.controller.applyResults, hasLength(3));
+      // The review is over: what it was built from has been written.
+      expect(find.byKey(const ValueKey('actions-cohort-banner')), findsNothing);
+      expect(find.byKey(const ValueKey('actions-search')), findsOneWidget);
+    });
+
+    testWidgets('a dry-run covers the same cohort and leaves it standing',
+        (WidgetTester tester) async {
+      final harness = await openRollover(tester);
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      await _select(tester, sam);
+      await tester.ensureVisible(applyAll(sam, 1));
+      await tester.tap(applyAll(sam, 1));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('actions-cohort-dry-run')));
+      await tester.pumpAndSettle();
+
+      expect(harness.controller.dryRunResults, hasLength(3));
+      expect(classMoves(harness), 0);
+      expect(find.text('Resultaat van de dry-run'), findsOneWidget);
+      expect(
+          find.byKey(const ValueKey('actions-cohort-banner')), findsOneWidget,
+          reason: 'the dry-run is what the operator reads before pressing the '
+              'button beside it, so it must not dissolve the review');
+    });
+  });
+
   testWidgets('cancelling the apply dialog writes nothing (#154)',
       (WidgetTester tester) async {
     _useWideWindow(tester);

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -3,39 +3,80 @@ import 'dart:async';
 import 'package:account_actions/account_actions.dart' show ActionOutcome;
 import 'package:account_core/account_core.dart' show Address, Origin;
 import 'package:account_manager/src/reconcile/reconcile_controller.dart'
-    show ApplyScope;
+    show ApplyScope, PendingAccountEntry, ReconcileController;
 import 'package:account_manager/src/screens/actions_screen.dart';
+import 'package:account_manager/src/screens/system_indicator.dart';
 import 'package:account_state/account_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:smartschool_api/smartschool_api.dart' show SmartschoolAccount;
 
 import '../reconcile/reconcile_fakes.dart';
 
 Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
 
-/// A tall viewport so the drill-down tree and a drilled-into classroom's tiles
-/// lay out without the assertions tripping on the fold.
-void _useTallWindow(WidgetTester tester) {
-  tester.view.physicalSize = const Size(800, 2400);
+/// A wide, tall viewport: the list and the details pane side by side, which is
+/// the layout #295 is about. Tall as well, so a pane's rows lay out without the
+/// assertions tripping on the fold.
+void _useWideWindow(WidgetTester tester) {
+  tester.view.physicalSize = const Size(1400, 2400);
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.reset);
 }
 
-/// Drills a Leerlingen top-level node — a merged "Jaar N" or the
-/// "Niet toegewezen" bucket — straight into one of its classrooms. #210 dropped
-/// the school level, so exactly one accordion sits above the class.
-Future<void> _drill(
-  WidgetTester tester, {
-  required String node,
-  required String classroom,
-}) async {
-  await tester.tap(find.text(node));
-  await tester.pumpAndSettle();
-  await tester.ensureVisible(find.text(classroom));
-  await tester.tap(find.text(classroom));
+/// A window below the split breakpoint, where the two panes become one.
+void _useNarrowWindow(WidgetTester tester) {
+  tester.view.physicalSize = const Size(700, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+Finder _row(String id) => find.byKey(ValueKey('account-row-$id'));
+
+Finder _cell(String id, Origin system) =>
+    find.byKey(ValueKey('account-cell-$id-${system.name}'));
+
+SystemIndicatorState _cellState(
+  WidgetTester tester,
+  String id,
+  Origin system,
+) =>
+    tester.widget<SystemIndicatorCell>(_cell(id, system)).state;
+
+/// The linker's id for the account displayed as [label] — what every row,
+/// cell and details block on this screen is keyed by.
+String _idOf(ReconcileController controller, String label) =>
+    controller.linkedAccounts.firstWhere((a) => a.label == label).id.value;
+
+/// Selects one row of the flat list.
+Future<void> _select(WidgetTester tester, String id) async {
+  await tester.ensureVisible(_row(id));
+  await tester.tap(_row(id));
   await tester.pumpAndSettle();
 }
+
+/// The one pending entry of the student family, whichever fixture raised it.
+PendingAccountEntry _studentEntry(ReconcileController controller) =>
+    controller.pendingEntries.firstWhere((e) => e.family == 'student');
+
+/// A WISA-departed scenario: [count] Smartschool-only active accounts (no
+/// WISA, no Azure), each raising the mutually-exclusive unregister/delete
+/// choice (#110). They land in the "Zonder klas" bucket.
+ReconcileHarness departedHarness({int count = 1}) => ReconcileHarness(
+      wisa: wisaSnap(students: const []),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: [
+          for (var i = 0; i < count; i++)
+            ssAccount(
+              uid: 'user$i',
+              accountId: '$i',
+              mail: 'user$i@student.school.example',
+            ),
+        ],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+    );
 
 void main() {
   testWidgets('shows the not-configured panel when AAD is absent',
@@ -50,7 +91,7 @@ void main() {
 
   testWidgets('a failed bootstrap offers a retry, in Dutch (#253)',
       (WidgetTester tester) async {
-    // The stand-in panels are as operator-facing as the tree they replace, so
+    // The stand-in panels are as operator-facing as the list they replace, so
     // they speak the same language as it. The retry itself is the point of the
     // panel: a second attempt has to be one button away.
     var attempts = 0;
@@ -74,52 +115,235 @@ void main() {
     expect(find.text('Acties'), findsOneWidget);
   });
 
+  // --- The flat list itself (#295) -----------------------------------------
+
   testWidgets(
-      'the Actions tab browses actions by year → class drill-down and loads one '
-      "classroom's actions on demand via readClassroom (#154)",
+      'Acties opens on one flat list of accounts with three system '
+      'indicators, and no jaar → klas drill-down (#295)',
       (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final harness = ReconcileHarness();
+    _useWideWindow(tester);
+    final harness = appliedClassWorkHarness();
     // A sync on the Reconcile screen populates the shared controller; drive it
     // programmatically, then open the Actions tab over the same controller.
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    // The rollup tree is the browser; the flat list is gone. The top of it is
-    // the grade-year, never the school (#210). No classroom is loaded until the
-    // operator drills into one.
-    expect(find.text('Overzicht'), findsOneWidget);
-    expect(find.text('Jaar 3'), findsOneWidget);
-    expect(find.text('School 1'), findsNothing);
-    expect(harness.controller.selectedClassroom, isNull);
-    expect(harness.controller.classroomAccounts, isNull);
-    expect(find.byKey(const ValueKey('actions-classroom-back')), findsNothing);
+    // No tree: no "Overzicht" heading, no grade-year accordion, no class node.
+    expect(find.text('Overzicht'), findsNothing);
+    expect(find.text('Jaar 3'), findsNothing);
+    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsNothing);
 
-    // Drill in: only the 3C classroom's accounts load (via readClassroom), and
-    // that class's pending action tile builds.
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-    expect(harness.controller.selectedClassroom?.classroom, '3C');
-    expect(harness.controller.classroomAccounts, hasLength(1));
+    // Sam has the one piece of student work in this fixture (a stale Office
+    // 365 display name), so under the default filter he is the list.
+    final sam = _idOf(harness.controller, 'Sam Sels');
+    expect(_row(sam), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-list')), findsOneWidget);
+
+    // A row says who, where, and what each of the three systems thinks.
     expect(
-        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
-    expect(find.text('Wijzig de klas in Smartschool'), findsWidgets);
+      find.descendant(of: _row(sam), matching: find.text('Sam Sels')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: _row(sam), matching: find.text('3C')),
+      findsOneWidget,
+      reason: 'the class is on the row, not two clicks above it',
+    );
+    expect(_cellState(tester, sam, Origin.wisa), SystemIndicatorState.inOrder);
+    expect(_cellState(tester, sam, Origin.smartschool),
+        SystemIndicatorState.inOrder);
+    expect(
+        _cellState(tester, sam, Origin.azure), SystemIndicatorState.needsWork,
+        reason: 'his pending work is an Azure write, and the cell says so');
+  });
 
-    // Back to the overview tree.
-    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
+  testWidgets(
+      'an account missing from a system reads red there, and a system filter '
+      'is what finds them (#295/#298)', (WidgetTester tester) async {
+    _useWideWindow(tester);
+    // Two departed Smartschool-only students: no WISA record, no Azure account.
+    final harness = departedHarness(count: 2);
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
-    expect(find.text('Jaar 3'), findsOneWidget);
+
+    final id = _studentEntry(harness.controller).targetId;
+    expect(_cellState(tester, id, Origin.wisa), SystemIndicatorState.missing);
+    expect(_cellState(tester, id, Origin.azure), SystemIndicatorState.missing);
+    expect(_cellState(tester, id, Origin.smartschool),
+        SystemIndicatorState.needsWork,
+        reason: 'the account is there and the departure write lands there');
+
+    // "Sort by system" is a filter (#295): narrowing to Office 365 keeps
+    // everyone that system has something to say about — here, the two missing
+    // accounts — and dropping it back to "Alle" restores the list.
+    await tester.tap(find.byKey(const ValueKey('actions-system-azure')));
+    await tester.pumpAndSettle();
+    expect(_row(id), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('actions-system-wisa')));
+    await tester.pumpAndSettle();
+    expect(_row(id), findsOneWidget, reason: 'missing from WISA counts too');
+  });
+
+  testWidgets('the system filter hides the rows that system is happy with',
+      (WidgetTester tester) async {
+    _useWideWindow(tester);
+    // Sam's Office 365 display name is stale; Tom's is right. With the work
+    // filter off both are listed, and narrowing to Office 365 keeps only Sam.
+    final harness = appliedClassWorkHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-only-with-actions')));
+    await tester.pumpAndSettle();
+
+    final sam = _idOf(harness.controller, 'Sam Sels');
+    final tom = _idOf(harness.controller, 'Tom Tas');
+    expect(_row(sam), findsOneWidget);
+    expect(_row(tom), findsOneWidget);
+    expect(_cellState(tester, tom, Origin.azure), SystemIndicatorState.inOrder);
+
+    await tester.tap(find.byKey(const ValueKey('actions-system-azure')));
+    await tester.pumpAndSettle();
+    expect(_row(sam), findsOneWidget);
+    expect(_row(tom), findsNothing,
+        reason: 'Office 365 has nothing to say about Tom');
+
+    await tester.tap(find.byKey(const ValueKey('actions-system-alle')));
+    await tester.pumpAndSettle();
+    expect(_row(tom), findsOneWidget);
+  });
+
+  testWidgets(
+      'the list sorts by name and by class, and the choice survives a '
+      'selection (#295)', (WidgetTester tester) async {
+    _useWideWindow(tester);
+    // Three students in one situation across two classes: Sam and Sara in 3C,
+    // Tom in 3D. By name that is Sam, Sara, Tom; by class it is 3C before 3D,
+    // which puts Tom last either way — so the fixture is read by position, and
+    // the two orders are told apart by the *class* column, not the names.
+    final harness = crossClassSituationHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // The list's own WISA cells, in tree order — one per row, so their keys
+    // read out the order the rows are in. Scoped to the list, since the details
+    // pane repeats the three cells of whatever is selected.
+    List<String> labels() => tester
+        .widgetList<SystemIndicatorCell>(find.descendant(
+          of: find.byKey(const ValueKey('actions-list')),
+          matching: find.byWidgetPredicate(
+              (w) => w is SystemIndicatorCell && w.system == Origin.wisa),
+        ))
+        .map((c) => (c.key! as ValueKey<String>).value)
+        .toList();
+
+    final sam = _idOf(harness.controller, 'Sam Sels');
+    final sara = _idOf(harness.controller, 'Sara Segers');
+    final tom = _idOf(harness.controller, 'Tom Tas');
+
+    // Naam is the default order.
+    expect(
+      tester
+          .widget<ChoiceChip>(find.byKey(const ValueKey('actions-sort-naam')))
+          .selected,
+      isTrue,
+    );
+    expect(labels(), <String>[
+      'account-cell-$sam-wisa',
+      'account-cell-$sara-wisa',
+      'account-cell-$tom-wisa',
+    ]);
+
+    // By class, 3D comes after 3C — and the members of 3C keep their name
+    // order, so a class of twenty never reshuffles between rebuilds.
+    await tester.tap(find.byKey(const ValueKey('actions-sort-klas')));
+    await tester.pumpAndSettle();
+    expect(labels().last, 'account-cell-$tom-wisa');
+
+    // Selecting a row leaves the order alone — it describes the list, not the
+    // row.
+    await _select(tester, sara);
+    expect(
+      tester
+          .widget<ChoiceChip>(find.byKey(const ValueKey('actions-sort-klas')))
+          .selected,
+      isTrue,
+    );
+    expect(labels().last, 'account-cell-$tom-wisa');
+  });
+
+  testWidgets(
+      'the details pane shows every decision of the selected account, each '
+      'under its own heading and stated once (#281/#283/#300/#295)',
+      (WidgetTester tester) async {
+    _useWideWindow(tester);
+    // Jane raises two decisions — an Azure rename and a Smartschool class move
+    // — so this pins that both are on screen, once each, led by the system
+    // they write to.
+    final harness = ReconcileHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    final entry = _studentEntry(harness.controller);
+    final id = entry.targetId;
+
+    // Nothing selected: the pane says so and no decision is on screen.
+    expect(find.byKey(const ValueKey('actions-detail-empty')), findsOneWidget);
+    for (final summary in const <String>[
+      'Wijzig de naam in Azure',
+      'Wijzig de klas in Smartschool',
+    ]) {
+      expect(find.text(summary), findsNothing);
+    }
+
+    await _select(tester, id);
+
+    final Finder pane = find.byKey(ValueKey('actions-detail-$id'));
+    expect(pane, findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-detail-empty')), findsNothing);
+
+    for (final (index, summary) in const <String>[
+      'Wijzig de naam in Azure',
+      'Wijzig de klas in Smartschool',
+    ].indexed) {
+      expect(
+        find.descendant(of: pane, matching: find.text(summary)),
+        findsOneWidget,
+        reason: 'each decision is stated exactly once (#300)',
+      );
+      expect(
+        find.descendant(
+          of: find.byKey(ValueKey('entry-choice-student-$id-$index')),
+          matching: find.text(summary),
+        ),
+        findsOneWidget,
+        reason: 'and it is the heading that groups the diff below it (#281)',
+      );
+    }
+    // Each heading led by the system it writes to (#298).
+    expect(find.descendant(of: pane, matching: find.text('Smartschool ·')),
+        findsOneWidget);
+    expect(find.descendant(of: pane, matching: find.text('Office 365 ·')),
+        findsOneWidget);
+    // The per-card apply pair is the only apply on this screen.
+    expect(find.byKey(ValueKey('entry-apply-$id')), findsOneWidget);
+    expect(find.byKey(ValueKey('entry-dry-run-$id')), findsOneWidget);
   });
 
   testWidgets(
       'the header states the workload and offers nothing that acts on all of '
       'it (#294)', (WidgetTester tester) async {
     // The global "Dry-run alles" / "Alles toepassen" pair used to sit here and
-    // write every pending action in every class off one dialog, over a
-    // drill-down the operator had not opened. What replaces it is nothing: the
-    // count is a statement of how much work exists, and every way to act on
-    // that work is reached by looking at it first.
-    _useTallWindow(tester);
+    // write every pending action in every class off one dialog, over a list the
+    // operator had not looked at. What replaces it is nothing: the count is a
+    // statement of how much work exists, and every way to act on that work is
+    // reached by looking at it first.
+    _useWideWindow(tester);
     final harness = ReconcileHarness();
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
@@ -134,89 +358,21 @@ void main() {
     expect(find.byKey(const ValueKey('actions-apply')), findsNothing);
     expect(find.text('Dry-run alles'), findsNothing);
     expect(find.text('Alles toepassen'), findsNothing);
-    expect(find.byKey(const ValueKey('actions-progress')), findsNothing);
-
-    // Per-entry apply is untouched — bulk moves down to where the cohort is on
-    // screen, it is not taken away.
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-    final id = harness.controller.classroomPendingEntries.single.targetId;
-    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
-    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
-    await tester.pumpAndSettle();
-    expect(find.byKey(ValueKey('entry-apply-$id')), findsOneWidget);
-    expect(find.byKey(ValueKey('entry-dry-run-$id')), findsOneWidget);
-  });
-
-  testWidgets('an open account card states its summary once (#300)',
-      (WidgetTester tester) async {
-    // The same duplication the class rows had, on the tile this screen owns.
-    // The collapsed card previews its decisions; since #281 the expanded body
-    // leads each of them with the very same sentence, so opening the card
-    // printed every summary twice, one line directly above the other. Jane
-    // raises two — an Azure rename and a Smartschool class move — so this also
-    // pins that the preview goes as a whole rather than per decision.
-    _useTallWindow(tester);
-    final harness = ReconcileHarness();
-    await harness.controller.sync();
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-
-    final id = harness.controller.classroomPendingEntries.single.targetId;
-    final Finder tile = find.byKey(ValueKey('entry-student-$id'));
-    const List<String> summaries = <String>[
-      'Wijzig de naam in Azure',
-      'Wijzig de klas in Smartschool',
-    ];
-
-    for (final summary in summaries) {
-      expect(find.descendant(of: tile, matching: find.text(summary)),
-          findsOneWidget,
-          reason: 'collapsed, $summary is previewed once');
-    }
-
-    await tester.ensureVisible(tile);
-    await tester.tap(tile);
-    await tester.pumpAndSettle();
-
-    for (final (index, summary) in summaries.indexed) {
-      expect(
-        find.descendant(of: tile, matching: find.text(summary)),
-        findsOneWidget,
-        reason: 'the decision heading takes the preview line\'s place rather '
-            'than joining it',
-      );
-      expect(
-        find.descendant(
-          of: find.byKey(ValueKey('entry-choice-student-$id-$index')),
-          matching: find.text(summary),
-        ),
-        findsOneWidget,
-        reason: 'and the half that survives is the heading, which groups the '
-            'diff below it',
-      );
-    }
-    // Still led by the system it writes to (#298): with the preview gone, the
-    // headings are the only place on an open card that says so.
-    expect(find.descendant(of: tile, matching: find.text('Smartschool ·')),
-        findsOneWidget);
-    expect(find.descendant(of: tile, matching: find.text('Office 365 ·')),
-        findsOneWidget);
+    // And the flat list adds no cohort header of its own — school-wide bulk
+    // apply with its cohort visible first is #296's, not this layout's.
+    expect(find.textContaining('in dezelfde situatie'), findsNothing);
   });
 
   testWidgets('cancelling the apply dialog writes nothing (#154)',
       (WidgetTester tester) async {
-    _useTallWindow(tester);
+    _useWideWindow(tester);
     final harness = ReconcileHarness();
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
 
-    final id = harness.controller.classroomPendingEntries.single.targetId;
-    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
-    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
-    await tester.pumpAndSettle();
+    final id = _studentEntry(harness.controller).targetId;
+    await _select(tester, id);
     await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
     await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
     await tester.pumpAndSettle();
@@ -250,8 +406,8 @@ void main() {
         applyConfirmationMessage(
           scope(<Origin>[Origin.azure, Origin.smartschool, Origin.azure]),
         ),
-        startsWith('Dit schrijft 3 wijzigingen naar Smartschool en '
-            'Office 365.'),
+        startsWith('Dit schrijft 3 wijzigingen naar Smartschool en Office '
+            '365.'),
       );
     });
 
@@ -259,22 +415,20 @@ void main() {
       // DontImportStaffFromWisa & co carry Origin.wisa on their ChangeSet, but
       // WISA is read-only here: what they produce is an import rule.
       final message = applyConfirmationMessage(scope(<Origin>[Origin.wisa]));
-      expect(
-        message,
-        startsWith('Dit bewaart 1 importregel blijvend voor iedereen (er wordt '
-            'niets naar WISA geschreven).'),
-      );
-      expect(message, isNot(contains('schrijft 1 wijziging')));
+      expect(message, contains('bewaart 1 importregel'));
+      expect(message, contains('er wordt niets naar WISA geschreven'));
+      expect(message, isNot(contains('schrijft 1 wijziging naar WISA')));
     });
 
     test('the rule is announced as permanent and shared (#276)', () {
       // The rule is written to the shared settings document, so it outlives the
       // session and every other operator inherits it. A sentence that read like
       // a one-run decision would be the operator's only warning before an
-      // irreversible-looking click.
-      final message = applyConfirmationMessage(scope(<Origin>[Origin.wisa]));
-      expect(message, contains('blijvend'));
-      expect(message, contains('voor iedereen'));
+      // irreversible-by-one-click change.
+      expect(
+        applyConfirmationMessage(scope(<Origin>[Origin.wisa])),
+        contains('bewaart 1 importregel blijvend voor iedereen'),
+      );
     });
 
     test('a rule beside a real write is counted apart from it', () {
@@ -290,14 +444,13 @@ void main() {
         () {
       // A new student's Office 365 create writes Smartschool too (#230/#240).
       // Whether it runs is decided by the follow-up's own evaluate after the
-      // first write, so it is named, never counted.
-      expect(
-        applyConfirmationMessage(
-          scope(<Origin>[Origin.azure], chained: <Origin>{Origin.smartschool}),
-        ),
-        startsWith('Dit schrijft 1 wijziging naar Office 365. Een vervolgactie '
-            'kan ook naar Smartschool schrijven.'),
+      // first write, so it is named rather than counted.
+      final message = applyConfirmationMessage(
+        scope(<Origin>[Origin.azure], chained: <Origin>{Origin.smartschool}),
       );
+      expect(message, startsWith('Dit schrijft 1 wijziging naar Office 365.'));
+      expect(message,
+          contains('Een vervolgactie kan ook naar Smartschool schrijven.'));
     });
 
     test('nothing selected claims nothing', () {
@@ -329,16 +482,13 @@ void main() {
   testWidgets(
       'applying one Azure-only action announces Office 365, not "Smartschool '
       'and Azure AD" (#234)', (WidgetTester tester) async {
-    _useTallWindow(tester);
+    _useWideWindow(tester);
     final harness = nameDriftHarness();
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-
-    final entry = harness.controller.pendingEntries
-        .firstWhere((e) => e.family == 'student');
+    final entry = _studentEntry(harness.controller);
     expect(
       entry.choices.map((c) => c.selected.changes.summary),
       <String>['Wijzig de naam in Azure'],
@@ -346,9 +496,7 @@ void main() {
     );
 
     final id = entry.targetId;
-    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
-    await tester.tap(find.byKey(ValueKey('entry-student-$id')));
-    await tester.pumpAndSettle();
+    await _select(tester, id);
     await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
     await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
     await tester.pumpAndSettle();
@@ -370,48 +518,23 @@ void main() {
     );
   });
 
-  /// A WISA-departed scenario: [count] Smartschool-only active accounts (no
-  /// WISA, no Azure), each raising the mutually-exclusive unregister/delete
-  /// choice (#110). They land in the "Niet toegewezen" → "Zonder klas" bucket
-  /// (#210 collapsed its always-synthetic grade level away).
-  ReconcileHarness departedHarness({int count = 1}) => ReconcileHarness(
-        wisa: wisaSnap(students: const []),
-        smartschool: ssSnap(
-          groups: const [],
-          accounts: [
-            for (var i = 0; i < count; i++)
-              ssAccount(
-                uid: 'user$i',
-                accountId: '$i',
-                mail: 'user$i@student.school.example',
-              ),
-          ],
-          memberships: const [],
-        ),
-        azure: azSnap(users: const []),
-      );
-
   testWidgets(
-      'a departed student in the drill-down renders one entry with a '
-      'unregister/delete choice; picking delete applies delete (#110/#154)',
+      'a departed student is one row with a unregister/delete choice in the '
+      'details pane; picking delete applies delete (#110/#295)',
       (WidgetTester tester) async {
-    _useTallWindow(tester);
+    _useWideWindow(tester);
     final harness = departedHarness();
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
+    final id = _studentEntry(harness.controller).targetId;
+    expect(_row(id), findsOneWidget);
+    // The class column names the bucket a leaver falls into.
+    expect(find.descendant(of: _row(id), matching: find.text('Zonder klas')),
+        findsOneWidget);
 
-    final entry = harness.controller.pendingEntries
-        .firstWhere((e) => e.family == 'student');
-    final id = entry.targetId;
-    final entryKey = ValueKey('entry-student-$id');
-    expect(find.byKey(entryKey), findsOneWidget);
-
-    await tester.ensureVisible(find.byKey(entryKey));
-    await tester.tap(find.byKey(entryKey));
-    await tester.pumpAndSettle();
+    await _select(tester, id);
 
     final unregisterAlt = ValueKey('alt-$id-UnregisterStudentFromSmartschool');
     final deleteAlt = ValueKey('alt-$id-DeleteStudentFromSmartschool');
@@ -442,200 +565,59 @@ void main() {
   });
 
   testWidgets(
-      "a same-situation subset in one class offers a bulk apply per row's "
-      'choice (#110/#154)', (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final harness = departedHarness(count: 2);
-    await harness.controller.sync();
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
-
-    expect(
-        find.textContaining('accounts in dezelfde situatie'), findsOneWidget);
-    final key = harness.controller.classroomPendingSituations.single.key;
-    final bulkApply = ValueKey('situation-apply-$key');
-    expect(find.byKey(bulkApply), findsOneWidget);
-
-    // Switch the second row to delete, leaving the first on the default. The
-    // header hands the pass the entries it is *showing*, so the pick has to
-    // survive the rebuild that publishes it (#110/#252).
-    final second = harness.controller.classroomPendingEntries[1].targetId;
-    await tester.ensureVisible(find.byKey(ValueKey('entry-student-$second')));
-    await tester.tap(find.byKey(ValueKey('entry-student-$second')));
-    await tester.pumpAndSettle();
-    final deleteAlt =
-        find.byKey(ValueKey('alt-$second-DeleteStudentFromSmartschool'));
-    await tester.ensureVisible(deleteAlt);
-    await tester.tap(deleteAlt);
-    await tester.pumpAndSettle();
-
-    await tester.ensureVisible(find.byKey(bulkApply));
-    await tester.tap(find.byKey(bulkApply));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
-    expect(harness.controller.applyResults, hasLength(2));
-    final summaries =
-        harness.controller.applyResults!.map((r) => r.changes.summary).toList();
-    expect(summaries, contains('Schrijf de leerling uit in Smartschool'));
-    expect(summaries, contains('Verwijder dit account uit Smartschool'),
-        reason: "the bulk pass runs each row's own chosen alternative");
-  });
-
-  testWidgets(
-      "a class's bulk apply stops at that class: the identical situation in "
-      'another class is left untouched (#252)', (WidgetTester tester) async {
-    // Three students in one situation — a stale Office 365 name — split across
-    // two classes: Sam and Sara in 3C, Tom in 3D. The bulk header lives inside
-    // one class and counts one class, but the pass behind it used to resolve
-    // its situation key back through the whole linked view, so pressing
-    // "Alles toepassen (2)" in 3C wrote Tom too.
-    _useTallWindow(tester);
-    final harness = crossClassSituationHarness();
-    await harness.controller.sync();
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-
-    final inClass = harness.controller.classroomPendingEntries;
-    expect(inClass, hasLength(2), reason: '3C holds Sam and Sara');
-    final key = harness.controller.classroomPendingSituations.single.key;
-    expect(
-      harness.controller.pendingSituations
-          .firstWhere((c) => c.key == key)
-          .length,
-      3,
-      reason: "Tom's 3D entry is the very same situation, group-wide",
-    );
-
-    // The button's own count is the class's, and so is what it writes.
-    final bulkApply = find.byKey(ValueKey('situation-apply-$key'));
-    await tester.ensureVisible(bulkApply);
-    expect(tester.widget<FilledButton>(bulkApply).child, isA<Text>());
-    expect(
-        find.descendant(
-            of: bulkApply, matching: find.text('Alles toepassen (2)')),
-        findsOneWidget);
-
-    await tester.tap(bulkApply);
-    await tester.pumpAndSettle();
-    // The confirmation quotes the same two writes, not three (#234).
-    expect(find.textContaining('2 wijzigingen'), findsOneWidget);
-    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Resultaat van het toepassen'), findsOneWidget);
-    expect(harness.controller.applyResults, hasLength(2),
-        reason: 'one write per account of the open class');
-    final patched = harness.graph.requests
-        .where((r) => r.method == 'PATCH')
-        .map((r) => r.url.path)
-        .toList();
-    expect(patched, hasLength(2));
-    expect(patched.any((p) => p.endsWith(kSam3C)), isTrue);
-    expect(patched.any((p) => p.endsWith(kSara3C)), isTrue);
-    expect(patched.any((p) => p.endsWith(kTom3D)), isFalse,
-        reason: 'the operator never opened 3D — it must not be written');
-    // …and Tom's work is still pending, waiting for someone to open his class.
-    expect(
-      harness.controller.pendingSituations
-          .firstWhere((c) => c.key == key)
-          .length,
-      1,
-    );
-  });
-
-  testWidgets(
-      "a large class's actions virtualize: only a bounded number of entry "
-      'tiles build, and scrolling builds/unloads them (#111/#154)',
-      (WidgetTester tester) async {
-    _useTallWindow(tester);
+      'the flat list virtualizes: only a bounded number of rows build, and '
+      'scrolling builds/unloads them (#111/#295)', (WidgetTester tester) async {
+    _useWideWindow(tester);
     final harness = departedHarness(count: 2000);
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
+    // All 2000 are in one school-wide list — the thing the drill-down existed
+    // to avoid rendering, and which a lazy builder renders fine.
+    expect(harness.controller.pendingEntries, hasLength(2000));
 
-    // All 2000 sit in this one class, each one pending entry.
-    expect(harness.controller.classroomPendingEntries, hasLength(2000));
-
-    final entryTiles = find.byWidgetPredicate(
+    final rows = find.byWidgetPredicate(
       (w) =>
           w.key is ValueKey<String> &&
-          (w.key! as ValueKey<String>).value.startsWith('entry-'),
+          (w.key! as ValueKey<String>).value.startsWith('account-row-'),
     );
-    final builtInitially = entryTiles.evaluate().length;
-    expect(builtInitially, greaterThan(0));
-    expect(builtInitially, lessThan(200),
-        reason: 'virtualized: on-screen tiles only, not all 2000');
+    List<String> built() => <String>[
+          for (final e in rows.evaluate())
+            (e.widget.key! as ValueKey<String>).value,
+        ];
 
-    final entries = harness.controller.classroomPendingEntries;
-    final firstKey = ValueKey('entry-student-${entries.first.targetId}');
-    final lastKey = ValueKey('entry-student-${entries.last.targetId}');
-    expect(find.byKey(lastKey), findsNothing);
+    final List<String> initial = built();
+    expect(initial, isNotEmpty);
+    expect(initial, hasLength(lessThan(200)),
+        reason: 'virtualized: on-screen rows only, not all 2000');
 
-    await tester.scrollUntilVisible(
-      find.byKey(lastKey),
-      5000,
-      scrollable: find.byType(Scrollable).first,
-      maxScrolls: 200,
+    // Scrolling builds rows that were not there and unloads the ones that
+    // scrolled far off-screen.
+    await tester.drag(
+      find.byKey(const ValueKey('actions-list')),
+      const Offset(0, -20000),
     );
-    expect(find.byKey(lastKey), findsOneWidget);
-    expect(find.byKey(firstKey), findsNothing,
-        reason: 'the first tile unloaded once scrolled far off-screen');
-  });
-
-  // --- School-less student drill-down (#210) -------------------------------
-
-  testWidgets(
-      'the Leerlingen overview opens on grade-years merged across the managed '
-      'schools, with no school level anywhere (#210)',
-      (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final harness = twoSchoolHarness();
-    await harness.controller.sync();
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    // The years are the accordion, in a pinned order; neither school is a node.
-    expect(find.text('Jaar 1'), findsOneWidget);
-    expect(find.text('Jaar 3'), findsOneWidget);
-    expect(find.text('School 1'), findsNothing);
-    expect(find.text('School 2'), findsNothing);
-    // The synthetic non-numeric bucket never renders as "Jaar Overig".
-    expect(find.text('Overige klassen'), findsOneWidget);
-    expect(find.text('Jaar Overig'), findsNothing);
-
-    // "Jaar 1" holds both schools' first years side by side…
-    await tester.tap(find.text('Jaar 1'));
-    await tester.pumpAndSettle();
-    expect(find.text('1A'), findsOneWidget);
-    expect(find.text('1B'), findsOneWidget);
-
-    // …and opening one still targets that class's own school partition.
-    await tester.ensureVisible(find.text('1B'));
-    await tester.tap(find.text('1B'));
-    await tester.pumpAndSettle();
-    expect(harness.controller.selectedClassroom?.classroom, '1B');
-    expect(harness.controller.selectedClassroom?.school, '2');
-    expect(harness.controller.classroomAccounts, hasLength(1));
+    final List<String> after = built();
+    expect(after, isNotEmpty);
+    expect(after, hasLength(lessThan(200)));
+    expect(after.toSet().intersection(initial.toSet()), isEmpty,
+        reason: 'a different window of the list is built now');
+    expect(find.byKey(ValueKey(initial.first)), findsNothing,
+        reason: 'the first row unloaded once scrolled far off-screen');
   });
 
   // --- Personeel / Leerlingen family tabs (#179) ---------------------------
 
   testWidgets(
-      'the Actions view splits staff and student actions into Personeel and '
-      'Leerlingen tabs, each drilling only its own family (#179)',
+      'the Actions view splits staff and student accounts into Personeel and '
+      'Leerlingen tabs, each listing only its own family (#179/#295)',
       (WidgetTester tester) async {
-    _useTallWindow(tester);
+    _useWideWindow(tester);
     // One student (default fixture) plus one WISA staff member, so both
-    // families carry a rollup node.
+    // families carry a row.
     final harness = ReconcileHarness(
       wisa: wisaSnap(students: [wisaStudent()], staff: [wisaStaff()]),
     );
@@ -643,7 +625,6 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    // The horizontal family tab bar carries both tabs.
     expect(
         find.byKey(const ValueKey('actions-tab-leerlingen')), findsOneWidget);
     expect(find.byKey(const ValueKey('actions-tab-personeel')), findsOneWidget);
@@ -658,29 +639,26 @@ void main() {
       harness.controller.totalPendingCount,
     );
 
-    // Default tab = Leerlingen: the merged grade-year is the drill root (#210);
-    // the staff ("Personeel") node does not show. Neither does a class-groups
-    // node — since #227 the classes are a top-level tab of their own, so this
-    // tree carries accounts only.
-    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
-    expect(find.byKey(const ValueKey('rollup-groups')), findsNothing);
-    expect(
-        find.byKey(const ValueKey('rollup-school-school|staff')), findsNothing);
+    final student = _idOf(harness.controller, 'Jane Doe');
+    final staff = _idOf(harness.controller, 'Anna Smit');
 
-    // Switch to Personeel: the staff node appears and the student grade /
-    // class-groups nodes are gone — each tab shows only its own family.
+    // Default tab = Leerlingen.
+    expect(_row(student), findsOneWidget);
+    expect(_row(staff), findsNothing);
+
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-school-school|staff')),
+    expect(_row(staff), findsOneWidget);
+    expect(_row(student), findsNothing);
+    // A staff member's "class" is the synthetic Personeel bucket.
+    expect(find.descendant(of: _row(staff), matching: find.text('Personeel')),
         findsOneWidget);
-    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsNothing);
-    expect(find.byKey(const ValueKey('rollup-groups')), findsNothing);
   });
 
   testWidgets(
-      'switching tabs mid-drill closes the open classroom so each tab opens at '
-      'its own overview (#179)', (WidgetTester tester) async {
-    _useTallWindow(tester);
+      'switching family tabs drops the selection, so each tab opens on its own '
+      'list (#179/#295)', (WidgetTester tester) async {
+    _useWideWindow(tester);
     final harness = ReconcileHarness(
       wisa: wisaSnap(students: [wisaStudent()], staff: [wisaStaff()]),
     );
@@ -688,475 +666,317 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    // Drill into a student class on the Leerlingen tab.
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-    expect(harness.controller.selectedClassroom?.classroom, '3C');
-    expect(
-        find.byKey(const ValueKey('actions-classroom-back')), findsOneWidget);
+    final student = _idOf(harness.controller, 'Jane Doe');
+    await _select(tester, student);
+    expect(find.byKey(ValueKey('actions-detail-$student')), findsOneWidget);
 
-    // Switching to Personeel closes the drill-down; that tab opens at its own
-    // staff overview rather than showing the student class.
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
-    expect(harness.controller.selectedClassroom, isNull);
-    expect(find.byKey(const ValueKey('actions-classroom-back')), findsNothing);
-    expect(find.byKey(const ValueKey('rollup-school-school|staff')),
-        findsOneWidget);
+    expect(find.byKey(ValueKey('actions-detail-$student')), findsNothing,
+        reason: 'a selection belongs to the list it was made in');
+    expect(find.byKey(const ValueKey('actions-detail-empty')), findsOneWidget);
   });
 
-  // --- The global Acties filter + the Personeel name search (#187/#226) -----
+  // --- The work-list filter and the name search (#187/#217/#226) -----------
 
   testWidgets(
-      'the global filter lists only accounts with actions inside an opened '
-      'Leerlingen class, is set in exactly one place, and gives the full class '
-      'back when switched off (#187/#226)', (WidgetTester tester) async {
-    _useTallWindow(tester);
-    // A passive-session class with a mix: one student with an applyable action,
-    // one without. The filter must narrow to the former (its `hasPending`).
-    final store = await seededLinkedStore(<MaterializedAccount>[
-      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
-      matAccount(id: 's2', label: 'Kees Bakker', withAction: false),
-    ]);
-    final harness = ReconcileHarness(linkedStore: store);
+      'the work-list filter is on by default, set in exactly one place, and '
+      'gives the whole school back when switched off (#226/#295)',
+      (WidgetTester tester) async {
+    _useWideWindow(tester);
+    // Sam carries the one applyable student action; Tom is in order everywhere.
+    final harness = appliedClassWorkHarness();
+    await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    // One switch, on the Acties tab itself and already on — the operator never
-    // sets it per class (#226).
     final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
-    expect(toggle, findsOneWidget);
-    expect(tester.widget<Switch>(toggle).value, isTrue);
-
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-    // The action-free account is already out, with nothing touched in here; the
-    // Leerlingen tab has no search box, and no second copy of the switch.
-    expect(find.text('Jane Doe'), findsOneWidget);
-    expect(find.text('Kees Bakker'), findsNothing);
-    expect(find.byKey(const ValueKey('actions-search')), findsNothing);
     expect(toggle, findsOneWidget,
         reason: 'the filter is not settable in two places');
+    expect(tester.widget<Switch>(toggle).value, isTrue);
 
-    // Switched off, the class is the full inventory again.
-    await tester.ensureVisible(toggle);
+    final sam = _idOf(harness.controller, 'Sam Sels');
+    final tom = _idOf(harness.controller, 'Tom Tas');
+    expect(_row(sam), findsOneWidget);
+    expect(_row(tom), findsNothing);
+
+    // Switched off, the list is the whole school — which the drill-down could
+    // never show, because a rollup only knew the accounts that raised
+    // something.
     await tester.tap(toggle);
     await tester.pumpAndSettle();
-    expect(find.text('Jane Doe'), findsOneWidget);
-    expect(find.text('Kees Bakker'), findsOneWidget);
+    expect(_row(sam), findsOneWidget);
+    expect(_row(tom), findsOneWidget);
+    expect(_cellState(tester, tom, Origin.wisa), SystemIndicatorState.inOrder);
+    expect(_cellState(tester, tom, Origin.smartschool),
+        SystemIndicatorState.inOrder);
+    expect(_cellState(tester, tom, Origin.azure), SystemIndicatorState.inOrder);
   });
 
   testWidgets(
-      'the Personeel classroom search matches any part of the name in any '
-      'order and combines with the only-with-actions filter (#187/#217/#226)',
+      'the name search matches any part of the name in any order and combines '
+      'with the work-list filter (#187/#217/#226/#295)',
       (WidgetTester tester) async {
-    _useTallWindow(tester);
-    // Three staff in the one synthetic Personeel class: two share the surname
-    // "Smit" (one with an action, one without) and one distinct voornaam.
-    final store = await seededLinkedStore(<MaterializedAccount>[
-      matStaff(id: 't1', label: 'Anna Smit', withAction: true),
-      matStaff(id: 't2', label: 'Bram Jansen', withAction: false),
-      matStaff(id: 't3', label: 'Clara Smit', withAction: false),
-    ]);
-    final harness = ReconcileHarness(linkedStore: store);
+    _useWideWindow(tester);
+    // Three staff in the Personeel family: two share the surname "Smit" (one
+    // with an action, one without) and one has a distinct voornaam.
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(students: const [], staff: [
+        wisaStaff(
+            code: 'SMIT', wisaId: '42', firstName: 'Anna', lastName: 'Smit'),
+        wisaStaff(
+            code: 'JANS', wisaId: '43', firstName: 'Bram', lastName: 'Jansen'),
+        wisaStaff(
+            code: 'CSMI', wisaId: '44', firstName: 'Clara', lastName: 'Smit'),
+      ]),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+    );
+    await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
-
-    // The global filter is on by default (#226); this half of the test is about
-    // the name search, so start from the full inventory.
-    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
-    await tester.ensureVisible(toggle);
-    await tester.tap(toggle);
-    await tester.pumpAndSettle();
-
-    // Switch to the Personeel tab and drill into its single staff class.
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('rollup-school-school|staff')));
-    await tester.pumpAndSettle();
-    await tester
-        .tap(find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel')));
-    await tester.pumpAndSettle();
-    final staffClass = find
-        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
-    await tester.ensureVisible(staffClass);
-    await tester.tap(staffClass);
-    await tester.pumpAndSettle();
 
-    // All three show; the Personeel tab carries the search box.
-    expect(find.text('Anna Smit'), findsOneWidget);
-    expect(find.text('Bram Jansen'), findsOneWidget);
-    expect(find.text('Clara Smit'), findsOneWidget);
-    expect(find.byKey(const ValueKey('actions-search')), findsOneWidget);
+    final anna = _idOf(harness.controller, 'Anna Smit');
+    final bram = _idOf(harness.controller, 'Bram Jansen');
+    final clara = _idOf(harness.controller, 'Clara Smit');
+
+    // The search box is on the list itself now, on both tabs — it used to live
+    // inside an opened Personeel classroom (#187).
+    final search = find.byKey(const ValueKey('actions-search'));
+    expect(search, findsOneWidget);
+    expect(_row(anna), findsOneWidget);
+    expect(_row(bram), findsOneWidget);
+    expect(_row(clara), findsOneWidget);
 
     // Search on the naam "Smit": both Smits match, Jansen drops.
-    await tester.enterText(
-        find.byKey(const ValueKey('actions-search')), 'smit');
-    await tester.pump();
-    expect(find.text('Anna Smit'), findsOneWidget);
-    expect(find.text('Clara Smit'), findsOneWidget);
-    expect(find.text('Bram Jansen'), findsNothing);
+    await tester.enterText(search, 'smit');
+    await tester.pumpAndSettle();
+    expect(_row(anna), findsOneWidget);
+    expect(_row(clara), findsOneWidget);
+    expect(_row(bram), findsNothing);
 
     // Search on the voornaam "Bram": only Jansen matches.
-    await tester.enterText(
-        find.byKey(const ValueKey('actions-search')), 'bram');
-    await tester.pump();
-    expect(find.text('Bram Jansen'), findsOneWidget);
-    expect(find.text('Anna Smit'), findsNothing);
-    expect(find.text('Clara Smit'), findsNothing);
+    await tester.enterText(search, 'bram');
+    await tester.pumpAndSettle();
+    expect(_row(bram), findsOneWidget);
+    expect(_row(anna), findsNothing);
 
     // Both halves, in the stored order and reversed (#217): either way round
     // finds the one person. Reversed used to return nothing, because the needle
     // was matched as one contiguous substring of "Voornaam Naam".
-    await tester.enterText(
-        find.byKey(const ValueKey('actions-search')), 'anna smit');
-    await tester.pump();
-    expect(find.text('Anna Smit'), findsOneWidget);
-    expect(find.text('Clara Smit'), findsNothing);
-    await tester.enterText(
-        find.byKey(const ValueKey('actions-search')), 'smit anna');
-    await tester.pump();
-    expect(find.text('Anna Smit'), findsOneWidget);
-    expect(find.text('Clara Smit'), findsNothing);
-    expect(find.text('Bram Jansen'), findsNothing);
+    await tester.enterText(search, 'anna smit');
+    await tester.pumpAndSettle();
+    expect(_row(anna), findsOneWidget);
+    expect(_row(clara), findsNothing);
+    await tester.enterText(search, 'smit anna');
+    await tester.pumpAndSettle();
+    expect(_row(anna), findsOneWidget);
+    expect(_row(clara), findsNothing);
+    expect(_row(bram), findsNothing);
 
     // Every part must occur: parts taken from two different people match
     // neither, rather than matching both.
-    await tester.enterText(
-        find.byKey(const ValueKey('actions-search')), 'anna jansen');
-    await tester.pump();
+    await tester.enterText(search, 'anna jansen');
+    await tester.pumpAndSettle();
     expect(
         find.text('Geen accounts die aan de filter voldoen.'), findsOneWidget);
 
-    // Combine the two: search "Smit" AND the global only-with-actions filter
-    // back on keeps just Anna (Clara matches the name but has no action).
-    await tester.enterText(
-        find.byKey(const ValueKey('actions-search')), 'smit');
-    await tester.pump();
-    await tester.ensureVisible(toggle);
-    await tester.tap(toggle);
+    // The search survives a family tab change: the box stays on screen, so
+    // clearing it under the operator would read as a bug.
+    await tester.enterText(search, 'smit');
     await tester.pumpAndSettle();
-    expect(find.text('Anna Smit'), findsOneWidget);
-    expect(find.text('Clara Smit'), findsNothing);
-    expect(find.text('Bram Jansen'), findsNothing);
-
-    // A query matching nothing shows the filter-empty line, not the class-empty
-    // one.
-    await tester.enterText(find.byKey(const ValueKey('actions-search')), 'zzz');
-    await tester.pump();
-    expect(
-        find.text('Geen accounts die aan de filter voldoen.'), findsOneWidget);
-  });
-
-  // --- The filter thins out the jaar → klas tree (#226) --------------------
-
-  /// A passive-session view shaped for the tree filter: Jaar 3 has one class
-  /// with work (3A) and one without (3B); Jaar 4 has two classes and nothing to
-  /// do in either; Jaar 5 has a single class with nothing to do.
-  Future<ReconcileHarness> filterTreeHarness() async => ReconcileHarness(
-        linkedStore: await seededLinkedStore(<MaterializedAccount>[
-          matAccount(
-              id: 's1',
-              label: 'Jane Doe',
-              gradeYear: '3',
-              classroom: '3A',
-              withAction: true),
-          matAccount(
-              id: 's2', label: 'Kees Bakker', gradeYear: '3', classroom: '3B'),
-          matAccount(
-              id: 's3', label: 'Piet Peeters', gradeYear: '4', classroom: '4A'),
-          matAccount(
-              id: 's4', label: 'Marie Maes', gradeYear: '4', classroom: '4B'),
-          matAccount(
-              id: 's5', label: 'Sam Sels', gradeYear: '5', classroom: '5A'),
-        ]),
-      );
-
-  testWidgets(
-      'with the filter on, the jaar → klas tree drops the classrooms and the '
-      'whole years with nothing pending, and says how many it hid (#226)',
-      (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final harness = await filterTreeHarness();
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    // Only the year that still has work is an accordion at all.
-    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
-    expect(find.byKey(const ValueKey('rollup-grade-grades|4')), findsNothing,
-        reason: "both of Jaar 4's classes are done — the year goes with them");
-    expect(find.byKey(const ValueKey('rollup-grade-grades|5')), findsNothing,
-        reason: 'Jaar 5 has one class and nothing to do in it');
-
-    // The hiding is announced, so a year the operator expected is explained
-    // rather than merely absent: 3B, Jaar 4 and Jaar 5.
-    expect(find.byKey(const ValueKey('actions-filter-hidden')), findsOneWidget);
-    expect(find.textContaining('Verborgen door de filter: 3'), findsOneWidget);
-
-    // Inside the surviving year, only the class with work is listed.
-    await tester.tap(find.byKey(const ValueKey('rollup-grade-grades|3')));
-    await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-class-class|1|3|3A')),
-        findsOneWidget);
-    expect(
-        find.byKey(const ValueKey('rollup-class-class|1|3|3B')), findsNothing,
-        reason: 'a ticked-off class is not rendered under the filter');
-
-    // Switched off, the tree is the full inventory again — every year, every
-    // class, and nothing left for the note to explain.
-    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
-    await tester.ensureVisible(toggle);
-    await tester.tap(toggle);
-    await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
-    expect(find.byKey(const ValueKey('rollup-grade-grades|4')), findsOneWidget);
-    expect(find.byKey(const ValueKey('rollup-grade-grades|5')), findsOneWidget);
-    expect(find.byKey(const ValueKey('actions-filter-hidden')), findsNothing);
-    expect(find.byKey(const ValueKey('rollup-class-class|1|3|3B')),
-        findsOneWidget);
-  });
-
-  testWidgets(
-      'a view with nothing pending says the filter hid it all — not that there '
-      'is no overview (#226)', (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final store = await seededLinkedStore(<MaterializedAccount>[
-      matAccount(id: 's1', label: 'Jane Doe'),
-    ]);
-    final harness = ReconcileHarness(linkedStore: store);
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const ValueKey('actions-filter-all-hidden')),
-        findsOneWidget);
-    expect(find.textContaining('Zet de filter af'), findsOneWidget);
-    expect(find.text('Nog geen gematerialiseerd overzicht.'), findsNothing,
-        reason: 'there *is* a materialized overview — the filter is hiding it');
-
-    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
-    await tester.ensureVisible(toggle);
-    await tester.tap(toggle);
-    await tester.pumpAndSettle();
-    expect(
-        find.byKey(const ValueKey('actions-filter-all-hidden')), findsNothing);
-    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
-  });
-
-  testWidgets(
-      'the filter switch survives a Leerlingen ↔ Personeel tab change, and '
-      'thins the Personeel tree the same way (#226)',
-      (WidgetTester tester) async {
-    _useTallWindow(tester);
-    // One student and one staff member, neither carrying an action: both trees
-    // are empty under the filter and full without it.
-    final store = await seededLinkedStore(<MaterializedAccount>[
-      matAccount(id: 's1', label: 'Jane Doe'),
-      matStaff(id: 't1', label: 'Anna Smit'),
-    ]);
-    final harness = ReconcileHarness(linkedStore: store);
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
-    expect(tester.widget<Switch>(toggle).value, isTrue);
-
-    // Personeel obeys the same switch: its school node has no work under it, so
-    // it is gone too, with the same explanation in its place.
-    await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
-    await tester.pumpAndSettle();
-    expect(tester.widget<Switch>(toggle).value, isTrue,
-        reason: 'the mode outlives the tab it was set on');
-    expect(
-        find.byKey(const ValueKey('rollup-school-school|staff')), findsNothing);
-    expect(find.byKey(const ValueKey('actions-filter-all-hidden')),
-        findsOneWidget);
-
-    // Switch it off from the Personeel tab: the staff tree comes back.
-    await tester.ensureVisible(toggle);
-    await tester.tap(toggle);
-    await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-school-school|staff')),
-        findsOneWidget);
-
-    // Back to Leerlingen, and the off state came along — the tab change used to
-    // reset it, which is why the filter had to be re-flipped constantly (#226).
     await tester.tap(find.byKey(const ValueKey('actions-tab-leerlingen')));
     await tester.pumpAndSettle();
-    expect(tester.widget<Switch>(toggle).value, isFalse);
-    expect(find.byKey(const ValueKey('rollup-grade-grades|3')), findsOneWidget);
     expect(
-        find.byKey(const ValueKey('actions-filter-all-hidden')), findsNothing);
+      tester.widget<TextField>(search).controller!.text,
+      'smit',
+    );
   });
 
-  // --- The single-open accordion and its open path (#235) ------------------
-
   testWidgets(
-      'drilling into a class and pressing Overzicht comes back to the '
-      'grade-year it was opened from, still expanded (#235)',
-      (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final harness = twoSchoolHarness();
+      'a school with nothing pending says so, rather than reading as an empty '
+      'overview (#226/#295)', (WidgetTester tester) async {
+    _useWideWindow(tester);
+    // Tom alone: fully in sync in all three systems.
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(
+              wisaId: '4', classGroup: '3D', firstName: 'Tom', name: 'Tas'),
+        ],
+        schools: [wisaSchool(1)],
+        classGroups: [wisaClassGroup('3D', adminCode: 'a4', schoolCode: '111')],
+      ),
+      smartschool: ssSnap(
+        groups: [ssGroup('3D', code: '3D_ss', untis: '3D')],
+        accounts: [
+          ssAccount(
+            uid: 'tom',
+            accountId: '4',
+            mail: 'tom.tas@student.school.example',
+            givenName: 'Tom',
+            surname: 'Tas',
+          ),
+        ],
+        memberships: [member('tom', '3D_ss')],
+      ),
+      azure: azSnap(users: [
+        azUser(
+          id: 'az4',
+          upn: 'tom.tas@student.school.example',
+          employeeId: '4',
+          displayName: 'Tom Tas',
+        ),
+      ]),
+      ourSchoolIds: const {1},
+    );
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-    expect(harness.controller.selectedClassroom?.classroom, '3C');
-
-    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
-    await tester.pumpAndSettle();
-    expect(
-        find.byKey(const ValueKey('rollup-class-class|1|3|3C')), findsOneWidget,
-        reason: 'Overzicht used to come back to a fully collapsed tree');
-    expect(
-        find.byKey(const ValueKey('rollup-class-class|1|1|1A')), findsNothing,
-        reason: 'the years that were closed stay closed');
-    // The open node is remembered a level above the tiles, which is what let it
-    // survive them being disposed for the detail view.
-    expect(harness.controller.expandedPath, <String>['rollup-grade-grades|3']);
-  });
-
-  testWidgets('opening a grade-year closes the one that was open (#235)',
-      (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final harness = twoSchoolHarness();
-    await harness.controller.sync();
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.text('Jaar 1'));
-    await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-class-class|1|1|1A')),
+    expect(find.text('Geen openstaande acties — alles staat in orde.'),
         findsOneWidget);
 
-    await tester.ensureVisible(find.text('Jaar 3'));
-    await tester.tap(find.text('Jaar 3'));
+    // Switched off, the account is right there with three green cells.
+    await tester.tap(find.byKey(const ValueKey('actions-only-with-actions')));
     await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-class-class|1|3|3C')),
-        findsOneWidget);
-    expect(
-        find.byKey(const ValueKey('rollup-class-class|1|1|1A')), findsNothing,
-        reason: 'several grade-years could be open at once before #235');
-    expect(harness.controller.expandedPath, <String>['rollup-grade-grades|3']);
-
-    // Tapping the open year again shuts it, leaving nothing open.
-    await tester.ensureVisible(find.text('Jaar 3'));
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    expect(harness.controller.expandedPath, isEmpty);
-    expect(
-        find.byKey(const ValueKey('rollup-class-class|1|3|3C')), findsNothing);
+    final tom = _idOf(harness.controller, 'Tom Tas');
+    expect(_row(tom), findsOneWidget);
   });
 
   testWidgets(
-      'the nested Personeel tree keeps the school open under an opened '
-      'grade-year, and both open across a drill-down (#235)',
-      (WidgetTester tester) async {
-    _useTallWindow(tester);
-    // The staff tree is school → grade-year → class, so "one open node" has to
-    // mean one per level: a flat single-open key would collapse the school out
-    // from under the very year it was used to reach.
+      'the filter switch survives a Leerlingen ↔ Personeel tab change '
+      '(#226)', (WidgetTester tester) async {
+    _useWideWindow(tester);
     final harness = ReconcileHarness(
       wisa: wisaSnap(students: [wisaStudent()], staff: [wisaStaff()]),
     );
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
+
+    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
+    expect(tester.widget<Switch>(toggle).value, isTrue);
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+
     await tester.tap(find.byKey(const ValueKey('actions-tab-personeel')));
     await tester.pumpAndSettle();
+    expect(tester.widget<Switch>(toggle).value, isFalse,
+        reason: 'the mode outlives the tab it was set on');
 
-    final school = find.byKey(const ValueKey('rollup-school-school|staff'));
-    await tester.ensureVisible(school);
-    await tester.tap(school);
+    await tester.tap(find.byKey(const ValueKey('actions-tab-leerlingen')));
     await tester.pumpAndSettle();
-    final grade =
-        find.byKey(const ValueKey('rollup-grade-grade|staff|Personeel'));
-    await tester.ensureVisible(grade);
-    await tester.tap(grade);
-    await tester.pumpAndSettle();
-
-    final klas = find
-        .byKey(const ValueKey('rollup-class-class|staff|Personeel|Personeel'));
-    expect(klas, findsOneWidget,
-        reason: 'the school stayed open under the grade-year it revealed');
-    expect(harness.controller.expandedPath, <String>[
-      'rollup-school-school|staff',
-      'rollup-grade-grade|staff|Personeel',
-    ]);
-
-    await tester.ensureVisible(klas);
-    await tester.tap(klas);
-    await tester.pumpAndSettle();
-    expect(harness.controller.selectedClassroom?.classroom, 'Personeel');
-
-    await tester.tap(find.byKey(const ValueKey('actions-classroom-back')));
-    await tester.pumpAndSettle();
-    expect(klas, findsOneWidget,
-        reason: 'both levels of the staff path come back open');
+    expect(tester.widget<Switch>(toggle).value, isFalse);
   });
 
   testWidgets(
-      'a grade-year the filter hides is forgotten rather than re-opening when '
-      'the filter goes off again (#226/#235)', (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final harness = await filterTreeHarness();
+      'an informational candidate colours no cell and puts no row in the work '
+      'list, but is still readable in the details pane (#245/#255/#298)',
+      (WidgetTester tester) async {
+    _useWideWindow(tester);
+    // Sam sits in the wrong Office 365 class group. The write belongs to the
+    // class row on Klasgroepen — one `SyncAzureClassGroupMembers` per class
+    // rather than one per student — so here it only diagnoses.
+    final harness = azureClassMembershipHarness();
+    await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    // Filter off: the full inventory, including the years with nothing to do.
-    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
-    await tester.ensureVisible(toggle);
-    await tester.tap(toggle);
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('rollup-grade-grades|4')));
-    await tester.pumpAndSettle();
-    expect(harness.controller.expandedPath, <String>['rollup-grade-grades|4']);
+    final sam = _idOf(harness.controller, 'Sam Sels');
+    final entry =
+        harness.controller.pendingEntries.firstWhere((e) => e.targetId == sam);
+    expect(entry.canApply, isFalse,
+        reason: 'the fixture raises the informational candidate and no other');
 
-    // Filter back on: Jaar 4 has nothing pending, so it is gone — and with it
-    // the memory of it being open.
-    await tester.ensureVisible(toggle);
-    await tester.tap(toggle);
-    await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-grade-grades|4')), findsNothing);
-    expect(harness.controller.expandedPath, isEmpty);
+    // Not in the work list: it is not work this screen can do.
+    expect(_row(sam), findsNothing);
 
-    // Off once more: Jaar 4 is back, collapsed like every other node.
-    await tester.ensureVisible(toggle);
-    await tester.tap(toggle);
+    await tester.tap(find.byKey(const ValueKey('actions-only-with-actions')));
     await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('rollup-grade-grades|4')), findsOneWidget);
+    expect(_row(sam), findsOneWidget);
+    // Nothing is coloured by it — the rollover must not paint ~3000 rows orange
+    // for work that happens somewhere else.
+    expect(_cellState(tester, sam, Origin.azure), SystemIndicatorState.inOrder);
+
+    // …and it is still readable in the details pane as context, named by the
+    // system it concerns — with both apply affordances dead, because there is
+    // nothing here for this screen to write.
+    await _select(tester, sam);
+    expect(find.text(entry.choices.single.selected.changes.summary),
+        findsOneWidget);
+    expect(find.text('Office 365 ·'), findsWidgets);
+    expect(_cellState(tester, sam, Origin.azure), SystemIndicatorState.inOrder,
+        reason: 'the row keeps its reading while the pane is open');
     expect(
-        find.byKey(const ValueKey('rollup-class-class|1|4|4A')), findsNothing,
-        reason: 'a node hidden in between must not resurrect its open state');
+      tester
+          .widget<FilledButton>(find.byKey(ValueKey('entry-apply-$sam')))
+          .onPressed,
+      isNull,
+    );
+    expect(
+      tester
+          .widget<OutlinedButton>(find.byKey(ValueKey('entry-dry-run-$sam')))
+          .onPressed,
+      isNull,
+    );
   });
 
+  // --- The list / detail split on a narrow window (#295) -------------------
+
   testWidgets(
-      "a re-sync forgets the open node instead of aiming it at a generation "
-      'that no longer has it (#235)', (WidgetTester tester) async {
-    _useTallWindow(tester);
+      'on a narrow window the details replace the list, and Overzicht comes '
+      'back (#295)', (WidgetTester tester) async {
+    _useNarrowWindow(tester);
     final harness = ReconcileHarness();
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    expect(harness.controller.expandedPath, <String>['rollup-grade-grades|3']);
+    final id = _studentEntry(harness.controller).targetId;
+    // One pane: the list, and no empty details pane taking half of it.
+    expect(_row(id), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-detail-empty')), findsNothing);
+    expect(find.byKey(const ValueKey('actions-detail-back')), findsNothing);
 
-    // WISA moved the student, so this pass really re-links and re-materializes
-    // rather than taking the unchanged shortcut.
-    harness.wisaResult = wisaSnap(
-      students: [wisaStudent(classGroup: '3D')],
-      fetchedAt: kFixtureDate.add(const Duration(hours: 1)),
-    );
-    await harness.controller.sync();
-    await tester.pumpAndSettle();
+    await _select(tester, id);
 
-    expect(harness.controller.expandedPath, isEmpty);
-    expect(
-        find.byKey(const ValueKey('rollup-class-class|1|3|3D')), findsNothing,
-        reason: 'the tree comes back collapsed, not half-open');
+    // The details took the whole width; the list stood down.
+    expect(find.byKey(ValueKey('actions-detail-$id')), findsOneWidget);
+    expect(_row(id), findsNothing);
+    final back = find.byKey(const ValueKey('actions-detail-back'));
+    expect(back, findsOneWidget);
+
+    await tester.tap(back);
+    await tester.pumpAndSettle();
+    expect(_row(id), findsOneWidget);
+    expect(find.byKey(ValueKey('actions-detail-$id')), findsNothing);
   });
 
-  // --- Address diff in the drill-down (#153) -------------------------------
+  testWidgets('a wide window shows both panes at once, with no back button',
+      (WidgetTester tester) async {
+    _useWideWindow(tester);
+    final harness = ReconcileHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    final id = _studentEntry(harness.controller).targetId;
+    await _select(tester, id);
+
+    expect(_row(id), findsOneWidget, reason: 'the list stays put beside it');
+    expect(find.byKey(ValueKey('actions-detail-$id')), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-detail-back')), findsNothing);
+  });
+
+  // --- Address diff in the details pane (#153) -----------------------------
+
   const wisaAddr = Address(
     street: 'Koophandelstraat',
     houseNumber: '32',
@@ -1184,10 +1004,10 @@ void main() {
       );
 
   testWidgets(
-      'a real postalCode drift raises the address action in the class and its '
-      'expanded diff shows only the differing field (#153/#154)',
+      'a real postalCode drift raises the address action and the details pane '
+      'shows only the differing field (#153/#295)',
       (WidgetTester tester) async {
-    _useTallWindow(tester);
+    _useWideWindow(tester);
     final harness = addressHarness(ss: ssAddr(), wisa: wisaAddr);
     harness.wisaResult = wisaSnap(students: [
       wisaStudent(
@@ -1204,30 +1024,22 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-    expect(find.text('Wijzig het adres in Smartschool'), findsWidgets);
+    final id = _studentEntry(harness.controller).targetId;
+    await _select(tester, id);
 
-    final entry = harness.controller.pendingEntries
-        .firstWhere((e) => e.family == 'student');
-    final entryKey = ValueKey('entry-student-${entry.targetId}');
-    await tester.ensureVisible(find.byKey(entryKey));
-    await tester.tap(find.byKey(entryKey));
-    await tester.pumpAndSettle();
-
+    expect(find.text('Wijzig het adres in Smartschool'), findsOneWidget);
     expect(find.textContaining('postalCode: 3270 → 3271'), findsOneWidget);
     expect(find.textContaining('street:'), findsNothing);
     expect(find.textContaining('city:'), findsNothing);
   });
 
-  // --- Passive-session drill-downs (no pull, no link) ----------------------
+  // --- Where the session's view came from ----------------------------------
 
   testWidgets(
-      'a seeded session adopts the shared state and still reads only the class '
-      'it drills into (#115/#154/#287)', (WidgetTester tester) async {
-    // Tall, like its siblings: the notice above the list costs the first card
-    // its place on an 800×600 fold, and this test is about which class was
-    // read, not about where the fold falls.
-    _useTallWindow(tester);
+      'a seeded session adopts the shared state and lists the whole school '
+      'with no classroom read at all (#115/#287/#295)',
+      (WidgetTester tester) async {
+    _useWideWindow(tester);
     final snapshots = InMemorySnapshotStore();
     final linkedStore = InMemoryLinkedStore();
     await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
@@ -1241,126 +1053,79 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: s2.bootstrap)));
     await tester.pumpAndSettle();
 
-    expect(find.text('Overzicht'), findsOneWidget);
-    // The stored view projects to the same school-less tree the syncing
-    // session rendered (#210).
-    expect(find.text('Jaar 3'), findsOneWidget);
-    expect(find.text('School 1'), findsNothing);
     // Since #287 the cold seed is linked on open, so this session can act — and
     // it got there without asking any of the three systems for anything.
     expect(s2.controller.linked, isNotNull);
     expect(s2.controller.adoptedFrom?.syncedBy, 'operator@school.example');
-    // The drill-down is still lazy: nothing is read until the operator opens a
-    // class, and then only that class.
-    expect(s2.controller.classroomAccounts, isNull);
-
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-
-    expect(s2.controller.classroomAccounts, hasLength(1));
     expect(s2.wisaSyncs, 0);
     expect(s2.ssSyncs, 0);
     expect(s2.azSyncs, 0);
+
+    // The list is right there, school-wide, with no class to open first.
+    final id = _studentEntry(s2.controller).targetId;
+    expect(_row(id), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-shared-state')), findsOneWidget);
   });
 
   testWidgets(
-      'a read-only session badges an either/or once and lists it as the one '
-      'choice it is (#251)', (WidgetTester tester) async {
-    // A passive session over a departed student's stored doc: it carries the
-    // unregister *and* the delete, which are two readings of one situation the
-    // operator resolves once. The class node used to advertise 2 and the card
-    // listed both as separate bullets, so a class with one leaver read as two
-    // pieces of work — and since #226 that same count decides what is visible.
-    _useTallWindow(tester);
-    final store = await seededLinkedStore(<MaterializedAccount>[
-      matAccount(
-        id: 's1',
-        label: 'Jane Doe',
-        classroom: '3C',
-        candidates: departureChoice(),
-      ),
-    ]);
-    final harness = ReconcileHarness(linkedStore: store);
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    // The class node in the tree: one decision, badged once.
-    await tester.tap(find.text('Jaar 3'));
-    await tester.pumpAndSettle();
-    final klas3C = find.byKey(const ValueKey('rollup-class-class|1|3|3C'));
-    await tester.ensureVisible(klas3C);
-    expect(
-        find.descendant(of: klas3C, matching: find.text('1')), findsOneWidget,
-        reason: 'one leaver is one pending decision, not two');
-    expect(find.descendant(of: klas3C, matching: find.text('2')), findsNothing);
-
-    // Drilling in, the card says the same thing: one line, marked as the choice
-    // it is, with the alternative behind it rather than beside it.
-    await tester.ensureVisible(find.text('3C'));
-    await tester.tap(find.text('3C'));
-    await tester.pumpAndSettle();
-    expect(harness.controller.linked, isNull, reason: 'passive session');
-    expect(find.text('Schrijf de leerling uit in Smartschool (keuze)'),
-        findsOneWidget);
-    expect(find.text('Verwijder dit account uit Smartschool'), findsNothing,
-        reason: 'the delete is the alternative, not a second to-do');
-    // And since #298 the line says where the write lands.
-    expect(find.text('Smartschool ·'), findsOneWidget);
-  });
-
-  testWidgets(
-      'a read-only account card marks an informational candidate "(manueel)" '
-      '(#255)', (WidgetTester tester) async {
-    // A passive session over a student who sits in the wrong Office 365 class
-    // group (#245): the write belongs to the class row, so this candidate only
-    // diagnoses and the card's badge counts it zero. The card used to render
-    // every candidate as a bare bullet, so this line read exactly like due work
-    // beside a (0) badge — while the group tile and the interactive tile have
-    // both marked it "(manueel)" all along.
-    _useTallWindow(tester);
-    final store = await seededLinkedStore(<MaterializedAccount>[
-      matAccount(
-        id: 's1',
-        label: 'Sam Sels',
-        classroom: '3C',
-        candidates: wrongAzureClassGroupNotice(),
-      ),
-    ]);
-    final harness = ReconcileHarness(linkedStore: store);
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    // Nothing here is applyable, so the work list hides the class until the
-    // inventory toggle is flipped (#226) — the state the unmarked line was most
-    // misleading in.
-    final toggle = find.byKey(const ValueKey('actions-only-with-actions'));
-    await tester.ensureVisible(toggle);
-    await tester.tap(toggle);
-    await tester.pumpAndSettle();
-
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-    expect(harness.controller.linked, isNull, reason: 'passive session');
-    expect(find.text('Sam Sels'), findsOneWidget);
-
-    expect(
-      find.text('Zit in de verkeerde Office 365-klasgroep: GBS-1A in plaats '
-          'van GBS-1B. Werk het ledenbestand van beide klassen bij. (manueel)'),
-      findsOneWidget,
-      reason: 'the operator must be able to tell manual work from due work',
-    );
-    // The line names the system it concerns (#298) — and that tag is the only
-    // marking it gets: an informational candidate colours no indicator.
-    expect(find.text('Office 365 ·'), findsOneWidget);
-
-    // …and it stays a "(manueel)" line, never a "(keuze)" one: it stands alone.
-    expect(find.textContaining('(keuze)'), findsNothing);
-  });
-
-  testWidgets(
-      'a read-only account card leaves an applyable candidate unmarked (#255)',
+      'a session that adopted the shared state says whose sync it is working '
+      'from, and its rows are the interactive ones (#287)',
       (WidgetTester tester) async {
-    // The other half of the same rule: marking must distinguish, so an ordinary
-    // applyable candidate keeps its bare summary.
-    _useTallWindow(tester);
+    _useWideWindow(tester);
+    // Operator A syncs; operator B opens Acties five minutes later and never
+    // presses Synchroniseer. Before #287 that second session got the
+    // "nog niet gesynchroniseerd" read-only notice and static cards, after
+    // minutes of WISA/Smartschool/Azure traffic were the only way out of it.
+    final snapshots = InMemorySnapshotStore();
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
+        .controller
+        .sync();
+
+    final s2 = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: s2.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('actions-read-only')), findsNothing);
+    expect(find.byKey(const ValueKey('actions-shared-state')), findsOneWidget);
+    expect(find.text('Gedeelde synchronisatie'), findsOneWidget);
+    expect(find.textContaining('operator@school.example'), findsWidgets);
+    expect(find.byIcon(Icons.lock_outline), findsNothing);
+
+    // Both passes stay within reach for an operator who wants something
+    // fresher; taking one makes the view this session's own.
+    final sync = find.byKey(const ValueKey('actions-shared-state-sync'));
+    expect(
+      tester
+          .widget<OutlinedButton>(
+            find.byKey(const ValueKey('actions-shared-state-drift')),
+          )
+          .onPressed,
+      isNotNull,
+    );
+    await tester.ensureVisible(sync);
+    await tester.tap(sync);
+    await tester.pumpAndSettle();
+
+    expect(s2.wisaSyncs, 1);
+    expect(s2.controller.adoptedFrom, isNull);
+    expect(find.byKey(const ValueKey('actions-shared-state')), findsNothing);
+  });
+
+  // --- The one blocking notice a refused session gets (#214/#287/#295) -----
+
+  final readOnly = find.byKey(const ValueKey('actions-read-only'));
+  final readOnlySync = find.byKey(const ValueKey('actions-read-only-sync'));
+
+  testWidgets(
+      'a session that cannot seed shows one blocking notice and no list at '
+      'all (#214/#287/#295)', (WidgetTester tester) async {
+    _useWideWindow(tester);
+    // A session with stored documents to read but no snapshots to link from:
+    // nothing here can be chosen, dry-run or applied.
     final store = await seededLinkedStore(<MaterializedAccount>[
       matAccount(id: 's1', label: 'Jane Doe', withAction: true),
     ]);
@@ -1368,11 +1133,77 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-    expect(find.text('Wijzig de klas in Smartschool'), findsOneWidget);
-    expect(find.textContaining('(manueel)'), findsNothing);
-    expect(find.text('Smartschool ·'), findsOneWidget);
+    expect(harness.controller.linked, isNull);
+    expect(readOnly, findsOneWidget);
+    expect(find.text('Alleen-lezen overzicht'), findsOneWidget);
+    // Since #287 the notice names *why* there is nothing to act on rather than
+    // reporting the absence of a sync: this session holds no seeded snapshot to
+    // build a view from, which is a thing only a pull can fix.
+    expect(
+      find.textContaining('Geen opgeslagen momentopname voor WISA, '
+          'Smartschool en Azure AD'),
+      findsOneWidget,
+    );
+    // …with the sync affordance right there, and live.
+    expect(tester.widget<FilledButton>(readOnlySync).onPressed, isNotNull);
+
+    // One notice, not a second way to browse (#295): the read-only account
+    // cards of #214 are gone with the drill-down they hung under.
+    expect(find.byKey(const ValueKey('actions-list')), findsNothing);
+    expect(find.text('Jane Doe'), findsNothing);
+    expect(
+        find.byKey(const ValueKey('actions-only-with-actions')), findsNothing);
+    expect(find.byKey(const ValueKey('actions-search')), findsNothing);
   });
+
+  testWidgets(
+      'a session whose sync failed is told the sync failed, not that it never '
+      'ran (#214)', (WidgetTester tester) async {
+    _useWideWindow(tester);
+    // The second reproduction path of #214: the pass died before it could link
+    // (the Azure delta-token failure of #213 was one such), so this session has
+    // an error *and* no linked view. `_fail` leaves any previously linked view
+    // untouched, so this wording is only ever reached when there was none.
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store)
+      ..wisaError = StateError('WISA host unreachable');
+    await harness.controller.sync();
+    expect(harness.controller.error, contains('WISA host unreachable'));
+    expect(harness.controller.linked, isNull);
+
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(readOnly, findsOneWidget);
+    expect(find.textContaining('De laatste sync is mislukt'), findsOneWidget);
+    expect(find.textContaining('nog niet gesynchroniseerd'), findsNothing);
+  });
+
+  testWidgets(
+      "the read-only banner's sync is disabled and named when another operator "
+      'holds the lease (#214/#108)', (WidgetTester tester) async {
+    _useWideWindow(tester);
+    final linkedStore = InMemoryLinkedStore();
+    await ReconcileHarness(linkedStore: linkedStore).controller.sync();
+    await linkedStore.acquireLease(owner: 'mieke@school', now: kFixtureDate);
+
+    // Deliberately *not* a seeded session: since #287 one of those adopts the
+    // shared state and gets the interactive list plus [SharedStateNotice]
+    // instead. This is the session with nothing to build a view from, which is
+    // the one the read-only banner is for.
+    final s2 = ReconcileHarness(linkedStore: linkedStore);
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: s2.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(readOnly, findsOneWidget);
+    expect(tester.widget<FilledButton>(readOnlySync).onPressed, isNull);
+    expect(find.textContaining('mieke@school'), findsOneWidget,
+        reason: 'a dead button needs its reason on screen too');
+  });
+
+  // --- The freshness stamp above the list ----------------------------------
 
   testWidgets(
       "a generation bump refetches the passive Actions overview's freshness "
@@ -1404,8 +1235,8 @@ void main() {
   });
 
   testWidgets(
-      "the overview's freshness stamp carries the date once the shared state "
-      'is no longer from today (#192)', (WidgetTester tester) async {
+      "the freshness stamp carries the date once the shared state is no longer "
+      'from today (#192)', (WidgetTester tester) async {
     // The shared view was materialized at kFixtureDate, a past day. Time-only
     // rendered that as "Generatie 1 · 02:00 door …" —
     // indistinguishable from a view materialized minutes ago, the same
@@ -1431,8 +1262,8 @@ void main() {
   });
 
   testWidgets(
-      "the overview's freshness stamp names the werkdatum the roster was "
-      'pulled with (#247)', (WidgetTester tester) async {
+      'the freshness stamp names the werkdatum the roster was pulled with '
+      '(#247)', (WidgetTester tester) async {
     // "Wie synchroniseerde, wanneer" says when the pass ran, never which school
     // year it describes — and WISA answers *as of* a date, so a pull made on
     // the wrong side of the rollover reads here exactly like a class that went
@@ -1487,6 +1318,7 @@ void main() {
     // between a save and the next Synchroniseer the setting says one school
     // year and the installed roster is another. Driven over the *production*
     // WISA pull, so the date on screen is the one that really went out.
+    _useWideWindow(tester);
     final live = LiveSettings(AppSettings(
       wisa: WisaConnection(
         server: 'wisa.example',
@@ -1517,226 +1349,16 @@ void main() {
         reason: 'a saved werkdatum describes the next pull, not this view');
   });
 
-  // --- The read-only drill-down state (#214) -------------------------------
-
-  final readOnly = find.byKey(const ValueKey('actions-read-only'));
-  final readOnlySync = find.byKey(const ValueKey('actions-read-only-sync'));
-
-  testWidgets(
-      'a passive classroom drill-down announces itself as read-only, styles '
-      'its cards inert and offers the sync (#214)',
-      (WidgetTester tester) async {
-    _useTallWindow(tester);
-    // A passive session: the shared documents are there to read, but nothing is
-    // linked, so no choice, dry-run or apply exists for the accounts below.
-    final store = await seededLinkedStore(<MaterializedAccount>[
-      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
-    ]);
-    final harness = ReconcileHarness(linkedStore: store);
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    // The overview itself is browsable as ever — only a drill-down, where the
-    // actions are supposed to be actionable, carries the notice.
-    expect(readOnly, findsNothing);
-
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-    expect(harness.controller.linked, isNull);
-
-    // The state is named instead of silently swapping in static cards.
-    expect(readOnly, findsOneWidget);
-    expect(find.text('Alleen-lezen overzicht'), findsOneWidget);
-    // Since #287 the notice names *why* there is nothing to act on rather than
-    // reporting the absence of a sync: this session holds no seeded snapshot to
-    // build a view from, which is a thing only a pull can fix.
-    expect(
-      find.textContaining('Geen opgeslagen momentopname voor WISA, '
-          'Smartschool en Azure AD'),
-      findsOneWidget,
-    );
-
-    // …with the sync affordance right there, and live.
-    expect(tester.widget<FilledButton>(readOnlySync).onPressed, isNotNull);
-
-    // The account card is styled as the inert thing it is, rather than passing
-    // for one of the interactive entry tiles.
-    expect(find.text('Jane Doe'), findsOneWidget);
-    expect(find.byIcon(Icons.lock_outline), findsWidgets);
-    final candidate = tester.widget<Text>(
-      find.text('Wijzig de klas in Smartschool'),
-    );
-    expect(
-      candidate.style?.color,
-      Theme.of(tester.element(readOnly)).disabledColor,
-      reason: 'a summary nobody can act on is not rendered as live body text',
-    );
-  });
-
-  testWidgets(
-      'an active session drills into the same class with no read-only notice — '
-      'those tiles really are interactive (#214)', (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final harness = ReconcileHarness();
-    await harness.controller.sync();
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-
-    expect(harness.controller.linked, isNotNull);
-    expect(readOnly, findsNothing);
-    expect(find.byIcon(Icons.lock_outline), findsNothing);
-    expect(find.byKey(const ValueKey('rollup-groups')), findsNothing);
-  });
-
-  testWidgets(
-      'a session that adopted the shared state says whose sync it is working '
-      'from, and its tiles are the interactive ones (#287)',
-      (WidgetTester tester) async {
-    _useTallWindow(tester);
-    // Operator A syncs; operator B opens Acties five minutes later and never
-    // presses Synchroniseer. Before #287 that second session got the
-    // "nog niet gesynchroniseerd" read-only notice and static cards, after
-    // minutes of WISA/Smartschool/Azure traffic were the only way out of it.
-    final snapshots = InMemorySnapshotStore();
-    final linkedStore = InMemoryLinkedStore();
-    await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
-        .controller
-        .sync();
-
-    final s2 = await ReconcileHarness.resume(
-      store: snapshots,
-      linkedStore: linkedStore,
-    );
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: s2.bootstrap)));
-    await tester.pumpAndSettle();
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-
-    // The shared-state notice replaces the read-only one, and names the pull.
-    expect(readOnly, findsNothing);
-    expect(find.byKey(const ValueKey('actions-shared-state')), findsOneWidget);
-    expect(find.text('Gedeelde synchronisatie'), findsOneWidget);
-    expect(find.textContaining('operator@school.example'), findsWidgets);
-
-    // The tiles below it really are interactive — no locks, real entry tiles —
-    // and no system was asked for anything to get here.
-    expect(find.byIcon(Icons.lock_outline), findsNothing);
-    expect(
-      find.byWidgetPredicate((w) =>
-          w.key is ValueKey<String> &&
-          (w.key! as ValueKey<String>).value.startsWith('entry-')),
-      findsWidgets,
-    );
-    expect(s2.wisaSyncs, 0);
-    expect(s2.ssSyncs, 0);
-    expect(s2.azSyncs, 0);
-
-    // Both passes stay within reach for an operator who wants something
-    // fresher; taking one makes the view this session's own.
-    final sync = find.byKey(const ValueKey('actions-shared-state-sync'));
-    expect(
-      tester
-          .widget<OutlinedButton>(
-            find.byKey(const ValueKey('actions-shared-state-drift')),
-          )
-          .onPressed,
-      isNotNull,
-    );
-    await tester.ensureVisible(sync);
-    await tester.tap(sync);
-    await tester.pumpAndSettle();
-
-    expect(s2.wisaSyncs, 1);
-    expect(s2.controller.adoptedFrom, isNull);
-    expect(find.byKey(const ValueKey('actions-shared-state')), findsNothing);
-  });
-
-  testWidgets(
-      'a session whose sync failed is told the sync failed, not that it never '
-      'ran (#214)', (WidgetTester tester) async {
-    _useTallWindow(tester);
-    // The second reproduction path of #214: the pass died before it could link
-    // (the Azure delta-token failure of #213 was one such), so this session has
-    // an error *and* no linked view. `_fail` leaves any previously linked view
-    // untouched, so this wording is only ever reached when there was none.
-    final store = await seededLinkedStore(<MaterializedAccount>[
-      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
-    ]);
-    final harness = ReconcileHarness(linkedStore: store)
-      ..wisaError = StateError('WISA host unreachable');
-    await harness.controller.sync();
-    expect(harness.controller.error, contains('WISA host unreachable'));
-    expect(harness.controller.linked, isNull);
-
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-
-    expect(readOnly, findsOneWidget);
-    expect(find.textContaining('De laatste sync is mislukt'), findsOneWidget);
-    expect(find.textContaining('nog niet gesynchroniseerd'), findsNothing);
-  });
-
-  testWidgets(
-      "the read-only banner's sync is disabled and named when another operator "
-      'holds the lease (#214/#108)', (WidgetTester tester) async {
-    _useTallWindow(tester);
-    final linkedStore = InMemoryLinkedStore();
-    await ReconcileHarness(linkedStore: linkedStore).controller.sync();
-    await linkedStore.acquireLease(owner: 'mieke@school', now: kFixtureDate);
-
-    // Deliberately *not* a seeded session: since #287 one of those adopts the
-    // shared state and gets the interactive tiles plus [SharedStateNotice]
-    // instead. This is the session with nothing to build a view from, which is
-    // the one the read-only banner is for.
-    final s2 = ReconcileHarness(linkedStore: linkedStore);
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: s2.bootstrap)));
-    await tester.pumpAndSettle();
-
-    await _drill(tester, node: 'Jaar 3', classroom: '3C');
-
-    expect(readOnly, findsOneWidget);
-    expect(tester.widget<FilledButton>(readOnlySync).onPressed, isNull);
-    expect(find.textContaining('mieke@school'), findsOneWidget,
-        reason: 'a dead button needs its reason on screen too');
-  });
-
   group('a pass runs behind a modal progress dialog (#243)', () {
-    // An "Apply to all" over a September situation group writes hundreds of
-    // accounts, one connector round-trip at a time, for minutes. Its only
-    // feedback used to be greyed-out buttons plus an indeterminate bar in a
-    // page header the operator had long scrolled past — so a running pass was
-    // indistinguishable from a hung app, nothing named the account being
-    // written, and nothing stopped them scrolling away mid-write.
-
-    /// Two departed Smartschool-only students with **different names**, so an
-    /// assertion that the dialog names the account in flight is a real one.
-    ReconcileHarness twoDeparted({Future<void> Function()? gate}) =>
-        ReconcileHarness(
-          applyGate: gate,
-          wisa: wisaSnap(students: const []),
-          smartschool: ssSnap(
-            groups: const [],
-            accounts: <SmartschoolAccount>[
-              ssAccount(
-                uid: 'user0',
-                accountId: '0',
-                mail: 'user0@student.school.example',
-                givenName: 'Jan',
-                surname: 'Peeters',
-              ),
-              ssAccount(
-                uid: 'user1',
-                accountId: '1',
-                mail: 'user1@student.school.example',
-                givenName: 'Sofie',
-                surname: 'Claes',
-              ),
-            ],
-            memberships: const [],
-          ),
-          azure: azSnap(users: const []),
-        );
+    // A pass over an account's decisions is sequential, one connector
+    // round-trip at a time. Its only feedback used to be greyed-out buttons
+    // plus an indeterminate bar in a page header the operator had long scrolled
+    // past — so a running pass was indistinguishable from a hung app, and
+    // nothing named the action being written.
+    //
+    // The multi-*account* form of the pass lives on Klasgroepen's cohort header
+    // since #295 took bulk apply off this screen; here a two-step pass is one
+    // account's two decisions, which is what an entry apply runs.
 
     /// The text of one line of the progress dialog.
     String line(WidgetTester tester, String key) =>
@@ -1746,14 +1368,14 @@ void main() {
 
     testWidgets(
         'an apply holds the operator in a non-dismissible dialog that names '
-        'each account and action as it goes, and closes itself when the pass '
-        'ends', (WidgetTester tester) async {
-      _useTallWindow(tester);
+        'each action as it goes, and closes itself when the pass ends',
+        (WidgetTester tester) async {
+      _useWideWindow(tester);
       // One fresh gate per action, so the pass can be walked step by step and
       // the text observed on each — the bug is precisely that nobody could see
-      // which account was being written.
+      // what was being written.
       final gates = <Completer<void>>[];
-      final harness = twoDeparted(gate: () async {
+      final harness = ReconcileHarness(applyGate: () async {
         final gate = Completer<void>();
         gates.add(gate);
         await gate.future;
@@ -1763,30 +1385,31 @@ void main() {
           .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
       await tester.pumpAndSettle();
 
-      await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
+      final entry = _studentEntry(harness.controller);
+      final id = entry.targetId;
+      final steps = <String>[
+        for (final c in entry.choices)
+          '${entry.target} — ${c.selected.changes.summary}',
+      ];
+      expect(steps, hasLength(2), reason: 'Jane raises two decisions');
 
       // Idle: no dialog.
       expect(dialog, findsNothing);
 
-      // Driven from the cohort header — the two departed students are one
-      // decision, on screen, above the button that applies it.
-      final bulk = find.byKey(ValueKey(
-          'situation-apply-${harness.controller.classroomPendingSituations.single.key}'));
-      await tester.ensureVisible(bulk);
-      await tester.tap(bulk);
+      await _select(tester, id);
+      await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+      await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
       await tester.pumpAndSettle();
 
       // Parked on the first action: the dialog is up, headed as an apply, and
-      // says how far along it is and on whom.
+      // says how far along it is and on what.
       expect(dialog, findsOneWidget);
       expect(gates, hasLength(1));
       expect(find.text('Acties toepassen…'), findsOneWidget);
       expect(line(tester, 'actions-progress-count'), 'Actie 1 van 2');
-      expect(
-          line(tester, 'actions-progress-step'), startsWith('Jan Peeters —'));
-      expect(line(tester, 'actions-progress-step'), contains('Smartschool'));
+      expect(line(tester, 'actions-progress-step'), steps[0]);
 
       // Determinate, and it is a real bar — the motionless indeterminate sweep
       // is exactly what this replaces (#176).
@@ -1800,14 +1423,13 @@ void main() {
       await tester.pumpAndSettle();
       expect(dialog, findsOneWidget);
 
-      // The second action: the text follows the pass to the next account.
+      // The second action: the text follows the pass.
       gates[0].complete();
       await tester.pumpAndSettle();
       expect(gates, hasLength(2));
       expect(dialog, findsOneWidget);
       expect(line(tester, 'actions-progress-count'), 'Actie 2 van 2');
-      expect(
-          line(tester, 'actions-progress-step'), startsWith('Sofie Claes —'));
+      expect(line(tester, 'actions-progress-step'), steps[1]);
       expect(
         tester
             .widget<LinearProgressIndicator>(
@@ -1823,35 +1445,31 @@ void main() {
       expect(dialog, findsNothing);
       expect(find.text('Resultaat van het toepassen'), findsOneWidget);
       expect(harness.controller.applyResults, hasLength(2));
-      expect(harness.soap.soapActions, isNotEmpty);
     });
 
     testWidgets(
         'a dry-run gets the same dialog — just as slow, and it used to be just '
         'as silent', (WidgetTester tester) async {
-      _useTallWindow(tester);
+      _useWideWindow(tester);
       final gate = Completer<void>();
-      final harness = twoDeparted(gate: () => gate.future);
+      final harness = ReconcileHarness(applyGate: () => gate.future);
       await harness.controller.sync();
       await tester
           .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
       await tester.pumpAndSettle();
 
-      await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
+      final id = _studentEntry(harness.controller).targetId;
+      await _select(tester, id);
 
       // A dry-run needs no confirmation, so it goes straight into the pass.
-      final bulkDryRun = find.byKey(ValueKey(
-          'situation-dry-run-${harness.controller.classroomPendingSituations.single.key}'));
-      await tester.ensureVisible(bulkDryRun);
-      await tester.tap(bulkDryRun);
+      await tester.ensureVisible(find.byKey(ValueKey('entry-dry-run-$id')));
+      await tester.tap(find.byKey(ValueKey('entry-dry-run-$id')));
       await tester.pumpAndSettle();
 
       expect(dialog, findsOneWidget);
       expect(find.text('Dry-run bezig…'), findsOneWidget);
       expect(find.text('Er wordt niets geschreven.'), findsOneWidget);
       expect(line(tester, 'actions-progress-count'), 'Actie 1 van 2');
-      expect(
-          line(tester, 'actions-progress-step'), startsWith('Jan Peeters —'));
 
       gate.complete();
       await tester.pumpAndSettle();
@@ -1862,12 +1480,12 @@ void main() {
 
     testWidgets('a pass whose writes fail still clears the dialog',
         (WidgetTester tester) async {
-      _useTallWindow(tester);
+      _useWideWindow(tester);
       // The worst case for a modal: the pass blows up. Leaving the dialog up
       // would lock the operator out of the app entirely, so its lifetime is
       // bound to the pass's future, not to anything observed about the results.
       final gate = Completer<void>();
-      final harness = twoDeparted(gate: () async {
+      final harness = ReconcileHarness(applyGate: () async {
         await gate.future;
         throw StateError('Smartschool weigerde de schrijfactie');
       });
@@ -1876,12 +1494,10 @@ void main() {
           .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
       await tester.pumpAndSettle();
 
-      await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
-
-      final bulk = find.byKey(ValueKey(
-          'situation-apply-${harness.controller.classroomPendingSituations.single.key}'));
-      await tester.ensureVisible(bulk);
-      await tester.tap(bulk);
+      final id = _studentEntry(harness.controller).targetId;
+      await _select(tester, id);
+      await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
+      await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
       await tester.pumpAndSettle();
@@ -1901,40 +1517,6 @@ void main() {
         find.textContaining('Smartschool weigerde de schrijfactie'),
         findsWidgets,
       );
-    });
-
-    testWidgets('the per-entry affordance runs behind it too',
-        (WidgetTester tester) async {
-      _useTallWindow(tester);
-      final gate = Completer<void>();
-      final harness = twoDeparted(gate: () => gate.future);
-      await harness.controller.sync();
-      await tester
-          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-      await tester.pumpAndSettle();
-      await _drill(tester, node: 'Niet toegewezen', classroom: 'Zonder klas');
-
-      // A pass of exactly one, next to the two-account cohort pass above.
-      final entry = harness.controller.pendingEntries
-          .firstWhere((e) => e.target == 'Sofie Claes');
-      final id = entry.targetId;
-      await tester.ensureVisible(find.byKey(ValueKey('entry-student-$id')));
-      await tester.tap(find.byKey(ValueKey('entry-student-$id')));
-      await tester.pumpAndSettle();
-      await tester.ensureVisible(find.byKey(ValueKey('entry-apply-$id')));
-      await tester.tap(find.byKey(ValueKey('entry-apply-$id')));
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-      await tester.pumpAndSettle();
-
-      expect(dialog, findsOneWidget);
-      expect(line(tester, 'actions-progress-count'), 'Actie 1 van 1');
-      expect(
-          line(tester, 'actions-progress-step'), startsWith('Sofie Claes —'));
-      gate.complete();
-      await tester.pumpAndSettle();
-      expect(dialog, findsNothing);
-      expect(find.text('Resultaat van het toepassen'), findsOneWidget);
     });
   });
 }

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -574,6 +574,310 @@ void main() {
     });
   });
 
+  // --- Ticking the accounts a risky action runs on (#297) -------------------
+
+  group('a decision can be applied to the accounts the operator ticked (#297)',
+      () {
+    Finder check(String id) => find.byKey(ValueKey('account-check-$id'));
+
+    Finder chip(String key) => find.byKey(ValueKey('actions-decision-$key'));
+
+    /// The line under the chips: how much of the selection the chosen decision
+    /// covers, and how much of it it does not.
+    String scopeLine(WidgetTester tester) => tester
+        .widget<Text>(find.byKey(const ValueKey('actions-selection-scope')))
+        .data!;
+
+    Future<void> tick(WidgetTester tester, String id) async {
+      await tester.ensureVisible(check(id));
+      await tester.tap(check(id));
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> selectAll(WidgetTester tester) async {
+      await tester.tap(find.byKey(const ValueKey('actions-select-all')));
+      await tester.pumpAndSettle();
+    }
+
+    int classMoves(ReconcileHarness harness) => harness.soap.soapActions
+        .where((a) => a.endsWith('#saveUserToClass'))
+        .length;
+
+    /// The September rollover in miniature (see the #296 group): three students
+    /// share the sanctioned class move, and Sam alone also carries the Office
+    /// 365 rename that #293 withholds from any school-wide pass.
+    Future<ReconcileHarness> openRollover(WidgetTester tester) async {
+      _useWideWindow(tester);
+      final harness = rolloverHarness();
+      await harness.controller.sync();
+      await tester
+          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+      return harness;
+    }
+
+    testWidgets(
+        'only a row with applyable work can be ticked, and select-all covers '
+        'the visible rows and no others', (WidgetTester tester) async {
+      _useWideWindow(tester);
+      // Sam's Office 365 display name is stale; Tom is in order everywhere.
+      final harness = appliedClassWorkHarness();
+      await harness.controller.sync();
+      await tester
+          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      final tom = _idOf(harness.controller, 'Tom Tas');
+
+      expect(
+          find.byKey(const ValueKey('actions-selection-bar')), findsOneWidget);
+      expect(find.text('Selecteer alle zichtbare (1)'), findsOneWidget);
+      expect(check(sam), findsOneWidget);
+
+      // Off the work list Tom appears with nothing to tick: ticking a settled
+      // account adds nothing to a pass and would only inflate the skipped
+      // count. Select-all still covers one row.
+      await tester.tap(find.byKey(const ValueKey('actions-only-with-actions')));
+      await tester.pumpAndSettle();
+      expect(_row(tom), findsOneWidget);
+      expect(check(tom), findsNothing);
+      expect(find.text('Selecteer alle zichtbare (1)'), findsOneWidget);
+
+      await selectAll(tester);
+      expect(tester.widget<Checkbox>(check(sam)).value, isTrue);
+      expect(find.textContaining('1 account(s) geselecteerd'), findsOneWidget);
+    });
+
+    testWidgets(
+        'the bar names one decision and applies exactly it across the '
+        'selection (#292)', (WidgetTester tester) async {
+      final harness = await openRollover(tester);
+      await selectAll(tester);
+
+      expect(find.textContaining('3 account(s) geselecteerd'), findsOneWidget);
+      // Both decisions the ticked accounts raise are on offer, and the one the
+      // most of them share is the default — that is what the selection was
+      // almost certainly made for.
+      expect(chip('student|MoveToSmartschoolClassGroup'), findsOneWidget);
+      expect(chip('student|ModifyAzureName'), findsOneWidget);
+      expect(
+        tester
+            .widget<ChoiceChip>(chip('student|MoveToSmartschoolClassGroup'))
+            .selected,
+        isTrue,
+      );
+      expect(scopeLine(tester),
+          'Wordt toegepast op alle 3 geselecteerde account(s).');
+
+      await tester.tap(find.byKey(const ValueKey('actions-selection-apply')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Toepassen op 3 geselecteerd(e) account(s)?'),
+          findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.textContaining('3 wijzigingen naar Smartschool'),
+        ),
+        findsOneWidget,
+        reason: 'the dialog names the systems and the change count of this '
+            'selection, not of everything on those three cards',
+      );
+
+      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(classMoves(harness), 3);
+      expect(harness.graph.requests.where((r) => r.method == 'PATCH'), isEmpty,
+          reason: "Sam's rename shares his card but not this decision");
+      // The writes settled what the ticks named, so the selection is gone with
+      // the view it was made against.
+      expect(
+          find.byKey(const ValueKey('actions-selection-scope')), findsNothing);
+    });
+
+    testWidgets(
+        'the kinds that get no apply-all get this instead, and it says how '
+        'many of the selection it skips (#293)', (WidgetTester tester) async {
+      final harness = await openRollover(tester);
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      final sara = _idOf(harness.controller, 'Sara Segers');
+
+      // A rename over the whole school is exactly what the sanction refuses…
+      await _select(tester, sam);
+      expect(find.byKey(ValueKey('decision-apply-all-student-$sam-0')),
+          findsNothing);
+
+      // …yet it is on offer here, because the ticking is the consent.
+      await tick(tester, sam);
+      await tick(tester, sara);
+      await tester.tap(chip('student|ModifyAzureName'));
+      await tester.pumpAndSettle();
+
+      expect(
+        scopeLine(tester),
+        'Wordt toegepast op 1 van de 2 geselecteerde account(s) — 1 '
+        'overgeslagen, want daar staat deze beslissing niet open.',
+        reason: 'Sara raises the class move, not the rename, and a pass that '
+            'quietly passed over her would be the whole risk of a multi-select',
+      );
+      expect(find.text('Toepassen op selectie (1)'), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('actions-selection-apply')));
+      await tester.pumpAndSettle();
+      expect(find.text('Toepassen op 1 geselecteerd(e) account(s)?'),
+          findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(harness.graph.requests.where((r) => r.method == 'PATCH'),
+          hasLength(1));
+      expect(classMoves(harness), 0,
+          reason: 'the pass is one decision deep, whatever else the ticked '
+              'cards carry (#292)');
+    });
+
+    testWidgets(
+        'ticking every visible row selects what the filter shows, and the '
+        'dialog quotes that count', (WidgetTester tester) async {
+      final harness = await openRollover(tester);
+      final tom = _idOf(harness.controller, 'Tom Tas');
+
+      await tester.enterText(
+          find.byKey(const ValueKey('actions-search')), 'Sa');
+      await tester.pumpAndSettle();
+      expect(_row(tom), findsNothing);
+      expect(find.text('Selecteer alle zichtbare (2)'), findsOneWidget);
+
+      await selectAll(tester);
+      expect(find.text('Toepassen op selectie (2)'), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('actions-selection-apply')));
+      await tester.pumpAndSettle();
+      expect(find.text('Toepassen op 2 geselecteerd(e) account(s)?'),
+          findsOneWidget,
+          reason: 'select-all under a filter must never read as school-wide');
+      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(classMoves(harness), 2,
+          reason: 'Tom needs the very same move and was never on the screen');
+    });
+
+    testWidgets('a dry-run covers the selection and leaves it standing',
+        (WidgetTester tester) async {
+      final harness = await openRollover(tester);
+      await selectAll(tester);
+
+      await tester.tap(find.byKey(const ValueKey('actions-selection-dry-run')));
+      await tester.pumpAndSettle();
+
+      expect(harness.controller.dryRunResults, hasLength(3));
+      expect(classMoves(harness), 0);
+      expect(find.text('Resultaat van de dry-run'), findsOneWidget);
+      expect(scopeLine(tester),
+          'Wordt toegepast op alle 3 geselecteerde account(s).',
+          reason: 'the dry-run is what the operator reads before pressing the '
+              'button beside it, so it must not dissolve the selection');
+    });
+
+    testWidgets(
+        'the ticks survive a sort change and are retired by a refreshed view',
+        (WidgetTester tester) async {
+      final harness = await openRollover(tester);
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      await tick(tester, sam);
+      expect(find.textContaining('1 account(s) geselecteerd'), findsOneWidget);
+
+      // A sort describes the list, not the row, so it leaves the set alone.
+      await tester.tap(find.byKey(const ValueKey('actions-sort-klas')));
+      await tester.pumpAndSettle();
+      expect(tester.widget<Checkbox>(check(sam)).value, isTrue);
+      expect(find.textContaining('1 account(s) geselecteerd'), findsOneWidget);
+
+      // A refreshed linked view does not: the accounts under the ticks may no
+      // longer raise what they were ticked for.
+      await harness.controller.checkDrift();
+      await tester.pumpAndSettle();
+      expect(tester.widget<Checkbox>(check(sam)).value, isFalse);
+      expect(
+          find.byKey(const ValueKey('actions-selection-scope')), findsNothing);
+    });
+
+    testWidgets('a school-wide review takes the ticks and the checkboxes away',
+        (WidgetTester tester) async {
+      // The two bulk modes are exclusive: a review's list is its own cohort, so
+      // ticks made against the ordinary list would name a different set than
+      // the rows now on screen.
+      final harness = await openRollover(tester);
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      await tick(tester, sam);
+      await _select(tester, sam);
+
+      final Finder moveAll =
+          find.byKey(ValueKey('decision-apply-all-student-$sam-1'));
+      await tester.ensureVisible(moveAll);
+      await tester.tap(moveAll);
+      await tester.pumpAndSettle();
+
+      expect(
+          find.byKey(const ValueKey('actions-cohort-banner')), findsOneWidget);
+      expect(find.byKey(const ValueKey('actions-selection-bar')), findsNothing);
+      expect(check(sam), findsNothing);
+
+      await tester.tap(find.byKey(const ValueKey('actions-cohort-cancel')));
+      await tester.pumpAndSettle();
+      expect(check(sam), findsOneWidget);
+      expect(tester.widget<Checkbox>(check(sam)).value, isFalse,
+          reason: 'the review dropped the set; restoring one the operator has '
+              'not looked at since is exactly what must not happen');
+    });
+
+    testWidgets(
+        'the September leavers sweep: tick the departed and resolve them in '
+        'one pass', (WidgetTester tester) async {
+      _useWideWindow(tester);
+      // The case the issue is written for. Three Smartschool-only accounts, no
+      // WISA record: each resolves to the unregister/delete either-or, which is
+      // as far from a school-wide apply-all as an action gets.
+      final harness = departedHarness(count: 3);
+      await harness.controller.sync();
+      await tester
+          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+      await tester.pumpAndSettle();
+
+      final ids = <String>[
+        for (final e in harness.controller.pendingEntries)
+          if (e.family == 'student') e.targetId,
+      ];
+      expect(ids, hasLength(3));
+
+      await _select(tester, ids.first);
+      expect(find.textContaining('Toepassen op alle'), findsNothing,
+          reason: 'nobody presses one button that deletes every account the '
+              'app believes has left');
+
+      await selectAll(tester);
+      expect(chip('student|smartschool-departure'), findsOneWidget);
+      expect(scopeLine(tester),
+          'Wordt toegepast op alle 3 geselecteerde account(s).');
+
+      await tester.tap(find.byKey(const ValueKey('actions-selection-apply')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(harness.controller.applyResults, hasLength(3));
+      expect(
+        harness.controller.applyResults!.map((r) => r.changes.summary).toSet(),
+        <String>{'Schrijf de leerling uit in Smartschool'},
+        reason: 'each account still runs its own chosen alternative, and the '
+            'default of that either/or is the non-destructive one',
+      );
+    });
+  });
+
   testWidgets('cancelling the apply dialog writes nothing (#154)',
       (WidgetTester tester) async {
     _useWideWindow(tester);

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -1096,4 +1096,49 @@ void main() {
         reason: 'a non-numeric class sorts after every numbered year');
     expect(compareClassNames('3C', '3c'), 0);
   });
+
+  // --- The pointer at Acties (#301) -----------------------------------------
+
+  testWidgets(
+      'the Klasgroepen header says how many accounts are waiting on Acties '
+      '(#301)', (WidgetTester tester) async {
+    // The mirror of the line Acties carries at this tab. Sam's Office 365
+    // display name is stale, so exactly one *account* asks something — while
+    // both classes ask something here.
+    _useTallWindow(tester);
+    final harness = appliedClassWorkHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(harness.controller.accountsNeedingAttention, 1);
+    expect(
+      find.text('1 account(s) vragen ook aandacht op Acties.'),
+      findsOneWidget,
+    );
+    // Accounts, not actions: the whole view holds three pending cards, two of
+    // which are the classes on this very list.
+    expect(harness.controller.totalPendingCount, 3);
+  });
+
+  testWidgets('…and says nothing at all when no account needs anything (#301)',
+      (WidgetTester tester) async {
+    // Every student in this fixture is right everywhere a *person* can be; the
+    // only thing outstanding is the Office 365 group of `2F`, which is this
+    // tab's own work.
+    _useTallWindow(tester);
+    final harness = azureClassGroupHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(harness.controller.accountsNeedingAttention, 0);
+    expect(
+      find.byKey(const ValueKey('class-groups-account-attention')),
+      findsNothing,
+    );
+    expect(find.textContaining('aandacht op Acties'), findsNothing);
+  });
 }


### PR DESCRIPTION
The layout half of epic #291, completing it. Chunk C shipped the foundations; this chunk rebuilds the screen on top of them and restores the bulk affordances in a form the operator can see before pressing.

## What changed

- **#295 — the drill-down is replaced by one flat account list and a details pane.** Acties is now a single virtualized school-wide list (name · class · three #298 indicator cells) with a details pane rendering the `entryDetail` blocks from #281/#283 verbatim, sourced from a new memoized `ReconcileController.linkedAccounts` (materialize over the adopted linked view) joined to `pendingEntries`. The jaar→klas drill-down and its whole controller read path are retired: `openClassroom` / `classroomAccounts` / `classroomPendingEntries` / `classroomPendingSituations` / `expandedPath`, plus `PendingEntryTile` / `pendingRows`. A refused session gets one blocking notice and no list.

  The issue left two questions open; both are decided here. **"Sort by system" became a filter** — a tri-state indicator has no meaningful order, and the filter keeps rows whose cell for that system is not green, which answers both "who has Smartschool work?" and "who is missing from Office 365?". **The split folds at 900 logical px of pane width**, below which the details replace the list behind an `actions-detail-back` button, measured off the pane's own constraints so the nav rail is accounted for.

- **#296 — apply one action across the whole school, with its cohort visible before you press it.** A decision block offers "Toepassen op alle (N)" only where the action carries #293's `canApplyToAll` — the first consumer of that flag. Pressing it **writes nothing**: it arms a review, swapping the list's controls for a cohort banner and filtering to exactly the N accounts school-wide, then offering Dry-run alles / Alles toepassen (N) / Annuleer. `canApplyToAll` is plumbed through `PendingActionOption` / `PendingChoice` / `PendingDecision`; new memoized `applyToAllCohort` / `applyToAllCohortFor(key)` narrow the cohort to sanctioned + applyable members, so a mixed either/or cannot sweep in a withheld pick. The screen re-reads the cohort key every build, so a mid-review alternative switch moves the account out of N — the list and the write together. `confirmAndApply` now returns whether the pass ran, so a cancel leaves the review standing.

- **#297 — tick the accounts a risky action should run on.** Rows with applyable work carry a checkbox (`account-check-<id>`); a ticked selection raises `_SelectionBar` with a visible-scoped tristate select-all, ChoiceChips naming the decisions the selection raises (widest first), a scope line stating covered/skipped, and Dry-run / Toepassen running through the same `situationCohorts` → `applyScopeForDecisions` → `applyDecisions` path #296 uses. Offered regardless of `canApplyToAll` and bounded to the visible rows; ticks are keyed by id, so they survive a sort and are retired on a replaced linked view, a tab change, or arming a #296 review.

- **#299 — the list and the details pane update in place after an apply.** Two halves. The screen holds the accounts the last pass wrote through the *state* filters (work switch + system chip, never the name search) until the operator looks away, marks a held row with no work left "Toegepast" (`account-done-<id>`), and renders the account's own verdict via new `applyOutcomesForTarget` once its entry is gone. The controller pins `pendingEntries` / `linkedAccounts` / `_cohortIndex` to the view a pass starts from (`_holdDerived`) and drops them once via `_releaseDerived()` before the pass's closing notification — so a rollover refreshes twice instead of once per write.

  What "leave the operator where they were" means, per state: selection stays (id-keyed, and the row is held so it cannot be filtered out from under it); sort and filters are untouched by the pass, but changing them drops the hold, as do the search box, a family-tab change, and selecting an account the pass did not touch — selecting one it *did* keeps it, so a bulk pass's results stay readable one at a time; an armed #296 review still disarms on a pass that ran, and a #297 tick-set is still retired on the replaced view.

- **#301 — each action tab says what the other one is holding.** New `classesNeedingAttention` / `accountsNeedingAttention` on the controller are the single derivation both action screens quote (Klasgroepen's own header count moved onto it), rendered by a shared `OtherTabAttentionLine` under each header's count line and silent at zero. A `ShellTab` / `ShellNavigation` inherited seam (new `lib/src/shell/shell_navigation.dart`, kept out of `app_shell.dart` to avoid a screens↔tiles import ring) lets the line switch tabs. Acties lazily reads the class inventory through the same guarded `loadGroups()` Klasgroepen uses, so the pointer is present on the first visit rather than only after visiting the tab it points at.

## Test plan

Run per commit, each green on its own; figures below are at the branch tip:

- `dart format --set-exit-if-changed .` — clean (319 files, 0 changed)
- `dart analyze --fatal-infos --fatal-warnings` — clean over the workspace
- `dart test packages/*/test` — **1416 pass / 11 skipped** across all 8 packages (account_actions 224, account_core 99, account_linker 76, account_state 578, account_store 8, azure_api 150, smartschool_api 150, wisa_api 131)
- `flutter test` (account_manager) — **564 pass / 0 fail** (from 536 at branch point)
- `flutter test integration_test/app_launch_test.dart -d windows` — **114 pass / 0 fail**

New coverage: 42 rewritten `actions_screen_test.dart` cases for the new layout (#295); 9 controller tests in a new `reconcile_apply_to_all_test.dart` + 6 widget + 1 e2e (#296); 8 widget + 1 e2e (#297); 5 widget + 1 controller + 1 e2e, with 4 of the widget tests and the controller test verified failing on the unpatched code — the controller one reporting 5 derived-list refreshes instead of 2 (#299); 2 Acties widget + 2 Klasgroepen widget + 2 controller + 1 e2e (#301).

Two test-count movements worth naming rather than leaving to be noticed:

- **#295 removed the two Acties bulk e2e runs (#252/#292)** along with the affordance they drove, on the explicit understanding that #296 restores school-wide apply-all — which it does, with its own e2e. The same rules still run e2e over the Klasgroepen cohort headers throughout.
- **#299 updated the #236 e2e**, which asserted the old "row disappears immediately" contract, to read the departure where it now happens. That contract is exactly what the issue asked to change.

One reporting correction: the #297 worker reported 1340 package tests. Its commit touches nothing under `packages/`, and the count was re-measured at 1416 both by the #299 worker (with a per-package breakdown that adds up) and directly on the branch tip. The low figure was a shell-glob expansion quirk, not missing tests.

Closes #295
Closes #296
Closes #297
Closes #299
Closes #301