### PR TITLE
Acties layout cleanup + stale class-group deletes (#309-#313)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -389,16 +389,16 @@ void main() {
       findsNothing,
       reason: 'the drill-down it replaces is gone',
     );
-    // The header states the workload and stops there (#294): the global
-    // "Dry-run alles" / "Alles toepassen" pair that wrote every account in the
-    // school off one dialog is gone, and nothing on the overview replaces it.
-    // Whatever the operator applies, they reach by opening it first.
+    // The header is one eyebrow and stops there (#309/#294): the count line is
+    // gone, and so is the global "Dry-run alles" / "Alles toepassen" pair that
+    // wrote every account in the school off one dialog. Whatever the operator
+    // applies, they reach by opening it first.
     expect(
       find.descendant(
         of: find.byType(ActionsScreen),
         matching: find.textContaining('openstaande actie(s)'),
       ),
-      findsOneWidget,
+      findsNothing,
     );
     expect(find.byKey(const ValueKey('actions-dry-run')), findsNothing);
     expect(find.byKey(const ValueKey('actions-apply')), findsNothing);
@@ -1264,12 +1264,16 @@ void main() {
   });
 
   testWidgets(
-      "the Actions overview's freshness stamp carries the date once the shared "
-      'state is no longer from today end-to-end (#192)',
+      "the Klasgroepen overview's freshness stamp carries the date once the "
+      'shared state is no longer from today end-to-end (#192)',
       (WidgetTester tester) async {
     // A passive session over a shared view that was materialized in the past.
     // The header line used to read "Generatie 1 · 02:00 door …",
     // which is exactly as reassuring as a stamp from five minutes ago.
+    //
+    // Read on Klasgroepen since #309 took the stamp off Acties: it describes
+    // the shared state rather than either list, and this is the action view
+    // that still carries it.
     useTallWindow(tester);
     final store = await seededLinkedStore(<MaterializedAccount>[
       matAccount(id: 's1', label: 'Jane Doe', withAction: true),
@@ -1282,7 +1286,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Acties'));
+    await tester.tap(find.text('Klasgroepen'));
     await tester.pumpAndSettle();
 
     // Derived independently of the production formatter: the store was stamped
@@ -3253,17 +3257,24 @@ void main() {
   });
 
   testWidgets(
-      'each action tab says what the other one is holding, and following the '
-      'line lands there end-to-end (#301)', (WidgetTester tester) async {
-    // The real app, real rail, real navigation — which is the whole of this
-    // issue. Acties covers people and Klasgroepen covers classes, so "is
-    // everything as expected?" is only answerable by visiting both, and nothing
-    // prompted the operator to. The rollover is where that bites: the
-    // Smartschool class change is per student here while the Office 365 roster
-    // write is one action per class there, so a clean Acties list can sit above
-    // a pile of stale rosters.
+      'Klasgroepen says what Acties is holding and following the line lands '
+      'there, while Acties points back at nothing end-to-end (#301/#309)',
+      (WidgetTester tester) async {
+    // The real app, real rail, real navigation — which is the whole of #301.
+    // Acties covers people and Klasgroepen covers classes, so "is everything as
+    // expected?" is only answerable by visiting both, and nothing prompted the
+    // operator to. The rollover is where that bites: the Smartschool class
+    // change is per student on Acties while the Office 365 roster write is one
+    // action per class here, so a clean Acties list can sit above a pile of
+    // stale rosters.
     //
-    // Only a full run can show it. The two counts are derived on the shared
+    // #309 made the pointer one-way. Acties is a list of thousands whose header
+    // was five lines of preamble before anything actionable, so the line about
+    // the *other* tab came off it; Klasgroepen has the room and keeps the
+    // mirror. The asymmetry is the decision, and this run pins both halves of
+    // it.
+    //
+    // Only a full run can show either. The two counts are derived on the shared
     // controller, rendered by two screens that never see each other, and the
     // link has to reach across the shell that keeps both alive — three halves a
     // widget test of either screen structurally cannot put together.
@@ -3279,46 +3290,94 @@ void main() {
       reconcileBootstrap: harness.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await syncThenOpenActions(tester);
+    await syncThenOpenKlasgroepen(tester);
     expect(harness.controller.error, isNull);
-    expect(find.byType(ActionsScreen), findsOneWidget);
-
-    // Acties names what the other tab is holding, on the first visit — it reads
-    // the inventory itself rather than waiting for the operator to go to the
-    // very tab the line exists to send them to.
-    final Finder toClasses =
-        find.byKey(const ValueKey('actions-class-attention'));
-    expect(toClasses, findsOneWidget);
-    expect(find.text('2 klas(sen) vragen ook aandacht op Klasgroepen.'),
-        findsOneWidget);
-
-    // Following it lands on Klasgroepen, where the count is the one that tab
-    // states for itself — one derivation, so the pointer cannot contradict the
-    // list it points at.
-    await tester.ensureVisible(toClasses);
-    await tester.tap(toClasses);
-    await tester.pumpAndSettle();
     expect(find.byType(ClassGroupsScreen), findsOneWidget);
+
+    // The tab states its own inventory, and beside it what the other one is
+    // holding — one derivation on the shared controller, so the pointer cannot
+    // contradict the list it points at.
     expect(find.textContaining('2 klas(sen), waarvan 2 aandacht vragen'),
         findsOneWidget);
-
-    // And the mirror of it, back the other way.
     final Finder toAccounts =
         find.byKey(const ValueKey('class-groups-account-attention'));
     expect(toAccounts, findsOneWidget);
     expect(find.text('1 account(s) vragen ook aandacht op Acties.'),
         findsOneWidget);
+
+    // Following it lands on Acties, on the one account it counted, still under
+    // that screen's own work filter.
     await tester.ensureVisible(toAccounts);
     await tester.tap(toAccounts);
     await tester.pumpAndSettle();
     expect(find.byType(ActionsScreen), findsOneWidget);
-
-    // The one account it counted is the list Acties comes back to, still under
-    // its own work filter.
     final String sam = accountId(harness, 'Sam Sels');
     final String tom = accountId(harness, 'Tom Tas');
     expect(find.byKey(ValueKey('account-row-$sam')), findsOneWidget);
     expect(find.byKey(ValueKey('account-row-$tom')), findsNothing);
+
+    // …and there is no line back. Two classes really are waiting — the shared
+    // controller says so, on this very session, with the inventory already read
+    // by the tab we came from — and Acties states none of it.
+    expect(harness.controller.classesNeedingAttention, 2);
+    expect(find.byKey(const ValueKey('actions-class-attention')), findsNothing);
+    expect(find.textContaining('aandacht op Klasgroepen'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'the Acties header is one line, and the account list starts near the top '
+      'of a real window end-to-end (#309)', (WidgetTester tester) async {
+    // The reason the header was stripped, at the size it was costing something.
+    // On a 1080p window the eyebrow, the title, the count line, the pointer at
+    // Klasgroepen and the freshness stamp — plus the search box, the work
+    // switch and the filter chips under them — pushed the list into the lower
+    // half of the screen: two or three accounts at a time, on the view whose
+    // whole purpose is the list.
+    //
+    // A widget test cannot answer this. It renders the screen at whatever
+    // viewport it likes, in Ahem, outside the shell — so it can say the header
+    // has one line but not where the list ends up for the operator. This runs
+    // the real app in the real fonts at the real window size and measures it:
+    // the list top moved from 575 to 373 of 1080, from below the halfway mark
+    // to inside the top third.
+    tester.view.physicalSize = const Size(1920, 1080);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final harness = appliedClassWorkHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    expect(harness.controller.error, isNull);
+
+    // The header is the eyebrow, and the four lines that used to follow it are
+    // nowhere on the screen.
+    expect(find.text('ARCADIA · ACTIES'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(ActionsScreen),
+        matching: find.text('Acties'),
+      ),
+      findsNothing,
+      reason: 'the title restated the eyebrow; the rail label is not it',
+    );
+    expect(find.textContaining('openstaande actie(s)'), findsNothing);
+    expect(find.byKey(const ValueKey('actions-class-attention')), findsNothing);
+    expect(find.textContaining('Generatie'), findsNothing);
+
+    // The list starts inside the top 40% of the window instead of below the
+    // middle of it — measured in the real font, in the real shell, with the
+    // real rail beside it.
+    final Finder list = find.byKey(const ValueKey('actions-list'));
+    expect(tester.getTopLeft(list).dy, lessThan(1080 * 0.4));
+    // Which is the same statement from the operator's side: the list, not the
+    // preamble above it, gets the majority of the window it is the point of.
+    expect(tester.getSize(list).height, greaterThan(1080 / 2));
     expect(tester.takeException(), isNull);
   });
 
@@ -5344,7 +5403,9 @@ void main() {
       reconcileBootstrap: resumed.bootstrap,
     ));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Acties'));
+    // Read on Klasgroepen: since #309 that is the action view carrying the
+    // shared state's freshness stamp, which is what this run watches move.
+    await tester.tap(find.text('Klasgroepen'));
     await tester.pumpAndSettle();
 
     // The overview rendered at generation 1 and the subscriber connected.
@@ -7931,8 +7992,8 @@ void main() {
   });
 
   testWidgets(
-      "the Acties overview's freshness stamp names the werkdatum the shared "
-      'view was pulled with, and holds it across a settings save (#247)',
+      "the Klasgroepen overview's freshness stamp names the werkdatum the "
+      'shared view was pulled with, and holds it across a settings save (#247)',
       (WidgetTester tester) async {
     // #239 put the werkdatum in the Log panel, which is a *session* diagnostic:
     // it is gone when the app closes, and a passive operator reading the shared
@@ -7969,8 +8030,9 @@ void main() {
     expect(wire.werkdatums, <String>['01/09/2025']);
 
     // The overview names the school year it describes, in the wire's own
-    // dd/MM/yyyy, on the same line as the generation and the operator.
-    await tester.tap(find.text('Acties'));
+    // dd/MM/yyyy, on the same line as the generation and the operator. Read on
+    // Klasgroepen since #309 took the stamp off Acties.
+    await tester.tap(find.text('Klasgroepen'));
     await tester.pumpAndSettle();
     expect(
       find.textContaining('Generatie 1 · ', skipOffstage: false),
@@ -7982,8 +8044,8 @@ void main() {
     );
 
     // The operator moves the werkdatum in Instellingen and saves. That is the
-    // *next* pull's input; the view on Acties is still the one pulled as of
-    // 01/09/2025 and must keep saying so.
+    // *next* pull's input; the view on Klasgroepen is still the one pulled as
+    // of 01/09/2025 and must keep saying so.
     await tester.tap(find.text('Instellingen'));
     await tester.pumpAndSettle();
     final pick = find.byKey(const ValueKey('settings-workdate-pick'));
@@ -8005,7 +8067,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('settings-save')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Acties'));
+    await tester.tap(find.text('Klasgroepen'));
     await tester.pumpAndSettle();
     expect(
       find.textContaining('· werkdatum 01/09/2025', skipOffstage: false),
@@ -8024,7 +8086,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(wire.werkdatums, <String>['01/09/2025', '15/09/2025']);
 
-    await tester.tap(find.text('Acties'));
+    await tester.tap(find.text('Klasgroepen'));
     await tester.pumpAndSettle();
     expect(
       find.textContaining('· werkdatum 15/09/2025', skipOffstage: false),

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1095,7 +1095,7 @@ void main() {
     // The terminal ready line is logged (newest-first in the log panel) so the
     // operator knows the pass finished, and it names the pending-action count.
     expect(
-      find.textContaining('Sync voltooid — 4 openstaande actie(s). Klaar.'),
+      find.textContaining('Sync voltooid — 6 openstaande actie(s). Klaar.'),
       findsOneWidget,
     );
     // The last-sync freshness now renders as a dedicated box headed "Last sync"
@@ -3748,6 +3748,91 @@ void main() {
   });
 
   testWidgets(
+      'a Smartschool class WISA does not have offers its delete too, '
+      'end-to-end (#313)', (WidgetTester tester) async {
+    // The reported bug, in the real app. Our school runs `1A`; Smartschool
+    // still carries `9Z` and `8Y`, two official classes WISA has no counterpart
+    // for. Each row's whole content used to be
+    //
+    //   Deze klas bestaat in Smartschool maar niet in WISA. Verwijder ze
+    //   manueel als ze niet meer nodig is. (manueel)
+    //
+    // — an instruction to go and repeat the same judgement by hand in
+    // Smartschool's own UI, with `Toepassen` dead on the row. That is the dead
+    // end #271 removed on the Office 365 side, and at a September changeover
+    // there is a screenful of it.
+    //
+    // Only a full run shows the fix: the inventory is composed from the
+    // *stored* documents while the either/or radios come from the live
+    // dispatch, the same-situation bulk header from a third derivation, and
+    // "the tab still writes nothing by default" is a claim about the page as
+    // composed. The write itself has to travel the real Smartschool connector
+    // — a `delClass` addressed to the class **code**, not the name on screen.
+    useTallWindow(tester);
+    final harness = smartschoolLeftoverClassHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+    expect(harness.controller.error, isNull);
+
+    Finder row(String klas) => find.byKey(ValueKey('class-row-$klas'));
+
+    expect(row('1A'), findsOneWidget);
+    expect(row('9Z'), findsOneWidget);
+    expect(row('8Y'), findsOneWidget);
+    expect(find.textContaining('Verwijder ze manueel'), findsNothing,
+        reason: 'the app has the API to act on this; it stops delegating');
+
+    // Widened, not loosened: the notice is still the default of the pair, so a
+    // bulk pass over the whole tab writes nothing.
+    expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
+    final bulkApply = find.textContaining('Alles toepassen (');
+    expect(tester.widget<Text>(bulkApply).data, 'Alles toepassen (0)');
+
+    final entry = find.byKey(const ValueKey('entry-group-9Z'));
+    await tester.ensureVisible(entry);
+    await tester.tap(entry);
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Laat deze klas staan — ze bestaat in Smartschool maar niet '
+          'in WISA'),
+      findsWidgets,
+    );
+    expect(find.text('code: C9Z'), findsOneWidget);
+    expect(find.text('omschrijving: Zesde jaar Z'), findsOneWidget);
+    expect(find.textContaining('→ ∅'), findsNothing,
+        reason: 'the option that writes nothing clears nothing');
+
+    final delete = find.byKey(const ValueKey('alt-9Z-DeleteSmartschoolClass'));
+    await tester.ensureVisible(delete);
+    await tester.tap(delete);
+    await tester.pumpAndSettle();
+    expect(find.text('lidmaatschappen en subgroepen: verdwijnen mee'),
+        findsOneWidget);
+
+    final apply = find.byKey(const ValueKey('entry-apply-9Z'));
+    await tester.ensureVisible(apply);
+    expect(tester.widget<FilledButton>(apply).onPressed, isNotNull);
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    // Exactly the one class the operator picked, addressed by its code, and its
+    // row goes with it.
+    expect(harness.soap.deletedClasses, ['C9Z']);
+    expect(row('9Z'), findsNothing);
+    expect(row('8Y'), findsOneWidget,
+        reason: 'the class beside it was never selected');
+    expect(row('1A'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'the "laat de groep staan" notice states its facts end-to-end, it does '
       'not diff them (#305)', (WidgetTester tester) async {
     // The reported card, in the real app. `GBS-9Z` is the group of a class that
@@ -5210,8 +5295,9 @@ void main() {
       'a passive session surfaces pending group actions on Klasgroepen '
       'with no pull and no link() (#119)', (WidgetTester tester) async {
     // Session 1 (offline harness) syncs and materializes the shared view. The
-    // fixture's two Smartschool-only classes (2B, 3C) raise the informational
-    // orphan-class notice — the group-action family.
+    // fixture's two Smartschool-only classes (2B, 3C) raise the orphan-class
+    // either/or of #313 — the group-action family — whose pre-selected half is
+    // the notice that leaves the class standing.
     final snapshots = InMemorySnapshotStore();
     final linkedStore = InMemoryLinkedStore();
     await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
@@ -5236,8 +5322,8 @@ void main() {
 
     expect(find.byType(ClassGroupsScreen), findsOneWidget);
     expect(find.byKey(const ValueKey('class-row-2B')), findsOneWidget);
-    expect(
-        find.textContaining('Deze klas bestaat in Smartschool'), findsWidgets);
+    expect(find.textContaining('ze bestaat in Smartschool maar niet in WISA'),
+        findsWidgets);
     // …all without a single connector pull or link().
     expect(resumed.wisaSyncs, 0);
     expect(resumed.ssSyncs, 0);

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -754,22 +754,25 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  // The complement of the run above, for the kinds #293 deliberately withholds
-  // a school-wide apply from (#297). The operator ticks the accounts by hand,
-  // names the one decision, and the pass covers exactly the ticked accounts it
-  // stands open on. Worth a full run for the same reason #296 is: the count on
-  // the button, the rows the checkboxes sit on and the writes the pass makes are
-  // resolved in three different places, and only the real app composes all
-  // three — over real fonts, the real navigation shell and the real Graph and
-  // SOAP write paths.
+  // The complement of the run above went the other way (#311). #297 put a
+  // checkbox on every row carrying work and a "Selecteer alle zichtbare (N)"
+  // bar above the list, so one decision could be run over a hand-picked set —
+  // and select-all made that set whatever the filter happened to be showing,
+  // which is the objection that removed the global "Alles toepassen" in #294.
+  // Worth a full run for the same reason its arrival was: the bar, the row
+  // checkboxes and the vertical budget they cost are three different places,
+  // and only the real app composes them — in the real fonts, in the real shell,
+  // at a real window size.
   testWidgets(
-      'ticked accounts run one decision that gets no apply-all, and the pass '
-      'skips the ones it does not stand open on (#297)',
-      (WidgetTester tester) async {
-    useTallWindow(tester);
-    // The same rollover fixture: three students share the sanctioned class
-    // move, and Sam alone also carries the Office 365 rename — a judgement call
-    // the sanction refuses, and therefore exactly the kind this exists for.
+      'Acties offers no selection at all, and the list starts higher for it '
+      'end-to-end (#311)', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1920, 1080);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    // The rollover roster: three students each carrying applyable work, which
+    // is precisely when the bar rendered and every one of those rows carried a
+    // tick.
     final harness = rolloverHarness();
     await tester.pumpWidget(AccountManagerApp(
       session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
@@ -783,68 +786,44 @@ void main() {
     final String sam = accountId(harness, 'Sam Sels');
     final String sara = accountId(harness, 'Sara Segers');
     final String tom = accountId(harness, 'Tom Tas');
-    Finder check(String id) => find.byKey(ValueKey('account-check-$id'));
 
-    // The rename carries no school-wide affordance anywhere on Sam's card…
-    await selectAccount(tester, sam);
+    // Three rows with work on them, and not one tick between them.
+    for (final String id in <String>[sam, sara, tom]) {
+      expect(find.byKey(ValueKey('account-row-$id')), findsOneWidget);
+      expect(find.byKey(ValueKey('account-check-$id')), findsNothing);
+    }
+    expect(find.byKey(const ValueKey('actions-selection-bar')), findsNothing);
+    expect(find.byKey(const ValueKey('actions-select-all')), findsNothing);
+    expect(find.byKey(const ValueKey('actions-selection-apply')), findsNothing);
+    expect(find.textContaining('Selecteer alle zichtbare'), findsNothing);
+    // No checkbox anywhere on the screen: those were the only ones Acties ever
+    // rendered, so the whole affordance is gone rather than merely unreachable.
     expect(
-      find.byKey(ValueKey('decision-apply-all-student-$sam-0')),
+      find.descendant(
+        of: find.byType(ActionsScreen),
+        matching: find.byType(Checkbox),
+      ),
       findsNothing,
     );
 
-    // …so the bulk path is the ticks. Sam and Sara, by hand; Tom is left alone
-    // and stays that way.
-    for (final id in <String>[sam, sara]) {
-      await tester.ensureVisible(check(id));
-      await tester.tap(check(id));
-      await tester.pumpAndSettle();
-    }
-    expect(tester.widget<Checkbox>(check(tom)).value, isFalse);
+    // What the removal buys, measured where it was spent. The bar was a
+    // bordered block between the filter chips and the family tabs on every
+    // visit, ticks or no ticks; with it gone nothing but the tabs and their
+    // spacing stands between the last chip and the first row.
+    final Finder list = find.byKey(const ValueKey('actions-list'));
+    final double chipsBottom = tester
+        .getRect(find.byKey(const ValueKey('actions-system-azure')))
+        .bottom;
+    expect(tester.getTopLeft(list).dy - chipsBottom, lessThan(80),
+        reason: 'the bordered block alone was 126 logical pixels tall');
+    // And the window it gives back: two thirds of a 1080p screen is the list
+    // itself, on the view whose whole purpose is the list.
+    expect(tester.getSize(list).height, greaterThan(1080 * 0.7));
 
-    final Finder rename =
-        find.byKey(const ValueKey('actions-decision-student|ModifyAzureName'));
-    await tester.ensureVisible(rename);
-    await tester.tap(rename);
-    await tester.pumpAndSettle();
-
-    // Sara raises the class move, not the rename. The bar says so rather than
-    // quietly passing over her.
-    expect(
-      tester
-          .widget<Text>(find.byKey(const ValueKey('actions-selection-scope')))
-          .data,
-      'Wordt toegepast op 1 van de 2 geselecteerde account(s) — 1 '
-      'overgeslagen, want daar staat deze beslissing niet open.',
-    );
-
-    await tester.tap(find.byKey(const ValueKey('actions-selection-apply')));
-    await tester.pumpAndSettle();
-    expect(
-      find.text('Toepassen op 1 geselecteerd(e) account(s)?'),
-      findsOneWidget,
-    );
-    expect(
-      find.descendant(
-        of: find.byType(AlertDialog),
-        matching: find.textContaining('1 wijziging naar Office 365'),
-      ),
-      findsOneWidget,
-    );
-
-    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-    await tester.pumpAndSettle();
-
-    // One real Graph PATCH, and not one class move — the pass is one decision
-    // deep whatever else the ticked cards carry (#292).
-    expect(
-      harness.graph.requests.where((r) => r.method == 'PATCH'),
-      hasLength(1),
-    );
-    expect(
-      harness.soap.soapActions.where((a) => a.endsWith('#saveUserToClass')),
-      isEmpty,
-    );
-    expect(harness.controller.applyResults, hasLength(1));
+    // And a row still does the one thing a row is for.
+    await selectAccount(tester, sam);
+    expect(find.byKey(ValueKey('actions-detail-$sam')), findsOneWidget);
+    expect(find.byKey(const ValueKey('actions-selection-bar')), findsNothing);
     expect(tester.takeException(), isNull);
   });
 
@@ -3340,8 +3319,9 @@ void main() {
     // has one line but not where the list ends up for the operator. This runs
     // the real app in the real fonts at the real window size and measures it:
     // the list top moved from 575 to 373 of 1080, from below the halfway mark
-    // to inside the top third — and to 325 once #310 folded the work-list
-    // switch onto the search box's own row.
+    // to inside the top third — to 325 once #310 folded the work-list switch
+    // onto the search box's own row, and to 218 once #311 took the select-all
+    // bar out from between the chips and the list.
     tester.view.physicalSize = const Size(1920, 1080);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
@@ -3371,14 +3351,14 @@ void main() {
     expect(find.byKey(const ValueKey('actions-class-attention')), findsNothing);
     expect(find.textContaining('Generatie'), findsNothing);
 
-    // The list starts inside the top third of the window instead of below the
+    // The list starts inside the top quarter of the window instead of below the
     // middle of it — measured in the real font, in the real shell, with the
     // real rail beside it.
     final Finder list = find.byKey(const ValueKey('actions-list'));
-    expect(tester.getTopLeft(list).dy, lessThan(1080 / 3));
+    expect(tester.getTopLeft(list).dy, lessThan(1080 / 4));
     // Which is the same statement from the operator's side: the list, not the
     // preamble above it, gets the majority of the window it is the point of.
-    expect(tester.getSize(list).height, greaterThan(1080 / 2));
+    expect(tester.getSize(list).height, greaterThan(1080 * 0.7));
     expect(tester.takeException(), isNull);
   });
 

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3340,7 +3340,8 @@ void main() {
     // has one line but not where the list ends up for the operator. This runs
     // the real app in the real fonts at the real window size and measures it:
     // the list top moved from 575 to 373 of 1080, from below the halfway mark
-    // to inside the top third.
+    // to inside the top third — and to 325 once #310 folded the work-list
+    // switch onto the search box's own row.
     tester.view.physicalSize = const Size(1920, 1080);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
@@ -3370,14 +3371,89 @@ void main() {
     expect(find.byKey(const ValueKey('actions-class-attention')), findsNothing);
     expect(find.textContaining('Generatie'), findsNothing);
 
-    // The list starts inside the top 40% of the window instead of below the
+    // The list starts inside the top third of the window instead of below the
     // middle of it — measured in the real font, in the real shell, with the
     // real rail beside it.
     final Finder list = find.byKey(const ValueKey('actions-list'));
-    expect(tester.getTopLeft(list).dy, lessThan(1080 * 0.4));
+    expect(tester.getTopLeft(list).dy, lessThan(1080 / 3));
     // Which is the same statement from the operator's side: the list, not the
     // preamble above it, gets the majority of the window it is the point of.
     expect(tester.getSize(list).height, greaterThan(1080 / 2));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'the Acties name box is a name-sized box beside the work-list switch on '
+      'a real window, and folds instead of overflowing when the window '
+      'narrows end-to-end (#310)', (WidgetTester tester) async {
+    // A widget test renders these controls at whatever viewport it likes, in a
+    // test font, outside the shell. Both halves of #310 are about the real
+    // thing: how much of a *1920px window with the rail beside it* a name field
+    // was claiming, and whether the row folds or spills when that window is
+    // dragged narrow. The fold in particular runs through the real text metrics
+    // of a 30-character Dutch label — the exact place a fixed-width box would
+    // have overflowed in the app but not in Ahem.
+    tester.view.physicalSize = const Size(1920, 1080);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final harness = appliedClassWorkHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    expect(harness.controller.error, isNull);
+
+    final Finder searchFinder = find.byKey(const ValueKey('actions-search'));
+    final Finder toggleFinder =
+        find.byKey(const ValueKey('actions-only-with-actions'));
+    Rect search = tester.getRect(searchFinder);
+    Rect toggle = tester.getRect(toggleFinder);
+
+    // One row: the switch and its label stand to the right of the box and
+    // overlap it vertically, rather than sitting on a row of their own.
+    expect(toggle.left, greaterThan(search.right));
+    expect(toggle.top, lessThan(search.bottom));
+    expect(search.top, lessThan(toggle.bottom));
+    final Rect label =
+        tester.getRect(find.text('Toon enkel accounts met acties'));
+    expect(label.left, greaterThan(toggle.right));
+    expect(label.top, lessThan(search.bottom));
+
+    // Name-sized, not window-sized. The Acties pane is the full 1920 minus the
+    // navigation rail, and the box used to be exactly that wide.
+    final double paneWidth = tester.getSize(find.byType(ActionsScreen)).width;
+    expect(paneWidth, greaterThan(1500),
+        reason: 'the rail leaves the pane most of a 1920px window');
+    expect(search.width, lessThanOrEqualTo(380));
+    expect(search.width, lessThan(paneWidth / 4),
+        reason: 'the box stops a long way short of the content width');
+
+    // Now drag the window narrow — narrower than the box, the switch and the
+    // label side by side. The switch takes a second run and nothing overflows.
+    tester.view.physicalSize = const Size(900, 1080);
+    await tester.pumpAndSettle();
+    search = tester.getRect(searchFinder);
+    toggle = tester.getRect(toggleFinder);
+    expect(toggle.top, greaterThanOrEqualTo(search.bottom),
+        reason: 'the row folded rather than spilling off the right');
+    expect(search.width, lessThanOrEqualTo(380));
+    expect(search.right, lessThanOrEqualTo(900));
+    expect(toggle.right, lessThanOrEqualTo(900));
+    expect(tester.takeException(), isNull);
+
+    // And it is still the working switch, not a decoration that survived the
+    // fold: flipping it here gives the whole school back (#226).
+    final String tom = accountId(harness, 'Tom Tas');
+    expect(find.byKey(ValueKey('account-row-$tom')), findsNothing);
+    await tester.ensureVisible(toggleFinder);
+    await tester.pumpAndSettle();
+    await tester.tap(toggleFinder);
+    await tester.pumpAndSettle();
+    expect(find.byKey(ValueKey('account-row-$tom')), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -3646,6 +3646,108 @@ void main() {
   });
 
   testWidgets(
+      'the class groups the legacy app left behind offer their delete too, '
+      'end-to-end (#312)', (WidgetTester tester) async {
+    // The reported bug, in the real app. Our school runs `1A`; Office 365 still
+    // holds two groups of classes that stopped running, and neither is shaped
+    // the way *this* port creates one:
+    //
+    //   GBS-9Z            a plain security group with no address — how the
+    //                     legacy WPF app made every class group, and how
+    //                     `SSM-3ECO`, `SSM-3MRP`, `SSM-3MWW` … sit in the live
+    //                     tenant today;
+    //   Klas van juf An   renamed by hand in the portal, still answering on
+    //                     `GBS-8Y@…`.
+    //
+    // The linker orphans both, so both were Klasgroepen rows — each with a grey
+    // ✓ and no action anybody could take, the exact state #271 set out to
+    // remove. Only a full run shows that: the inventory is composed from the
+    // *stored* documents while the either/or radios come from the live
+    // dispatch, the bulk header from a third derivation, and "the tab still
+    // writes nothing by default" is a claim about the page as composed.
+    useTallWindow(tester);
+    final harness = legacyStaleClassGroupHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+    expect(harness.controller.error, isNull);
+
+    Finder row(String klas) => find.byKey(ValueKey('class-row-$klas'));
+
+    expect(row('1A'), findsOneWidget);
+    expect(row('GBS-9Z'), findsOneWidget);
+    expect(row('Klas van juf An'), findsOneWidget);
+    expect(find.textContaining('3 klas(sen), waarvan 2 aandacht vragen'),
+        findsOneWidget,
+        reason: 'both leftovers now ask something instead of showing a ✓');
+
+    // Widened, not loosened: the notice is still the default of the pair, so a
+    // bulk pass over the whole tab writes nothing.
+    expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
+    final bulkApply = find.textContaining('Alles toepassen (');
+    expect(tester.widget<Text>(bulkApply).data, 'Alles toepassen (0)');
+
+    // The renamed group is its class's group by the address it answers on
+    // (#280), so its row carries the pair under the name somebody typed over
+    // it.
+    final renamed = find.byKey(const ValueKey('entry-group-Klas van juf An'));
+    await tester.ensureVisible(renamed);
+    await tester.tap(renamed);
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Laat de Office 365-groep Klas van juf An staan — klas 8Y '
+          'bestaat niet meer in WISA of Smartschool'),
+      findsWidgets,
+    );
+    expect(
+      find.byKey(const ValueKey('alt-Klas van juf An-DeleteAzureClassGroup')),
+      findsOneWidget,
+    );
+    await tester.tap(renamed);
+    await tester.pumpAndSettle();
+
+    // The security group's own row: 21 members still in it, and no line
+    // claiming an address, because it has none.
+    final entry = find.byKey(const ValueKey('entry-group-GBS-9Z'));
+    await tester.ensureVisible(entry);
+    await tester.tap(entry);
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Laat de Office 365-groep GBS-9Z staan — klas 9Z bestaat niet '
+          'meer in WISA of Smartschool'),
+      findsWidgets,
+    );
+    expect(find.text('leden: 21'), findsOneWidget);
+    expect(find.text('mail: '), findsNothing,
+        reason: 'a security group has no address, so no line states one');
+
+    final delete =
+        find.byKey(const ValueKey('alt-GBS-9Z-DeleteAzureClassGroup'));
+    await tester.ensureVisible(delete);
+    await tester.tap(delete);
+    await tester.pumpAndSettle();
+    final apply = find.byKey(const ValueKey('entry-apply-GBS-9Z'));
+    await tester.ensureVisible(apply);
+    expect(tester.widget<FilledButton>(apply).onPressed, isNotNull);
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    // Exactly the one group the operator picked, and its row goes with it.
+    expect(harness.graph.deletedGroups, ['az-GBS-9Z']);
+    expect(row('GBS-9Z'), findsNothing);
+    expect(row('Klas van juf An'), findsOneWidget,
+        reason: 'the group beside it was never selected');
+    expect(row('1A'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'the "laat de groep staan" notice states its facts end-to-end, it does '
       'not diff them (#305)', (WidgetTester tester) async {
     // The reported card, in the real app. `GBS-9Z` is the group of a class that

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -1060,8 +1060,9 @@ class ReconcileController extends ChangeNotifier {
   /// - **The action must be sanctioned.** `null` unless the resolution
   ///   [decision] is set to declares [PendingActionOption.canApplyToAll] (#293).
   ///   That is what keeps the destructive and judgement-call actions — a delete,
-  ///   a rename, a blacklist — off this path entirely; they get checkbox
-  ///   multi-select instead (#297).
+  ///   a rename, a blacklist — off this path entirely. They get no bulk path at
+  ///   all since #311 withdrew the ticked selection of #297: one account at a
+  ///   time, from the details pane that shows what the write would do.
   /// - **Every member must be sanctioned too**, not merely the one the operator
   ///   is looking at. The staff import decision mixes the two in one either/or,
   ///   so a colleague set to "never import" is not swept along by a cohort

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -1136,6 +1136,12 @@ class _ActionsHeader extends StatelessWidget {
 /// of a row. The switch in particular is set in exactly one place (#226); its
 /// per-classroom ancestor had to be re-flipped in every class the operator
 /// opened, which is why it never actually collapsed anything to the work list.
+///
+/// The name box and the work-list switch share one row since #310. Each of
+/// them shapes the same list, so reading them together matches what they do —
+/// and the box no longer claims 1500px of a wide window for a field that holds
+/// a name. Laid out as a [Wrap] so a window too narrow for both puts the switch
+/// on a second run instead of overflowing.
 class _ListControls extends StatelessWidget {
   const _ListControls({
     required this.searchController,
@@ -1155,6 +1161,14 @@ class _ListControls extends StatelessWidget {
   final _SystemFilter system;
   final ValueChanged<_SystemFilter> onSystemChanged;
 
+  /// The widest the name box gets (#310).
+  ///
+  /// A name is a handful of words; beyond this the field is empty rubber, and
+  /// the width is better spent on the switch beside it. Bounded rather than
+  /// fixed: on a window narrower than this the box takes what there is, so the
+  /// cap never becomes the thing that overflows.
+  static const double _searchMaxWidth = 380.0;
+
   @override
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
@@ -1162,38 +1176,52 @@ class _ListControls extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        TextField(
-          key: const ValueKey('actions-search'),
-          controller: searchController,
-          decoration: InputDecoration(
-            isDense: true,
-            prefixIcon: const Icon(Icons.search, size: 18),
-            // Same wording as the Wachtwoorden → Personeel box, which matches
-            // the same way (#217): any part of the name, in any order.
-            hintText: 'Zoek op naam…',
-            border: const OutlineInputBorder(),
-            suffixIcon: searchController.text.isEmpty
-                ? null
-                : IconButton(
-                    key: const ValueKey('actions-search-clear'),
-                    icon: const Icon(Icons.close, size: 18),
-                    tooltip: 'Wis zoekopdracht',
-                    onPressed: searchController.clear,
-                  ),
-          ),
-        ),
-        const SizedBox(height: PlinkSpacing.s2),
-        Row(
+        Wrap(
+          spacing: PlinkSpacing.s4,
+          runSpacing: PlinkSpacing.s2,
+          crossAxisAlignment: WrapCrossAlignment.center,
           children: <Widget>[
-            Switch(
-              key: const ValueKey('actions-only-with-actions'),
-              value: onlyWithActions,
-              onChanged: onOnlyWithActionsChanged,
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: _searchMaxWidth),
+              child: TextField(
+                key: const ValueKey('actions-search'),
+                controller: searchController,
+                decoration: InputDecoration(
+                  isDense: true,
+                  prefixIcon: const Icon(Icons.search, size: 18),
+                  // Same wording as the Wachtwoorden → Personeel box, which
+                  // matches the same way (#217): any part of the name, in any
+                  // order.
+                  hintText: 'Zoek op naam…',
+                  border: const OutlineInputBorder(),
+                  suffixIcon: searchController.text.isEmpty
+                      ? null
+                      : IconButton(
+                          key: const ValueKey('actions-search-clear'),
+                          icon: const Icon(Icons.close, size: 18),
+                          tooltip: 'Wis zoekopdracht',
+                          onPressed: searchController.clear,
+                        ),
+                ),
+              ),
             ),
-            const SizedBox(width: PlinkSpacing.s2),
-            Expanded(
-              child: Text('Toon enkel accounts met acties',
-                  style: text.bodyMedium),
+            // Sized to the switch and its label rather than stretched: the Wrap
+            // already bounds it to the row, so the label folds before anything
+            // can spill.
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Switch(
+                  key: const ValueKey('actions-only-with-actions'),
+                  value: onlyWithActions,
+                  onChanged: onOnlyWithActionsChanged,
+                ),
+                const SizedBox(width: PlinkSpacing.s2),
+                Flexible(
+                  child: Text('Toon enkel accounts met acties',
+                      style: text.bodyMedium),
+                ),
+              ],
             ),
           ],
         ),

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -611,36 +611,12 @@ class _ActionsBodyState extends State<_ActionsBody>
     _settled.clear();
   }
 
-  /// Whether an inventory read is already queued, so a burst of notifications
-  /// schedules one.
-  bool _scheduledGroups = false;
-
-  /// Reads the class inventory when this session does not have it, so the
-  /// header can say how many classes are waiting on Klasgroepen (#301).
-  ///
-  /// The very read Klasgroepen does, through the same controller and the same
-  /// guard, so opening either tab first costs one partition read and the other
-  /// finds it already there. Without it the pointer would only appear once the
-  /// operator had visited the tab it is meant to send them to, which is the one
-  /// case it is not needed.
-  ///
-  /// Always **deferred to a microtask**, never run inline: this is reached from
-  /// a build, and the read's own first act is to publish its loading state — so
-  /// calling it inline would notify the other screens' listeners mid-frame.
-  /// A failed read answers `const []`, so it is attempted once and not retried
-  /// into a loop.
-  void _ensureGroupsLoaded() {
-    if (!mounted || _scheduledGroups) return;
-    if (controller.groupDocs != null || controller.loadingGroups) return;
-    _scheduledGroups = true;
-    scheduleMicrotask(() {
-      _scheduledGroups = false;
-      if (!mounted) return;
-      if (controller.groupDocs == null && !controller.loadingGroups) {
-        unawaited(controller.loadGroups());
-      }
-    });
-  }
+  // The class-inventory pre-read this screen used to schedule from `build` is
+  // gone with the pointer at Klasgroepen it existed for (#301 → #309). Nothing
+  // Acties renders reads `groupDocs` any more, so warming it here was a
+  // partition read on every cold visit that no pixel on this screen depended
+  // on. Klasgroepen still reads it, through its own identical guard, on the tab
+  // where the classes actually are.
 
   /// Ticks or unticks one account (#297).
   void _setTicked(String id, bool ticked) => setState(() {
@@ -802,7 +778,6 @@ class _ActionsBodyState extends State<_ActionsBody>
   Widget _body(BuildContext context, BoxConstraints constraints) {
     _retireStaleTicks();
     _holdSettled();
-    _ensureGroupsLoaded();
     final bool wide = constraints.maxWidth >= _splitBreakpoint;
     final bool active = controller.linked != null;
     final SituationCohort? cohort = active ? _armedCohort() : null;
@@ -828,15 +803,7 @@ class _ActionsBodyState extends State<_ActionsBody>
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         const SizedBox(height: PlinkSpacing.s6),
-        Padding(
-          padding: _hPad,
-          child: _ActionsHeader(
-            controller: controller,
-            onlyWithActions: _onlyWithActions,
-            reviewingCohort: cohort != null,
-            classesNeedingAttention: controller.classesNeedingAttention,
-          ),
-        ),
+        const Padding(padding: _hPad, child: _ActionsHeader()),
         const SizedBox(height: PlinkSpacing.s4),
         Padding(padding: _hPad, child: _stateNotice()),
       ],
@@ -1120,86 +1087,43 @@ class _ActionsBodyState extends State<_ActionsBody>
   }
 }
 
-/// The Actions title and how much work is pending — and, since #294, nothing
-/// that acts on it.
+/// The Acties eyebrow — and, since #309, nothing else.
 ///
-/// It used to carry a global "Dry-run alles" / "Alles toepassen" pair that ran
-/// every pending action of every family in every class in one pass. There is no
-/// safe reading of that: the operator had seen none of the changes, and at a
-/// September changeover the count behind the button is in the thousands. Its
-/// confirmation named systems and a number, which is not the same as having
-/// looked. Bulk itself is not gone — #296 put it back on the decision block,
-/// where pressing it filters the list to the cohort and shows the operator the
-/// accounts before offering a confirmation — but the affordance that applied
-/// what nobody had read is.
+/// The account list *is* this view; everything stacked above it is preamble the
+/// operator reads once and then scrolls past on every visit afterwards, while
+/// the vertical budget it eats is paid every time. On a 1080p window the header,
+/// the search box, the work switch and the filter chips together left the list
+/// the lower half of the screen — two or three accounts at a time. So four lines
+/// came off, each for its own reason:
 ///
-/// The count line stays. It states how much work exists; it is not a button.
+/// - **The title.** `Arcadia · acties` says the same thing one line above it.
+/// - **The count** (`N openstaande actie(s) — …`). Four digits of pending work
+///   is not actionable, and its trailing clause explained the work-list switch
+///   that is visible two lines further down anyway.
+/// - **The pointer at Klasgroepen** (#301). What the other tab is holding
+///   belongs on that tab; the mirror line there — how many accounts Acties is
+///   holding — stays, because Klasgroepen has the room and its list is shorter.
+///   The asymmetry is the choice, not an oversight.
+/// - **The freshness stamp** (#247/#287). It is a property of the shared state
+///   rather than of this list. [sharedViewFreshness] still renders it on
+///   Klasgroepen, and Start/Synchronisatie still carries the per-system
+///   last-sync box, so an operator judging staleness has not lost the signal.
+///
+/// It has carried nothing that *acts* since #294 either: the global "Dry-run
+/// alles" / "Alles toepassen" pair that wrote every pending action of every
+/// family in one pass, over a list nobody had looked at. Bulk itself came back
+/// on the decision block in #296, where pressing it filters the list to the
+/// cohort and shows the accounts before offering a confirmation.
 class _ActionsHeader extends StatelessWidget {
-  const _ActionsHeader({
-    required this.controller,
-    required this.onlyWithActions,
-    this.reviewingCohort = false,
-    this.classesNeedingAttention = 0,
-  });
-
-  final ReconcileController controller;
-
-  /// Whether the work-list filter is on, so the sub-line describes the list the
-  /// operator is actually looking at.
-  final bool onlyWithActions;
-
-  /// Whether a school-wide cohort is under review (#296), in which case neither
-  /// reading of [onlyWithActions] describes the list: it is one decision's
-  /// cohort, and the banner right below says so.
-  final bool reviewingCohort;
-
-  /// How many classes are waiting on the Klasgroepen tab (#301) — the one thing
-  /// in this header that is not about the list below it.
-  final int classesNeedingAttention;
+  const _ActionsHeader();
 
   @override
   Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
     final bool ink = Theme.of(context).brightness == Brightness.dark;
-    final count = controller.totalPendingCount;
-    // The shared stamp both action views carry (#247), so Acties and
-    // Klasgroepen name the same generation the same way.
-    final freshness = sharedViewFreshness(controller);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Eyebrow('Arcadia · acties', onInk: ink),
-        const SizedBox(height: PlinkSpacing.s4),
-        Text('Acties', style: text.headlineMedium),
-        const SizedBox(height: PlinkSpacing.s2),
-        Text(
-          switch ((count, reviewingCohort, onlyWithActions)) {
-            (0, _, _) => 'Geen openstaande acties.',
-            (_, true, _) => '$count openstaande actie(s) — de lijst toont de '
-                'accounts van één beslissing.',
-            (_, _, true) =>
-              '$count openstaande actie(s) — de lijst toont enkel '
-                  'accounts met werk.',
-            (_, _, false) => '$count openstaande actie(s) — de lijst toont elk '
-                'account. Drie groene vinkjes betekent dat het account overal '
-                'juist staat.',
-          },
-          style: text.bodyMedium,
-        ),
-        // The other half of "is everything as expected?" (#301). It sits under
-        // the count line and above the freshness stamp because it is a
-        // statement about the work, not about the view — and it says nothing at
-        // all when Klasgroepen is holding nothing.
-        if (classesNeedingAttention > 0) ...<Widget>[
-          const SizedBox(height: PlinkSpacing.s1),
-          OtherTabAttentionLine.classes(count: classesNeedingAttention),
-        ],
-        if (freshness != null) ...<Widget>[
-          const SizedBox(height: PlinkSpacing.s1),
-          Text(freshness, style: text.bodySmall),
-        ],
-      ],
+      children: <Widget>[Eyebrow('Arcadia · acties', onInk: ink)],
     );
   }
 }

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:account_actions/account_actions.dart' as actions;
 import 'package:account_core/account_core.dart' as core;
-import 'package:account_state/account_state.dart'
-    show LinkedState, MaterializedAccount;
+import 'package:account_state/account_state.dart' show MaterializedAccount;
 import 'package:flutter/material.dart';
 import 'package:plink_design_system/plink_design_system.dart';
 
@@ -111,50 +110,30 @@ export 'action_tiles.dart' show applyConfirmationMessage, systemLabel;
 /// it out of the cohort instead of being written as the resolution the operator
 /// changed their mind about.
 ///
-/// ## Ticking the accounts a risky action runs on (#297)
+/// ## Why there is no selection here any more (#311)
 ///
-/// The complement of the above, for the actions the sanction deliberately
-/// withholds. The September leavers sweep is the case: filter to "rood in WISA",
-/// read down the list, and the accounts resolve to unregister / delete / remove
-/// — a judgement call per person, but dozens of them in one sitting. There is no
-/// apply-all for those and there should not be; without a selection the operator
-/// opens each account and presses **Toepassen**, which is slow enough that it
-/// does not get done.
+/// #297 answered the same need from the other side: a checkbox on every row
+/// carrying work, and a **Selecteer alle zichtbare (N)** bar above the list, so
+/// one decision could be run over a hand-picked set — the affordance for the
+/// destructive kinds #293 withholds a school-wide apply from. Both are gone.
 ///
-/// So a row with applyable work carries a checkbox, and a ticked selection gets
-/// [_SelectionBar]: it names **one** decision the ticked accounts raise, says how
-/// many of them raise it and how many are skipped, and offers a dry-run and an
-/// apply over exactly those. The pass behind it is the same per-decision
-/// [ReconcileController.applyDecisions] the cohort review and the Klasgroepen
-/// cohort headers run, so a bulk write is one decision deep wherever it starts
-/// (#292).
+/// Select-all is what took it down. It was one press to stage a write across
+/// every account the current filter happened to be showing — four hundred and
+/// more on an ordinary visit — which is the objection that removed the global
+/// "Alles toepassen" in #294, with a filter standing in front of it. The count
+/// beside it was whatever the filter was showing, which is not a set anybody has
+/// read, and "the operator has looked at every row they ticked" stops being true
+/// the moment one press ticks all of them. The bar also cost a bordered block
+/// standing between the filter chips and the list on every visit, ticks or no
+/// ticks — 126 logical pixels with its gap, on the view whose whole point is the
+/// list.
 ///
-/// Where it and #296 are the same, and where they must not be:
-///
-/// - **Same.** Both are "one decision, over a set of accounts". Both group with
-///   [ReconcileController.situationCohorts], scope their confirmation with
-///   [ReconcileController.applyScopeForDecisions] and write with
-///   [ReconcileController.applyDecisions]. Neither shows the operator a number
-///   whose members are off screen.
-/// - **Not the same.** #296's cohort is *computed* — the whole school, resolved
-///   by the controller, which is why the action must be sanctioned for it. This
-///   set is *chosen*, account by account, precisely because the action is one
-///   that must never sweep. The ticking is the consent, so this is offered
-///   whatever `canApplyToAll` says (#293): withholding it here would leave the
-///   risky kinds with no bulk path at all, which is the whole of #297.
-///
-/// Two rules keep "tick everything" from quietly becoming a school-wide apply.
-/// Select-all is scoped to the **visible** rows, and the effective selection is
-/// re-intersected with them on every build — the same rule the details pane's
-/// selection already follows, because an account the filters have hidden is one
-/// the operator cannot see themselves acting on. And the confirmation quotes the
-/// count of that intersection, so the number in the dialog is the number of rows
-/// on the screen behind it.
-///
-/// Ticks are keyed by account id, so they survive a sort change and a rebuild;
-/// they are dropped when the linked view is replaced — a sync, or an apply that
-/// settled them — and when the family tab changes, because both make the set
-/// name accounts that are no longer the list.
+/// So bulk on this screen is #296's cohort and nothing else: one *sanctioned*
+/// decision, the list narrowed to exactly the accounts the pass will write, and
+/// the confirmation offered over rows the operator is scrolling. What the
+/// sanction withholds — the deletes, the unregisters, the renames — is applied
+/// one account at a time from the details pane, which is the pace those actions
+/// were always meant to run at.
 ///
 /// ## Where an apply leaves the operator (#299)
 ///
@@ -197,9 +176,9 @@ export 'action_tiles.dart' show applyConfirmationMessage, systemLabel;
 ///
 /// Nothing here applies an action the operator has not seen. The header's global
 /// "Dry-run alles" / "Alles toepassen" pair went in #294 for exactly that
-/// reason, and it is not coming back: every apply is started from a list that is
-/// on screen — a cohort the screen filtered itself down to (#296), or a set the
-/// operator ticked row by row (#297).
+/// reason, and the select-all bar of #297 followed it in #311 for the same one.
+/// Every bulk apply is started from a list that is on screen: the cohort the
+/// screen filtered itself down to (#296), and no other.
 ///
 /// A running pass cannot be cancelled and is never concurrent — a rollover over
 /// ~3000 accounts takes a long time, and is resumable in practice because every
@@ -458,31 +437,6 @@ class _ActionsBodyState extends State<_ActionsBody>
   /// [ReconcileController.applyToAllCohortFor].
   String? _cohortKey;
 
-  /// The ticked accounts (#297), by id — the set one decision may be applied to
-  /// when there is no apply-all for it.
-  ///
-  /// Ids rather than rows, for the reason [_selectedId] is an id: a row is
-  /// rebuilt from the live view on every notification, and a captured one would
-  /// carry the resolution the operator has since changed their mind about. It
-  /// also makes the set survive a sort and a filter change untouched, while what
-  /// the buttons act on is re-intersected with the visible rows every build.
-  final Set<String> _ticked = <String>{};
-
-  /// The [SituationCohort.key] of the decision the selection bar is set to, or
-  /// `null` to take whichever decision the most ticked accounts raise. Re-checked
-  /// against the live candidates on every build, so unticking the last account
-  /// that raised the chosen decision falls back rather than going inert.
-  String? _decisionKey;
-
-  /// The linked view the ticks were made against, so a replaced one retires them
-  /// — a sync, or an apply whose writes settled the very decisions they named.
-  ///
-  /// Reconciled in [_body] rather than from a controller listener: the build is
-  /// where the cleared set is needed, the comparison is an identity check, and a
-  /// listener that calls `setState` would have to defend against firing while a
-  /// frame is already building.
-  LinkedState? _tickedView;
-
   /// The accounts the last apply pass wrote to, by id — the rows the list holds
   /// on screen for a moment longer than the filter would (#299).
   ///
@@ -544,38 +498,17 @@ class _ActionsBodyState extends State<_ActionsBody>
       _shownIndex = index;
       _selectedId = null;
       _cohortKey = null;
-      // The ticks name accounts of the family being left behind, and a pass is
-      // single-family anyway (#297).
-      _clearTicks();
       // …as do the rows the last pass is holding on screen (#299).
       _forgetSettled();
     }
     if (mounted) setState(() {});
   }
 
-  /// Drops the multi-select (#297) — the ticks and the decision they were
-  /// pointed at, which means nothing without them.
-  void _clearTicks() {
-    _ticked.clear();
-    _decisionKey = null;
-  }
-
-  /// Retires the ticks when the linked view underneath them has been replaced
-  /// (#297) — a sync, or an apply whose writes settled the decisions they named.
-  ///
-  /// Called at the top of [_body] rather than from a controller listener: this
-  /// is a reconciliation of state against what the build is about to read, it is
-  /// idempotent, and the frame that follows renders the cleared set — so there is
-  /// no `setState` to schedule and no chance of scheduling one mid-frame.
-  void _retireStaleTicks() {
-    final LinkedState? view = controller.linked;
-    if (identical(_tickedView, view)) return;
-    _tickedView = view;
-    _clearTicks();
-  }
-
   /// Re-reads [_settled] off the last pass's results (#299), at the top of
-  /// [_body] and for the same reasons [_retireStaleTicks] sits there.
+  /// [_body] — a reconciliation of state against what the build is about to
+  /// read, rather than a controller listener: it is idempotent, the build is
+  /// where the re-read set is needed, and a listener calling `setState` would
+  /// have to defend against firing while a frame is already building.
   ///
   /// The whole pass, not only the accounts that came out clean: one that failed
   /// still has work and stays visible on its own, and one whose card now shows
@@ -617,34 +550,6 @@ class _ActionsBodyState extends State<_ActionsBody>
   // partition read on every cold visit that no pixel on this screen depended
   // on. Klasgroepen still reads it, through its own identical guard, on the tab
   // where the classes actually are.
-
-  /// Ticks or unticks one account (#297).
-  void _setTicked(String id, bool ticked) => setState(() {
-        if (ticked) {
-          _ticked.add(id);
-        } else {
-          _ticked.remove(id);
-        }
-      });
-
-  /// Select-all / clear, scoped to [tickable] — the rows on screen that carry
-  /// applyable work, and nothing else (#297).
-  ///
-  /// The scoping is the safety: an operator who ticks everything after filtering
-  /// to "rood in WISA" has selected the leavers, not the school. Ticks made
-  /// against another filter are left alone rather than cleared, because they are
-  /// still the operator's — what the buttons act on is the intersection with the
-  /// visible rows, which [_SelectionBar] recomputes every build.
-  void _selectAll(List<_AccountRow> tickable, bool ticked) => setState(() {
-        for (final row in tickable) {
-          if (ticked) {
-            _ticked.add(row.id);
-          } else {
-            _ticked.remove(row.id);
-          }
-        }
-        if (_ticked.isEmpty) _decisionKey = null;
-      });
 
   /// Whether the Personeel family tab is the selected one.
   bool get _staffTab => _tabs.index == _ActionFamilyTab.personeel.index;
@@ -745,18 +650,13 @@ class _ActionsBodyState extends State<_ActionsBody>
   /// Arms the school-wide review of [decision]: the list narrows to its cohort
   /// and the banner takes over from the list controls. Nothing is written.
   ///
-  /// The two bulk modes are exclusive, so this drops the multi-select (#297).
-  /// A review's list *is* its cohort, resolved school-wide — ticks made against
-  /// the list before it would name a different set of accounts than the rows
-  /// now on screen, which is precisely the mismatch both affordances exist to
-  /// avoid.
+  /// Since #311 this is the only bulk path on the screen, so there is no second
+  /// set of accounts to reconcile it against: the review's list *is* its cohort,
+  /// resolved school-wide.
   void _armCohort(PendingDecision decision) {
     final cohort = controller.applyToAllCohort(decision);
     if (cohort == null) return;
-    setState(() {
-      _cohortKey = cohort.key;
-      _clearTicks();
-    });
+    setState(() => _cohortKey = cohort.key);
   }
 
   @override
@@ -776,7 +676,6 @@ class _ActionsBodyState extends State<_ActionsBody>
       EdgeInsets.symmetric(horizontal: PlinkSpacing.s6);
 
   Widget _body(BuildContext context, BoxConstraints constraints) {
-    _retireStaleTicks();
     _holdSettled();
     final bool wide = constraints.maxWidth >= _splitBreakpoint;
     final bool active = controller.linked != null;
@@ -788,15 +687,6 @@ class _ActionsBodyState extends State<_ActionsBody>
     final _AccountRow? selected = _selectedRow(visible);
     // In one pane the details take the whole width, so the list stands down.
     final bool showList = wide || selected == null;
-    // What may be ticked right now (#297): the visible rows carrying applyable
-    // work, which is also what select-all covers. None while a cohort is under
-    // review — that list is the review's own, and the two modes are exclusive.
-    final List<_AccountRow> tickable = cohort != null
-        ? const <_AccountRow>[]
-        : <_AccountRow>[
-            for (final r in visible)
-              if (r.hasWork) r,
-          ];
 
     final Widget head = Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -860,22 +750,6 @@ class _ActionsBodyState extends State<_ActionsBody>
                         onDisarm: () => setState(() => _cohortKey = null),
                       ),
               ),
-              if (tickable.isNotEmpty) ...<Widget>[
-                const SizedBox(height: PlinkSpacing.s3),
-                Padding(
-                  padding: _hPad,
-                  child: _SelectionBar(
-                    controller: controller,
-                    tickable: tickable,
-                    ticked: _ticked,
-                    decisionKey: _decisionKey,
-                    onSelectAll: (v) => _selectAll(tickable, v),
-                    onClear: () => setState(_clearTicks),
-                    onDecisionChanged: (key) =>
-                        setState(() => _decisionKey = key),
-                  ),
-                ),
-              ],
               const SizedBox(height: PlinkSpacing.s3),
               Padding(
                 padding: _hPad,
@@ -896,7 +770,6 @@ class _ActionsBodyState extends State<_ActionsBody>
                     rows: rows,
                     visible: visible,
                     selected: selected,
-                    ticking: cohort == null,
                   ),
                 ),
               if (wide) const VerticalDivider(width: 1, thickness: 1),
@@ -976,7 +849,6 @@ class _ActionsBodyState extends State<_ActionsBody>
     required List<_AccountRow> rows,
     required List<_AccountRow> visible,
     required _AccountRow? selected,
-    required bool ticking,
   }) {
     if (rows.isEmpty) {
       return Padding(
@@ -1013,8 +885,6 @@ class _ActionsBodyState extends State<_ActionsBody>
             if (!_settled.contains(row.id)) _forgetSettled();
             _selectedId = row.id;
           }),
-          ticked: _ticked.contains(row.id),
-          onTicked: ticking ? (v) => _setTicked(row.id, v) : null,
           justApplied: _settled.contains(row.id),
         );
       },
@@ -1371,270 +1241,6 @@ class _CohortReviewBanner extends StatelessWidget {
   }
 }
 
-/// The multi-select bar (#297): tick the accounts, name the one decision, run it
-/// over exactly them.
-///
-/// The affordance for the actions #293 refuses a school-wide apply — the
-/// deletes, the unregisters, the renames. The refusal is right: nobody should
-/// press one button that deletes every account the app believes has left. But
-/// the *work* is still bulk work, and the September leavers sweep is dozens of
-/// those judgement calls in one sitting. Ticking is what keeps the judgement and
-/// drops the repetition: the operator has looked at every row they ticked, and
-/// the ticking is the consent.
-///
-/// So, unlike [_CohortReviewBanner], this is offered whatever `canApplyToAll`
-/// says. The two are otherwise deliberately the same machine — one decision,
-/// grouped with [ReconcileController.situationCohorts], confirmed through
-/// [ReconcileController.applyScopeForDecisions], written by
-/// [ReconcileController.applyDecisions] — because a bulk write that resolved its
-/// work a second way is exactly how a button comes to mean something other than
-/// what it says (#252).
-///
-/// Three things it is careful to state:
-///
-/// - **Which decision.** A ticked set is not "everything on those cards": the
-///   pass is one decision deep (#292), so the decision is picked explicitly from
-///   the ones the selection actually raises, defaulting to whichever the most of
-///   them share.
-/// - **How many it skips.** Ticking twenty leavers and applying the Smartschool
-///   unregister must not silently pass over the three who are Azure-only. The
-///   line under the chips says how many of the ticked accounts the decision does
-///   not stand open on.
-/// - **That the count is the rows on screen.** [tickable] is the *visible* work
-///   rows, the effective selection is its intersection with [ticked], and the
-///   confirmation quotes that number — so select-all under a filter is a
-///   selection of what the filter shows, never of the school.
-class _SelectionBar extends StatelessWidget {
-  const _SelectionBar({
-    required this.controller,
-    required this.tickable,
-    required this.ticked,
-    required this.decisionKey,
-    required this.onSelectAll,
-    required this.onClear,
-    required this.onDecisionChanged,
-  });
-
-  final ReconcileController controller;
-
-  /// The rows that may be ticked right now: visible, and carrying applyable
-  /// work. Select-all covers exactly these.
-  final List<_AccountRow> tickable;
-
-  /// Every ticked id the screen is holding — including ones the current filter
-  /// has taken off screen, which is why this is intersected with [tickable]
-  /// rather than counted.
-  final Set<String> ticked;
-
-  /// The [SituationCohort.key] the operator picked, or `null` for the default.
-  final String? decisionKey;
-
-  final ValueChanged<bool> onSelectAll;
-  final VoidCallback onClear;
-  final ValueChanged<String> onDecisionChanged;
-
-  /// The decisions a selection raises that a pass could actually write, most
-  /// widely shared first — the chips, in the order they are offered.
-  ///
-  /// Grouped from the rows on screen with the same public
-  /// [ReconcileController.situationCohorts] the Klasgroepen headers use, which
-  /// is the point of it being public (#252): a bulk button's cohort is resolved
-  /// from the very list it was built over, never re-derived from the whole view.
-  ///
-  /// A cohort with no applyable member is dropped — an informational notice is a
-  /// diagnosis, not work this screen can do — so every chip offered leads to a
-  /// pass that writes something.
-  static List<SituationCohort> candidateDecisions(
-    List<_AccountRow> selection,
-  ) {
-    final entries = <PendingAccountEntry>[
-      for (final r in selection)
-        if (r.entry != null) r.entry!,
-    ];
-    final cohorts = <SituationCohort>[
-      for (final c in ReconcileController.situationCohorts(entries))
-        if (c.applyableCount > 0) c,
-    ];
-    // Widest first, so the decision the selection was probably made for is the
-    // default. Keyed tie-break because `List.sort` is not stable and the chips
-    // must not reshuffle between builds.
-    cohorts.sort((a, b) {
-      final byCount = b.applyableCount - a.applyableCount;
-      return byCount != 0 ? byCount : a.key.compareTo(b.key);
-    });
-    return cohorts;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final TextTheme text = Theme.of(context).textTheme;
-    final ColorScheme colors = Theme.of(context).colorScheme;
-
-    final List<_AccountRow> selection = <_AccountRow>[
-      for (final r in tickable)
-        if (ticked.contains(r.id)) r,
-    ];
-    final List<SituationCohort> candidates = candidateDecisions(selection);
-    final SituationCohort? decision = candidates.isEmpty
-        ? null
-        : candidates.firstWhere(
-            (c) => c.key == decisionKey,
-            orElse: () => candidates.first,
-          );
-    // What the pass runs: this one decision, for the ticked accounts it stands
-    // open on. Non-applyable members are out for the same reason they are out of
-    // every other cohort — they write nothing.
-    final List<PendingDecision> members = decision == null
-        ? const <PendingDecision>[]
-        : <PendingDecision>[
-            for (final d in decision.decisions)
-              if (d.canApply) d,
-          ];
-    final Set<String> covered = <String>{
-      for (final d in members) d.entry.targetId,
-    };
-    final int skipped = selection.length - covered.length;
-    final bool? allValue = selection.isEmpty
-        ? false
-        : selection.length == tickable.length
-            ? true
-            : null;
-
-    return Container(
-      key: const ValueKey('actions-selection-bar'),
-      padding: const EdgeInsets.all(PlinkSpacing.s4),
-      decoration: BoxDecoration(
-        border: Border.all(color: Theme.of(context).dividerColor),
-        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Row(
-            children: <Widget>[
-              Checkbox(
-                key: const ValueKey('actions-select-all'),
-                // Tristate for the reading, not for the cycle: a partial
-                // selection has to look partial. The press itself is decided
-                // here — everything ticked clears, anything else selects — so it
-                // never lands the operator on the dash.
-                tristate: true,
-                value: allValue,
-                onChanged: (_) => onSelectAll(allValue != true),
-              ),
-              const SizedBox(width: PlinkSpacing.s2),
-              Expanded(
-                child: Text(
-                  'Selecteer alle zichtbare (${tickable.length})',
-                  style: text.bodyMedium,
-                ),
-              ),
-              if (selection.isNotEmpty)
-                TextButton(
-                  key: const ValueKey('actions-selection-clear'),
-                  onPressed: controller.busy ? null : onClear,
-                  child: const Text('Wis selectie'),
-                ),
-            ],
-          ),
-          if (selection.isEmpty)
-            Text(
-              'Vink accounts aan om één beslissing op meerdere tegelijk toe te '
-              'passen — ook de beslissingen die geen "toepassen op alle" '
-              'krijgen.',
-              style: text.bodySmall,
-            )
-          else ...<Widget>[
-            const SizedBox(height: PlinkSpacing.s2),
-            Text(
-              '${selection.length} account(s) geselecteerd. Kies de beslissing '
-              'die je toepast:',
-              style: text.bodySmall,
-            ),
-            const SizedBox(height: PlinkSpacing.s2),
-            if (decision == null)
-              Text(
-                'Geen van de geselecteerde accounts heeft een beslissing die '
-                'automatisch geschreven kan worden.',
-                key: const ValueKey('actions-selection-no-decision'),
-                style: text.bodySmall,
-              )
-            else ...<Widget>[
-              Wrap(
-                spacing: PlinkSpacing.s2,
-                runSpacing: PlinkSpacing.s2,
-                children: <Widget>[
-                  for (final c in candidates)
-                    ChoiceChip(
-                      key: ValueKey('actions-decision-${c.key}'),
-                      label: Text('${c.label} (${c.applyableCount})'),
-                      selected: c.key == decision.key,
-                      onSelected: controller.busy
-                          ? null
-                          : (_) => onDecisionChanged(c.key),
-                    ),
-                ],
-              ),
-              const SizedBox(height: PlinkSpacing.s2),
-              Text(
-                key: const ValueKey('actions-selection-scope'),
-                skipped == 0
-                    ? 'Wordt toegepast op alle ${covered.length} '
-                        'geselecteerde account(s).'
-                    : 'Wordt toegepast op ${covered.length} van de '
-                        '${selection.length} geselecteerde account(s) — '
-                        '$skipped overgeslagen, want daar staat deze '
-                        'beslissing niet open.',
-                style: text.bodySmall?.copyWith(color: colors.primary),
-              ),
-              const SizedBox(height: PlinkSpacing.s3),
-              Wrap(
-                spacing: PlinkSpacing.s2,
-                runSpacing: PlinkSpacing.s2,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: <Widget>[
-                  OutlinedButton(
-                    key: const ValueKey('actions-selection-dry-run'),
-                    onPressed: controller.busy || members.isEmpty
-                        ? null
-                        : () => runWithProgress(
-                              context,
-                              controller: controller,
-                              dry: true,
-                              run: () => controller.dryRunDecisions(members),
-                            ),
-                    child: const Text('Dry-run selectie'),
-                  ),
-                  FilledButton(
-                    key: const ValueKey('actions-selection-apply'),
-                    onPressed: controller.busy || members.isEmpty
-                        ? null
-                        : () => confirmAndApply(
-                              context,
-                              controller: controller,
-                              // The count of the rows on screen behind the
-                              // dialog, so "alles aanvinken" can never read as a
-                              // school-wide apply.
-                              title: 'Toepassen op ${covered.length} '
-                                  'geselecteerd(e) account(s)?',
-                              // One decision deep (#292), over exactly the
-                              // ticked members — the same list the button counts
-                              // and the pass writes.
-                              scope: controller.applyScopeForDecisions(members),
-                              apply: () => controller.applyDecisions(members),
-                            ),
-                    child: Text('Toepassen op selectie (${covered.length})'),
-                  ),
-                ],
-              ),
-            ],
-          ],
-        ],
-      ),
-    );
-  }
-}
-
 /// The horizontal family tab bar (#179): switches the list below between the
 /// Leerlingen (student) and Personeel (staff) action families, each carrying a
 /// pending-count badge so the operator sees where the work sits without opening
@@ -1699,17 +1305,12 @@ class _AccountListRow extends StatelessWidget {
     required this.row,
     required this.selected,
     required this.onTap,
-    this.ticked = false,
-    this.onTicked,
     this.justApplied = false,
   });
 
   final _AccountRow row;
   final bool selected;
   final VoidCallback onTap;
-
-  /// Whether this row is in the multi-select (#297).
-  final bool ticked;
 
   /// Whether the last apply pass wrote to this account (#299) — which is why
   /// the row may be here at all with nothing left to do.
@@ -1719,19 +1320,6 @@ class _AccountListRow extends StatelessWidget {
   /// the difference between "nothing to do here" and "this is what you just
   /// did" is the whole reason the row is being held.
   final bool justApplied;
-
-  /// Ticks/unticks the row, or `null` when this list offers no ticking at all —
-  /// which is what a cohort under review is, its list being the review's own.
-  final ValueChanged<bool>? onTicked;
-
-  /// The width the tick column reserves, so a row without a checkbox still
-  /// lines its name up with the rows that have one.
-  ///
-  /// The measure a [Checkbox] takes at [VisualDensity.compact] with a
-  /// shrink-wrapped tap target — pinned rather than left to the theme, because
-  /// the blank has to match it exactly or every settled row's name sits a few
-  /// pixels off the ones above it.
-  static const double _checkboxColumn = 32.0;
 
   @override
   Widget build(BuildContext context) {
@@ -1757,26 +1345,6 @@ class _AccountListRow extends StatelessWidget {
             children: <Widget>[
               Row(
                 children: <Widget>[
-                  // Only a row with applyable work can be ticked — ticking a
-                  // settled account would add nothing to a pass and inflate the
-                  // "overgeslagen" count with accounts that were never work. The
-                  // blank keeps the names in one column either way.
-                  if (onTicked != null) ...<Widget>[
-                    SizedBox(
-                      width: _checkboxColumn,
-                      child: row.hasWork
-                          ? Checkbox(
-                              key: ValueKey('account-check-${row.id}'),
-                              value: ticked,
-                              visualDensity: VisualDensity.compact,
-                              materialTapTargetSize:
-                                  MaterialTapTargetSize.shrinkWrap,
-                              onChanged: (v) => onTicked!(v ?? false),
-                            )
-                          : null,
-                    ),
-                    const SizedBox(width: PlinkSpacing.s3),
-                  ],
                   Expanded(
                     child: Text(
                       row.account.label,

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -154,17 +154,19 @@ void main() {
       await h.controller.sync();
 
       // The count mirrors the relink summary's pendingActions.length (the
-      // fixture derives four pending actions across the families), and the line
-      // names the operator who ran the pass (#169).
+      // fixture derives six pending actions across the families — its two
+      // Smartschool-only classes each carry the #313 either/or, which is two
+      // actions and one decision), and the line names the operator who ran the
+      // pass (#169).
       expect(
         h.log.entries.map((e) => e.message),
-        contains('Sync voltooid — 4 openstaande actie(s). Klaar. '
+        contains('Sync voltooid — 6 openstaande actie(s). Klaar. '
             'Operator: operator@school.example.'),
       );
       // It is the *last* line — the operator sees it closing the pass.
       expect(
           h.log.entries.last.message,
-          'Sync voltooid — 4 openstaande actie(s). Klaar. '
+          'Sync voltooid — 6 openstaande actie(s). Klaar. '
           'Operator: operator@school.example.');
     });
 
@@ -175,7 +177,7 @@ void main() {
       await h.controller.sync();
 
       expect(h.log.entries.last.message,
-          'Sync voltooid — 4 openstaande actie(s). Klaar.');
+          'Sync voltooid — 6 openstaande actie(s). Klaar.');
     });
 
     test('the "no changes needed" path also logs a ready line', () async {
@@ -213,7 +215,7 @@ void main() {
       // actually ran, because a drift check is not a sync.
       expect(
           h.log.entries.last.message,
-          'Driftcontrole voltooid — 4 openstaande actie(s). Klaar. '
+          'Driftcontrole voltooid — 6 openstaande actie(s). Klaar. '
           'Operator: operator@school.example.');
       expect(
         h.log.entries.where((e) => e.message.startsWith('Sync voltooid')),
@@ -231,7 +233,7 @@ void main() {
       await h.controller.checkDrift();
 
       expect(h.log.entries.last.message,
-          'Driftcontrole voltooid — 4 openstaande actie(s). Klaar.');
+          'Driftcontrole voltooid — 6 openstaande actie(s). Klaar.');
     });
   });
 

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1926,6 +1926,59 @@ ReconcileHarness staleClassGroupHarness() => ReconcileHarness(
       ourSchoolIds: const {1},
     );
 
+/// A harness for the stale Office 365 class groups the port used to say nothing
+/// about (#312) — the same situation [staleClassGroupHarness] sets up, but with
+/// neither leftover group shaped the way *this* port creates one.
+///
+/// Our school 1 runs exactly one class, `1A`, correct in all three systems.
+/// Office 365 still holds two groups of classes that stopped running:
+///
+/// - `GBS-9Z`, a plain security group with no address and its 21 members still
+///   in it — the shape the legacy WPF app made every class group in;
+/// - `Klas van juf An`, renamed by hand in the portal, still answering on the
+///   address `GBS-8Y@…`.
+///
+/// The linker orphans both — the `<PREFIX>-` namespace plus a class-shaped
+/// remainder is its whole rule — yet the action engine used to demand a
+/// mail-enabled group whose nickname equalled its display name, so both rows
+/// reached Klasgroepen carrying a grey ✓ and nothing anybody could do.
+ReconcileHarness legacyStaleClassGroupHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(wisaId: '1', classGroup: '1A')],
+        schools: [wisaSchool(1)],
+        classGroups: [wisaClassGroup('1A', description: 'Eerste jaar A')],
+      ),
+      smartschool: ssSnap(
+        groups: [
+          ssGroup('1A',
+              description: 'Eerste jaar A',
+              instituteNumber: '123',
+              untis: '1A'),
+        ],
+        accounts: [
+          ssAccount(
+              uid: 'jane', accountId: '1', mail: 'a1@student.school.example'),
+        ],
+        memberships: [member('jane', '1A')],
+      ),
+      azure: azSnap(
+        users: [
+          azUser(
+              id: 'az1',
+              upn: 'a1@student.school.example',
+              employeeId: '1',
+              displayName: 'Jane Doe'),
+        ],
+        groups: [
+          azClassGroup('1A', memberIds: const ['az1']),
+          azLegacyClassGroup('9Z',
+              memberIds: List<String>.generate(21, (int i) => 'az-oud-$i')),
+          azRenamedClassGroup('8Y', displayName: 'Klas van juf An'),
+        ],
+      ),
+      ourSchoolIds: const {1},
+    );
+
 /// A harness for the **per-student** view of Office 365 class-group membership
 /// (#245). Both classes already have their group, and both classes are in sync
 /// between WISA and Smartschool, so the only work anywhere is the Azure roster:
@@ -2720,6 +2773,42 @@ az.AzureGroup azClassGroup(
     az.AzureGroup(
       id: 'az-GBS-$className',
       displayName: 'GBS-$className',
+      mail: 'GBS-$className@student.school.example',
+      mailNickname: 'GBS-$className',
+      memberIds: memberIds,
+    );
+
+/// An Office 365 class group as the **legacy WPF app** created one (#312): a
+/// plain security group, `GBS-<class>` in both display name and nickname, and
+/// no address at all.
+///
+/// This is what the live tenant is full of — `SSM-3ECO`, `SSM-3MRP`, `SSM-3MWW`
+/// are each `securityEnabled: true, mail: null` — and `isUnified` is false for
+/// every one of them, which is what used to silence the stale-group either/or
+/// on exactly the rows that needed it most.
+az.AzureGroup azLegacyClassGroup(
+  String className, {
+  List<String> memberIds = const [],
+}) =>
+    az.AzureGroup(
+      id: 'az-GBS-$className',
+      displayName: 'GBS-$className',
+      mailNickname: 'GBS-$className',
+      securityEnabled: true,
+      memberIds: memberIds,
+    );
+
+/// An Office 365 class group somebody **renamed by hand** in the portal (#280):
+/// the display name says nothing about the class, and only the address it still
+/// answers on identifies it as ours.
+az.AzureGroup azRenamedClassGroup(
+  String className, {
+  required String displayName,
+  List<String> memberIds = const [],
+}) =>
+    az.AzureGroup(
+      id: 'az-GBS-$className',
+      displayName: displayName,
       mail: 'GBS-$className@student.school.example',
       mailNickname: 'GBS-$className',
       memberIds: memberIds,

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -41,6 +41,14 @@ const core.Address _addr = core.Address(
 class RecordingSoap implements ss.SmartschoolSoapTransport {
   final List<String> soapActions = <String>[];
 
+  /// The class codes of every `delClass` this transport accepted, in order —
+  /// the Smartschool classes a delete action actually removed (#313). The twin
+  /// of [RecordingGraph.deletedGroups], and read off the envelope for the same
+  /// reason: "a write happened" is not "this record was written".
+  final List<String> deletedClasses = <String>[];
+
+  static final RegExp _codeArg = RegExp(r'<code[^>]*>([^<]*)</code>');
+
   @override
   Future<String> send({
     required Uri endpoint,
@@ -48,6 +56,10 @@ class RecordingSoap implements ss.SmartschoolSoapTransport {
     required String envelope,
   }) async {
     soapActions.add(soapAction);
+    if (soapAction.contains('delClass')) {
+      final match = _codeArg.firstMatch(envelope);
+      if (match != null) deletedClasses.add(match.group(1)!);
+    }
     // Every recorded write succeeds (return code 0).
     return '<?xml version="1.0" encoding="utf-8"?>'
         '<soap:Envelope '
@@ -1974,6 +1986,66 @@ ReconcileHarness legacyStaleClassGroupHarness() => ReconcileHarness(
           azLegacyClassGroup('9Z',
               memberIds: List<String>.generate(21, (int i) => 'az-oud-$i')),
           azRenamedClassGroup('8Y', displayName: 'Klas van juf An'),
+        ],
+      ),
+      ourSchoolIds: const {1},
+    );
+
+/// A harness for the Smartschool classes WISA does not have (#313) — the
+/// mirror image of [staleClassGroupHarness], on the system the app can actually
+/// delete a class in.
+///
+/// Our school 1 runs exactly one class, `1A`, correct in all three systems.
+/// Smartschool additionally carries two official classes that stopped running,
+/// each under the code the operator would have to hunt for by hand:
+///
+/// - `9Z` (`C9Z`), and
+/// - `8Y` (`C8Y`).
+///
+/// Two of them, deliberately: one leftover is a row, **two** are a "same
+/// situation" bulk subset, and that is where a destructive default would do its
+/// worst. Before #313 each row's whole content was "Verwijder ze manueel als ze
+/// niet meer nodig is" — an instruction to go elsewhere, and a screenful of them
+/// at a September changeover.
+ReconcileHarness smartschoolLeftoverClassHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(wisaId: '1', classGroup: '1A')],
+        schools: [wisaSchool(1)],
+        classGroups: [wisaClassGroup('1A', description: 'Eerste jaar A')],
+      ),
+      smartschool: ssSnap(
+        groups: [
+          ssGroup('1A',
+              description: 'Eerste jaar A',
+              instituteNumber: '123',
+              untis: '1A'),
+          ssGroup('9Z',
+              code: 'C9Z',
+              description: 'Zesde jaar Z',
+              instituteNumber: '123',
+              untis: '9Z'),
+          ssGroup('8Y',
+              code: 'C8Y',
+              description: 'Achtste jaar Y',
+              instituteNumber: '123',
+              untis: '8Y'),
+        ],
+        accounts: [
+          ssAccount(
+              uid: 'jane', accountId: '1', mail: 'a1@student.school.example'),
+        ],
+        memberships: [member('jane', '1A')],
+      ),
+      azure: azSnap(
+        users: [
+          azUser(
+              id: 'az1',
+              upn: 'a1@student.school.example',
+              employeeId: '1',
+              displayName: 'Jane Doe'),
+        ],
+        groups: [
+          azClassGroup('1A', memberIds: const ['az1'])
         ],
       ),
       ourSchoolIds: const {1},

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -112,7 +112,9 @@ void main() {
 
     expect(attempts, 2);
     expect(find.text('Kan het Acties-scherm niet openen'), findsNothing);
-    expect(find.text('Acties'), findsOneWidget);
+    // The screen behind the panel, named by the one line its header still
+    // carries since #309 — the eyebrow, in the design system's own upper case.
+    expect(find.text('ARCADIA · ACTIES'), findsOneWidget);
   });
 
   // --- The flat list itself (#295) -----------------------------------------
@@ -336,24 +338,37 @@ void main() {
   });
 
   testWidgets(
-      'the header states the workload and offers nothing that acts on all of '
-      'it (#294)', (WidgetTester tester) async {
-    // The global "Dry-run alles" / "Alles toepassen" pair used to sit here and
-    // write every pending action in every class off one dialog, over a list the
-    // operator had not looked at. What replaces it is nothing: the count is a
-    // statement of how much work exists, and every way to act on that work is
-    // reached by looking at it first.
+      'the header is the eyebrow and nothing else, and still offers nothing '
+      'that acts on the whole list (#309/#294)', (WidgetTester tester) async {
+    // #309: the account list is the view, and everything stacked above it was
+    // preamble charged to every visit. The title restated the eyebrow, the
+    // count was four digits nobody can act on, the pointer at Klasgroepen
+    // belonged on Klasgroepen and the freshness stamp describes the shared
+    // state rather than this list.
+    //
+    // #294's half of the same header still holds: the global "Dry-run alles" /
+    // "Alles toepassen" pair that wrote every pending action in every class off
+    // one dialog is gone, and nothing replaces it. Every way to act on the work
+    // is reached by opening it first.
     _useWideWindow(tester);
     final harness = ReconcileHarness();
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    expect(
-      find.textContaining(
-          '${harness.controller.totalPendingCount} openstaande actie(s)'),
-      findsOneWidget,
-    );
+    // The one line that stays.
+    expect(find.text('ARCADIA · ACTIES'), findsOneWidget);
+    // …and the four that came off.
+    expect(find.text('Acties'), findsNothing,
+        reason: 'the title restated the eyebrow one line above it');
+    expect(find.textContaining('openstaande actie'), findsNothing,
+        reason: 'the count line is gone from this header');
+    expect(find.byKey(const ValueKey('actions-class-attention')), findsNothing,
+        reason: 'what Klasgroepen is holding is stated on Klasgroepen');
+    expect(find.textContaining('Generatie'), findsNothing,
+        reason:
+            'the freshness stamp describes the shared state, not this list');
+
     expect(find.byKey(const ValueKey('actions-dry-run')), findsNothing);
     expect(find.byKey(const ValueKey('actions-apply')), findsNothing);
     expect(find.text('Dry-run alles'), findsNothing);
@@ -361,6 +376,39 @@ void main() {
     // And the flat list adds no cohort header of its own — school-wide bulk
     // apply with its cohort visible first is #296's, not this layout's.
     expect(find.textContaining('in dezelfde situatie'), findsNothing);
+  });
+
+  testWidgets('the stripped header lifts the list toward the top (#309)',
+      (WidgetTester tester) async {
+    // The point of the removal, measured rather than asserted about: with the
+    // title, the count, the pointer and the stamp gone, the search box and the
+    // list start materially higher than the four lines they used to sit under.
+    // The fixture carries class work as well, so the pointer at Klasgroepen
+    // would have rendered under the old header — this is the worst case, not
+    // the best one.
+    _useWideWindow(tester);
+    final harness = appliedClassWorkHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    final double eyebrowBottom =
+        tester.getBottomLeft(find.text('ARCADIA · ACTIES')).dy;
+    final double searchTop =
+        tester.getTopLeft(find.byKey(const ValueKey('actions-search'))).dy;
+
+    // One `PlinkSpacing.s4` gap (the state notice is absent in this session)
+    // rather than four text lines plus their spacing — which is what "the list
+    // starts materially higher" concretely means.
+    expect(searchTop - eyebrowBottom, lessThan(40),
+        reason: 'nothing but spacing stands between the eyebrow and the box');
+    // And a pin on the whole block above the list — eyebrow, search box, work
+    // switch, sort and system chips, family tabs. It measures 422 here; every
+    // line put back into the header adds some 30 to that, which is what this
+    // number is guarding. What the operator actually gains from it is asserted
+    // at a real 1080p window in the integration suite, in rows on screen.
+    expect(tester.getTopLeft(find.byKey(const ValueKey('actions-list'))).dy,
+        lessThan(450));
   });
 
   // --- School-wide apply-all, cohort first (#296) ---------------------------
@@ -482,12 +530,10 @@ void main() {
       expect(find.byKey(const ValueKey('actions-search')), findsNothing);
       expect(find.byKey(const ValueKey('actions-only-with-actions')),
           findsNothing);
-      // …and the header stops describing the list as the work list, which it
-      // no longer is.
-      expect(
-        find.textContaining('de lijst toont de accounts van één beslissing'),
-        findsOneWidget,
-      );
+      // The header used to restate that the list is one decision's cohort. It
+      // says nothing at all since #309 — the banner above the list, asserted on
+      // just above, is what describes the list the operator is confirming.
+      expect(find.textContaining('de lijst toont'), findsNothing);
 
       // And nothing has been written.
       expect(
@@ -1940,72 +1986,20 @@ void main() {
         reason: 'a dead button needs its reason on screen too');
   });
 
-  // --- The freshness stamp above the list ----------------------------------
+  // --- The freshness stamp -------------------------------------------------
+  //
+  // It used to sit above this list too. #309 took it off Acties — it is a
+  // property of the shared state, not of this account list — so the four tests
+  // that pinned its wording (#108/#192/#247) moved with it, to
+  // `class_groups_screen_test.dart`, where the stamp still renders. What Acties
+  // owes the removal is the assertion that it is gone, which is in the header
+  // test above.
 
-  testWidgets(
-      "a generation bump refetches the passive Actions overview's freshness "
-      '(#108)', (WidgetTester tester) async {
-    final linkedStore = InMemoryLinkedStore();
-    final snapshots = InMemorySnapshotStore();
-
-    final s1 = ReconcileHarness(store: snapshots, linkedStore: linkedStore);
-    await s1.controller.sync();
-
-    final s2 = await ReconcileHarness.resume(
-      store: snapshots,
-      linkedStore: linkedStore,
-    );
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: s2.bootstrap)));
-    await tester.pumpAndSettle();
-    expect(find.textContaining('Generatie 1'), findsOneWidget);
-
-    s1.wisaResult = wisaSnap(
-      fetchedAt: kFixtureDate.add(const Duration(hours: 1)),
-      students: [wisaStudent(classGroup: '3D')],
-    );
-    await s1.controller.sync();
-    await s2.controller.onStoreChanged(2);
-    await tester.pumpAndSettle();
-
-    expect(find.textContaining('Generatie 2'), findsOneWidget);
-    expect(find.textContaining('Generatie 1'), findsNothing);
-  });
-
-  testWidgets(
-      "the freshness stamp carries the date once the shared state is no longer "
-      'from today (#192)', (WidgetTester tester) async {
-    // The shared view was materialized at kFixtureDate, a past day. Time-only
-    // rendered that as "Generatie 1 · 02:00 door …" —
-    // indistinguishable from a view materialized minutes ago, the same
-    // confusion #192 fixes on the Reconcile last-sync box.
-    final store = await seededLinkedStore(<MaterializedAccount>[
-      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
-    ]);
-    final harness = ReconcileHarness(linkedStore: store);
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    // Derived here rather than through the production formatter, so this pins
-    // the rendered text instead of restating the implementation.
-    final DateTime t = kFixtureDate.toLocal();
-    final String dm = '${t.day.toString().padLeft(2, '0')}/'
-        '${t.month.toString().padLeft(2, '0')}';
-    final String hhmm = '${t.hour.toString().padLeft(2, '0')}:'
-        '${t.minute.toString().padLeft(2, '0')}';
-
-    expect(find.textContaining('Generatie 1 · $dm'), findsOneWidget);
-    expect(find.textContaining('Generatie 1 · $hhmm'), findsNothing,
-        reason: 'a stamp from a past day is never rendered as bare time');
-  });
-
-  testWidgets(
-      'the freshness stamp names the werkdatum the roster was pulled with '
-      '(#247)', (WidgetTester tester) async {
-    // "Wie synchroniseerde, wanneer" says when the pass ran, never which school
-    // year it describes — and WISA answers *as of* a date, so a pull made on
-    // the wrong side of the rollover reads here exactly like a class that went
-    // missing (#239). The stamp comes off the shared per-system record, so this
-    // passive session reads the date without having run the pull.
+  testWidgets('the header carries no freshness stamp at all (#309)',
+      (WidgetTester tester) async {
+    // The worst case for the removal: a shared view stamped with everything the
+    // line could have said — a generation, an operator, a werkdatum. None of it
+    // reaches this screen.
     final store = await seededLinkedStore(
       <MaterializedAccount>[
         matAccount(id: 's1', label: 'Jane Doe', withAction: true),
@@ -2022,68 +2016,9 @@ void main() {
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    // In the wire's own dd/MM/yyyy, the way the Log panel's pull line and the
-    // `Werkdatum` SOAP parameter both spell it.
-    expect(find.textContaining('· werkdatum 01/09/2025'), findsOneWidget);
-  });
-
-  testWidgets(
-      'a shared view synced before the werkdatum was recorded renders the '
-      'stamp unchanged (#247)', (WidgetTester tester) async {
-    // The store in production already holds views written without it, and a
-    // Smartschool/Azure-only stamp never has one. Neither may invent a date,
-    // and neither may lose the "wie, wanneer" half over its absence.
-    final store = await seededLinkedStore(<MaterializedAccount>[
-      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
-    ]);
-    final harness = ReconcileHarness(linkedStore: store);
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
+    expect(find.textContaining('Generatie'), findsNothing);
     expect(find.textContaining('werkdatum'), findsNothing);
-    expect(
-      find.textContaining('Generatie 1'),
-      findsOneWidget,
-      reason: 'the who/when half stands on its own',
-    );
-  });
-
-  testWidgets(
-      'the stamp names the werkdatum the stored view was pulled with, not the '
-      'one Instellingen now holds (#247)', (WidgetTester tester) async {
-    // The disagreement the issue is about. #238 made the werkdatum live, so
-    // between a save and the next Synchroniseer the setting says one school
-    // year and the installed roster is another. Driven over the *production*
-    // WISA pull, so the date on screen is the one that really went out.
-    _useWideWindow(tester);
-    final live = LiveSettings(AppSettings(
-      wisa: WisaConnection(
-        server: 'wisa.example',
-        port: '9000',
-        workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9, 1)),
-      ),
-    ));
-    final wire = RecordingWisaSoap();
-    final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
-    await harness.controller.sync();
-    expect(wire.werkdatums, <String>['01/09/2025']);
-
-    // The operator moves the werkdatum to the new school year and saves. Until
-    // they sync, the overview below is still the old year's.
-    live.publish(AppSettings(
-      wisa: WisaConnection(
-        server: 'wisa.example',
-        port: '9000',
-        workDate: WorkDateSetting(isNow: false, date: DateTime(2026, 9, 1)),
-      ),
-    ));
-
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-    await tester.pumpAndSettle();
-
-    expect(find.textContaining('· werkdatum 01/09/2025'), findsOneWidget);
-    expect(find.textContaining('01/09/2026'), findsNothing,
-        reason: 'a saved werkdatum describes the next pull, not this view');
+    expect(find.textContaining('operator@school.example'), findsNothing);
   });
 
   group('a pass runs behind a modal progress dialog (#243)', () {
@@ -2257,58 +2192,38 @@ void main() {
     });
   });
 
-  // --- The pointer at Klasgroepen (#301) ------------------------------------
+  // --- No pointer at Klasgroepen any more (#301 → #309) ---------------------
 
   testWidgets(
-      'the Acties header says how many classes are waiting on Klasgroepen '
-      '(#301)', (WidgetTester tester) async {
-    // Acties covers people and Klasgroepen covers classes, and nothing on this
-    // screen said the second half existed. The fixture is the rollover shape in
-    // miniature: `3C` and `3D` are both missing their Office 365 group, which is
-    // work that can only be done on the other tab.
+      'the header never points at Klasgroepen, however much that tab is '
+      'holding (#309)', (WidgetTester tester) async {
+    // #301 put the pointer on both action tabs so each said what the other was
+    // holding. The Acties half is gone: what Klasgroepen is holding is stated
+    // on Klasgroepen, where the mirror line — how many accounts Acties is
+    // holding — stays (see `class_groups_screen_test.dart`). The asymmetry is
+    // deliberate: that tab has the room, this one is a list of thousands.
+    //
+    // The fixture is the case that used to render the line: `3C` and `3D` are
+    // both missing their Office 365 group, which is work only the other tab can
+    // do.
     _useWideWindow(tester);
     final harness = appliedClassWorkHarness();
     await harness.controller.sync();
     await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    // The screen reads the inventory itself, so the line is there on the first
-    // visit rather than only after the operator has been to the tab it points
-    // at — which is the one case it is not needed.
-    expect(harness.controller.groupDocs, isNotNull);
-    expect(harness.controller.classesNeedingAttention, 2);
-    expect(
-      find.text('2 klas(sen) vragen ook aandacht op Klasgroepen.'),
-      findsOneWidget,
-    );
-    // Pumped outside the shell there is no tab to switch to, and the sentence is
-    // true anyway — so it degrades to prose instead of vanishing.
-    expect(
-      find.byKey(const ValueKey('actions-class-attention')),
-      findsOneWidget,
-    );
-    expect(
-      find.descendant(
-        of: find.byKey(const ValueKey('actions-class-attention')),
-        matching: find.byType(InkWell),
-      ),
-      findsNothing,
-      reason: 'no shell above it, so there is nothing to follow the line to',
-    );
-  });
+    // With nothing left on this screen reading the class inventory, it no
+    // longer schedules the partition read that only ever fed the pointer.
+    expect(harness.controller.groupDocs, isNull);
+    expect(find.byKey(const ValueKey('actions-class-attention')), findsNothing);
 
-  testWidgets('…and says nothing at all when no class needs anything (#301)',
-      (WidgetTester tester) async {
-    // A line reading "0 klas(sen)" is noise in the one case where the operator
-    // is done. This fixture has departed Smartschool accounts and no class at
-    // all, so Acties has work and Klasgroepen has none.
-    _useWideWindow(tester);
-    final harness = departedHarness();
-    await harness.controller.sync();
-    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    // …and once the inventory *is* loaded — the operator visited Klasgroepen,
+    // which reads it through the same controller — the count is there to be
+    // rendered and this screen still renders none of it.
+    await harness.controller.loadGroups();
     await tester.pumpAndSettle();
 
-    expect(harness.controller.classesNeedingAttention, 0);
+    expect(harness.controller.classesNeedingAttention, 2);
     expect(find.byKey(const ValueKey('actions-class-attention')), findsNothing);
     expect(find.textContaining('aandacht op Klasgroepen'), findsNothing);
   });

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -404,13 +404,14 @@ void main() {
         reason: 'nothing but spacing stands between the eyebrow and the box');
     // And a pin on the whole block above the list — eyebrow, search box, work
     // switch, sort and system chips, family tabs. It measured 422 when #309
-    // landed and measures 366 since #310 put the box and the switch on one
-    // row; every line put back into the header adds some 30 to that, which is
-    // what this number is guarding. What the operator actually gains from it is
-    // asserted at a real 1080p window in the integration suite, in rows on
-    // screen.
+    // landed, 366 once #310 put the box and the switch on one row, and 240
+    // since #311 took the select-all bar out from under them; every line put
+    // back into the header adds some 30 to that, and the bar alone was worth
+    // 126, which is what this number is guarding. What the operator actually
+    // gains from it is asserted at a real 1080p window in the integration
+    // suite, in rows on screen.
     expect(tester.getTopLeft(find.byKey(const ValueKey('actions-list'))).dy,
-        lessThan(390));
+        lessThan(260));
   });
 
   // --- The name box and the work-list switch on one row (#310) -------------
@@ -705,247 +706,95 @@ void main() {
     });
   });
 
-  // --- Ticking the accounts a risky action runs on (#297) -------------------
+  // --- No selection anywhere on the list (#311) ----------------------------
 
-  group('a decision can be applied to the accounts the operator ticked (#297)',
-      () {
-    Finder check(String id) => find.byKey(ValueKey('account-check-$id'));
-
-    Finder chip(String key) => find.byKey(ValueKey('actions-decision-$key'));
-
-    /// The line under the chips: how much of the selection the chosen decision
-    /// covers, and how much of it it does not.
-    String scopeLine(WidgetTester tester) => tester
-        .widget<Text>(find.byKey(const ValueKey('actions-selection-scope')))
-        .data!;
-
-    Future<void> tick(WidgetTester tester, String id) async {
-      await tester.ensureVisible(check(id));
-      await tester.tap(check(id));
-      await tester.pumpAndSettle();
-    }
-
-    Future<void> selectAll(WidgetTester tester) async {
-      await tester.tap(find.byKey(const ValueKey('actions-select-all')));
-      await tester.pumpAndSettle();
-    }
-
-    int classMoves(ReconcileHarness harness) => harness.soap.soapActions
-        .where((a) => a.endsWith('#saveUserToClass'))
-        .length;
-
-    /// The September rollover in miniature (see the #296 group): three students
-    /// share the sanctioned class move, and Sam alone also carries the Office
-    /// 365 rename that #293 withholds from any school-wide pass.
-    Future<ReconcileHarness> openRollover(WidgetTester tester) async {
+  group('the list offers no selection at all (#311)', () {
+    /// Opens Acties over [harness] with the flat list on screen.
+    Future<void> open(WidgetTester tester, ReconcileHarness harness) async {
       _useWideWindow(tester);
-      final harness = rolloverHarness();
       await harness.controller.sync();
       await tester
           .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
       await tester.pumpAndSettle();
-      return harness;
+    }
+
+    /// Everything #297 put on the screen, asserted absent in one place.
+    void expectNoSelection(WidgetTester tester) {
+      expect(find.byKey(const ValueKey('actions-selection-bar')), findsNothing);
+      expect(find.byKey(const ValueKey('actions-select-all')), findsNothing);
+      expect(
+          find.byKey(const ValueKey('actions-selection-clear')), findsNothing);
+      expect(
+          find.byKey(const ValueKey('actions-selection-scope')), findsNothing);
+      expect(find.byKey(const ValueKey('actions-selection-dry-run')),
+          findsNothing);
+      expect(
+          find.byKey(const ValueKey('actions-selection-apply')), findsNothing);
+      expect(find.textContaining('Selecteer alle zichtbare'), findsNothing);
+      expect(find.textContaining('geselecteerd'), findsNothing);
+      // And no checkbox anywhere on the screen — the bar's select-all and the
+      // per-row ticks were the only ones this view ever rendered.
+      expect(find.byType(Checkbox), findsNothing);
     }
 
     testWidgets(
-        'only a row with applyable work can be ticked, and select-all covers '
-        'the visible rows and no others', (WidgetTester tester) async {
-      _useWideWindow(tester);
-      // Sam's Office 365 display name is stale; Tom is in order everywhere.
+        'no bar above the list and no checkbox on a row that carries work',
+        (WidgetTester tester) async {
+      // The state #297's bar was loudest in: rows with applyable work, which is
+      // when it rendered at all. Sam's Office 365 display name is stale; Tom is
+      // in order everywhere.
       final harness = appliedClassWorkHarness();
-      await harness.controller.sync();
-      await tester
-          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-      await tester.pumpAndSettle();
+      await open(tester, harness);
 
       final sam = _idOf(harness.controller, 'Sam Sels');
-      final tom = _idOf(harness.controller, 'Tom Tas');
+      expect(_row(sam), findsOneWidget, reason: 'he does carry work');
+      expect(find.byKey(ValueKey('account-check-$sam')), findsNothing);
+      expectNoSelection(tester);
 
-      expect(
-          find.byKey(const ValueKey('actions-selection-bar')), findsOneWidget);
-      expect(find.text('Selecteer alle zichtbare (1)'), findsOneWidget);
-      expect(check(sam), findsOneWidget);
-
-      // Off the work list Tom appears with nothing to tick: ticking a settled
-      // account adds nothing to a pass and would only inflate the skipped
-      // count. Select-all still covers one row.
+      // Off the work list the settled accounts come back, and they have nothing
+      // to tick either — nor a blank column where a checkbox used to be.
       await tester.tap(find.byKey(const ValueKey('actions-only-with-actions')));
       await tester.pumpAndSettle();
-      expect(_row(tom), findsOneWidget);
-      expect(check(tom), findsNothing);
-      expect(find.text('Selecteer alle zichtbare (1)'), findsOneWidget);
-
-      await selectAll(tester);
-      expect(tester.widget<Checkbox>(check(sam)).value, isTrue);
-      expect(find.textContaining('1 account(s) geselecteerd'), findsOneWidget);
-    });
-
-    testWidgets(
-        'the bar names one decision and applies exactly it across the '
-        'selection (#292)', (WidgetTester tester) async {
-      final harness = await openRollover(tester);
-      await selectAll(tester);
-
-      expect(find.textContaining('3 account(s) geselecteerd'), findsOneWidget);
-      // Both decisions the ticked accounts raise are on offer, and the one the
-      // most of them share is the default — that is what the selection was
-      // almost certainly made for.
-      expect(chip('student|MoveToSmartschoolClassGroup'), findsOneWidget);
-      expect(chip('student|ModifyAzureName'), findsOneWidget);
-      expect(
-        tester
-            .widget<ChoiceChip>(chip('student|MoveToSmartschoolClassGroup'))
-            .selected,
-        isTrue,
-      );
-      expect(scopeLine(tester),
-          'Wordt toegepast op alle 3 geselecteerde account(s).');
-
-      await tester.tap(find.byKey(const ValueKey('actions-selection-apply')));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Toepassen op 3 geselecteerd(e) account(s)?'),
-          findsOneWidget);
-      expect(
-        find.descendant(
-          of: find.byType(AlertDialog),
-          matching: find.textContaining('3 wijzigingen naar Smartschool'),
-        ),
-        findsOneWidget,
-        reason: 'the dialog names the systems and the change count of this '
-            'selection, not of everything on those three cards',
-      );
-
-      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-      await tester.pumpAndSettle();
-
-      expect(classMoves(harness), 3);
-      expect(harness.graph.requests.where((r) => r.method == 'PATCH'), isEmpty,
-          reason: "Sam's rename shares his card but not this decision");
-      // The writes settled what the ticks named, so the selection is gone with
-      // the view it was made against.
-      expect(
-          find.byKey(const ValueKey('actions-selection-scope')), findsNothing);
-    });
-
-    testWidgets(
-        'the kinds that get no apply-all get this instead, and it says how '
-        'many of the selection it skips (#293)', (WidgetTester tester) async {
-      final harness = await openRollover(tester);
-      final sam = _idOf(harness.controller, 'Sam Sels');
-      final sara = _idOf(harness.controller, 'Sara Segers');
-
-      // A rename over the whole school is exactly what the sanction refuses…
-      await _select(tester, sam);
-      expect(find.byKey(ValueKey('decision-apply-all-student-$sam-0')),
-          findsNothing);
-
-      // …yet it is on offer here, because the ticking is the consent.
-      await tick(tester, sam);
-      await tick(tester, sara);
-      await tester.tap(chip('student|ModifyAzureName'));
-      await tester.pumpAndSettle();
-
-      expect(
-        scopeLine(tester),
-        'Wordt toegepast op 1 van de 2 geselecteerde account(s) — 1 '
-        'overgeslagen, want daar staat deze beslissing niet open.',
-        reason: 'Sara raises the class move, not the rename, and a pass that '
-            'quietly passed over her would be the whole risk of a multi-select',
-      );
-      expect(find.text('Toepassen op selectie (1)'), findsOneWidget);
-
-      await tester.tap(find.byKey(const ValueKey('actions-selection-apply')));
-      await tester.pumpAndSettle();
-      expect(find.text('Toepassen op 1 geselecteerd(e) account(s)?'),
-          findsOneWidget);
-      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-      await tester.pumpAndSettle();
-
-      expect(harness.graph.requests.where((r) => r.method == 'PATCH'),
-          hasLength(1));
-      expect(classMoves(harness), 0,
-          reason: 'the pass is one decision deep, whatever else the ticked '
-              'cards carry (#292)');
-    });
-
-    testWidgets(
-        'ticking every visible row selects what the filter shows, and the '
-        'dialog quotes that count', (WidgetTester tester) async {
-      final harness = await openRollover(tester);
       final tom = _idOf(harness.controller, 'Tom Tas');
-
-      await tester.enterText(
-          find.byKey(const ValueKey('actions-search')), 'Sa');
-      await tester.pumpAndSettle();
-      expect(_row(tom), findsNothing);
-      expect(find.text('Selecteer alle zichtbare (2)'), findsOneWidget);
-
-      await selectAll(tester);
-      expect(find.text('Toepassen op selectie (2)'), findsOneWidget);
-
-      await tester.tap(find.byKey(const ValueKey('actions-selection-apply')));
-      await tester.pumpAndSettle();
-      expect(find.text('Toepassen op 2 geselecteerd(e) account(s)?'),
-          findsOneWidget,
-          reason: 'select-all under a filter must never read as school-wide');
-      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
-      await tester.pumpAndSettle();
-
-      expect(classMoves(harness), 2,
-          reason: 'Tom needs the very same move and was never on the screen');
+      expect(_row(tom), findsOneWidget);
+      expect(find.byKey(ValueKey('account-check-$tom')), findsNothing);
+      expectNoSelection(tester);
     });
 
-    testWidgets('a dry-run covers the selection and leaves it standing',
+    testWidgets('nor over a whole rollover roster',
         (WidgetTester tester) async {
-      final harness = await openRollover(tester);
-      await selectAll(tester);
+      // Three students sharing one decision is the case the bar was built for,
+      // and the one where "Selecteer alle zichtbare (3)" was one press away from
+      // staging every row the filter happened to be showing.
+      final harness = rolloverHarness();
+      await open(tester, harness);
 
-      await tester.tap(find.byKey(const ValueKey('actions-selection-dry-run')));
-      await tester.pumpAndSettle();
+      for (final label in <String>['Sam Sels', 'Sara Segers', 'Tom Tas']) {
+        final id = _idOf(harness.controller, label);
+        expect(_row(id), findsOneWidget);
+        expect(find.byKey(ValueKey('account-check-$id')), findsNothing);
+      }
+      expectNoSelection(tester);
 
-      expect(harness.controller.dryRunResults, hasLength(3));
-      expect(classMoves(harness), 0);
-      expect(find.text('Resultaat van de dry-run'), findsOneWidget);
-      expect(scopeLine(tester),
-          'Wordt toegepast op alle 3 geselecteerde account(s).',
-          reason: 'the dry-run is what the operator reads before pressing the '
-              'button beside it, so it must not dissolve the selection');
+      // Selecting a row still opens its pane, which is the one thing a row was
+      // ever meant to do.
+      final sam = _idOf(harness.controller, 'Sam Sels');
+      await _select(tester, sam);
+      expect(find.byKey(ValueKey('actions-detail-$sam')), findsOneWidget);
+      expectNoSelection(tester);
     });
 
     testWidgets(
-        'the ticks survive a sort change and are retired by a refreshed view',
-        (WidgetTester tester) async {
-      final harness = await openRollover(tester);
+        'the cohort review is the only bulk path left, and it still works '
+        '(#296)', (WidgetTester tester) async {
+      // #311 removes the *chosen* set, not the computed one. The sanctioned
+      // decision still arms its school-wide review, still shows the cohort
+      // before confirming, and still writes exactly it.
+      final harness = rolloverHarness();
+      await open(tester, harness);
+
       final sam = _idOf(harness.controller, 'Sam Sels');
-      await tick(tester, sam);
-      expect(find.textContaining('1 account(s) geselecteerd'), findsOneWidget);
-
-      // A sort describes the list, not the row, so it leaves the set alone.
-      await tester.tap(find.byKey(const ValueKey('actions-sort-klas')));
-      await tester.pumpAndSettle();
-      expect(tester.widget<Checkbox>(check(sam)).value, isTrue);
-      expect(find.textContaining('1 account(s) geselecteerd'), findsOneWidget);
-
-      // A refreshed linked view does not: the accounts under the ticks may no
-      // longer raise what they were ticked for.
-      await harness.controller.checkDrift();
-      await tester.pumpAndSettle();
-      expect(tester.widget<Checkbox>(check(sam)).value, isFalse);
-      expect(
-          find.byKey(const ValueKey('actions-selection-scope')), findsNothing);
-    });
-
-    testWidgets('a school-wide review takes the ticks and the checkboxes away',
-        (WidgetTester tester) async {
-      // The two bulk modes are exclusive: a review's list is its own cohort, so
-      // ticks made against the ordinary list would name a different set than
-      // the rows now on screen.
-      final harness = await openRollover(tester);
-      final sam = _idOf(harness.controller, 'Sam Sels');
-      await tick(tester, sam);
       await _select(tester, sam);
-
       final Finder moveAll =
           find.byKey(ValueKey('decision-apply-all-student-$sam-1'));
       await tester.ensureVisible(moveAll);
@@ -954,29 +803,32 @@ void main() {
 
       expect(
           find.byKey(const ValueKey('actions-cohort-banner')), findsOneWidget);
-      expect(find.byKey(const ValueKey('actions-selection-bar')), findsNothing);
-      expect(check(sam), findsNothing);
+      expectNoSelection(tester);
 
-      await tester.tap(find.byKey(const ValueKey('actions-cohort-cancel')));
+      await tester.tap(find.byKey(const ValueKey('actions-cohort-apply')));
       await tester.pumpAndSettle();
-      expect(check(sam), findsOneWidget);
-      expect(tester.widget<Checkbox>(check(sam)).value, isFalse,
-          reason: 'the review dropped the set; restoring one the operator has '
-              'not looked at since is exactly what must not happen');
+      expect(find.text('Toepassen op 3 account(s)?'), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      await tester.pumpAndSettle();
+
+      expect(
+        harness.soap.soapActions
+            .where((a) => a.endsWith('#saveUserToClass'))
+            .length,
+        3,
+      );
     });
 
     testWidgets(
-        'the September leavers sweep: tick the departed and resolve them in '
-        'one pass', (WidgetTester tester) async {
-      _useWideWindow(tester);
-      // The case the issue is written for. Three Smartschool-only accounts, no
-      // WISA record: each resolves to the unregister/delete either-or, which is
-      // as far from a school-wide apply-all as an action gets.
+        'the September leavers sweep runs one account at a time from the pane',
+        (WidgetTester tester) async {
+      // The workflow #297 was written for, and what it costs now that the ticks
+      // are gone: three Smartschool-only accounts, each raising the
+      // unregister/delete either-or, resolved one pane at a time. Slower on
+      // purpose — the safety of a destructive action is that it is never
+      // applied to a set nobody opened.
       final harness = departedHarness(count: 3);
-      await harness.controller.sync();
-      await tester
-          .pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
-      await tester.pumpAndSettle();
+      await open(tester, harness);
 
       final ids = <String>[
         for (final e in harness.controller.pendingEntries)
@@ -989,23 +841,29 @@ void main() {
           reason: 'nobody presses one button that deletes every account the '
               'app believes has left');
 
-      await selectAll(tester);
-      expect(chip('student|smartschool-departure'), findsOneWidget);
-      expect(scopeLine(tester),
-          'Wordt toegepast op alle 3 geselecteerde account(s).');
-
-      await tester.tap(find.byKey(const ValueKey('actions-selection-apply')));
+      // The risky-action confirmation path from the pane is untouched: it names
+      // the write, and only on Annuleer-free confirmation does anything happen.
+      final Finder apply = find.byKey(ValueKey('entry-apply-${ids.first}'));
+      await tester.ensureVisible(apply);
+      await tester.tap(apply);
       await tester.pumpAndSettle();
+      expect(find.byType(AlertDialog), findsOneWidget);
       await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
       await tester.pumpAndSettle();
 
-      expect(harness.controller.applyResults, hasLength(3));
+      expect(harness.controller.applyResults, hasLength(1),
+          reason: 'one account, because one account is what was opened');
+      expect(harness.controller.applyResults!.single.targetId, ids.first);
       expect(
         harness.controller.applyResults!.map((r) => r.changes.summary).toSet(),
         <String>{'Schrijf de leerling uit in Smartschool'},
-        reason: 'each account still runs its own chosen alternative, and the '
-            'default of that either/or is the non-destructive one',
+        reason: 'the default of that either/or is the non-destructive one',
       );
+      // The other two are on the list beside him, each still its own decision
+      // to make — which is exactly what removing the sweep costs, and buys.
+      for (final id in ids.skip(1)) {
+        expect(_row(id), findsOneWidget);
+      }
     });
   });
 
@@ -1192,6 +1050,16 @@ void main() {
       // The pass a rollover really runs: one decision over a set of accounts,
       // all of them settling at once. Opening the second of them must not
       // delete the first out from under the tap that opened it.
+      //
+      // The pass is started on the controller rather than from a button,
+      // because since #311 no affordance on this screen starts a multi-account
+      // pass over a decision #293 withholds — and every decision the offline
+      // fakes really *settle* is one of those. (The Smartschool fake takes a
+      // write without folding it back into its snapshot, so the sanctioned
+      // class move of #296 leaves its accounts pending and never reaches the
+      // state this test is about.) What #299 pins here is what the screen does
+      // once a pass has written several accounts, whichever button began it;
+      // the cohort review's own path is covered in the #296 group above.
       final harness = crossClassSituationHarness();
       await open(tester, harness);
 
@@ -1199,11 +1067,13 @@ void main() {
       final sara = _idOf(harness.controller, 'Sara Segers');
       final tom = _idOf(harness.controller, 'Tom Tas');
 
-      await tester.tap(find.byKey(const ValueKey('actions-select-all')));
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('actions-selection-apply')));
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+      final cohort = ReconcileController.situationCohorts(<PendingAccountEntry>[
+        for (final e in harness.controller.pendingEntries)
+          if (e.family == 'student') e,
+      ]).single;
+      expect(cohort.key, 'student|ModifyAzureName');
+      expect(cohort.length, 3, reason: 'one decision, three accounts');
+      await harness.controller.applyDecisions(cohort.decisions);
       await tester.pumpAndSettle();
 
       expect(harness.controller.applyResults, hasLength(3));

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -403,12 +403,97 @@ void main() {
     expect(searchTop - eyebrowBottom, lessThan(40),
         reason: 'nothing but spacing stands between the eyebrow and the box');
     // And a pin on the whole block above the list — eyebrow, search box, work
-    // switch, sort and system chips, family tabs. It measures 422 here; every
-    // line put back into the header adds some 30 to that, which is what this
-    // number is guarding. What the operator actually gains from it is asserted
-    // at a real 1080p window in the integration suite, in rows on screen.
+    // switch, sort and system chips, family tabs. It measured 422 when #309
+    // landed and measures 366 since #310 put the box and the switch on one
+    // row; every line put back into the header adds some 30 to that, which is
+    // what this number is guarding. What the operator actually gains from it is
+    // asserted at a real 1080p window in the integration suite, in rows on
+    // screen.
     expect(tester.getTopLeft(find.byKey(const ValueKey('actions-list'))).dy,
-        lessThan(450));
+        lessThan(390));
+  });
+
+  // --- The name box and the work-list switch on one row (#310) -------------
+
+  testWidgets(
+      'the name box and the work-list switch share one row, and the box is '
+      'bounded rather than full-bleed (#310)', (WidgetTester tester) async {
+    // Two controls that shape the same list, stacked as two full-width rows:
+    // the box claimed the whole content width — well over 1200px here — for a
+    // field that holds a name, and the switch cost a row of its own under it.
+    _useWideWindow(tester);
+    final harness = appliedClassWorkHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    final Rect search =
+        tester.getRect(find.byKey(const ValueKey('actions-search')));
+    final Rect toggle =
+        tester.getRect(find.byKey(const ValueKey('actions-only-with-actions')));
+    final Rect label =
+        tester.getRect(find.text('Toon enkel accounts met acties'));
+
+    // One row: the switch and its label stand to the right of the box, and
+    // every one of the three overlaps the others vertically instead of
+    // stacking under them.
+    expect(toggle.left, greaterThan(search.right));
+    expect(label.left, greaterThan(toggle.right));
+    expect(toggle.top, lessThan(search.bottom));
+    expect(search.top, lessThan(toggle.bottom));
+    expect(label.top, lessThan(search.bottom));
+
+    // Bounded, not full-bleed: a fraction of the width it used to fill.
+    final double paneWidth = tester.getSize(find.byType(ActionsScreen)).width;
+    expect(paneWidth, greaterThan(1000), reason: 'a genuinely wide window');
+    expect(search.width, lessThanOrEqualTo(380));
+    expect(search.width, lessThan(paneWidth / 3));
+
+    // And the row it saved: the filter chips follow the box by one spacing gap,
+    // where a whole switch row used to stand between them.
+    final Rect chips =
+        tester.getRect(find.byKey(const ValueKey('actions-system-azure')));
+    expect(chips.top - search.bottom, lessThan(24),
+        reason: 'nothing but spacing separates the box from the chips');
+  });
+
+  testWidgets(
+      'a window too narrow for both wraps the row instead of overflowing '
+      '(#310)', (WidgetTester tester) async {
+    // The failure mode a fixed-width box would have introduced. At 700px the
+    // box, the switch and a 30-character label do not fit side by side, so the
+    // switch takes a second run — and the box shrinks to what there is rather
+    // than holding its cap and spilling.
+    _useNarrowWindow(tester);
+    final harness = appliedClassWorkHarness();
+    await harness.controller.sync();
+    await tester.pumpWidget(_wrap(ActionsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    final Rect search =
+        tester.getRect(find.byKey(const ValueKey('actions-search')));
+    final Rect toggle =
+        tester.getRect(find.byKey(const ValueKey('actions-only-with-actions')));
+
+    expect(toggle.top, greaterThanOrEqualTo(search.bottom),
+        reason: 'the switch wrapped onto its own run');
+    // Still capped, even on the run it now has to itself — a narrow window is
+    // not a reason to give a name field 636px.
+    expect(search.width, lessThanOrEqualTo(380));
+    // Both stay inside the 700px window: nothing is clipped off the right.
+    expect(search.right, lessThanOrEqualTo(700));
+    expect(toggle.right, lessThanOrEqualTo(700));
+    // Still one switch and one box, still operable.
+    await tester.tap(find.byKey(const ValueKey('actions-only-with-actions')));
+    await tester.pumpAndSettle();
+    expect(
+      tester
+          .widget<Switch>(
+              find.byKey(const ValueKey('actions-only-with-actions')))
+          .value,
+      isFalse,
+    );
   });
 
   // --- School-wide apply-all, cohort first (#296) ---------------------------

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -1,7 +1,15 @@
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_manager/src/screens/class_groups_screen.dart';
 import 'package:account_manager/src/screens/system_indicator.dart';
-import 'package:account_state/account_state.dart' show InMemoryLinkedStore;
+import 'package:account_state/account_state.dart'
+    show
+        AppSettings,
+        InMemoryLinkedStore,
+        LiveSettings,
+        MaterializedAccount,
+        SystemSyncMeta,
+        WisaConnection,
+        WorkDateSetting;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -1140,5 +1148,164 @@ void main() {
       findsNothing,
     );
     expect(find.textContaining('aandacht op Acties'), findsNothing);
+  });
+
+  // --- The freshness stamp above the inventory ------------------------------
+  //
+  // These four came over from `actions_screen_test.dart` when #309 stripped the
+  // Acties header down to its eyebrow. The stamp is a property of the shared
+  // state rather than of either list, and this is now the only action view that
+  // renders it — so this is where its wording is pinned.
+
+  testWidgets(
+      "a generation bump refetches the passive Klasgroepen overview's "
+      'freshness (#108)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final linkedStore = InMemoryLinkedStore();
+    final snapshots = InMemorySnapshotStore();
+
+    final s1 = ReconcileHarness(store: snapshots, linkedStore: linkedStore);
+    await s1.controller.sync();
+
+    final s2 = await ReconcileHarness.resume(
+      store: snapshots,
+      linkedStore: linkedStore,
+    );
+    await tester.pumpWidget(_wrap(ClassGroupsScreen(bootstrap: s2.bootstrap)));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Generatie 1'), findsOneWidget);
+
+    s1.wisaResult = wisaSnap(
+      fetchedAt: kFixtureDate.add(const Duration(hours: 1)),
+      students: [wisaStudent(classGroup: '3D')],
+    );
+    await s1.controller.sync();
+    await s2.controller.onStoreChanged(2);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Generatie 2'), findsOneWidget);
+    expect(find.textContaining('Generatie 1'), findsNothing);
+  });
+
+  testWidgets(
+      'the freshness stamp carries the date once the shared state is no longer '
+      'from today (#192)', (WidgetTester tester) async {
+    // The shared view was materialized at kFixtureDate, a past day. Time-only
+    // rendered that as "Generatie 1 · 02:00 door …" —
+    // indistinguishable from a view materialized minutes ago, the same
+    // confusion #192 fixes on the Reconcile last-sync box.
+    _useTallWindow(tester);
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // Derived here rather than through the production formatter, so this pins
+    // the rendered text instead of restating the implementation.
+    final DateTime t = kFixtureDate.toLocal();
+    final String dm = '${t.day.toString().padLeft(2, '0')}/'
+        '${t.month.toString().padLeft(2, '0')}';
+    final String hhmm = '${t.hour.toString().padLeft(2, '0')}:'
+        '${t.minute.toString().padLeft(2, '0')}';
+
+    expect(find.textContaining('Generatie 1 · $dm'), findsOneWidget);
+    expect(find.textContaining('Generatie 1 · $hhmm'), findsNothing,
+        reason: 'a stamp from a past day is never rendered as bare time');
+  });
+
+  testWidgets(
+      'the freshness stamp names the werkdatum the roster was pulled with '
+      '(#247)', (WidgetTester tester) async {
+    // "Wie synchroniseerde, wanneer" says when the pass ran, never which school
+    // year it describes — and WISA answers *as of* a date, so a pull made on
+    // the wrong side of the rollover reads here exactly like a class that went
+    // missing (#239). The stamp comes off the shared per-system record, so this
+    // passive session reads the date without having run the pull.
+    _useTallWindow(tester);
+    final store = await seededLinkedStore(
+      <MaterializedAccount>[
+        matAccount(id: 's1', label: 'Jane Doe', withAction: true),
+      ],
+      systemSyncs: <core.Origin, SystemSyncMeta>{
+        core.Origin.wisa: SystemSyncMeta(
+          syncedBy: 'operator@school.example',
+          at: kFixtureDate,
+          workDate: DateTime(2025, 9, 1),
+        ),
+      },
+    );
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // In the wire's own dd/MM/yyyy, the way the Log panel's pull line and the
+    // `Werkdatum` SOAP parameter both spell it.
+    expect(find.textContaining('· werkdatum 01/09/2025'), findsOneWidget);
+  });
+
+  testWidgets(
+      'a shared view synced before the werkdatum was recorded renders the '
+      'stamp unchanged (#247)', (WidgetTester tester) async {
+    // The store in production already holds views written without it, and a
+    // Smartschool/Azure-only stamp never has one. Neither may invent a date,
+    // and neither may lose the "wie, wanneer" half over its absence.
+    _useTallWindow(tester);
+    final store = await seededLinkedStore(<MaterializedAccount>[
+      matAccount(id: 's1', label: 'Jane Doe', withAction: true),
+    ]);
+    final harness = ReconcileHarness(linkedStore: store);
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('werkdatum'), findsNothing);
+    expect(
+      find.textContaining('Generatie 1'),
+      findsOneWidget,
+      reason: 'the who/when half stands on its own',
+    );
+  });
+
+  testWidgets(
+      'the stamp names the werkdatum the stored view was pulled with, not the '
+      'one Instellingen now holds (#247)', (WidgetTester tester) async {
+    // The disagreement the issue is about. #238 made the werkdatum live, so
+    // between a save and the next Synchroniseer the setting says one school
+    // year and the installed roster is another. Driven over the *production*
+    // WISA pull, so the date on screen is the one that really went out.
+    _useTallWindow(tester);
+    final live = LiveSettings(AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2025, 9, 1)),
+      ),
+    ));
+    final wire = RecordingWisaSoap();
+    final harness = ReconcileHarness(wisaTransport: wire, liveSettings: live);
+    await harness.controller.sync();
+    expect(wire.werkdatums, <String>['01/09/2025']);
+
+    // The operator moves the werkdatum to the new school year and saves. Until
+    // they sync, the overview below is still the old year's.
+    live.publish(AppSettings(
+      wisa: WisaConnection(
+        server: 'wisa.example',
+        port: '9000',
+        workDate: WorkDateSetting(isNow: false, date: DateTime(2026, 9, 1)),
+      ),
+    ));
+
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('· werkdatum 01/09/2025'), findsOneWidget);
+    expect(find.textContaining('01/09/2026'), findsNothing,
+        reason: 'a saved werkdatum describes the next pull, not this view');
   });
 }

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -719,9 +719,12 @@ void main() {
     // The stored classes are there, with their stored candidates marked exactly
     // as Acties marks them (#255).
     expect(find.byKey(const ValueKey('class-row-2B')), findsOneWidget);
-    expect(
-        find.textContaining('Deze klas bestaat in Smartschool'), findsWidgets);
-    expect(find.textContaining('(manueel)'), findsWidgets);
+    // A Smartschool class WISA does not have is an either/or since #313, so the
+    // stored row reads as the choice it is — on its pre-selected half, which is
+    // the notice that writes nothing.
+    expect(find.textContaining('ze bestaat in Smartschool maar niet in WISA'),
+        findsWidgets);
+    expect(find.textContaining('(keuze)'), findsWidgets);
     // Nothing interactive: a passive session has nothing to apply.
     expect(find.byKey(const ValueKey('entry-group-2B')), findsNothing);
   });
@@ -1094,6 +1097,144 @@ void main() {
     expect(find.text('postvak, Teams en bestanden: verdwijnen mee'),
         findsOneWidget);
     expect(find.textContaining('→ ∅'), findsNothing);
+  });
+
+  // --- The Smartschool leftovers (#313) --------------------------------------
+
+  testWidgets(
+      'a Smartschool class WISA does not have offers a delete, and leaving it '
+      'alone is the default (#313)', (WidgetTester tester) async {
+    // Until #313 this row's whole content was "Verwijder ze manueel als ze niet
+    // meer nodig is" — an instruction to go and do it by hand in Smartschool,
+    // the dead end #271 removed on the Office 365 side.
+    _useTallWindow(tester);
+    final harness = smartschoolLeftoverClassHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    const entry = ValueKey('entry-group-9Z');
+    await tester.ensureVisible(find.byKey(entry));
+    await tester.tap(find.byKey(entry));
+    await tester.pumpAndSettle();
+
+    // Two radios, one choice — never two independent to-dos.
+    final leave =
+        find.byKey(const ValueKey('alt-9Z-DoNotImportFromSmartschool'));
+    final delete = find.byKey(const ValueKey('alt-9Z-DeleteSmartschoolClass'));
+    expect(leave, findsOneWidget);
+    expect(delete, findsOneWidget);
+    expect(
+      find.text('Laat deze klas staan — ze bestaat in Smartschool maar niet '
+          'in WISA'),
+      findsWidgets,
+    );
+    expect(find.textContaining('Verwijder ze manueel'), findsNothing);
+    // The notice states the class instead of instructing; the code is how the
+    // operator finds it in Smartschool.
+    expect(find.text('code: C9Z'), findsOneWidget);
+    expect(find.textContaining('→ ∅'), findsNothing,
+        reason: 'the option that writes nothing clears nothing');
+
+    // The default is the informational half, so nothing is applyable until the
+    // operator deliberately picks the delete.
+    final apply = find.byKey(const ValueKey('entry-apply-9Z'));
+    await tester.ensureVisible(apply);
+    expect(tester.widget<FilledButton>(apply).onPressed, isNull,
+        reason: 'a delete must never be the pre-selected resolution');
+
+    await tester.ensureVisible(delete);
+    await tester.tap(delete);
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Verwijder de klas 9Z uit Smartschool — ze bestaat niet in '
+          'WISA'),
+      findsWidgets,
+    );
+    expect(find.text('lidmaatschappen en subgroepen: verdwijnen mee'),
+        findsOneWidget);
+
+    await tester.ensureVisible(apply);
+    expect(tester.widget<FilledButton>(apply).onPressed, isNotNull);
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(harness.soap.deletedClasses, ['C9Z'],
+        reason: 'addressed by the class code, not its name');
+    expect(_row('9Z'), findsNothing,
+        reason: 'the relink drops the class the operator just removed');
+    expect(_row('8Y'), findsOneWidget,
+        reason: 'the class beside it was never selected');
+    expect(_row('1A'), findsOneWidget, reason: 'no other class was touched');
+  });
+
+  testWidgets(
+      'a bulk header over Smartschool leftovers writes nothing by default '
+      '(#293/#313)', (WidgetTester tester) async {
+    // `9Z` and `8Y` share the situation, so the tab collects them into one
+    // header — the surface where a destructive default would do the most
+    // damage, and the reason the delete withholds `canApplyToAll`.
+    _useTallWindow(tester);
+    final harness = smartschoolLeftoverClassHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
+    final bulk = find.textContaining('Alles toepassen (');
+    expect(tester.widget<Text>(bulk).data, 'Alles toepassen (0)',
+        reason: 'the default resolution of both rows writes nothing');
+    expect(
+      tester
+          .widget<FilledButton>(find.ancestor(
+            of: bulk,
+            matching: find.byType(FilledButton),
+          ))
+          .onPressed,
+      isNull,
+    );
+
+    // Flipping one row to the delete moves the header by exactly one: the
+    // classes beside it keep the notice they defaulted to, so a leftover is
+    // never swept into a delete somebody else's row asked for. That is what
+    // makes the label honest — "alles" is only ever the picks on screen.
+    const entry = ValueKey('entry-group-9Z');
+    await tester.ensureVisible(find.byKey(entry));
+    await tester.tap(find.byKey(entry));
+    await tester.pumpAndSettle();
+    final delete = find.byKey(const ValueKey('alt-9Z-DeleteSmartschoolClass'));
+    await tester.ensureVisible(delete);
+    await tester.tap(delete);
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<Text>(find.textContaining('Alles toepassen (')).data,
+        'Alles toepassen (1)');
+    expect(find.byKey(const ValueKey('alt-8Y-DeleteSmartschoolClass')),
+        findsNothing,
+        reason: 'the row beside it was never opened, let alone flipped');
+    expect(harness.soap.deletedClasses, isEmpty,
+        reason: 'nothing is written until the operator confirms');
+  });
+
+  testWidgets('a class WISA still has is offered no Smartschool delete (#313)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = smartschoolLeftoverClassHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(_row('1A'), findsOneWidget);
+    expect(find.byKey(const ValueKey('alt-1A-DeleteSmartschoolClass')),
+        findsNothing);
+    expect(find.textContaining('Verwijder de klas 1A uit Smartschool'),
+        findsNothing,
+        reason: '1A is a running class — deleting it is not on offer');
   });
 
   testWidgets('classes sort by year, numerically (#227)',

--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -163,9 +163,11 @@ class's Smartschool state and ride alongside **both** branches:
   parser order: `DoNotImportFromWisa` (WISA-only class; adds a `DontImportClass`
   rule), `AddToSmartschool` (WISA-only class **with students**; creates the
   official class in Smartschool), `CreateInSmartschool` (WISA-only class with
-  **no** students; informational), and `DoNotImportFromSmartschool` (orphan
-  Smartschool class; informational). A WISA-only class therefore raises
-  `DoNotImportFromWisa` plus exactly one of `AddToSmartschool` /
+  **no** students; informational), and the `staleSmartschoolClassAlternative`
+  pair of #313 for an orphan Smartschool class — the informational
+  `DoNotImportFromSmartschool` (leave it standing) and the applyable
+  `DeleteSmartschoolClass` (`delClass` on the class code). A WISA-only class
+  therefore raises `DoNotImportFromWisa` plus exactly one of `AddToSmartschool` /
   `CreateInSmartschool` — or, when Smartschool already carries the name on a
   group the linker could not adopt (#225), the informational
   `ClassExistsAsSmartschoolGroup` in place of both creates.
@@ -176,7 +178,10 @@ class's Smartschool state and ride alongside **both** branches:
   `classImportAlternative` for a genuinely new class (#244) and
   `namesakeClassAlternative` for one Smartschool already has (#250), which keeps
   the two situations in separate bulk-apply subsets. The default is always the
-  provisioning/diagnosis half, never the blacklist.
+  provisioning/diagnosis half, never the blacklist — and the same holds for the
+  Smartschool leftovers, where the notice is the default so a bulk pass writes
+  nothing and the delete is a per-row pick a bulk affordance may never reach
+  (#293).
 - **Azure-only, class-shaped** (a group whose class stopped running) → the
   `staleClassGroupAlternative` pair of #271: the informational
   `AzureClassGroupWithoutClass` (leave it standing) and the applyable
@@ -196,7 +201,10 @@ for the two creation actions, an injected `GroupPlacement` (see below).
 returns a `WisaImportRule` via `ActionResult.wisaRule`. `DoNotImportFromSmartschool`
 and `CreateInSmartschool` are **informational** (`canApply == false`, legacy
 `CanBeApplied == false`): they surface a diagnosis and their `apply` throws
-`UnsupportedError`.
+`UnsupportedError`. The two deletes — `DeleteAzureClassGroup` and
+`DeleteSmartschoolClass` — carry no record back at all: they set
+`ActionResult.removed`, and the State layer drops the record from the owning
+snapshot rather than patching it.
 
 ### Group placement (#65)
 

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -81,17 +81,19 @@ sealed class GroupAction {
   /// The same line is drawn: the mechanical class syncs and the class-group
   /// provisioning are granted ([AddToSmartschool], [ModifySmartschoolData],
   /// [CreateAzureClassGroup], [SyncAzureClassGroupMembers]); the blacklist
-  /// ([DoNotImportFromWisa]) and the delete ([DeleteAzureClassGroup]) are
-  /// withheld, and the informational members cannot have it at all.
+  /// ([DoNotImportFromWisa]) and the two deletes ([DeleteAzureClassGroup],
+  /// [DeleteSmartschoolClass]) are withheld, and the informational members
+  /// cannot have it at all.
   bool get canApplyToAll => false;
 
   /// The key shared by mutually-exclusive alternatives resolving the same
   /// situation (#110). `null` (the default) means the action stands on its own.
-  /// The group family has three: [classImportAlternative] for a class
+  /// The group family has four: [classImportAlternative] for a class
   /// Smartschool does not have (#244), [namesakeClassAlternative] for one it
-  /// already carries under a group the linker could not adopt (#250), and
+  /// already carries under a group the linker could not adopt (#250),
   /// [staleClassGroupAlternative] for an Office 365 group whose class is gone
-  /// (#271). See [StudentAction.alternativeGroup].
+  /// (#271), and [staleSmartschoolClassAlternative] for a Smartschool class
+  /// WISA does not have (#313). See [StudentAction.alternativeGroup].
   String? get alternativeGroup => null;
 
   /// Whether this action is the default alternative within its
@@ -578,27 +580,73 @@ class ClassExistsAsSmartschoolGroup extends GroupAction {
       );
 }
 
-/// An orphan Smartschool class with no matching WISA class. Ported from
-/// `Action\Group\DoNotImportFromSmartschool`, whose legacy `Apply` throws
-/// `NotImplementedException` — it is **informational only** (legacy
-/// `CanBeApplied == false`): it tells the operator the class exists in
-/// Smartschool but not WISA, and the resolution (keep it, or delete it by hand)
-/// is theirs. There is no automated write, so [canApply] is `false` and [apply]
-/// throws.
+/// The [GroupAction.alternativeGroup] key shared by the two readings of an
+/// official Smartschool class WISA does not have (#313): leave it standing
+/// ([DoNotImportFromSmartschool]) *or* delete it ([DeleteSmartschoolClass]).
+///
+/// The Smartschool twin of [staleClassGroupAlternative], and deliberately the
+/// same shape — one predicate, one facts helper, the notice as the default and
+/// the delete as the non-default that no bulk pass may reach. Until #313 the
+/// notice was the *only* reading, and its whole content was an instruction to
+/// go and do it by hand in Smartschool: the dead end #271 removed on the Office
+/// 365 side, still standing here, and a screenful of it at a September
+/// changeover.
+///
+/// **The default is the notice**, and here the polarity carries an extra job
+/// the Azure pair does not have. Early in a school year the WISA snapshot lags
+/// the real world, so a legitimately new class reads as Smartschool-only until
+/// it lands — and a class the school deliberately maintains only in Smartschool
+/// reads that way forever. Leaving it alone is therefore the right answer far
+/// more often than deleting it, which is why "Alles toepassen" over these rows
+/// writes nothing at all and the delete is a radio the operator flips on one
+/// row.
+///
+/// A key of its own rather than a third member of [classImportAlternative], for
+/// the reason [namesakeClassAlternative] is separate from it: the pending list
+/// keys its "same situation" bulk subsets on this very string
+/// (`PendingChoice.situationId`), so pooling the Smartschool leftovers with the
+/// genuinely new WISA classes would file both under one header offering one
+/// **Apply to all**.
+const String staleSmartschoolClassAlternative = 'class-smartschool-stale';
+
+/// An orphan Smartschool class with no matching WISA class — **leave it
+/// standing**, the conservative half of the [staleSmartschoolClassAlternative]
+/// pair and its default (#313).
+///
+/// Ported from `Action\Group\DoNotImportFromSmartschool`, whose legacy `Apply`
+/// throws `NotImplementedException` — it is **informational only** (legacy
+/// `CanBeApplied == false`), so [canApply] is `false` and [apply] throws. It is
+/// the Smartschool analogue of [AzureClassGroupWithoutClass], down to the
+/// wording: it states what the class is, and it no longer tells the operator to
+/// go and delete it by hand, because [DeleteSmartschoolClass] now sits beside it
+/// as the non-default alternative.
 class DoNotImportFromSmartschool extends GroupAction {
   const DoNotImportFromSmartschool(super.group);
 
   @override
-  bool evaluate() => group.wisa == null && group.smartschool != null;
+  bool evaluate() => _smartschoolOnlyClass(group);
 
   @override
   bool get canApply => false;
 
+  /// The notice leads — and is the default of — the pair (#313), so a bulk
+  /// apply over Smartschool leftovers writes nothing and the delete stays a
+  /// deliberate, per-row pick.
   @override
-  ChangeSet describeChanges() => const ChangeSet(
+  String? get alternativeGroup => staleSmartschoolClassAlternative;
+
+  @override
+  bool get isDefaultAlternative => true;
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
         system: Origin.smartschool,
-        summary: 'Deze klas bestaat in Smartschool maar niet in WISA. '
-            'Verwijder ze manueel als ze niet meer nodig is.',
+        summary: 'Laat deze klas staan — ze bestaat in Smartschool maar niet '
+            'in WISA',
+        // Nothing is written here, so nothing moves: these lines describe the
+        // class the operator is being told about (#305), and are how they find
+        // it in Smartschool if they decide to look.
+        fields: _smartschoolClassFacts(group.smartschool),
       );
 
   @override
@@ -607,6 +655,149 @@ class DoNotImportFromSmartschool extends GroupAction {
         'DoNotImportFromSmartschool is informational and cannot be applied '
         '(canApply is false)',
       );
+}
+
+/// Delete a Smartschool class WISA no longer has (#313) — the applyable half of
+/// the [staleSmartschoolClassAlternative] pair, and never its default.
+///
+/// Genuinely destructive: `delClass` takes the class, the membership of every
+/// student in it, and whatever hangs under it. The same three things hold it in
+/// place that hold [DeleteAzureClassGroup] in place, and each of them is
+/// tested:
+///
+/// - **It proposes on exactly the record the notice does**, via the one
+///   [_smartschoolOnlyClass] predicate — no WISA class, a Smartschool one —
+///   plus a restatement of the linker's own orphan rule: only an **official**
+///   Smartschool class ever seeds an orphan record, so an organisational group
+///   is already out of scope and must stay out. The restatement is
+///   belt-and-braces and deliberately redundant: a delete must not inherit its
+///   whole scope from a filter one layer away.
+/// - **It is never the selected option of a bulk pass**, because the notice
+///   beside it is the default of their shared alternative group. The operator
+///   flips this radio on one row, and only that row is written.
+/// - **The linked record must actually name a class to delete** — a blank
+///   Smartschool class code yields no proposal rather than a `delClass` with an
+///   empty `code`.
+///
+/// Deliberately no `unlocks`: nothing follows a delete.
+///
+/// **What this is not.** Legacy's neighbour here was `Klas Negeren` — a
+/// persistent "do not import this class" decision. That is a third option, not
+/// a replacement for either half: if such a blacklist ever comes back it
+/// belongs in this same alternative group, beside the notice and the delete.
+class DeleteSmartschoolClass extends GroupAction {
+  const DeleteSmartschoolClass(super.group);
+
+  @override
+  bool evaluate() =>
+      _smartschoolOnlyClass(group) &&
+      _ss.official &&
+      _ss.id.value.trim().isNotEmpty;
+
+  /// The destructive half, so never the default (#313). See
+  /// [staleSmartschoolClassAlternative].
+  @override
+  String? get alternativeGroup => staleSmartschoolClassAlternative;
+
+  @override
+  bool get isDefaultAlternative => false;
+
+  /// **Never in bulk** (#293), for the reason [DeleteAzureClassGroup] is not:
+  /// `delClass` takes the class and everything in it, and a WISA snapshot that
+  /// merely lags makes a perfectly live class look like a leftover. The
+  /// operator flips this radio on one row, and even then no bulk affordance may
+  /// offer it.
+  @override
+  bool get canApplyToAll => false;
+
+  @override
+  ChangeSet describeChanges() => ChangeSet(
+        system: Origin.smartschool,
+        summary: 'Verwijder de klas ${_ss.name} uit Smartschool — ze bestaat '
+            'niet in WISA',
+        // What the delete takes with it, stated (#305). The summary already
+        // says the class goes; these lines are the inventory of it, and an
+        // arrow on each would claim three separate fields were being cleared.
+        fields: [
+          ..._smartschoolClassFacts(group.smartschool),
+          const FieldChange.statement(
+            'lidmaatschappen en subgroepen',
+            'verdwijnen mee',
+          ),
+        ],
+      );
+
+  @override
+  Future<ActionResult> apply(
+    Connectors connectors,
+    ApplyOptions options,
+  ) async {
+    final changes = describeChanges();
+
+    if (options.dryRun) {
+      return ActionResult(
+        outcome: ActionOutcome.dryRun,
+        changes: changes,
+        system: Origin.smartschool,
+        removed: true,
+      );
+    }
+
+    try {
+      // The same code `saveClass` writes and `ModifySmartschoolData` addresses
+      // its rewrite to — the class's own Smartschool code, not its name.
+      final ok =
+          await _requireSmartschool(connectors).deleteClass(_ss.id.value);
+      if (!ok) {
+        return _failed(
+          changes,
+          Origin.smartschool,
+          StateError('Smartschool delClass returned failure'),
+        );
+      }
+      return ActionResult(
+        outcome: ActionOutcome.applied,
+        changes: changes,
+        system: Origin.smartschool,
+        removed: true,
+      );
+    } on Object catch (e) {
+      return _failed(changes, Origin.smartschool, e);
+    }
+  }
+}
+
+/// Whether [group] is a Smartschool class WISA does not have (#52/#313) — the
+/// one condition [DoNotImportFromSmartschool] and [DeleteSmartschoolClass]
+/// share.
+///
+/// One definition rather than two copies, because the pair are alternatives:
+/// they must fire together or a leftover class is left with a lone applyable
+/// delete as its only reading, which is precisely the "no safe default" state
+/// [staleSmartschoolClassAlternative] exists to prevent.
+///
+/// It asks the linker's own question and no stricter one, exactly as
+/// [_staleClassGroup] does on the Azure side: the record is on screen because
+/// `link()` seeded an orphan for an official Smartschool class it could match to
+/// nothing in WISA, and this restates that and nothing else.
+bool _smartschoolOnlyClass(LinkedGroup group) =>
+    group.wisa == null && group.smartschool != null;
+
+/// The facts both halves of [staleSmartschoolClassAlternative] state about the
+/// class they are describing (#305) — stated, never diffed.
+///
+/// Each is stated only when the class carries it: an empty statement renders as
+/// a bare `code: ` under the heading, a label for a fact that is not there.
+List<FieldChange> _smartschoolClassFacts(Group? smartschool) {
+  final code = smartschool?.id.value.trim() ?? '';
+  final description = smartschool?.description.trim() ?? '';
+  return <FieldChange>[
+    // How the operator finds the class in Smartschool, and what the delete
+    // beside this is addressed to.
+    if (code.isNotEmpty) FieldChange.statement('code', code),
+    if (description.isNotEmpty)
+      FieldChange.statement('omschrijving', description),
+  ];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -1034,12 +1034,14 @@ const String staleClassGroupAlternative = 'class-group-stale';
 /// carrying rows whose whole content was an instruction to go elsewhere.
 /// [DeleteAzureClassGroup] now sits beside it as the non-default alternative.
 ///
-/// It is deliberately narrow. An unmatched Azure group is only reported when it
-/// is shaped exactly like one this app creates: inside the school's `<PREFIX>-`
-/// namespace, a mail-enabled Microsoft 365 group, and answering on a nickname
-/// equal to its display name. A security group, a hand-made Team, or anything
-/// outside the namespace is left unmentioned rather than filling the Klasgroepen
-/// list with rows nobody will act on (the clutter #209/#225/#271 fixed).
+/// It is narrow, but no narrower than the linker's own orphan rule: an
+/// unmatched Azure group is reported when the name it answers on inside the
+/// school's `<PREFIX>-` namespace is *shaped like a class* — the one signal
+/// #228 made available and the only one [_staleClassGroup] reads (#312).
+/// Anything outside the namespace, and anything prefixed that is not
+/// class-shaped (`SSM-GOK`, `SSM-Personeel`), is left unmentioned rather than
+/// filling the Klasgroepen list with rows nobody will act on (the clutter
+/// #209/#225/#271 fixed).
 class AzureClassGroupWithoutClass extends GroupAction {
   const AzureClassGroupWithoutClass(super.group);
 
@@ -1065,15 +1067,12 @@ class AzureClassGroupWithoutClass extends GroupAction {
         system: Origin.azure,
         summary: 'Laat de Office 365-groep ${_azure?.displayName} staan — '
             'klas ${group.className} bestaat niet meer in WISA of Smartschool',
-        // Nothing is written here, so nothing moves: these two lines describe
-        // the group the operator is being told about (#305). Put through the
+        // Nothing is written here, so nothing moves: these lines describe the
+        // group the operator is being told about (#305). Put through the
         // before → after template they read `mail: GBS-9Z@… → ∅` and
         // `leden: 21 → ∅` — the address and the members going away, which is
         // what the *other* half of this either/or does.
-        fields: [
-          FieldChange.statement('mail', _azure?.mail ?? ''),
-          FieldChange.statement('leden', '${_azure?.memberIds.length ?? 0}'),
-        ],
+        fields: _staleGroupFacts(_azure),
       );
 
   @override
@@ -1093,12 +1092,11 @@ class AzureClassGroupWithoutClass extends GroupAction {
 /// files. Three things therefore hold it in place, and each of them is tested:
 ///
 /// - **It proposes on exactly the record the notice does**, via the one
-///   [_staleClassGroup] predicate — Azure-only, inside the school's `<PREFIX>-`
-///   namespace, a mail-enabled Microsoft 365 group whose nickname is its display
-///   name — plus one guard of its own: the recovered class name must be
-///   *shaped* like a class ([looksLikeClassName]). The linker already refuses to
-///   orphan anything else since #271, so that guard is belt-and-braces: a delete
-///   must not inherit its scope from a filter one layer away.
+///   [_staleClassGroup] predicate — Azure-only, and carrying a class name the
+///   linker recovered from inside the school's `<PREFIX>-` namespace — plus a
+///   restatement of that predicate's own shape guard ([looksLikeClassName]).
+///   The restatement is belt-and-braces and deliberately redundant: a delete
+///   must not inherit its whole scope from a predicate it does not spell out.
 /// - **It is never the selected option of a bulk pass**, because the notice
 ///   beside it is the default of their shared alternative group. The operator
 ///   flips this radio on one row, and only that row is written.
@@ -1144,8 +1142,7 @@ class DeleteAzureClassGroup extends GroupAction {
         // cleared — least of all `postvak, Teams en bestanden: verdwijnen
         // mee → ∅`, which was never a value in the first place.
         fields: [
-          FieldChange.statement('mail', _azure?.mail ?? ''),
-          FieldChange.statement('leden', '${_azure?.memberIds.length ?? 0}'),
+          ..._staleGroupFacts(_azure),
           const FieldChange.statement(
             'postvak, Teams en bestanden',
             'verdwijnen mee',
@@ -1191,16 +1188,47 @@ class DeleteAzureClassGroup extends GroupAction {
 /// they must fire together or a stale group is left with a lone applyable
 /// delete as its only reading, which is precisely the "no safe default" state
 /// [staleClassGroupAlternative] exists to prevent.
+///
+/// **It reads the linker's own orphan rule, not a second, stricter one**
+/// (#312). [LinkedGroup.className] on an Azure-only record is exactly the bare
+/// name `azureClassNameOf` recovered from the group's `displayName` *or* its
+/// `mailNickname` (#280), stamped by the linker only when that name is
+/// class-shaped. Testing that same name here is therefore the whole condition:
+/// the record is on screen because the linker judged it a stale class group,
+/// and this asks the identical question rather than a narrower one.
+///
+/// Two guards used to sit on top of it, and between them they silenced the
+/// delete on every group the operator most wanted it for:
+///
+/// - `azure.isUnified` — the class groups the **legacy WPF app** created are
+///   plain security groups with no address at all (`SSM-3ECO`, `SSM-3MRP`,
+///   `SSM-3MWW`, … are `securityEnabled: true, mail: null` in the live tenant),
+///   so the port refused to name any group it had not created itself. The
+///   `<PREFIX>-` namespace plus the class-name shape is what makes a group
+///   ours, not its mail-enablement — and `SSM-Personeel`, the security/plain
+///   pair the guard was worried about, fails the name shape on its own.
+/// - `mailNickname == displayName` — a group renamed by hand in the portal
+///   fails it, which re-derives the opposite of #280's conclusion that the
+///   address is the identity signal and the display name is not to be trusted.
 bool _staleClassGroup(LinkedGroup group) {
   final azure = group.azure;
   return group.wisa == null &&
       group.smartschool == null &&
       azure is az.AzureGroup &&
-      group.className != null &&
-      azure.isUnified &&
-      _sameName(azure.mailNickname, azure.displayName);
+      looksLikeClassName(group.className);
 }
 
-/// Trimmed, case-folded equality (INV-12) for the nickname/display-name check.
-bool _sameName(String? a, String? b) =>
-    a != null && b != null && a.trim().toLowerCase() == b.trim().toLowerCase();
+/// The facts both halves of [staleClassGroupAlternative] state about the group
+/// they are describing (#305) — stated, never diffed.
+///
+/// The address is stated only when there is one: a legacy class group is a
+/// security group carrying no `mail` (#312), and an empty statement renders as
+/// a bare `mail: ` under the heading — a label for a fact the group does not
+/// have.
+List<FieldChange> _staleGroupFacts(az.AzureGroup? azure) {
+  final mail = azure?.mail?.trim() ?? '';
+  return <FieldChange>[
+    if (mail.isNotEmpty) FieldChange.statement('mail', mail),
+    FieldChange.statement('leden', '${azure?.memberIds.length ?? 0}'),
+  ];
+}

--- a/packages/account_actions/lib/src/group_dispatch.dart
+++ b/packages/account_actions/lib/src/group_dispatch.dart
@@ -13,13 +13,16 @@ import 'group_placement.dart';
 /// - If the class is missing from WISA **or** Smartschool, the lifecycle-style
 ///   actions ([ClassExistsAsSmartschoolGroup], [AddToSmartschool],
 ///   [CreateInSmartschool], [DoNotImportFromWisa],
-///   [DoNotImportFromSmartschool]) are considered, so a WISA-only class raises
-///   [DoNotImportFromWisa] *and* exactly one of [AddToSmartschool] /
-///   [CreateInSmartschool]. Those two are not two to-dos: they share the
-///   [classImportAlternative] key, so the pending list renders them as one
-///   either/or choice and an apply runs only the picked one (#244). Legacy
-///   ordered [DoNotImportFromWisa] first; it now trails the create it is an
-///   alternative to, so the create leads the radio pair.
+///   [DoNotImportFromSmartschool], [DeleteSmartschoolClass]) are considered, so
+///   a WISA-only class raises [DoNotImportFromWisa] *and* exactly one of
+///   [AddToSmartschool] / [CreateInSmartschool]. Those two are not two to-dos:
+///   they share the [classImportAlternative] key, so the pending list renders
+///   them as one either/or choice and an apply runs only the picked one (#244).
+///   Legacy ordered [DoNotImportFromWisa] first; it now trails the create it is
+///   an alternative to, so the create leads the radio pair. A **Smartschool-only**
+///   class is the mirror image: it raises the [staleSmartschoolClassAlternative]
+///   pair of #313 — the informational [DoNotImportFromSmartschool] (leave it
+///   standing, the default) and the applyable [DeleteSmartschoolClass].
 /// - If it is present in both, only [ModifySmartschoolData] is considered.
 ///
 /// [ClassExistsAsSmartschoolGroup] (#225) sits where the two create actions
@@ -97,7 +100,12 @@ List<GroupAction> groupActionsFor(
       if (placement != null) AddToSmartschool(group, placement),
       if (placement != null) CreateInSmartschool(group, placement),
       DoNotImportFromWisa(group),
+      // The Smartschool-leftover either/or (#313), notice first for the same
+      // reason the create leads the blacklist above: the order is the order the
+      // operator reads the radios in, and the fallback the grouping uses if a
+      // default is ever forgotten — so the delete is never first.
       DoNotImportFromSmartschool(group),
+      DeleteSmartschoolClass(group),
     ],
     // The Office 365 group of a class is orthogonal to its Smartschool state,
     // so these ride alongside both branches (#228).

--- a/packages/account_actions/test/azure_class_group_test.dart
+++ b/packages/account_actions/test/azure_class_group_test.dart
@@ -556,8 +556,8 @@ void main() {
         final actions = groupActionsFor(
           orphan(azureClassGroup(name), className: name),
         );
-        expect(actions.whereType<DeleteAzureClassGroup>(), isEmpty,
-            reason: '$name is not a class');
+        expect(actions, isEmpty,
+            reason: '$name is not a class — and both halves move together');
       }
     });
 
@@ -568,31 +568,100 @@ void main() {
           reason: 'there is nothing to address the DELETE to');
     });
 
-    test('a security group or a hand-made Team is left unmentioned', () {
-      // Not mail-enabled ⇒ not a group this app created.
+    test(
+        'a class group the legacy app created raises the pair too — it is no '
+        'less stale for being a security group (#312)', () {
+      // The reported bug. The `SSM-3ECO`-shaped groups in the live tenant are
+      // plain security groups carrying no address at all, made by the WPF app
+      // long before this port existed. `isUnified` is false for every one of
+      // them, so the whole either/or went silent and each row was inventory
+      // with an instruction to go elsewhere — the state #271 set out to remove.
+      final actions = groupActionsFor(orphan(az.AzureGroup(
+        id: 'g-legacy',
+        displayName: 'SSM-9Z',
+        securityEnabled: true,
+        mailNickname: 'SSM-9Z',
+      )));
+
       expect(
-        groupActionsFor(orphan(az.AzureGroup(
-          id: 'g',
-          displayName: 'SSM-9Z',
-          securityEnabled: true,
-        ))),
-        isEmpty,
+        actions.map((a) => a.runtimeType),
+        [AzureClassGroupWithoutClass, DeleteAzureClassGroup],
+        reason: 'the delete may not be limited to groups this port created',
       );
-      // Mail-enabled, but its nickname is not the display name — somebody made
-      // it by hand.
       expect(
-        groupActionsFor(orphan(az.AzureGroup(
-          id: 'g',
-          displayName: 'SSM-Wiskunde',
-          mail: 'wiskunde@school.example',
-          mailNickname: 'wiskunde',
-        ))),
-        isEmpty,
+        actions.map((a) => a.alternativeGroup),
+        everyElement(staleClassGroupAlternative),
+        reason: 'widened together, so the delete is never a lone reading',
       );
-      // Outside our `<PREFIX>-` namespace ⇒ the linker never recovered a class
-      // name for it.
+    });
+
+    test('a group with no address states only the facts it has (#312)', () {
+      final actions = groupActionsFor(orphan(az.AzureGroup(
+        id: 'g-legacy',
+        displayName: 'SSM-9Z',
+        securityEnabled: true,
+        mailNickname: 'SSM-9Z',
+        memberIds: const ['az-1', 'az-2'],
+      )));
+
+      expect(
+        actions
+            .whereType<AzureClassGroupWithoutClass>()
+            .single
+            .describeChanges()
+            .fields
+            .map((f) => f.field),
+        ['leden'],
+        reason: 'a security group has no mail, and `mail: ` states nothing',
+      );
+      expect(
+        actions
+            .whereType<DeleteAzureClassGroup>()
+            .single
+            .describeChanges()
+            .fields
+            .map((f) => f.field),
+        ['leden', 'postvak, Teams en bestanden'],
+      );
+    });
+
+    test('a class group renamed by hand is still a stale class group (#312)',
+        () {
+      // The linker recovered `9Z` from the **nickname** (#280) — the address is
+      // what makes a group ours and the display name is not to be trusted.
+      // Requiring the two to be equal re-derived the opposite, stricter rule.
+      final actions = groupActionsFor(orphan(az.AzureGroup(
+        id: 'g-renamed',
+        displayName: 'Klas van juf An',
+        mail: 'SSM-9Z@student.school.example',
+        mailNickname: 'SSM-9Z',
+      )));
+
+      expect(
+        actions.map((a) => a.runtimeType),
+        [AzureClassGroupWithoutClass, DeleteAzureClassGroup],
+      );
+    });
+
+    test('a group the linker recovered no class name for is left unmentioned',
+        () {
+      // Outside our `<PREFIX>-` namespace ⇒ no class name was ever stamped on
+      // the record, so there is nothing here to call stale.
       expect(
         groupActionsFor(orphan(azureClassGroup('9Z'), className: null)),
+        isEmpty,
+      );
+      // Prefixed, but the remainder is a subject and not a class.
+      expect(
+        groupActionsFor(orphan(
+          az.AzureGroup(
+            id: 'g',
+            displayName: 'SSM-Wiskunde',
+            mail: 'wiskunde@school.example',
+            mailNickname: 'SSM-Wiskunde',
+          ),
+          className: 'Wiskunde',
+        )),
         isEmpty,
       );
     });

--- a/packages/account_actions/test/can_apply_to_all_test.dart
+++ b/packages/account_actions/test/can_apply_to_all_test.dart
@@ -68,10 +68,12 @@ bool _bulkApplyableGroup(GroupAction a) => switch (a) {
       ModifySmartschoolData() => true,
       CreateAzureClassGroup() => true,
       SyncAzureClassGroupMembers() => true,
-      // Withheld: a blacklist is a per-class judgement, a delete takes the
-      // mailbox, Team and files with it.
+      // Withheld: a blacklist is a per-class judgement, and a delete takes the
+      // mailbox, Team and files with it — or, in Smartschool, the class and
+      // everyone's membership of it.
       DoNotImportFromWisa() => false,
       DeleteAzureClassGroup() => false,
+      DeleteSmartschoolClass() => false,
       // Informational — cannot be applied at all.
       CreateInSmartschool() => false,
       ClassExistsAsSmartschoolGroup() => false,
@@ -139,6 +141,7 @@ List<GroupAction> _groupActions() {
     CreateInSmartschool(linked, placement),
     ClassExistsAsSmartschoolGroup(linked),
     DoNotImportFromSmartschool(linked),
+    DeleteSmartschoolClass(linked),
     ModifySmartschoolData(linked),
     CreateAzureClassGroup(linked, plan),
     SyncAzureClassGroupMembers(linked, plan),
@@ -243,6 +246,7 @@ void main() {
         RemoveStaffFromAzure,
         // Groups.
         DeleteAzureClassGroup,
+        DeleteSmartschoolClass,
         // The blacklists, which are destructive in effect: the record drops out
         // of the next WISA snapshot while what exists downstream survives.
         DontImportStaffFromWisa,
@@ -274,8 +278,8 @@ void main() {
           reason: 'StudentAction has 16 members');
       expect(_staffActions().map((a) => a.runtimeType).toSet(), hasLength(8),
           reason: 'StaffAction has 8 members');
-      expect(_groupActions().map((a) => a.runtimeType).toSet(), hasLength(10),
-          reason: 'GroupAction has 10 members');
+      expect(_groupActions().map((a) => a.runtimeType).toSet(), hasLength(11),
+          reason: 'GroupAction has 11 members');
     });
   });
 }

--- a/packages/account_actions/test/group_apply_test.dart
+++ b/packages/account_actions/test/group_apply_test.dart
@@ -123,6 +123,155 @@ void main() {
         throwsUnsupportedError,
       );
     });
+
+    test('it no longer sends the operator into Smartschool by hand (#313)', () {
+      // The dead end #271 removed on the Office 365 side: a row whose whole
+      // content was "go and do this somewhere else". The applyable delete now
+      // sits beside it, so the notice states the class instead of instructing.
+      final change =
+          DoNotImportFromSmartschool(linkedGroup(smartschool: ssGroup()))
+              .describeChanges();
+
+      expect(change.summary,
+          'Laat deze klas staan — ze bestaat in Smartschool maar niet in WISA');
+      expect(change.summary, isNot(contains('Verwijder ze manueel')));
+      expect(change.system, Origin.smartschool);
+      // Stated, never diffed: this half writes nothing, so nothing moves.
+      expect(change.fields.map((f) => '${f.field}:${f.before}'),
+          ['code:3A', 'omschrijving:Klas 3A']);
+      expect(
+        change.fields.every((f) => f.shape == FieldChangeShape.statement),
+        isTrue,
+      );
+      expect(change.fields.every((f) => f.after == null), isTrue);
+    });
+
+    test('a class with no description states only the facts it has (#313)', () {
+      final change = DoNotImportFromSmartschool(
+        linkedGroup(smartschool: ssGroup(description: '')),
+      ).describeChanges();
+      expect(change.fields.map((f) => f.field), ['code'],
+          reason: 'an empty statement renders as a bare `omschrijving: `');
+    });
+  });
+
+  group('a Smartschool class WISA does not have is one choice (#313)', () {
+    test('the notice and the delete are raised as one either/or', () {
+      final actions = groupActionsFor(linkedGroup(smartschool: ssGroup()));
+
+      expect(
+        actions.map((a) => a.runtimeType),
+        [DoNotImportFromSmartschool, DeleteSmartschoolClass],
+        reason: 'the notice leads, so the delete is never the fallback pick',
+      );
+      expect(
+        actions.map((a) => a.alternativeGroup),
+        everyElement(staleSmartschoolClassAlternative),
+        reason: 'both halves fire on the one predicate, or the delete is a '
+            'lone reading with no safe default beside it',
+      );
+      expect(
+        actions.where((a) => a.isDefaultAlternative).single,
+        isA<DoNotImportFromSmartschool>(),
+      );
+    });
+
+    test('the delete describes what goes with the class', () {
+      final change = DeleteSmartschoolClass(linkedGroup(smartschool: ssGroup()))
+          .describeChanges();
+
+      expect(change.system, Origin.smartschool);
+      expect(change.summary,
+          'Verwijder de klas 3A uit Smartschool — ze bestaat niet in WISA');
+      expect(
+        change.fields.map((f) => f.field),
+        ['code', 'omschrijving', 'lidmaatschappen en subgroepen'],
+      );
+      expect(
+        change.fields.every((f) => f.shape == FieldChangeShape.statement),
+        isTrue,
+        reason: 'an inventory of what goes, not three fields being cleared',
+      );
+    });
+
+    test('apply calls delClass with the class code and reports it removed',
+        () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = DeleteSmartschoolClass(
+        // The code differs from the name on purpose: `delClass` takes the code.
+        linkedGroup(smartschool: ssGroup(code: 'C3A', name: '3A')),
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+
+      expect(result.outcome, ActionOutcome.applied);
+      expect(result.system, Origin.smartschool);
+      expect(result.removed, isTrue,
+          reason: 'the State layer drops it from the snapshot');
+      expect(result.group, isNull, reason: 'a delete carries no record back');
+      expect(transport.calledMethod('delClass'), isTrue);
+      expect(transport.envelopes.single, contains('C3A'));
+      expect(transport.envelopes.single, isNot(contains('>3A<')),
+          reason: 'the class is addressed by its code, not its name');
+    });
+
+    test('a dry run of the delete writes nothing (PAIN-3)', () async {
+      final transport = RecordingSmartschoolTransport();
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = DeleteSmartschoolClass(
+        linkedGroup(smartschool: ssGroup(code: 'C3A')),
+      );
+
+      final result = await action.apply(connectors, ApplyOptions.dry);
+
+      expect(result.outcome, ActionOutcome.dryRun);
+      expect(result.removed, isTrue);
+      expect(transport.soapActions, isEmpty);
+    });
+
+    test('a refused delClass surfaces as a failure (INV-41)', () async {
+      final transport = RecordingSmartschoolTransport(resultCode: 1);
+      final connectors =
+          Connectors(smartschool: smartschoolConnector(transport));
+      final action = DeleteSmartschoolClass(
+        linkedGroup(smartschool: ssGroup(code: 'C3A')),
+      );
+
+      final result = await action.apply(connectors, const ApplyOptions());
+
+      expect(result.outcome, ActionOutcome.failed);
+      expect(result.error, isNotNull);
+      expect(result.removed, isFalse,
+          reason: 'nothing was removed, so nothing may be dropped');
+    });
+
+    test('a record naming no class code raises no delete', () {
+      final actions =
+          groupActionsFor(linkedGroup(smartschool: ssGroup(code: ' ')));
+      expect(actions.whereType<DoNotImportFromSmartschool>(), hasLength(1));
+      expect(actions.whereType<DeleteSmartschoolClass>(), isEmpty,
+          reason: 'there is nothing to address the delClass to');
+    });
+
+    test('an organisational group is never offered for deletion', () {
+      // The linker only ever seeds an orphan from an *official* class, so this
+      // shape does not reach the dispatch — but a delete must not inherit its
+      // whole scope from a filter one layer away.
+      final actions = groupActionsFor(
+        linkedGroup(smartschool: ssGroupNode(code: 'leerlingen')),
+      );
+      expect(actions.whereType<DeleteSmartschoolClass>(), isEmpty);
+    });
+
+    test('a class WISA still has is offered no delete', () {
+      expect(
+        groupActionsFor(fullySyncedGroup()).whereType<DeleteSmartschoolClass>(),
+        isEmpty,
+      );
+    });
   });
 
   group('ModifySmartschoolData converges a drifted Untis code (#65)', () {

--- a/packages/account_actions/test/group_dispatch_test.dart
+++ b/packages/account_actions/test/group_dispatch_test.dart
@@ -128,9 +128,15 @@ void main() {
       expect(actions, isEmpty);
     });
 
-    test('Smartschool only → DoNotImportFromSmartschool (informational)', () {
+    test('Smartschool only → the leave-it/delete-it pair (#313)', () {
+      // The notice used to stand alone and tell the operator to go and delete
+      // the class by hand in Smartschool — a row whose whole content was an
+      // instruction to go elsewhere.
       final actions = groupActionsFor(linkedGroup(smartschool: ssGroup()));
-      expect(actions.map((a) => a.runtimeType), [DoNotImportFromSmartschool]);
+      expect(
+        actions.map((a) => a.runtimeType),
+        [DoNotImportFromSmartschool, DeleteSmartschoolClass],
+      );
     });
 
     test('orphan group with neither WISA nor Smartschool → no action', () {
@@ -209,9 +215,28 @@ void main() {
       expect(actions.single.alternativeGroup, isNull);
     });
 
-    test('the Smartschool-only orphan notice stands on its own', () {
+    test('the Smartschool-only orphan notice leads a choice of its own (#313)',
+        () {
+      // A key of its own, for the reason the namesake pair has one: the pending
+      // list bulk-applies per situation key, and "this Smartschool class is not
+      // in WISA" is not the situation "this WISA class is not in Smartschool".
       final actions = groupActionsFor(linkedGroup(smartschool: ssGroup()));
-      expect(actions.single.alternativeGroup, isNull);
+      final notice = actions.whereType<DoNotImportFromSmartschool>().single;
+      final delete = actions.whereType<DeleteSmartschoolClass>().single;
+
+      expect(notice.alternativeGroup, staleSmartschoolClassAlternative);
+      expect(delete.alternativeGroup, staleSmartschoolClassAlternative);
+      expect(notice.alternativeGroup, isNot(classImportAlternative));
+      expect(notice.alternativeGroup, isNot(staleClassGroupAlternative));
+
+      // Polarity: the informational notice leads and is the default, so a bulk
+      // apply writes *nothing* for a Smartschool leftover and the delete stays
+      // a deliberate, per-row pick.
+      expect(notice.isDefaultAlternative, isTrue);
+      expect(notice.canApply, isFalse);
+      expect(delete.isDefaultAlternative, isFalse);
+      expect(delete.canApplyToAll, isFalse);
+      expect(actions.indexOf(notice), lessThan(actions.indexOf(delete)));
     });
 
     test('the namesake notice (#225) leads a choice of its own (#250)', () {

--- a/packages/account_actions/test/support/fixtures.dart
+++ b/packages/account_actions/test/support/fixtures.dart
@@ -461,6 +461,10 @@ class RecordingSmartschoolTransport implements ss.SmartschoolSoapTransport {
   /// name). Empty after a dry run.
   final List<String> soapActions = [];
 
+  /// The request envelope of every call, in order — so a test can assert which
+  /// record a write was addressed to, not merely that a write happened.
+  final List<String> envelopes = [];
+
   /// When set, the integer result to return (non-zero = failure). Applied to
   /// every write for which [resultFor] returns null.
   final int resultCode;
@@ -483,6 +487,7 @@ class RecordingSmartschoolTransport implements ss.SmartschoolSoapTransport {
     required String envelope,
   }) async {
     soapActions.add(soapAction);
+    envelopes.add(envelope);
     final code = resultFor?.call(soapAction) ?? resultCode;
     return '<?xml version="1.0" encoding="utf-8"?>'
         '<soap:Envelope '

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -522,6 +522,56 @@ void main() {
     });
 
     test(
+        'a legacy security class group whose class is gone is an orphan all '
+        'the same (#312)', () {
+      // What the WPF app left behind: a plain security group with no address,
+      // named `<PREFIX>-<KLAS>` like every other class group. The naming
+      // convention is the signal (#228), so mail-enablement decides nothing
+      // here — and the class name it carries is what the stale-group either/or
+      // on the action side reads.
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('2A')]),
+        ssSnap(const []),
+        azSnap(const [], groups: [
+          azureGroup('$_prefix-9Z',
+              securityEnabled: true, memberIds: const ['az-oud']),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final orphan = snapshot.groups.firstWhere((g) => g.wisa == null);
+      expect(orphan.azure!.displayName, '$_prefix-9Z');
+      expect(orphan.className, '9Z');
+    });
+
+    test(
+        'a renamed group whose class is gone stays an orphan by its nickname '
+        '(#280/#312)', () {
+      // The #280 leg, on a class that no longer runs: the display name says
+      // nothing, the address still says `<PREFIX>-8Y`, and the record reaches
+      // the inventory carrying `8Y` as its class name.
+      final snapshot = link(
+        wisaSnap(const [], classGroups: [wisaClassGroup('2A')]),
+        ssSnap(const []),
+        azSnap(const [], groups: [
+          azureGroup(
+            'Klas van juf An',
+            id: 'g-renamed',
+            mail: '$_prefix-8Y@student.s.be',
+            mailNickname: '$_prefix-8Y',
+          ),
+        ]),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final orphan = snapshot.groups.firstWhere((g) => g.wisa == null);
+      expect(orphan.azure!.id, 'g-renamed');
+      expect(orphan.className, '8Y');
+    });
+
+    test(
         'the prefix strip never turns a staff group into a class orphan '
         '(#228)', () {
       final snapshot = link(

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -186,12 +186,14 @@ Group ssGroup(
 /// An Azure group, matched to WISA by [displayName] — prefix-aware for a class
 /// group, so `Arcadia-2A` is the group of class `2A` (#228). [id] defaults to
 /// [displayName]. Pass [mail]/[mailNickname] to make it a *unified* group, the
-/// shape a class group has.
+/// shape a class group this app creates has; pass [securityEnabled] for the
+/// plain security group the legacy WPF app created its class groups as (#312).
 az.AzureGroup azureGroup(
   String displayName, {
   String? id,
   String? mail,
   String? mailNickname,
+  bool securityEnabled = false,
   List<String> memberIds = const [],
 }) =>
     az.AzureGroup(
@@ -199,6 +201,7 @@ az.AzureGroup azureGroup(
       displayName: displayName,
       mail: mail,
       mailNickname: mailNickname,
+      securityEnabled: securityEnabled,
       memberIds: memberIds,
     );
 

--- a/packages/account_state/lib/src/apply/state_applier.dart
+++ b/packages/account_state/lib/src/apply/state_applier.dart
@@ -327,6 +327,7 @@ class StateApplier {
     final result = await action.apply(connectors, options);
     return _refresh(
       result,
+      // The Smartschool class `DeleteSmartschoolClass` removes (#313).
       removedGroupId: action.target.smartschool?.id,
       // The Office 365 group `DeleteAzureClassGroup` removes (#271). A delete
       // carries no record back, so the key comes off the bound target — and it
@@ -709,9 +710,12 @@ ss.SmartschoolSnapshot _dropFromSmartschool(
 }) {
   return ss.SmartschoolSnapshot(
     fetchedAt: current.fetchedAt,
-    // Drop the group by id (no group-delete action ships yet, so this is a
-    // defensive branch), else drop the account and its now-dangling
-    // memberships by uid.
+    // Drop the group by id — the class `DeleteSmartschoolClass` removes
+    // (#313), so the relink sees the leftover gone instead of re-raising the
+    // very pair the operator just resolved — else drop the account and its
+    // now-dangling memberships by uid. A deleted class's memberships are left
+    // where they are: `PlacementResolver` resolves each one through the group
+    // list and skips the ones that no longer land anywhere.
     groups: groupId == null
         ? current.groups
         : [

--- a/packages/account_state/test/state_applier_test.dart
+++ b/packages/account_state/test/state_applier_test.dart
@@ -213,13 +213,26 @@ wapi.WisaSnapshot _wSnap({
       schools: const [],
     );
 
-ss.SmartschoolSnapshot _sSnap(
-        {List<ss.SmartschoolAccount> accounts = const []}) =>
+ss.SmartschoolSnapshot _sSnap({
+  List<ss.SmartschoolAccount> accounts = const [],
+  List<core.Group> groups = const [],
+}) =>
     ss.SmartschoolSnapshot(
       fetchedAt: _d,
-      groups: const [],
+      groups: groups,
       accounts: accounts,
       memberships: const [],
+    );
+
+/// An **official** Smartschool class, the only shape the linker ever seeds a
+/// Smartschool orphan record from.
+core.Group _ssClass(String name, {String? code}) => core.Group(
+      id: core.GroupId(code ?? name),
+      name: name,
+      description: 'Klas $name',
+      type: core.GroupType.classGroup,
+      official: true,
+      origin: core.Origin.smartschool,
     );
 
 az.AzureSnapshot _aSnap({
@@ -1033,6 +1046,80 @@ void main() {
           everyElement(contains('ledenbestand')),
         );
       });
+    });
+  });
+
+  group('Smartschool classes WISA does not have (#313)', () {
+    /// Two official Smartschool classes and a WISA snapshot that only knows one
+    /// of them: `9Z` is the leftover, and the relink raises the
+    /// leave-it/delete-it pair on it.
+    _Harness leftoverHarness() => _Harness(
+          wisa: _wSnap(
+            students: [_wStudent(wisaId: 'W1', classGroup: '2A')],
+            classGroups: [
+              const wapi.WisaClassGroup(
+                name: '2A',
+                groupName: '00',
+                description: 'Klas 2A',
+                adminCode: '',
+                schoolCode: '123',
+                schoolId: 1,
+              ),
+            ],
+          ),
+          smartschool: _sSnap(
+            groups: [_ssClass('2A'), _ssClass('9Z', code: 'C9Z')],
+          ),
+        );
+
+    test('deleting a leftover class drops it from the snapshot', () async {
+      // The Smartschool twin of the #271 delete: applying it has to remove the
+      // *group* from the Smartschool snapshot, or the relink re-raises the very
+      // pair the operator just resolved.
+      final harness = leftoverHarness();
+      final before = await harness.applier.link();
+      final delete =
+          before.groupActions.whereType<DeleteSmartschoolClass>().single;
+
+      final applied = await harness.applier.applyGroup(delete);
+
+      expect(applied.result.outcome, ActionOutcome.applied);
+      expect(applied.refreshed, isTrue);
+      expect(harness.soap.soapActions.single, contains('delClass'));
+      expect(
+        harness.app.smartschool.snapshot!.groups.map((g) => g.id.value),
+        ['2A'],
+        reason: 'only the leftover goes — no re-sync (#72)',
+      );
+      expect(applied.followUps, isEmpty, reason: 'nothing follows a delete');
+      expect(
+        applied.linked!.groupActions.whereType<DeleteSmartschoolClass>(),
+        isEmpty,
+        reason: 'the leftover is gone from the relinked view',
+      );
+      expect(
+        applied.linked!.groupActions.whereType<DoNotImportFromSmartschool>(),
+        isEmpty,
+        reason: 'and so is the notice that was its alternative',
+      );
+      expect(harness.counts, [0, 0, 0], reason: 'nothing was re-pulled');
+    });
+
+    test('a dry run writes nothing and patches nothing', () async {
+      final harness = leftoverHarness();
+      final before = await harness.applier.link();
+      final delete =
+          before.groupActions.whereType<DeleteSmartschoolClass>().single;
+
+      final applied = await harness.applier.applyGroup(
+        delete,
+        options: const ApplyOptions(dryRun: true),
+      );
+
+      expect(applied.result.outcome, ActionOutcome.dryRun);
+      expect(applied.refreshed, isFalse);
+      expect(harness.soap.soapActions, isEmpty);
+      expect(harness.app.smartschool.snapshot!.groups, hasLength(2));
     });
   });
 


### PR DESCRIPTION
Five issues in one chunk: three successive refinements of the Acties screen, then the two halves of the stale class-group either/or.

## What changed

- **#309** — `_ActionsHeader` is now just the `Arcadia · acties` eyebrow. The title, count line, Klasgroepen pointer and freshness stamp are gone, and the dead class-inventory pre-read behind the pointer went with them (it was a partition read per cold visit that nothing rendered). The freshness/pointer coverage moved to Klasgroepen, where those lines still render.
- **#310** — the name search box and the "Toon enkel accounts met acties" switch share one `Wrap` row, the box bounded by `ConstrainedBox(maxWidth: 380)` so a narrow window shrinks it instead of overflowing.
- **#311** — the select-all bar, the per-row checkboxes and *all* the selection state behind them (from #297) are deleted. Nothing outside the screen read that state. Risky actions go back to one-at-a-time from the detail pane; #296's cohort review is the only bulk path left.
- **#312** — `_staleClassGroup` demanded `isUnified` **and** `mailNickname == displayName` on top of the linker's orphan rule, which silenced the notice/delete pair on exactly the legacy security groups that fill the live tenant (`SSM-3ECO`, `SSM-3MRP`, … are all `securityEnabled: true, mail: null`). It now reads the linker's own class-shaped `className`. `mail` is stated only when the group has one, instead of rendering a dangling `mail: ` label.
- **#313** — new `staleSmartschoolClassAlternative` key with a `DeleteSmartschoolClass` action, mirroring the shape #312 left: notice as default, delete non-default with `canApplyToAll == false`, guarded on a non-blank class code, and addressed to the class **code** rather than its name. `DoNotImportFromSmartschool` is reworded to match its Azure counterpart. The state applier's Smartschool group-drop branch, defensive since #271, becomes a real path.

Both either/ors surface on Klasgroepen through the generic `alt-<target>-<kind>` radios, so neither touches the Acties rework above.

The three layout commits each moved the account list further up the page and re-measured the pins rather than leaving them slack: the widget head-block pin went 422 → 366 → 240 (threshold now `lessThan(260)`), and the 1080p e2e pin 575 → 373 → 325 → 218 (threshold now `lessThan(1080/4)`).

## Test plan

Every commit passed the full local gates on its own — `dart format --set-exit-if-changed`, `flutter analyze` / `dart analyze --fatal-infos --fatal-warnings`, the whole unit + widget suite, and the touched integration file run individually.

- `dart format --set-exit-if-changed .` — clean, 319 files, on every commit
- `flutter analyze` — clean on every commit
- Unit/package suites at the tip: 1433 package tests pass (11 skipped — the opt-in live tests), 566 `account_manager` widget tests pass
- `flutter test integration_test/app_launch_test.dart -d windows` — 119 pass at the tip (116 → 117 → 117 → 118 → 119 as each commit added its own)
- Every new test was confirmed **failing on the unpatched code** before being accepted: the #309 header layout e2e (list top 575 vs. threshold 432), the #310 one-row widget + e2e pair, the #311 leavers-sweep e2e (found `account-check-p0`), the #312 predicate at both layers (3 unit + 1 e2e), and the #313 e2e.

New coverage worth naming: a widget test that the September leavers sweep still works one-account-at-a-time from the detail pane after #311 removed the bulk affordance, and a 900px-wide e2e that #310's row folds without spilling and the wrapped switch still filters.

## Notes

- #311 adapted rather than deleted the #299 test "a bulk pass holds every account it settled" — it drove its multi-account pass through the select-all bar, and no remaining UI affordance can replace it, so it now starts the pass on the controller and asserts the screen's response, with the reason written into the test.
- #313 records (and pins with a widget test) that the Klasgroepen cohort header counts `canApply` on the *selected* option, not `canApplyToAll`, so flipping one row to a delete reads "Alles toepassen (1)". Pre-existing and identical for `DeleteAzureClassGroup` since #271; it writes only the flipped row.

Closes #309
Closes #310
Closes #311
Closes #312
Closes #313
