### PR TITLE
Azure drift re-read, delta hygiene, and linker id collisions (#315-#319, #321)

### DIFF
--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -9046,6 +9046,180 @@ void main() {
   });
 
   testWidgets(
+      'a delta row that hands an account to another school stops the app '
+      'proposing writes against it (#317)', (WidgetTester tester) async {
+    // The report: Graph says an account moved out of our school and the snapshot
+    // goes on insisting it is ours. `_walkDelta` merges the sparse row onto the
+    // record we hold and then keeps it only if the merged record still passes
+    // the school test — and when it does not, the row was simply thrown away.
+    // Applied as an upsert, "thrown away" means *nothing happens*: our own copy
+    // survives with the `companyName` it had, and every later pass reaches the
+    // same verdict about the same row, so the contradiction never resolves.
+    //
+    // Two students in one pass, because the fix has two legs that have to agree:
+    //
+    // - **Jane** is gone from the group — no WISA anywhere, no Smartschool — and
+    //   another school has claimed her Office 365 account. While our stale copy
+    //   still carries `GBS`, `RemoveStudentFromAzure` evaluates true, so Acties
+    //   offers a **delete** against an account SSM now owns. That is the danger
+    //   the snapshot hygiene is really about.
+    // - **Tom** is still ours in WISA; the same claim landed on his account by
+    //   mistake. He leaves on the delta leg and comes straight back on the
+    //   `employeeId` back-fill (#224) — with the record as Graph holds it, so
+    //   what the operator is offered is putting *our* school back.
+    //
+    // Only this layer sees it: it needs the seeded snapshot and its token to make
+    // the pass incremental, the production Azure pull to run both legs in one
+    // pass, the linker to rebuild both records, and the action engine to turn the
+    // result into what Acties shows.
+    useTallWindow(tester);
+    final azureWire = SchoolMovedUserGraph(
+      // Exactly what Graph sends when other software rewrites one property.
+      rows: <Map<String, dynamic>>[
+        <String, dynamic>{'id': 'az1', 'companyName': 'SSM'},
+        <String, dynamic>{'id': 'az2', 'companyName': 'SSM'},
+      ],
+      // Tom's account as Graph holds it — the answer to the targeted lookup the
+      // pass makes for the id WISA still places here.
+      backfill: <Map<String, dynamic>>[
+        <String, dynamic>{
+          'id': 'az2',
+          'userPrincipalName': 'tom.peeters@student.school.example',
+          'employeeId': '2',
+          'displayName': 'Tom Peeters',
+          'givenName': 'Tom',
+          'surname': 'Peeters',
+          'companyName': 'SSM',
+          'accountEnabled': true,
+        },
+      ],
+    );
+    final tomAzure = azUser(
+      id: 'az2',
+      upn: 'tom.peeters@student.school.example',
+      employeeId: '2',
+      displayName: 'Tom Peeters',
+      givenName: 'Tom',
+      surname: 'Peeters',
+    );
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(
+        // Jane is not here at all; Tom is, in 3C.
+        students: [
+          wisaStudent(
+            wisaId: '2',
+            classGroup: '3C',
+            firstName: 'Tom',
+            name: 'Peeters',
+          ),
+        ],
+        schools: [wisaSchool(1)],
+        classGroups: [wisaClassGroup('3C', adminCode: 'a3')],
+      ),
+      smartschool: ssSnap(
+        groups: [ssGroup('3C', code: '3C_ss', untis: '3C')],
+        accounts: [
+          ssAccount(
+            uid: 'tom',
+            accountId: '2',
+            mail: 'tom.peeters@student.school.example',
+            givenName: 'Tom',
+            surname: 'Peeters',
+          ),
+        ],
+        memberships: [member('tom', '3C_ss')],
+      ),
+      azureTransport: azureWire,
+      // Last night's snapshot: both accounts still stamped with our school, and
+      // the token this pass resumes from.
+      azureInitial: azSnap(
+        deltaToken: 'AZ-TOKEN',
+        users: [azUser(displayName: 'Jane Doe'), tomAzure],
+      ),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    // Yesterday's session: the seeded Azure snapshot is reused untouched, its
+    // token unspent — so the linked view is built on the stale copies.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(azureWire.resumeTokens, isEmpty);
+
+    // And there is the dangerous one, on screen: a delete proposed for an
+    // account we no longer own. Tom has nothing to do — he is in step.
+    await tester.tap(find.text('Acties'));
+    await tester.pumpAndSettle();
+    final phantom = harness.controller.pendingEntries
+        .singleWhere((e) => e.family == 'student');
+    expect(
+      phantom.choices.map((c) => c.selected.changes.summary),
+      <String>['Verwijder Azure account'],
+    );
+    await selectAccount(tester, phantom.targetId);
+    expect(find.text('Verwijder Azure account'), findsOneWidget);
+
+    // Today: the operator flips a school **beheerd** in Instellingen, so the next
+    // Synchroniseer re-pulls Azure (#259) — incrementally, from the stored token.
+    // Since #316 that is the pass which resumes a delta at all; Controleer op
+    // drift re-reads in full, and a full read never sees this row.
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    harness.markSchoolManaged(1);
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // The pass really was the incremental one, so the delta walk really was the
+    // only thing that could have carried the news — and the back-fill asked
+    // about exactly the id WISA still places here, never about Jane.
+    expect(azureWire.resumeTokens, <String>['AZ-TOKEN']);
+    expect(azureWire.bulkReads, 0);
+    expect(azureWire.employeeIdLookups, <String>["employeeId in ('2')"]);
+
+    // Jane is out of the snapshot; Tom is back in it, as Graph holds him.
+    expect(harness.app.azure.snapshot!.users.single,
+        tomAzure.copyWith(companyName: 'SSM'));
+
+    // Which is what the operator sees. The delete against SSM's account is gone
+    // — and it is gone because the record is, not because some other rule
+    // happened to mask it.
+    expect(
+        harness.controller.linked!.snapshot.accounts
+            .where((a) => a.azure?.id == 'az1'),
+        isEmpty);
+    await tester.tap(find.text('Acties'));
+    await tester.pumpAndSettle();
+    expect(find.text('Verwijder Azure account'), findsNothing);
+
+    // And Tom's account, which Graph really did move, is now offered the repair
+    // it needs instead of being silently believed to be fine.
+    final repair = harness.controller.pendingEntries
+        .singleWhere((e) => e.family == 'student');
+    expect(
+      repair.choices.map((c) => c.selected.changes.summary),
+      <String>['Wijzig de school in Azure'],
+    );
+    await selectAccount(tester, repair.targetId);
+    expect(find.text('Wijzig de school in Azure'), findsOneWidget);
+
+    // The Log panel counts what happened, so a pass that handed accounts over is
+    // distinguishable from an uneventful one afterwards.
+    expect(
+      harness.log.entries.map((e) => e.message),
+      contains('Azure: delta voor "GBS" — 0 gewijzigd, 0 verwijderd, '
+          '2 niet langer van onze school.'),
+    );
+  });
+
+  testWidgets(
       'a staff member who left WISA still gets their Office 365 account '
       'proposed for deletion (#269)', (WidgetTester tester) async {
     // The other half of #268, and the worse one. Anna Smit has left the school:

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -8339,7 +8339,7 @@ void main() {
   });
 
   testWidgets(
-      'a Check for drift whose stored Azure delta token Graph refuses still '
+      'an Azure re-pull whose stored delta token Graph refuses still '
       'finishes, on a full re-read that leaves a usable token behind, and '
       'reads as the clean pass it was (#213/#229)',
       (WidgetTester tester) async {
@@ -8377,9 +8377,14 @@ void main() {
     await tester.pumpAndSettle();
     expect(azureWire.resumeTokens, isEmpty);
 
-    // Today: Check for drift, which is what re-reads Azure.
-    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-drift')));
-    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    // Today: the operator flips a school **beheerd** in Instellingen, so the
+    // next Synchroniseer re-pulls Azure (#259) — incrementally, from the token
+    // the session holds. That is the pass a refusal can still happen on:
+    // **Controleer op drift** drops the stored token by design since #316, so
+    // it never sends one to be refused.
+    harness.markSchoolManaged(1);
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
 
     // The pass finished instead of dying: no inline failure, not busy, and the
@@ -8446,10 +8451,11 @@ void main() {
       )),
     );
 
-    // A second drift check resumes from that fresh token: the recovery restored
+    // A second such pass resumes from that fresh token: the recovery restored
     // incremental syncing rather than condemning the app to full reads.
-    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-drift')));
-    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    harness.markSchoolManaged(2);
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
     expect(azureWire.resumeTokens, <String>['DEADTOKEN', 'FRESH-DELTA-TOKEN']);
     expect(azureWire.bulkReads, 1, reason: 'no second full read');
@@ -8776,10 +8782,14 @@ void main() {
     await tester.pumpAndSettle();
     expect(azureWire.resumeTokens, isEmpty);
 
-    // Today: Check for drift, which is what re-reads Azure — incrementally,
-    // from the stored token.
-    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-drift')));
-    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    // Today: the operator flips a school **beheerd** in Instellingen, so the
+    // next Synchroniseer re-pulls Azure (#259) — incrementally, from the stored
+    // token. That is the pass this bug lives on: **Controleer op drift** re-reads
+    // in full since #316, and a full read is not what the delta walk has to
+    // survive.
+    harness.markSchoolManaged(1);
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
     expect(harness.controller.error, isNull);
 
@@ -8813,8 +8823,8 @@ void main() {
   });
 
   testWidgets(
-      'an edit made by hand in Office 365 shows up on the very next Controleer '
-      'op drift, with the rest of the account intact (#288)',
+      'an edit made by hand in Office 365 shows up on the very next incremental '
+      'Azure pull, with the rest of the account intact (#288)',
       (WidgetTester tester) async {
     // The report: an administrator renames someone in the Entra portal, the
     // operator presses Controleer op drift, and nothing happens — the log says
@@ -8827,6 +8837,11 @@ void main() {
     // no `$select`, so every resumed row came back as `{id, <what changed>}`.
     // Read as a whole user such a row names no school, and the connector's
     // client-side prefix test dropped it.
+    //
+    // (The report came from **Controleer op drift**, which was the only pass
+    // that re-read Azure at the time. Since #316 that button drops the token and
+    // re-reads in full, so the incremental pass this bug lives on is reached the
+    // way the sync below reaches it — the walk itself is unchanged.)
     //
     // Only this layer sees the whole thing: it needs the stored token and the
     // seeded snapshot to make the pass incremental, the merge to keep the record
@@ -8882,10 +8897,14 @@ void main() {
           'entirely the hand-edit',
     );
 
-    // Today: Check for drift, the only route to an Azure read in normal
-    // operation — and incrementally, from the stored token.
-    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-drift')));
-    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    // Today: the operator flips a school **beheerd** in Instellingen, so the
+    // next Synchroniseer re-pulls Azure (#259) — incrementally, from the stored
+    // token. Since #316 that is the pass which resumes a delta at all;
+    // **Controleer op drift** re-reads in full, and a sparse resumed row is
+    // precisely what a full read never has to cope with.
+    harness.markSchoolManaged(1);
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
     await tester.pumpAndSettle();
     expect(harness.controller.error, isNull);
 
@@ -8920,6 +8939,113 @@ void main() {
   });
 
   testWidgets(
+      'Controleer op drift re-reads Azure in full, so a stale field no delta '
+      'could ever report is repaired and the phantom action goes away (#316)',
+      (WidgetTester tester) async {
+    // The report (#315): Acties offers `Office 365 · Wijzig de school in Azure`
+    // for a student whose Azure account already carries the school — and the
+    // proposal survives **Controleer op drift**, pass after pass, because the
+    // pass ran the ordinary incremental pull. `/users/delta` reports what
+    // changed *since our token*, which is precisely not "what does Azure hold
+    // right now": an edit older than the token, or one an earlier walk dropped,
+    // is unreachable forever. The only things that ever forced a full read were
+    // accidents (a token Graph refused, #213; a changed prefix, #246), neither
+    // of which an operator can ask for.
+    //
+    // Only this layer sees it: it needs the seeded snapshot and its token to
+    // make the pass incremental, the production Azure pull to decide which leg
+    // to take, the linker to rebuild the record, and the action engine to stop
+    // offering the write — which is the thing the operator was actually looking
+    // at.
+    useTallWindow(tester);
+    // Graph holds her with our school on it; the app's stored copy says another.
+    // Everything else about the account is in step, so the school is the only
+    // thing this pass can be about.
+    final azureWire = DriftedUserGraph(user: azUser(displayName: 'Jane Doe'));
+    final harness = ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(wisaId: '1', classGroup: '3C')],
+        schools: [wisaSchool(1)],
+        classGroups: [wisaClassGroup('3C', adminCode: 'a3')],
+      ),
+      smartschool: ssSnap(
+        groups: [ssGroup('3C', code: '3C_ss', untis: '3C')],
+        accounts: [ssAccount()],
+        memberships: [member('jane', '3C_ss')],
+      ),
+      azureTransport: azureWire,
+      // Last night's snapshot, holding the school she was at *before* the
+      // transfer — and the token whose walks all missed the correction.
+      azureInitial: azSnap(
+        deltaToken: 'AZ-TOKEN',
+        users: [azUser(displayName: 'Jane Doe', companyName: 'SBE')],
+      ),
+    );
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    // The seeded Azure snapshot is reused untouched, its token unspent — so the
+    // linked view is built on the stale copy, exactly as the operator's was.
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(azureWire.resumeTokens, isEmpty);
+    expect(azureWire.bulkReads, 0);
+
+    // And there is the phantom, on screen, the way it was reported.
+    await tester.tap(find.text('Acties'));
+    await tester.pumpAndSettle();
+    final stale = harness.controller.pendingEntries
+        .singleWhere((e) => e.family == 'student');
+    expect(
+      stale.choices.map((c) => c.selected.changes.summary),
+      <String>['Wijzig de school in Azure'],
+    );
+    await selectAccount(tester, stale.targetId);
+    expect(find.text('Wijzig de school in Azure'), findsOneWidget);
+
+    // So the operator does the one thing the screen offers for exactly this:
+    // Controleer op drift.
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.tap(find.byKey(const ValueKey('reconcile-drift')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // The pass asked Azure what it holds *now*: the stored token was not sent,
+    // the `$filter`-scoped bulk read ran, and a fresh token was left behind. The
+    // delta this wire would have answered reports nothing at all, so before
+    // #316 every one of these passes was a no-op.
+    expect(azureWire.resumeTokens, isEmpty);
+    expect(azureWire.bulkReads, 1);
+    expect(harness.app.azure.snapshot?.deltaToken, 'AZ-NEXT');
+    expect(harness.app.azure.snapshot?.users.single.companyName, 'GBS');
+
+    // Which is the whole point: the action the operator was staring at is gone,
+    // and no PATCH that would have changed nothing is offered for bulk apply.
+    expect(
+      harness.controller.pendingEntries.where((e) => e.family == 'student'),
+      isEmpty,
+    );
+    await tester.tap(find.text('Acties'));
+    await tester.pumpAndSettle();
+    expect(find.text('Wijzig de school in Azure'), findsNothing);
+
+    // And the log says which kind of pass it was, so the two are still
+    // distinguishable afterwards — the diagnostic #315 went without.
+    expect(
+      harness.log.entries.map((e) => e.message),
+      contains('Azure AD volledig opnieuw gelezen — 1 account(s).'),
+    );
+  });
+
+  testWidgets(
       'a staff member who left WISA still gets their Office 365 account '
       'proposed for deletion (#269)', (WidgetTester tester) async {
     // The other half of #268, and the worse one. Anna Smit has left the school:
@@ -8939,9 +9065,11 @@ void main() {
     // evaluated, and the account lives on with nothing but Office 365 itself to
     // show for it.
     //
-    // The unavoidable trigger is here too: the stored delta token is past Graph's
-    // 30-day window, so this pass recovers with a full read (#213) and the
-    // previous user list — which had been carrying her — is discarded.
+    // The trigger is the drift pass itself: since #316 it re-reads Azure in
+    // full, which discards the previous user list — the very list that had been
+    // carrying her. (Before that the same loss only arrived by accident, when
+    // Graph refused an aged token; this snapshot still carries one, and the
+    // pass no longer even sends it.)
     //
     // Only this layer sees the whole thing: the Azure pull has to remember her
     // from the snapshot it already holds, the linker has to keep the row it
@@ -8984,9 +9112,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(harness.controller.error, isNull);
 
-    // The pass really was the losing one: the stale token was sent and refused,
-    // so the recovery re-read in full and the previous user list is gone.
-    expect(azureWire.resumeTokens, <String>['AZ-STALE']);
+    // The pass really was the losing one: it re-read in full, so the previous
+    // user list is gone. The stored token was not resumed from at all (#316) —
+    // dropping it is what makes this the full read, and the snapshot it came
+    // with still goes in, which is the only reason she survives below.
+    expect(azureWire.resumeTokens, isEmpty);
     expect(azureWire.bulkReads, 1);
 
     // She came back on the only leg left — one targeted lookup for an id WISA no

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -9858,6 +9858,86 @@ void main() {
     expect(harness.wisaSyncs, pulls);
     expect(outcomes, everyElement('applied'));
   });
+
+  testWidgets(
+      'a card owing two Office 365 writes keeps both after one apply, and '
+      're-offers neither (#321)', (WidgetTester tester) async {
+    // Found while working #315, on the apply side rather than the read side. A
+    // whole-card pass resolves **every** action once, up front, from the
+    // pre-apply linked view, and each Azure modify projects its mutated record
+    // as `_az.copyWith(…)` off that same frozen record. So the second write's
+    // snapshot splice put the first write's field back to the value it had
+    // before the pass: Graph held both PATCHes, the in-memory record held one,
+    // and the relink behind the pass re-raised an action for a change Azure
+    // already carried — the contradicted record being also what the shared
+    // store publishes to the other operators.
+    //
+    // Only a run of the real app covers the whole of it: the card the operator
+    // reads, the confirmation they answer, the pass, the relink behind it, and
+    // the list that has to stop offering what was just written.
+    useTallWindow(tester);
+    final harness = twoAzureWritesHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenActions(tester);
+    expect(harness.controller.error, isNull);
+
+    // Her card owes two Office 365 writes and nothing else: the display name
+    // WISA disagrees with, and the school her account does not carry.
+    final String id = harness.controller.pendingEntries
+        .singleWhere((e) => e.family == 'student')
+        .targetId;
+    await selectAccount(tester, id);
+    expect(find.text('Wijzig de naam in Azure'), findsOneWidget);
+    expect(find.text('Wijzig de school in Azure'), findsOneWidget);
+
+    // Apply the whole card, confirmation and all.
+    final Finder apply = find.byKey(ValueKey('entry-apply-$id'));
+    await tester.ensureVisible(apply);
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // Two real Graph PATCHes went out…
+    expect(
+      harness.graph.requests.where((r) => r.method == 'PATCH'),
+      hasLength(2),
+    );
+    // …and the record the app holds carries both of them. Before the fix it
+    // carried the school alone, with the display name back at its pre-apply
+    // value.
+    final user = harness.app.azure.snapshot!.users.single;
+    expect(user.displayName, 'Jane Doe');
+    expect(user.companyName, 'GBS');
+
+    // Which is what the operator sees: both writes reported on her card, and
+    // nothing left to apply on it — the re-offered rename is gone.
+    expect(find.byKey(ValueKey('actions-detail-$id')), findsOneWidget);
+    final Finder verdict = find.byKey(ValueKey('entry-outcomes-student-$id'));
+    await tester.ensureVisible(verdict);
+    expect(
+      find.descendant(
+          of: verdict, matching: find.text('Wijzig de naam in Azure')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: verdict, matching: find.text('Wijzig de school in Azure')),
+      findsOneWidget,
+    );
+    expect(
+      harness.controller.pendingEntries.where((e) => e.family == 'student'),
+      isEmpty,
+    );
+    expect(find.byKey(ValueKey('entry-apply-$id')), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
 }
 
 /// A broker scripted per test — a fake WAM broker so no live tenant is touched.

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -5805,6 +5805,68 @@ void main() {
   });
 
   testWidgets(
+      'an id collision is named on Synchronisatie and in the log, and the one '
+      'card it corrupts is still reachable (#319)',
+      (WidgetTester tester) async {
+    // Two records on one LinkedAccountId. Constructed through the resolver:
+    // #318 removed the one known way a snapshot produces this, and INV-24 is
+    // the guard for the cause nobody has found yet. Driven through the real
+    // app, on the real window, the way the operator meets it.
+    useTallWindow(tester);
+    final harness = idCollisionHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    // The overview names the collision, open, with a line per colliding record
+    // — no tap, because there is nothing here for the operator to decide.
+    final tile = find.byKey(const ValueKey('id-collision-p-shared'));
+    expect(tile, findsOneWidget);
+    await tester.ensureVisible(tile);
+    await tester.pumpAndSettle();
+    expect(
+      find.descendant(
+          of: tile, matching: find.textContaining('Koppelingsfout')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: tile, matching: find.textContaining('WISA W1')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: tile, matching: find.textContaining('WISA W2')),
+      findsOneWidget,
+    );
+
+    // …and the log panel says it too, which is the surface that still works
+    // when the colliding records have no Smartschool account to hang a card on.
+    expect(
+      harness.log.entries
+          .map((e) => e.message)
+          .where((m) => m.contains('Koppelingsfout') && m.contains('p-shared')),
+      hasLength(1),
+    );
+
+    // The damage itself: both records became one document id, so Acties shows
+    // the single card the warning is about. Left as-is deliberately — #319
+    // makes the collision visible, it does not decide how to merge the records.
+    expect(
+      harness.controller.linkedAccounts
+          .where((a) => a.id.value == 'p-shared')
+          .length,
+      2,
+    );
+  });
+
+  testWidgets(
       'creating an account captures its password into the shared queue, which '
       'the Passwords view surfaces as a printable sheet and drains on export '
       '(#105/#180)', (WidgetTester tester) async {

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -1687,6 +1687,79 @@ void main() {
   });
 
   testWidgets(
+      'a student enrolled in two WISA schools gets one card, offering only the '
+      'provisioning work (#318)', (WidgetTester tester) async {
+    // The screenshot on the report: one card offering "Maak een nieuw Office
+    // 365 account" *and* the Smartschool departure either/or — create this
+    // student's account and unregister it in the same breath, for someone
+    // enrolled with us right now. Two linked records carrying one
+    // `LinkedAccountId`, because both of the person's WISA rows keyed on
+    // `wisa:1`, and the card is assembled from that id.
+    //
+    // Driven end-to-end because the collapse is invisible below this level: the
+    // linker's own records are individually coherent, and it is only where the
+    // screen groups them by id that the contradiction appears.
+    useTallWindow(tester);
+    final harness = dualEnrolledHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Synchronisatie'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+    expect(harness.controller.error, isNull);
+
+    // One person, one pending entry — and both of their schools on the record,
+    // which is what makes the presence read `ours` instead of `groupOnly`.
+    final students = harness.controller.pendingEntries
+        .where((e) => e.family == 'student')
+        .toList();
+    expect(students, hasLength(1));
+    final entry = students.single;
+
+    // The contradiction itself: provisioning and departure can never both be
+    // true of one account, and before #318 this entry carried all three.
+    final kinds =
+        entry.choices.expand((c) => c.alternatives).map((a) => a.kind).toList();
+    expect(kinds, contains('AddStudentToAzure'));
+    expect(kinds, isNot(contains('UnregisterStudentFromSmartschool')),
+        reason: 'the student is enrolled with us — never offer to unregister');
+    expect(kinds, isNot(contains('DeleteStudentFromSmartschool')));
+
+    // One person, one linked record, carrying *both* of their schools — which
+    // is what makes the presence read `ours` instead of `groupOnly`.
+    expect(
+      harness.controller.linked!.snapshot.accounts.single.wisaSchoolIds,
+      const {1, 2},
+    );
+
+    // On screen: the row files them under **our** class — the placement comes
+    // from the ours-school row, not from whichever school the concatenated pull
+    // read first (the sibling's `4ECO` arrives ahead of our `3BO` here).
+    await tester.tap(find.text('Acties'));
+    await tester.pumpAndSettle();
+    final Finder row = find.byKey(ValueKey('account-row-${entry.targetId}'));
+    expect(row, findsOneWidget);
+    expect(
+        find.descendant(of: row, matching: find.text('3BO')), findsOneWidget);
+    expect(find.descendant(of: row, matching: find.text('4ECO')), findsNothing);
+    expect(find.descendant(of: row, matching: find.text('Zonder klas')),
+        findsNothing);
+
+    // …and the card offers the provisioning alone. The departure either/or is
+    // the half that must never share a card with it.
+    await selectAccount(tester, entry.targetId);
+    expect(find.text('Maak een nieuw Office 365 account'), findsOneWidget);
+    expect(find.text('Schrijf de leerling uit in Smartschool'), findsNothing);
+    expect(find.text('Verwijder dit account uit Smartschool'), findsNothing);
+  });
+
+  testWidgets(
       'the Actions list hides a school the operator does not manage in '
       'Settings, re-bucketing its student to the leaver group (#178)',
       (WidgetTester tester) async {

--- a/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
+++ b/account_manager/lib/src/reconcile/reconcile_bootstrap.dart
@@ -443,7 +443,11 @@ Future<ReconcileServices> bootstrapReconcile({
         // whichever pass the operator runs next: a moved
         // `smartschoolPullFingerprint` makes the smart sync re-pull this system
         // instead of leaving the snapshot it already holds alone.
-        inner: (_) => ssConnector.sync(rules: live.current.smartschoolRules),
+        // `fullRead` is ignored here and everywhere Smartschool is pulled: the
+        // connector reads the whole site every pass, so there is no resume
+        // point a drift check could be asked to drop (#316).
+        inner: (_, {bool fullRead = false}) =>
+            ssConnector.sync(rules: live.current.smartschoolRules),
       ),
     ),
     azure: SystemState<az.AzureSnapshot>(
@@ -666,7 +670,9 @@ Syncer<wapi.WisaSnapshot> wisaSyncer(
   core.ILog? log,
   DateTime Function() clock = DateTime.now,
 }) =>
-    (_) async {
+    // `fullRead` is ignored: WISA is read whole on every pass, so a drift check
+    // asking for a re-read is asking for what it already gets (#316).
+    (_, {bool fullRead = false}) async {
       // One consistent read for the whole pull: a save landing mid-pull must not
       // split the school list and the work dates across two documents.
       final current = settings.current;

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:account_actions/account_actions.dart' as actions;
 import 'package:account_core/account_core.dart' as core;
 import 'package:account_state/account_state.dart';
+import 'package:azure_api/azure_api.dart' as az;
 import 'package:flutter/foundation.dart';
 import 'package:smartschool_api/smartschool_api.dart' as ss;
 import 'package:wisa_api/wisa_api.dart' as wapi;
@@ -2196,6 +2197,18 @@ class ReconcileController extends ChangeNotifier {
   /// through other tools) and re-links. WISA is not re-pulled — that is what
   /// [sync] is for.
   ///
+  /// "Re-reads" is meant literally on both systems since #316. Smartschool
+  /// always was one — its syncer reads the whole site — but Azure ran the
+  /// ordinary incremental pull, resuming `/users/delta` from the stored token,
+  /// so the pass could only surface what Graph reported *since that token*.
+  /// Anything older, or anything an earlier walk dropped, was invisible to every
+  /// later pass, and the only things that ever forced a full read were accidents
+  /// (a token Graph refused, #213; a changed school prefix, #246). This pass now
+  /// asks for the full read outright. It is materially more expensive than a
+  /// delta — the whole school, though still `$filter`-bounded — and that is the
+  /// trade: the delta path stays what [sync] uses, and the operator pays for the
+  /// re-read only on the button whose job is to repair drift.
+  ///
   /// Refuses outright while [driftBlockedReason] is set: because WISA is not
   /// re-pulled here, a pass run after a werkdatum change would reconcile against
   /// the roster the change never reached and publish that to the whole team
@@ -2239,8 +2252,27 @@ class ReconcileController extends ChangeNotifier {
       await _renewLock();
       log.addMessage(core.Origin.azure, 'Azure AD controleren op drift…');
       final azPulledWith = _settingsFingerprint(core.Origin.azure);
-      _recordPull(core.Origin.azure, await app.sync(core.Origin.azure));
+      // **In full**, not as an incremental resume (#316). `/users/delta` reports
+      // what Graph chose to send since our stored token, which is precisely not
+      // "what does Azure hold right now": an edit older than the token — or one
+      // an earlier walk dropped — survives every later delta, so the pass whose
+      // whole job is to repair drift could never see the drift it was run for.
+      // Only the *token* is dropped; the snapshot in hand still goes to the
+      // syncer, which remembers from it the staff ids the back-fill must keep
+      // asking about (#269).
+      final azure =
+          await app.sync(core.Origin.azure, fullRead: true) as az.AzureSnapshot;
+      _recordPull(core.Origin.azure, azure);
       _stampPull(core.Origin.azure, azPulledWith);
+      // Says which kind of pass this was, in the panel the operator reads: a
+      // delta pass leaves `Azure: delta voor "…" — N gewijzigd` behind, this one
+      // leaves the size of the whole read. Without it the two are
+      // indistinguishable after the fact, which is what made #315 so hard to
+      // pin down.
+      log.addMessage(
+        core.Origin.azure,
+        'Azure AD volledig opnieuw gelezen — ${azure.users.length} account(s).',
+      );
       _setProgress(0.6);
 
       if (app.wisa.snapshot == null) {

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -2727,8 +2727,35 @@ class ReconcileController extends ChangeNotifier {
       'openstaande actie(s).',
     );
 
+    // The view [selected] is bound to, and the actions the view in hand raises
+    // (#321). Both stay null-ish until a write replaces the view — a dry run
+    // patches nothing, so it never re-resolves anything.
+    var boundTo = _linked;
+    Map<String, Object>? relinked;
+
     try {
-      for (final (index, option) in selected.indexed) {
+      for (final (index, planned) in selected.indexed) {
+        // Re-resolve this decision against the view the **previous** write
+        // produced (#321).
+        //
+        // Every action of a pass is resolved once, up front, from the pre-apply
+        // linked view, and an Azure modify projects its mutated record as
+        // `_az.copyWith(…)` off the record it was bound to. So a pass with two
+        // Azure writes on one account had its second snapshot splice put the
+        // pre-apply value of the first write's field back: Graph held both
+        // PATCHes, the in-memory record held one, and the relink behind it
+        // re-raised an action for a change Azure already had — which is also
+        // what [_shareApplied] then published to the other operators.
+        //
+        // [_chainFollowUps] never had the problem, because it takes each link
+        // off the freshly relinked view's own dispatch; this gives the pass
+        // loop the same treatment.
+        final current = _linked;
+        if (current != null && !identical(current, boundTo)) {
+          relinked = _actionsByIdentity(current);
+          boundTo = current;
+        }
+        final option = relinked == null ? planned : _rebind(planned, relinked);
         // Name the action *before* it runs, so the modal progress dialog says
         // what is in flight rather than what just finished (#243). `results`
         // already holds one row per write performed, so anything in it beyond
@@ -2801,6 +2828,82 @@ class ReconcileController extends ChangeNotifier {
       return applier.applyStaff(action, options: options);
     }
     return applier.applyGroup(action as actions.GroupAction, options: options);
+  }
+
+  /// Every pending action of [linked] under the identity a
+  /// [PendingActionOption] carries — `family|targetId|kind` (#321).
+  ///
+  /// Keyed with the very values [_entriesFor] stamps its options with, so a
+  /// lookup answers with the action the pending list *would* offer for that
+  /// decision had it been rebuilt from this view. First-seen wins, matching the
+  /// entry list's own grouping; a kind that names more than one decision on a
+  /// card is already ambiguous there (#283).
+  ///
+  /// Rebuilt once per write rather than per remaining decision: the relink it
+  /// follows already walks the whole roster, so this is a constant factor on
+  /// top of something the pass pays anyway.
+  Map<String, Object> _actionsByIdentity(LinkedState linked) {
+    final index = <String, Object>{};
+    for (final a in linked.studentActions) {
+      index.putIfAbsent(
+        'student|${a.target.id.value}|${a.runtimeType}',
+        () => a,
+      );
+    }
+    for (final a in linked.staffActions) {
+      index.putIfAbsent('staff|${a.target.id.value}|${a.runtimeType}', () => a);
+    }
+    for (final a in linked.groupActions) {
+      index.putIfAbsent(
+        'group|${_groupLabel(a.target)}|${a.runtimeType}',
+        () => a,
+      );
+    }
+    return index;
+  }
+
+  /// [planned] re-bound to the action [index] holds for the same decision, with
+  /// its diff re-read off that action (#321).
+  ///
+  /// Only the live action and its [PendingActionOption.changes] move. The
+  /// identity stamps are what route the pass's verdict back to the card and the
+  /// decision it answers (#272/#283), the operator's pick is what the pass
+  /// agreed to run, and the label is the one they read on the confirmation —
+  /// none of which a write may re-decide underneath them.
+  ///
+  /// A decision the relinked view no longer raises keeps the binding it was
+  /// planned with. That is what this pass has always run, and it is the safe
+  /// side of the trade: a target can change identity under a write (a class
+  /// entry is keyed by its label), so treating "not found" as "no longer
+  /// needed" would silently drop the rest of an operator's card.
+  PendingActionOption _rebind(
+    PendingActionOption planned,
+    Map<String, Object> index,
+  ) {
+    final fresh =
+        index['${planned.family}|${planned.targetId}|${planned.kind}'];
+    if (fresh == null || identical(fresh, planned.action)) return planned;
+    return PendingActionOption(
+      action: fresh,
+      kind: planned.kind,
+      group: planned.group,
+      isDefault: planned.isDefault,
+      family: planned.family,
+      targetId: planned.targetId,
+      target: planned.target,
+      changes: _describeAny(fresh),
+      canApply: planned.canApply,
+      canApplyToAll: planned.canApplyToAll,
+      unlockedSystems: planned.unlockedSystems,
+    );
+  }
+
+  /// One action's pure diff, whichever family it belongs to — the read half of
+  /// [_applyAny]'s dispatch.
+  static actions.ChangeSet _describeAny(Object action) {
+    if (action is actions.StudentAction) return action.describeChanges();
+    if (action is actions.StaffAction) return action.describeChanges();
+    return (action as actions.GroupAction).describeChanges();
   }
 
   /// Runs one selected option and returns a result row per **write it

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -462,6 +462,25 @@ class DuplicateMailWarning {
   List<String> get uids => sortedDuplicateUids(accounts.map((a) => a.uid));
 }
 
+/// A linker id collision (INV-24) shaped for the reconcile screen (#319): the
+/// [id] two or more records resolved to, and one already-rendered line per
+/// colliding record saying what it holds.
+///
+/// Unlike a duplicate mail there is nothing for the operator to *accept* — a
+/// shared [LinkedAccountId] is a linker bug, not a deliberate configuration —
+/// so this carries no decision state. It exists so the collision is visible
+/// while it lasts, instead of only showing up as a card whose presence chips
+/// and actions come from different records.
+class LinkIdCollision {
+  const LinkIdCollision({required this.id, required this.records});
+
+  /// The `LinkedAccountId` value the colliding records share.
+  final String id;
+
+  /// One line per colliding record; at least two, in snapshot order.
+  final List<String> records;
+}
+
 /// A per-category summary for the Reconcile overview (#163): how many accounts
 /// (or class groups) the category holds, and how many of them carry an applyable
 /// pending action. Derived from the stored [Rollup]s, so it is readable in a
@@ -1398,6 +1417,31 @@ class ReconcileController extends ChangeNotifier {
           ),
     ];
   }
+
+  /// The id collisions of the current linked view (INV-24, #319), each with its
+  /// colliding records flattened for display. Empty before a sync this session,
+  /// and — the normal case — empty afterwards too: a non-empty list means the
+  /// linker minted one id for two records, and every layer below it (the
+  /// materialized document, the pending entry, the stored account) has already
+  /// merged or dropped one of them.
+  List<LinkIdCollision> get linkIdCollisions {
+    final l = _linked;
+    if (l == null) return const [];
+    return [
+      for (final w in l.snapshot.warnings)
+        if (w is core.DuplicateLinkedId)
+          LinkIdCollision(
+            id: w.id.value,
+            records: [for (final h in w.holdings) _describeHolding(h)],
+          ),
+    ];
+  }
+
+  /// One colliding record as a single line: its role and the key it carries in
+  /// each system, so two records on one id can be told apart at a glance.
+  static String _describeHolding(core.LinkedIdHolding h) =>
+      '${h.role.toJson()} · WISA ${h.wisa ?? '—'} · '
+      'Smartschool ${h.smartschool ?? '—'} · Azure ${h.azure ?? '—'}';
 
   DuplicateAccountRow _duplicateRow(core.SmartschoolAccount account) {
     final concrete = account is ss.SmartschoolAccount ? account : null;
@@ -2878,6 +2922,7 @@ class ReconcileController extends ChangeNotifier {
       '${s.warnings.length} waarschuwing(en).',
     );
     _logSkippedNamesakes(s.warnings);
+    _logIdCollisions(s.warnings);
   }
 
   Future<void> _relink() async {
@@ -2929,6 +2974,33 @@ class ReconcileController extends ChangeNotifier {
         '"${ss.name}" (code ${ss.id.value}), '
         '${ss.official ? 'met een andere schrijfwijze' : 'maar geen '
             'officiële klas'}.',
+      );
+    }
+  }
+
+  /// Names every id two or more linker records resolved to (INV-24, #319).
+  ///
+  /// This should never fire. It gets a log line anyway because everything below
+  /// the linker is keyed by that id and each layer degrades differently and
+  /// without a word — the materialized document receives the union of both
+  /// records' candidates, the Acties list keeps whichever pending entry came
+  /// last, and the shared store holds one document per id, so one of the two is
+  /// what every other operator inherits. Left silent, the first sign of trouble
+  /// is a card that contradicts itself: presence chips off one record above a
+  /// choice that can only exist for the other.
+  ///
+  /// It is logged rather than hung on the account cards because the colliding
+  /// records share one card — the card is the symptom, not a place to report
+  /// from — and because a collision between two records with no Smartschool
+  /// account has no card at all.
+  void _logIdCollisions(List<core.LinkWarning> warnings) {
+    for (final w in warnings) {
+      if (w is! core.DuplicateLinkedId) continue;
+      log.addMessage(
+        core.Origin.all,
+        'Koppelingsfout: ${w.holdings.length} records delen id '
+        '"${w.id.value}", zodat hun acties op één kaart terechtkomen. '
+        'Records: ${w.holdings.map(_describeHolding).join(' | ')}.',
       );
     }
   }

--- a/account_manager/lib/src/screens/actions_screen.dart
+++ b/account_manager/lib/src/screens/actions_screen.dart
@@ -564,6 +564,16 @@ class _ActionsBodyState extends State<_ActionsBody>
   /// Every account of the selected family, with its live entry joined on — the
   /// unfiltered list, in the chosen order.
   List<_AccountRow> _rows() {
+    // Keyed by target id, which is a `LinkedAccountId` — unique per person by
+    // INV-24. This map literal is last-wins, so on a collision it is the one
+    // place in this screen that loses an entry outright rather than merging it:
+    // the row keeps whichever entry the controller listed last and the other
+    // record's decisions never render. That is deliberate rather than defended
+    // against here, because a row can only show one entry and picking between
+    // two contradictory ones is not this screen's call. The collision itself is
+    // caught upstream, where it can be reported as the linker bug it is —
+    // `LinkedSnapshot.fromRecords` raises a `DuplicateLinkedId` warning, which
+    // the sync log and the Synchronisatie overview both name (#319).
     final byTarget = <String, PendingAccountEntry>{
       for (final e in controller.pendingEntries)
         if (e.family != 'group') e.targetId: e,

--- a/account_manager/lib/src/screens/reconcile_screen.dart
+++ b/account_manager/lib/src/screens/reconcile_screen.dart
@@ -594,6 +594,7 @@ class _OverviewSection extends StatelessWidget {
     final TextTheme text = Theme.of(context).textTheme;
     final ColorScheme colors = Theme.of(context).colorScheme;
     final duplicates = controller.duplicateWarnings;
+    final collisions = controller.linkIdCollisions;
     final students = controller.studentSummary;
     final staff = controller.staffSummary;
     final groups = controller.groupSummary;
@@ -639,7 +640,69 @@ class _OverviewSection extends StatelessWidget {
           for (final w in duplicates)
             _DuplicateWarningTile(controller: controller, warning: w),
         ],
+        // Above nothing and below everything: an id collision (#319) is rarer
+        // and more serious than a duplicate mail — it means the view itself is
+        // wrong, not that two accounts need tidying — so it is never folded
+        // into the duplicate list.
+        if (collisions.isNotEmpty) ...<Widget>[
+          const SizedBox(height: PlinkSpacing.s3),
+          for (final c in collisions) _IdCollisionTile(collision: c),
+        ],
       ],
+    );
+  }
+}
+
+/// An id collision as a plain, always-expanded notice (#319): the headline says
+/// how many records share the id, and each colliding record gets a line naming
+/// what it holds in each system.
+///
+/// Not an [ExpansionTile] like the duplicate-mail warning next to it, and with
+/// no accept/revoke: there is nothing here for the operator to decide. The one
+/// useful thing is that they can see the collision at all — and can tell support
+/// exactly which id and which records are involved — so it is shown open.
+class _IdCollisionTile extends StatelessWidget {
+  const _IdCollisionTile({required this.collision});
+
+  final LinkIdCollision collision;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    return Container(
+      key: ValueKey('id-collision-${collision.id}'),
+      margin: const EdgeInsets.only(top: PlinkSpacing.s2),
+      padding: const EdgeInsets.all(PlinkSpacing.s4),
+      decoration: BoxDecoration(
+        border: Border.all(color: colors.error),
+        borderRadius: const BorderRadius.all(Radius.circular(PlinkRadius.base)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(Icons.error_outline, size: 20, color: colors.error),
+          const SizedBox(width: PlinkSpacing.s3),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Koppelingsfout: ${collision.records.length} records delen '
+                  'id "${collision.id}", zodat hun acties op één kaart '
+                  'terechtkomen.',
+                  style: text.bodyMedium,
+                ),
+                for (final r in collision.records) ...<Widget>[
+                  const SizedBox(height: PlinkSpacing.s2),
+                  Text(r, style: text.bodySmall),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -3293,6 +3293,89 @@ void main() {
     });
   });
 
+  group('a second Azure write in one pass (#321)', () {
+    PendingAccountEntry studentEntry(ReconcileHarness h) =>
+        h.controller.pendingEntries.singleWhere((e) => e.family == 'student');
+
+    List<String> summariesOf(PendingAccountEntry e) =>
+        <String>[for (final c in e.choices) c.selected.changes.summary];
+
+    test('the card owes both Azure modifies before the pass', () async {
+      final h = twoAzureWritesHarness();
+      await h.controller.sync();
+
+      expect(
+        summariesOf(studentEntry(h)),
+        containsAll(<String>[
+          'Wijzig de naam in Azure',
+          'Wijzig de school in Azure',
+        ]),
+        reason: 'the fixture is the two-Azure-writes card the bug needs',
+      );
+    });
+
+    test('the held record carries both writes, not only the last', () async {
+      // The pass resolved every action once, up front, off the pre-apply view,
+      // and an Azure modify projects its mutated record as `_az.copyWith(…)`
+      // off the record it was bound to. So the second splice put the pre-apply
+      // value of the first write's field back: Graph held both PATCHes and the
+      // snapshot held one.
+      final h = twoAzureWritesHarness();
+      await h.controller.sync();
+
+      await h.controller.applyEntry(studentEntry(h));
+
+      expect(h.controller.error, isNull);
+      expect(
+        h.controller.applyResults!.map((r) => r.outcome),
+        everyElement(actions.ActionOutcome.applied),
+      );
+      expect(
+        h.graph.requests.where((r) => r.method == 'PATCH'),
+        hasLength(2),
+        reason: 'both writes really went out',
+      );
+      final user = h.app.azure.snapshot!.users.single;
+      expect(user.displayName, 'Jane Doe');
+      expect(user.companyName, 'GBS');
+    });
+
+    test('neither write is re-offered the moment it landed', () async {
+      // The contradicted record is what the relink dispatches from — and what
+      // `_shareApplied` publishes to the other operators — so a reverted splice
+      // re-raises an action for a change Azure already holds.
+      final h = twoAzureWritesHarness();
+      await h.controller.sync();
+
+      await h.controller.applyEntry(studentEntry(h));
+
+      expect(
+        h.controller.pendingEntries.where((e) => e.family == 'student'),
+        isEmpty,
+      );
+    });
+
+    test('a dry-run still projects both, writing nothing', () async {
+      // A projection refreshes no view, so there is nothing to re-resolve
+      // against and the pass must behave exactly as it always did.
+      final h = twoAzureWritesHarness();
+      await h.controller.sync();
+
+      await h.controller.dryRunEntry(studentEntry(h));
+
+      expect(
+        h.controller.dryRunResults!.map((r) => r.changes.summary),
+        containsAll(<String>[
+          'Wijzig de naam in Azure',
+          'Wijzig de school in Azure',
+        ]),
+      );
+      expect(h.graph.requests, isEmpty);
+      expect(summariesOf(studentEntry(h)), hasLength(2),
+          reason: 'nothing was written, so nothing was settled');
+    });
+  });
+
   group('LogBuffer', () {
     test('caps its entries and reports errors', () {
       final log = LogBuffer(capacity: 3, clock: () => kFixtureDate);

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -2975,6 +2975,60 @@ void main() {
     });
   });
 
+  group('a LinkedAccountId claimed twice (INV-24, #319)', () {
+    test('the collision reaches the controller instead of vanishing', () async {
+      final h = idCollisionHarness();
+      await h.controller.sync();
+
+      final collisions = h.controller.linkIdCollisions;
+      expect(collisions, hasLength(1));
+      expect(collisions.single.id, 'p-shared');
+      // Two records, each named by what it holds so they can be told apart —
+      // which is the only thing that makes the collision actionable.
+      expect(collisions.single.records, hasLength(2));
+      expect(collisions.single.records.first, contains('WISA W1'));
+      expect(collisions.single.records.first, contains('Smartschool jane'));
+      expect(collisions.single.records.last, contains('WISA W2'));
+      expect(collisions.single.records.last, contains('Smartschool —'));
+    });
+
+    test('the sync log names it, so it is visible with no card at all',
+        () async {
+      final h = idCollisionHarness();
+      await h.controller.sync();
+
+      final lines = h.log.entries.map((e) => e.message).toList();
+      final named = lines.where((l) => l.contains('Koppelingsfout')).toList();
+      expect(named, hasLength(1));
+      expect(named.single, contains('p-shared'));
+      expect(named.single, contains('WISA W1'));
+      expect(named.single, contains('WISA W2'));
+    });
+
+    test('the tally counts the shared id once, so the overview is honest',
+        () async {
+      final h = idCollisionHarness();
+      await h.controller.sync();
+
+      // Two WISA students on one id ⇒ one person. Counting per record made the
+      // WISA total 2 and the dashboard's linked/total ratio wrong for as long
+      // as the collision lasted.
+      expect(h.controller.linked!.snapshot.wisa.total, 1);
+    });
+
+    test('an ordinary sync reports no collision', () async {
+      final h = ReconcileHarness();
+      await h.controller.sync();
+      expect(h.controller.linkIdCollisions, isEmpty);
+      expect(
+        h.log.entries
+            .map((e) => e.message)
+            .where((l) => l.contains('Koppelingsfout')),
+        isEmpty,
+      );
+    });
+  });
+
   group('a class entry that owes two writes (#272)', () {
     /// The Smartschool half: the recorded SOAP action is the fully-qualified
     /// `…V3#saveClass`.

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1672,6 +1672,29 @@ ReconcileHarness dualEnrolledHarness() => ReconcileHarness(
       azure: azSnap(users: const []),
     );
 
+/// A harness for a card that owes **two Azure writes on one account** (#321).
+///
+/// One student, fully linked and already in step with Smartschool, whose
+/// Office 365 account is wrong in two independent ways: its `displayName` is
+/// blank (so `ModifyAzureName` raises) and its `companyName` names another
+/// school (so `ModifyAzureSchool` does). Applying her card is therefore a pass
+/// of two Azure PATCHes against one record — the shape whose second snapshot
+/// splice used to revert the first one's, because every action was resolved
+/// once, up front, off the pre-apply view.
+ReconcileHarness twoAzureWritesHarness() => ReconcileHarness(
+      wisa: wisaSnap(
+        students: [wisaStudent(wisaId: '1', classGroup: '3C')],
+        schools: [wisaSchool(1)],
+        classGroups: [wisaClassGroup('3C', adminCode: 'a3')],
+      ),
+      smartschool: ssSnap(
+        groups: [ssGroup('3C', code: '3C_ss', untis: '3C')],
+        accounts: [ssAccount()],
+        memberships: [member('jane', '3C_ss')],
+      ),
+      azure: azSnap(users: [azUser(companyName: 'SBE')]),
+    );
+
 /// A harness for the school-less Actions drill-down (#210). Two managed schools
 /// (1 and 2) each hold students, and their years overlap: school 1 has `1A` and
 /// `3C`, school 2 has `1B` and the non-numeric `OKAN`. So a correct overview

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -562,6 +562,89 @@ class HandEditedUserGraph implements az.GraphTransport {
       );
 }
 
+/// A [az.GraphTransport] answering a resumed `/users/delta` the way Graph
+/// answers it after another school's software claimed an account of ours
+/// (#317): a sparse row whose `companyName`/`department` now names somebody
+/// else.
+///
+/// Merged onto the record the app holds, such a row reads as an account that is
+/// no longer ours — and the walk used to drop it, silently. Because the delta is
+/// applied as an upsert, dropping meant the app's own copy (which still carries
+/// *our* prefix) survived untouched, on this pass and on every later one: the
+/// same row is dropped again for the same reason, forever. That is the state in
+/// which the app goes on proposing writes against an account another school now
+/// owns.
+///
+/// [backfill] is what a targeted `employeeId in (…)` lookup answers with, so a
+/// test can drive the other leg of the same pass: a student WISA still places
+/// here is re-adopted (#224) with the record straight off Graph, and the two
+/// legs have to agree rather than fight. The `$filter`-scoped bulk read answers
+/// empty and is counted, so a test can prove the pass really was the incremental
+/// one.
+///
+/// Wire it into [ReconcileHarness.azureTransport] together with an
+/// `azureInitial` carrying the token to resume from and the accounts as the app
+/// still remembers them.
+class SchoolMovedUserGraph implements az.GraphTransport {
+  SchoolMovedUserGraph({
+    required this.rows,
+    this.backfill = const <Map<String, dynamic>>[],
+    this.freshToken = 'AZ-NEXT',
+  });
+
+  /// The sparse rows the resumed walk reports — `{id, <changed props>}`.
+  final List<Map<String, dynamic>> rows;
+
+  /// The full records a targeted `employeeId` lookup turns up.
+  final List<Map<String, dynamic>> backfill;
+
+  /// The token this walk leaves behind for the next pass.
+  final String freshToken;
+
+  final List<az.GraphRequest> requests = <az.GraphRequest>[];
+
+  /// Every delta token Graph was asked to resume from, in order.
+  final List<String> resumeTokens = <String>[];
+
+  /// Every `employeeId in (…)` filter the connector issued, in order.
+  final List<String> employeeIdLookups = <String>[];
+
+  /// How many `$filter`-scoped bulk reads ran — none, on an incremental pass.
+  int bulkReads = 0;
+
+  @override
+  Future<az.GraphResponse> send(az.GraphRequest request) async {
+    requests.add(request);
+    final String path = request.url.path;
+    if (path.contains('/members') || path.contains('groups')) {
+      return _ok(<String, dynamic>{'value': const <Object>[]});
+    }
+    if (path.contains('users/delta')) {
+      final String token = request.url.queryParameters[r'$deltatoken'] ?? '';
+      if (token != 'latest') resumeTokens.add(token);
+      return _ok(<String, dynamic>{
+        '@odata.deltaLink':
+            'https://graph.microsoft.com/v1.0/users/delta?\$deltatoken='
+                '$freshToken',
+        'value': token == 'latest' ? const <Object>[] : rows,
+      });
+    }
+    final String filter = request.url.queryParameters[r'$filter'] ?? '';
+    if (filter.startsWith('employeeId in')) {
+      employeeIdLookups.add(filter);
+      return _ok(<String, dynamic>{'value': backfill});
+    }
+    bulkReads++;
+    return _ok(<String, dynamic>{'value': const <Object>[]});
+  }
+
+  static az.GraphResponse _ok(Map<String, dynamic> body) => az.GraphResponse(
+        statusCode: 200,
+        headers: const <String, String>{'content-type': 'application/json'},
+        body: jsonEncode(body),
+      );
+}
+
 /// A [az.GraphTransport] answering the way the tenant answers when the app's
 /// stored copy of an account has drifted **past what any delta can report**
 /// (#315/#316).

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -562,6 +562,91 @@ class HandEditedUserGraph implements az.GraphTransport {
       );
 }
 
+/// A [az.GraphTransport] answering the way the tenant answers when the app's
+/// stored copy of an account has drifted **past what any delta can report**
+/// (#315/#316).
+///
+/// Graph holds the account as it stands now — that is [user], and the
+/// `$filter`-scoped bulk read returns it. A resumed `/users/delta` reports
+/// **nothing**: the edit predates the token the session holds, which is the
+/// whole point. So an incremental pass, however many times it is run, can only
+/// ever confirm the stale copy the app already has, while a re-read repairs it
+/// in one.
+///
+/// Wire it into [ReconcileHarness.azureTransport] together with an
+/// `azureInitial` carrying the token to resume from and the account as the app
+/// wrongly remembers it.
+class DriftedUserGraph implements az.GraphTransport {
+  DriftedUserGraph({az.AzureUser? user, this.freshToken = 'AZ-NEXT'})
+      : user = user ?? azUser();
+
+  /// The account exactly as Graph holds it — what a full read returns.
+  final az.AzureUser user;
+
+  /// The token a pass leaves behind, whichever leg it took.
+  final String freshToken;
+
+  final List<az.GraphRequest> requests = <az.GraphRequest>[];
+
+  /// Every delta token Graph was asked to resume from, in order — empty on a
+  /// pass that re-read instead.
+  final List<String> resumeTokens = <String>[];
+
+  /// Every `employeeId in (…)` filter the connector issued.
+  final List<String> employeeIdLookups = <String>[];
+
+  /// How many `$filter`-scoped bulk reads ran.
+  int bulkReads = 0;
+
+  @override
+  Future<az.GraphResponse> send(az.GraphRequest request) async {
+    requests.add(request);
+    final String path = request.url.path;
+    if (path.contains('/members') || path.contains('groups')) {
+      return _ok(<String, dynamic>{'value': const <Object>[]});
+    }
+    if (path.contains('users/delta')) {
+      final String token = request.url.queryParameters[r'$deltatoken'] ?? '';
+      if (token != 'latest') resumeTokens.add(token);
+      // Nothing changed *since the token*, which is not the same thing as
+      // nothing being wrong.
+      return _ok(<String, dynamic>{
+        '@odata.deltaLink':
+            'https://graph.microsoft.com/v1.0/users/delta?\$deltatoken='
+                '$freshToken',
+        'value': const <Object>[],
+      });
+    }
+    final String filter = request.url.queryParameters[r'$filter'] ?? '';
+    if (filter.startsWith('employeeId in')) {
+      employeeIdLookups.add(filter);
+      return _ok(<String, dynamic>{'value': const <Object>[]});
+    }
+    bulkReads++;
+    return _ok(<String, dynamic>{
+      'value': <Map<String, dynamic>>[_row(user)],
+    });
+  }
+
+  static Map<String, dynamic> _row(az.AzureUser u) => <String, dynamic>{
+        'id': u.id,
+        'userPrincipalName': u.upn,
+        if (u.employeeId != null) 'employeeId': u.employeeId,
+        'displayName': u.displayName,
+        'givenName': u.givenName,
+        'surname': u.surname,
+        if (u.companyName != null) 'companyName': u.companyName,
+        if (u.department != null) 'department': u.department,
+        'accountEnabled': u.accountEnabled,
+      };
+
+  static az.GraphResponse _ok(Map<String, dynamic> body) => az.GraphResponse(
+        statusCode: 200,
+        headers: const <String, String>{'content-type': 'application/json'},
+        body: jsonEncode(body),
+      );
+}
+
 /// A [az.GraphTransport] answering the way the tenant answers on the pass that
 /// has to notice a staff member **left** WISA (#269).
 ///
@@ -1158,6 +1243,10 @@ az.AzureUser azUser({
   String displayName = '',
   String givenName = '',
   String surname = '',
+  // The school stamped on a student account. The harness prefix by default, so
+  // the account is in step; a fixture about a *stale* copy of it (#315/#316)
+  // names another school here.
+  String companyName = 'GBS',
 }) =>
     az.AzureUser(
       id: id,
@@ -1166,7 +1255,7 @@ az.AzureUser azUser({
       displayName: displayName,
       givenName: givenName,
       surname: surname,
-      companyName: 'GBS',
+      companyName: companyName,
     );
 
 /// An Azure **staff** account. Staff carry no `companyName`; their school lives
@@ -3452,14 +3541,14 @@ class ReconcileHarness {
         log: log,
         clock: () => kFixtureDate,
       );
-      wisaSync = (previous) async {
+      wisaSync = (previous, {bool fullRead = false}) async {
         wisaSyncs++;
         final error = wisaError;
         if (error != null) throw error;
-        return inner(previous);
+        return inner(previous, fullRead: fullRead);
       };
     } else {
-      wisaSync = (_) async {
+      wisaSync = (_, {bool fullRead = false}) async {
         wisaSyncs++;
         final error = wisaError;
         if (error != null) throw error;
@@ -3483,7 +3572,7 @@ class ReconcileHarness {
         transport: ssTransport,
         log: log,
       );
-      ssSync = (_) async {
+      ssSync = (_, {bool fullRead = false}) async {
         ssSyncs++;
         // The live document's rules win when it carries any (#246), exactly as
         // `bootstrapReconcile` reads `live.current.smartschoolRules` at pull
@@ -3494,7 +3583,7 @@ class ReconcileHarness {
         );
       };
     } else {
-      ssSync = (_) async {
+      ssSync = (_, {bool fullRead = false}) async {
         ssSyncs++;
         return ssResult;
       };
@@ -3547,13 +3636,18 @@ class ReconcileHarness {
           return prefix.isEmpty ? 'GBS' : prefix;
         },
       );
-      azSync = (previous) async {
+      azSync = (previous, {bool fullRead = false}) async {
         azSyncs++;
-        return inner(previous);
+        // Forwarded, so a test can press **Controleer op drift** and see the
+        // production syncer take the full-read branch it forces (#316).
+        return inner(previous, fullRead: fullRead);
       };
     } else {
-      azSync = (_) async {
+      azSync = (_, {bool fullRead = false}) async {
         azSyncs++;
+        // What the pass asked for, so a test with a scripted Azure pull can
+        // still assert that a drift check asks for a re-read (#316).
+        azFullReads += fullRead ? 1 : 0;
         // When a test wires a gate, the Azure pull parks here until released,
         // so a widget test can hold a sync mid-flight and observe the busy
         // progress bar the earlier stages have already advanced (#176).
@@ -3881,6 +3975,37 @@ class ReconcileHarness {
   int wisaSyncs = 0;
   int ssSyncs = 0;
   int azSyncs = 0;
+
+  /// How many of those [azSyncs] were asked for as a **re-read** rather than an
+  /// incremental resume (#316) — what **Controleer op drift** forces. Counted on
+  /// the scripted pull, so a test that models no Graph at all can still prove
+  /// which kind of pass ran.
+  int azFullReads = 0;
+
+  /// Models the operator flipping a WISA school **beheerd** in Instellingen —
+  /// a saved *Azure pull input* (`azurePullFingerprint`, #259), so the next
+  /// **Synchroniseer** re-pulls Azure instead of leaving the snapshot this
+  /// session already holds alone.
+  ///
+  /// Which is what a test about the **incremental** Azure pass has to reach for
+  /// since #316: **Controleer op drift** re-reads Azure in full by design, so
+  /// the smart sync is the pass that still resumes the stored delta token. The
+  /// school is written with the name and code a [wisaSchool] fixture carries, so
+  /// the school-profile back-fill (#207) finds nothing to repair afterwards.
+  void markSchoolManaged(int schoolId) {
+    final profiles = <WisaSchoolProfile>[
+      for (final p in liveSettings.current.wisaSchools)
+        if (p.schoolId != schoolId) p,
+      WisaSchoolProfile(
+        schoolId: schoolId,
+        name: 'School $schoolId',
+        ours: true,
+      ),
+    ]..sort((a, b) => a.schoolId.compareTo(b.schoolId));
+    liveSettings.publish(
+      liveSettings.current.copyWith(wisaSchools: profiles),
+    );
+  }
 
   final RecordingSoap soap = RecordingSoap();
   final RecordingGraph graph = RecordingGraph();

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1600,6 +1600,37 @@ ReconcileHarness managedSchoolsHarness({required Set<int> ourSchoolIds}) =>
       ourSchoolIds: ourSchoolIds,
     );
 
+/// A harness for the dual-enrolled student (#318). One person — WISA id `1`,
+/// the Smartschool account [ssAccount] already carries — enrolled in **two**
+/// group schools, of which only school 1 is ours. The shared WISA credentials
+/// pull one school at a time and concatenate, so that person arrives as two
+/// rows sharing a `wisaId`: the sibling school's `4ECO` first, our own `3BO`
+/// second. There is no Azure account yet, so the only work owed is the
+/// provisioning.
+///
+/// Before #318 the second row spawned a *second* record, both keyed
+/// `wisa:1` and so handed the same `LinkedAccountId`: one card offering "Maak
+/// een nieuw Office 365 account" (the ours record) next to the Smartschool
+/// unregister/delete either/or (the sibling record) — a proposal to unregister
+/// a student who is enrolled with us right now.
+ReconcileHarness dualEnrolledHarness() => ReconcileHarness(
+      ourSchoolIds: const {1},
+      wisa: wisaSnap(
+        students: [
+          wisaStudent(wisaId: '1', classGroup: '4ECO', schoolId: 2),
+          wisaStudent(wisaId: '1', classGroup: '3BO', schoolId: 1),
+        ],
+        classGroups: [wisaClassGroup('3BO')],
+        schools: [wisaSchool(1), wisaSchool(2)],
+      ),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: [ssAccount()],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+    );
+
 /// A harness for the school-less Actions drill-down (#210). Two managed schools
 /// (1 and 2) each hold students, and their years overlap: school 1 has `1A` and
 /// `3C`, school 2 has `1B` and the non-numeric `OKAN`. So a correct overview

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -1533,6 +1533,47 @@ ReconcileHarness dupMailHarness({
       syncedBy: syncedBy,
     );
 
+/// A [core.PersonIdResolver] that hands every natural key the same id — the way
+/// a test constructs the INV-24 collision (#319).
+///
+/// It has to be constructed. #318 removed the one known way two records ended up
+/// on one `LinkedAccountId`, and re-breaking that merge to get a collision back
+/// is not what the invariant is for: INV-24 is defence in depth against a cause
+/// nobody has found yet, and the resolver is the seam where any such cause
+/// ultimately expresses itself.
+class CollidingResolver implements core.PersonIdResolver {
+  CollidingResolver([this.id = 'p-shared']);
+
+  /// The id every key resolves to.
+  final String id;
+
+  @override
+  core.PersonId resolve(String naturalKey) => core.PersonId(id);
+}
+
+/// A reconcile harness whose linker puts two students on **one**
+/// `LinkedAccountId` (#319): two ordinary, unrelated WISA students and a
+/// [CollidingResolver], so the pass produces two records claiming one id.
+///
+/// Everything below the linker then behaves as the issue describes — one
+/// materialized document carrying the union of both records' candidates — which
+/// is exactly what the `DuplicateLinkedId` warning has to make visible.
+ReconcileHarness idCollisionHarness({InMemoryLinkedStore? linkedStore}) =>
+    ReconcileHarness(
+      resolver: CollidingResolver(),
+      linkedStore: linkedStore,
+      wisa: wisaSnap(students: [
+        wisaStudent(wisaId: 'W1', classGroup: '3A'),
+        wisaStudent(wisaId: 'W2', classGroup: '3A'),
+      ]),
+      smartschool: ssSnap(
+        groups: const [],
+        accounts: [ssAccount(uid: 'jane', accountId: 'W1')],
+        memberships: const [],
+      ),
+      azure: azSnap(users: const []),
+    );
+
 /// A reconcile harness over [count] WISA-departed, Smartschool-only active
 /// accounts (no WISA, no Azure): each raises the mutually-exclusive
 /// unregister/delete choice (#110), so the pending list holds [count] entries in
@@ -3604,7 +3645,9 @@ class ReconcileHarness {
     this.settingsStore,
     this.modelsSettings = true,
     LiveSettings? liveSettings,
-  })  : wisaResult = (wisa ?? wisaSnap()),
+    core.PersonIdResolver? resolver,
+  })  : resolver = resolver ?? SeqResolver(),
+        wisaResult = (wisa ?? wisaSnap()),
         ssResult = (smartschool ?? ssSnap()),
         azResult = (azure ?? azSnap()),
         liveSettings = liveSettings ?? LiveSettings(),
@@ -3837,7 +3880,7 @@ class ReconcileHarness {
           transport: graph,
         ),
       ),
-      resolver: SeqResolver(),
+      resolver: this.resolver,
       wisaRules: wisaRules,
       passwordQueue: passwordQueue,
       // Every settings-derived input, read from the live document on each link
@@ -3932,6 +3975,12 @@ class ReconcileHarness {
   /// per-system sync-metadata author (#108). Vary it to model a second operator
   /// sharing the same [linkedStore].
   final String syncedBy;
+
+  /// The identity resolver the applier links with. Defaults to [SeqResolver],
+  /// the deterministic one-id-per-natural-key fixture; a test overrides it to
+  /// construct an INV-24 id collision (#319), which no snapshot can produce on
+  /// its own once #318 merged the dual-enrolment rows.
+  final core.PersonIdResolver resolver;
 
   /// When set, the Azure syncer parks on this completer until a test releases
   /// it — a seam to freeze a sync mid-pass (WISA + Smartschool already pulled)

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -615,6 +615,53 @@ void main() {
   });
 
   testWidgets(
+      'an id collision is named on the overview, open, with both records '
+      '(#319)', (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = idCollisionHarness();
+    await tester
+        .pumpWidget(_wrap(ReconcileScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    final tile = find.byKey(const ValueKey('id-collision-p-shared'));
+    expect(tile, findsOneWidget);
+    await tester.ensureVisible(tile);
+    expect(
+      find.descendant(
+          of: tile, matching: find.textContaining('Koppelingsfout')),
+      findsOneWidget,
+    );
+
+    // Shown open, with no tap: there is nothing to decide, so the two records
+    // have to be readable straight away or the notice says nothing useful.
+    expect(
+      find.descendant(of: tile, matching: find.textContaining('WISA W1')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: tile, matching: find.textContaining('WISA W2')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('an ordinary sync shows no collision notice (#319)',
+      (WidgetTester tester) async {
+    _useTallWindow(tester);
+    final harness = ReconcileHarness();
+    await tester
+        .pumpWidget(_wrap(ReconcileScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('reconcile-sync')));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Koppelingsfout'), findsNothing);
+  });
+
+  testWidgets(
       'dragging the divider handle grows the log panel and clamps to a min '
       '(#152)', (WidgetTester tester) async {
     tester.view.physicalSize = const Size(800, 1000);

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -234,7 +234,7 @@ class LinkedSnapshot {
 }
 ```
 
-`LinkCounts` mirrors the legacy `LinkedAccounts` counters: a person counts toward a system's `linked` only when present in all three systems, otherwise `unlinked`. `LinkWarning` is a sealed type; its `ResolveDuplicateMail` variant carries the shared `mail` and every colliding Smartschool account (INV-23, PAIN-7).
+`LinkCounts` mirrors the legacy `LinkedAccounts` counters: a person counts toward a system's `linked` only when present in all three systems, otherwise `unlinked`. The unit is a **person**, so `LinkedSnapshot.fromRecords` counts each `LinkedAccountId` once — counting per record let one colliding id inflate a system's total and skew the dashboard ratio (INV-24). `LinkWarning` is a sealed type; its `ResolveDuplicateMail` variant carries the shared `mail` and every colliding Smartschool account (INV-23, PAIN-7), and its `DuplicateLinkedId` variant carries the shared id and a `LinkedIdHolding` per colliding record (INV-24).
 
 ### 3.10 `Action`
 
@@ -310,6 +310,7 @@ The legacy school-marking rules `MarkAsVirtual` (WorkDate, schoolCode) and `Mark
 - **INV-21 [D]:** Every WISA **person** appears in **exactly one** `LinkedAccount` — per person, not per row (#318, and see INV-11). A person the aggregated pull returns twice merges into one record whose `wisaSchoolIds` holds *both* schools, so `WisaPresence` reads `ours` when either of them is ours; the record's `wisa` — the row the class placement is derived from — is the row of a managed school, never whichever school the pull happened to read first. Linking per row instead minted a second record for the same person, and since both rows key on `wisa:<wisaId>` the resolver handed the two records the **same** `LinkedAccountId`, putting two records' actions on one card.
 - **INV-22 [D]:** Every Azure user with `companyName == schoolPrefix` (students) or `department contains schoolPrefix` (staff) appears in **exactly one** `LinkedAccount`, even after the person has left the school (so the engine can raise a remove action). Both tests have a single implementation, `account_core`'s `studentBelongsToSchool` / `staffBelongsToSchool` (and their union `belongsToSchool`), which the linker, the Azure connector's client-side reads, and the staff-retention rule all call (#279). Blank prefix matches nobody. A connector read narrower than the linker is silently lossy — the linker never gets to ask about a row the read dropped — which is why the rule may not be re-implemented per package.
 - **INV-23 [D]:** When two Smartschool accounts collide on `mail`, **both** end up in some `LinkedAccount`, never silently dropped. A `ResolveDuplicateMail` warning action is raised.
+- **INV-24 [D]:** No two records in a `LinkedSnapshot` — `LinkedAccount` or `LinkedStaff` — share a `LinkedAccountId`. Enforced in `LinkedSnapshot.fromRecords` rather than in `link()`, so it holds for every snapshot built that way: a repeated id raises a `DuplicateLinkedId` warning naming the id and what each colliding record holds, and the id is counted once (#319). Every *known* cause is fixed at its source (INV-21), so this is defence in depth — but it earns its place because everything below the linker is keyed by that id and each layer degrades differently and silently: the materializer hands both records the **union** of their candidate actions, the Acties list is a last-wins map on `targetId`, and the shared store keeps one document per id, so one record is what every other operator inherits. The colliding records are **kept**, never deduped away — a silent drop is exactly what INV-23 exists to prevent.
 
 ### Membership
 
@@ -336,7 +337,7 @@ The legacy school-marking rules `MarkAsVirtual` (WorkDate, schoolCode) and `Mark
 ### 6.2 `link(wisa, smartschool, azure) → LinkedSnapshot`
 
 - **Pre:** Three snapshots (any may be empty).
-- **Post:** `LinkedSnapshot` satisfying INV-20..23. Pure, deterministic.
+- **Post:** `LinkedSnapshot` satisfying INV-20..24. Pure, deterministic.
 - The algorithm is structurally the same as legacy [`LinkedAccounts.DoRelink`](../legacy-wpf/AccountManager/State/Linked/LinkedAccounts.cs) but extracted from WPF state and fixed for case-insensitive matching and duplicate-mail.
 
 ### 6.3 `evaluate(LinkedSnapshot) → List<Action>`
@@ -361,6 +362,7 @@ The legacy school-marking rules `MarkAsVirtual` (WorkDate, schoolCode) and `Mark
 | Former member (Azure-only w/ school prefix) | Preserved as Azure-only `LinkedAccount` | **Fix**: surface as Azure-only `LinkedAccount` (`confidence: Medium`); the action engine raises a remove action — we don't keep alumni | Students who leave are deleted, not retained |
 | WISA-only student (no SS, no Azure) | Placeholder keyed by `WisaID` | **Keep**; surfaces "add" actions naturally | Drives onboarding |
 | Two Smartschool accounts share `mail` | First wins, second lost silently | **Fix**: both retained, raise `ResolveDuplicateMail` warning | INV-23 |
+| Two linked records share a `LinkedAccountId` | Consumers union or last-wins, silently | **Fix**: both retained, raise `DuplicateLinkedId` warning; the id is counted once | INV-24 |
 | Case-sensitive mail/UPN comparison | `.Equals()` | **Fix**: case-insensitive + trim | INV-12 — latent bug |
 | Smartschool multi-membership | Tree walk + skip-if-seen | **Fix**: first-class `Membership` | PAIN-1 |
 | Co-accounts (parents) | Implicit via `AccountType` enum | **Keep enum**; passwords managed separately | Minimal scope expansion |

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -300,14 +300,14 @@ The legacy school-marking rules `MarkAsVirtual` (WorkDate, schoolCode) and `Mark
 ### Account / person
 
 - **INV-10 [I]:** Every `WisaStudent` has a non-null, non-empty `wisaId`. *Legacy assumes; CSV may produce empty rows.*
-- **INV-11 [I]:** No two `WisaStudent`s share a `wisaId`. *Assumed, not checked.*
+- **INV-11 [I]:** No two `WisaStudent`s share a `wisaId` **within one school**. Across the aggregated pull they do: the shared WISA credentials are queried one school at a time and the results concatenated, and `WisaStudent.schoolId` is a single int, so a student enrolled in two group schools arrives as two rows carrying the same `wisaId` and different `schoolId`/`classGroup` (#318). A `wisaId` identifies a **person**, not a row.
 - **INV-12 [D]:** `mail` and `upn` are compared **case-insensitively** and trimmed. *Legacy `.Equals()` is case-sensitive — a latent bug we don't preserve.*
 - **INV-13 [I]:** Two Smartschool accounts may legitimately share a `mail` only via the co-account mechanism. The legacy linker silently drops one when this happens; see INV-23.
 
 ### Linking
 
 - **INV-20 [D]:** `link` is a **pure function**: `(WisaSnapshot, SmartschoolSnapshot, AzureSnapshot) → LinkedSnapshot`. Same input ⇒ same output.
-- **INV-21 [D]:** Every WISA student appears in **exactly one** `LinkedAccount`.
+- **INV-21 [D]:** Every WISA **person** appears in **exactly one** `LinkedAccount` — per person, not per row (#318, and see INV-11). A person the aggregated pull returns twice merges into one record whose `wisaSchoolIds` holds *both* schools, so `WisaPresence` reads `ours` when either of them is ours; the record's `wisa` — the row the class placement is derived from — is the row of a managed school, never whichever school the pull happened to read first. Linking per row instead minted a second record for the same person, and since both rows key on `wisa:<wisaId>` the resolver handed the two records the **same** `LinkedAccountId`, putting two records' actions on one card.
 - **INV-22 [D]:** Every Azure user with `companyName == schoolPrefix` (students) or `department contains schoolPrefix` (staff) appears in **exactly one** `LinkedAccount`, even after the person has left the school (so the engine can raise a remove action). Both tests have a single implementation, `account_core`'s `studentBelongsToSchool` / `staffBelongsToSchool` (and their union `belongsToSchool`), which the linker, the Azure connector's client-side reads, and the staff-retention rule all call (#279). Blank prefix matches nobody. A connector read narrower than the linker is silently lossy — the linker never gets to ask about a row the read dropped — which is why the rule may not be re-implemented per package.
 - **INV-23 [D]:** When two Smartschool accounts collide on `mail`, **both** end up in some `LinkedAccount`, never silently dropped. A `ResolveDuplicateMail` warning action is raised.
 

--- a/packages/account_core/lib/src/linked.dart
+++ b/packages/account_core/lib/src/linked.dart
@@ -234,12 +234,88 @@ class SmartschoolNamesakeSkipped extends LinkWarning {
   });
 }
 
+/// What one of the records behind a [DuplicateLinkedId] holds — enough of each
+/// colliding record for an operator (or a log line) to tell them apart.
+///
+/// Deliberately flattened to the per-system keys rather than carrying the
+/// records themselves: a collision can be between two [LinkedAccount]s, two
+/// [LinkedStaff], or one of each, and a single shape lets every consumer render
+/// all three the same way.
+class LinkedIdHolding {
+  /// The role the colliding record was minted with.
+  final PersonRole role;
+
+  /// The WISA key — a student's `wisaId` or a staff member's `code`. Null when
+  /// the record has no WISA side.
+  final String? wisa;
+
+  /// The Smartschool `uid`, or null when the record has no Smartschool side.
+  final String? smartschool;
+
+  /// The Azure object id, or null when the record has no Azure side.
+  final String? azure;
+
+  const LinkedIdHolding({
+    required this.role,
+    this.wisa,
+    this.smartschool,
+    this.azure,
+  });
+
+  /// The holding of a colliding student record.
+  factory LinkedIdHolding.ofAccount(LinkedAccount a) => LinkedIdHolding(
+        role: a.role,
+        wisa: a.wisa?.wisaId.value,
+        smartschool: a.smartschool?.uid,
+        azure: a.azure?.id,
+      );
+
+  /// The holding of a colliding staff record.
+  factory LinkedIdHolding.ofStaff(LinkedStaff s) => LinkedIdHolding(
+        role: s.role,
+        wisa: s.wisa?.code.value,
+        smartschool: s.smartschool?.uid,
+        azure: s.azure?.id,
+      );
+}
+
+/// INV-24: two or more linker records resolved to the same [LinkedAccountId].
+///
+/// Every layer below the linker is keyed by that id and each one degrades
+/// differently and silently — the materializer hands both records the *union*
+/// of their candidate actions, the Acties list keeps whichever pending entry
+/// arrived last, and the shared store holds one document per id, so one record
+/// is what every other operator inherits. The first sign of trouble used to be
+/// an operator reading a card whose presence chips come from one record and
+/// whose actions come from another (#319).
+///
+/// So a collision is reported as what it is — a linker invariant violation —
+/// rather than merged away by each consumer's own assumption. Both records are
+/// kept in the [LinkedSnapshot]: dropping one silently is the very failure
+/// INV-23 exists to prevent. The tally counts the id once ([LinkCounts]), so
+/// the dashboard's linked/total ratio does not drift while the collision lasts.
+class DuplicateLinkedId extends LinkWarning {
+  /// The id the colliding records share.
+  final LinkedAccountId id;
+
+  /// What each record claiming [id] holds; at least two, in snapshot order
+  /// (students before staff).
+  final List<LinkedIdHolding> holdings;
+
+  const DuplicateLinkedId({required this.id, required this.holdings});
+}
+
 /// Per-system tally for one [LinkedSnapshot], mirroring the counters legacy
 /// `LinkedAccounts.DoRelink` exposed.
 ///
 /// A record counts toward [linked] when it is present in *every* system, and
 /// toward [unlinked] when it is present in this system but missing from at
 /// least one other. [total] == [linked] + [unlinked].
+///
+/// The unit is a **person**, not a record: [LinkedSnapshot.fromRecords] counts
+/// each [LinkedAccountId] once, so a colliding id (INV-24, #319) cannot inflate
+/// a system's total or skew the dashboard's linked/total ratio for as long as
+/// the collision lasts.
 class LinkCounts {
   final int total;
   final int linked;
@@ -287,6 +363,19 @@ class LinkedSnapshot {
   /// `LinkedAccounts.DoRelink`: a person counts toward a system's [total]
   /// when present there, and toward that system's [linked] only when present
   /// in all three systems. Groups are listed but not counted.
+  ///
+  /// This is also where [LinkedAccountId] uniqueness (INV-24) is enforced, so
+  /// the invariant lives with the type rather than in each consumer's
+  /// assumptions (#319). Every record — student or staff — is bucketed by its
+  /// id, and any id claimed more than once yields one [DuplicateLinkedId]
+  /// warning appended to [warnings], in first-seen order.
+  ///
+  /// The colliding records are **kept**, never deduped away: a silent drop is
+  /// what INV-23 exists to prevent, and one of the two is generally the record
+  /// carrying the actions an operator is about to apply. What changes is that
+  /// the collision is now loud, and that the tally below counts each id once —
+  /// counting per record inflated a system's [total] by one per collision and
+  /// skewed the dashboard's linked/total ratio.
   factory LinkedSnapshot.fromRecords({
     required List<LinkedAccount> accounts,
     required List<LinkedStaff> staff,
@@ -296,6 +385,12 @@ class LinkedSnapshot {
     var wisaTotal = 0, wisaLinked = 0;
     var ssTotal = 0, ssLinked = 0;
     var azTotal = 0, azLinked = 0;
+
+    // INV-24 bookkeeping: what each id is claimed by, in first-seen order so
+    // the warnings a given input produces are deterministic (INV-20).
+    final holdingsById = <String, List<LinkedIdHolding>>{};
+    final idOrder = <String>[];
+    final idByValue = <String, LinkedAccountId>{};
 
     void tally({
       required bool inWisa,
@@ -317,7 +412,23 @@ class LinkedSnapshot {
       }
     }
 
+    /// Registers a record's claim on [id] and reports whether it is the first —
+    /// the only claim that counts toward the tally, since the unit is a person.
+    bool claim(LinkedAccountId id, LinkedIdHolding holding) {
+      final key = id.value;
+      final existing = holdingsById[key];
+      if (existing == null) {
+        idOrder.add(key);
+        idByValue[key] = id;
+        holdingsById[key] = <LinkedIdHolding>[holding];
+        return true;
+      }
+      existing.add(holding);
+      return false;
+    }
+
     for (final a in accounts) {
+      if (!claim(a.id, LinkedIdHolding.ofAccount(a))) continue;
       tally(
         inWisa: a.wisa != null,
         inSmartschool: a.smartschool != null,
@@ -325,12 +436,22 @@ class LinkedSnapshot {
       );
     }
     for (final s in staff) {
+      if (!claim(s.id, LinkedIdHolding.ofStaff(s))) continue;
       tally(
         inWisa: s.wisa != null,
         inSmartschool: s.smartschool != null,
         inAzure: s.azure != null,
       );
     }
+
+    final collisions = <DuplicateLinkedId>[
+      for (final key in idOrder)
+        if (holdingsById[key]!.length > 1)
+          DuplicateLinkedId(
+            id: idByValue[key]!,
+            holdings: List<LinkedIdHolding>.unmodifiable(holdingsById[key]!),
+          ),
+    ];
 
     LinkCounts counts(int total, int linked) =>
         LinkCounts(total: total, linked: linked, unlinked: total - linked);
@@ -339,7 +460,11 @@ class LinkedSnapshot {
       accounts: accounts,
       staff: staff,
       groups: groups,
-      warnings: warnings,
+      // A fresh list rather than an append: `warnings` is the caller's own
+      // accumulator (and may be `const []`).
+      warnings: collisions.isEmpty
+          ? warnings
+          : <LinkWarning>[...warnings, ...collisions],
       wisa: counts(wisaTotal, wisaLinked),
       smartschool: counts(ssTotal, ssLinked),
       azure: counts(azTotal, azLinked),

--- a/packages/account_core/test/linked_test.dart
+++ b/packages/account_core/test/linked_test.dart
@@ -314,4 +314,149 @@ void main() {
     expect(snapshot.warnings, hasLength(1));
     expect(snapshot.warnings.single, isA<ResolveDuplicateMail>());
   });
+
+  group('INV-24: LinkedAccountId uniqueness (#319)', () {
+    // Two records that resolve to the same id. Constructed rather than driven
+    // through the dual-enrolment path #318 fixed: the point of this invariant
+    // is to catch a cause nobody has found yet, so it must not be tied to the
+    // one cause that is already fixed at its source.
+    const first = LinkedAccount(
+      id: LinkedAccountId('la-same'),
+      role: PersonRole.student,
+      wisa: _FakeWisaStudent(WisaId('w-1')),
+      smartschool: _FakeSmartschoolAccount(
+        uid: 'jan.peeters',
+        mail: 'jan@school.be',
+        accountId: 'w-1',
+        accountType: AccountType.student,
+      ),
+      confidence: LinkConfidence.high,
+    );
+    const second = LinkedAccount(
+      id: LinkedAccountId('la-same'),
+      role: PersonRole.student,
+      wisa: _FakeWisaStudent(WisaId('w-1')),
+      azure: _FakeAzureUser(id: 'az-9', upn: 'jan@school.be'),
+      confidence: LinkConfidence.medium,
+    );
+    const other = LinkedAccount(
+      id: LinkedAccountId('la-other'),
+      role: PersonRole.student,
+      wisa: _FakeWisaStudent(WisaId('w-2')),
+      confidence: LinkConfidence.medium,
+    );
+
+    test('a repeated id raises one DuplicateLinkedId naming both records', () {
+      final snapshot = LinkedSnapshot.fromRecords(
+        accounts: const [first, second, other],
+        staff: const [],
+        groups: const [],
+      );
+
+      final warning = snapshot.warnings.whereType<DuplicateLinkedId>().single;
+      expect(warning.id, equals(const LinkedAccountId('la-same')));
+      expect(warning.holdings, hasLength(2));
+
+      // What each record holds — the whole point of the payload is that an
+      // operator can tell the two apart.
+      expect(warning.holdings.first.smartschool, equals('jan.peeters'));
+      expect(warning.holdings.first.azure, isNull);
+      expect(warning.holdings.last.smartschool, isNull);
+      expect(warning.holdings.last.azure, equals('az-9'));
+      for (final h in warning.holdings) {
+        expect(h.wisa, equals('w-1'));
+        expect(h.role, equals(PersonRole.student));
+      }
+    });
+
+    test('both colliding records are kept — never silently deduped', () {
+      // A silent drop is exactly what INV-23 exists to prevent, so the
+      // invariant reports the collision instead of resolving it.
+      final snapshot = LinkedSnapshot.fromRecords(
+        accounts: const [first, second, other],
+        staff: const [],
+        groups: const [],
+      );
+      expect(snapshot.accounts, hasLength(3));
+    });
+
+    test('the colliding id is counted once, so no total is inflated', () {
+      final snapshot = LinkedSnapshot.fromRecords(
+        accounts: const [first, second, other],
+        staff: const [],
+        groups: const [],
+      );
+      // Two people, both in WISA — not three records' worth. Counting per
+      // record made this 3 and skewed the dashboard's linked/total ratio.
+      expect(snapshot.wisa.total, equals(2));
+      expect(snapshot.wisa.linked, equals(0));
+      expect(snapshot.wisa.unlinked, equals(2));
+      // Only the first claim on the id counts, so the second record's Azure
+      // side does not quietly add a person Azure does not separately have.
+      expect(snapshot.smartschool.total, equals(1));
+      expect(snapshot.azure.total, equals(0));
+    });
+
+    test('a student and a staff record can collide too', () {
+      const staff = LinkedStaff(
+        id: LinkedAccountId('la-other'),
+        role: PersonRole.teacher,
+        wisa: _FakeWisaStaff(WisaStaffCode('PEE'), WisaId('w-100')),
+        confidence: LinkConfidence.medium,
+      );
+      final snapshot = LinkedSnapshot.fromRecords(
+        accounts: const [other],
+        staff: const [staff],
+        groups: const [],
+      );
+
+      final warning = snapshot.warnings.whereType<DuplicateLinkedId>().single;
+      expect(warning.id, equals(const LinkedAccountId('la-other')));
+      expect(warning.holdings.map((h) => h.role),
+          equals([PersonRole.student, PersonRole.teacher]));
+      // The staff holding carries the WISA *code*, which is the staff key.
+      expect(warning.holdings.last.wisa, equals('PEE'));
+      // And still only two people, not three.
+      expect(snapshot.wisa.total, equals(1));
+    });
+
+    test('collisions are appended after the caller\'s own warnings', () {
+      final snapshot = LinkedSnapshot.fromRecords(
+        accounts: const [first, second],
+        staff: const [],
+        groups: const [],
+        warnings: const [
+          ResolveDuplicateMail(mail: 'dup@school.be', accounts: []),
+        ],
+      );
+      expect(snapshot.warnings, hasLength(2));
+      expect(snapshot.warnings.first, isA<ResolveDuplicateMail>());
+      expect(snapshot.warnings.last, isA<DuplicateLinkedId>());
+    });
+
+    test('unique ids raise nothing and count exactly as before', () {
+      final snapshot = LinkedSnapshot.fromRecords(
+        accounts: const [first, other],
+        staff: const [],
+        groups: const [],
+      );
+      expect(snapshot.warnings, isEmpty);
+      expect(snapshot.wisa.total, equals(2));
+    });
+
+    test('three records on one id yield one warning listing all three', () {
+      const third = LinkedAccount(
+        id: LinkedAccountId('la-same'),
+        role: PersonRole.student,
+        confidence: LinkConfidence.medium,
+      );
+      final snapshot = LinkedSnapshot.fromRecords(
+        accounts: const [first, second, third],
+        staff: const [],
+        groups: const [],
+      );
+      final warning = snapshot.warnings.whereType<DuplicateLinkedId>().single;
+      expect(warning.holdings, hasLength(3));
+    });
+  });
 }

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -47,6 +47,14 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 ///   case-insensitive (legacy `.Equals()` was case-sensitive).
 /// - **INV-23:** two Smartschool accounts sharing a `mail` are *both* kept and
 ///   a [ResolveDuplicateMail] warning is raised (legacy silently dropped one).
+/// - **INV-24:** two records that resolve to the same [LinkedAccountId] raise a
+///   [DuplicateLinkedId] warning (#319). The check is not written here: it lives
+///   in [LinkedSnapshot.fromRecords], which this function returns through, so it
+///   holds for every snapshot built that way rather than only for this pass. It
+///   is defence in depth — every *known* cause is fixed at its source (see
+///   INV-21 and [_buildStudentRecords]) — but the layers below the linker are
+///   all keyed by that id and every one of them unions or drops without a word,
+///   so a cause nobody has found yet must not be able to reach them quietly.
 ///
 /// [schoolPrefix] is the Azure `companyName` value the school stamps on its
 /// own users; an Azure-only user carrying it is a former student kept as an

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -57,11 +57,13 @@ import 'package:wisa_api/wisa_api.dart' as wapi;
 /// one who is genuinely present here. It comes from Settings and nowhere else
 /// (#286): null and empty both mean ownership is unconfigured, in which case
 /// every WISA-present student is treated as ours, preserving the pre-#134
-/// behaviour. For students
-/// and staff, membership never changes which records exist or their identity
-/// keys, only how each is classified ([WisaPresence]); for **groups** it is a
-/// filter (#205), because a class of a school we do not manage has no business
-/// reaching the action engine at all (see [_linkGroups]).
+/// behaviour. For students and staff, membership never changes which records
+/// exist or their identity keys, only how each is classified
+/// ([WisaPresence]) — and, for a student the shared pull returns *twice*
+/// because they are enrolled in two group schools, which of those two rows
+/// supplies the class placement (#318, see [_prefersWisaRow]). For **groups**
+/// it is a filter (#205), because a class of a school we do not manage has no
+/// business reaching the action engine at all (see [_linkGroups]).
 ///
 /// A second group-only filter composes with it: the class groups of a school
 /// flagged [wapi.WisaSchool.isVirtual] are skipped too (#209). A virtual school
@@ -97,6 +99,7 @@ LinkedSnapshot link(
     smartschoolSnapshot,
     azureSnapshot,
     schoolPrefix: schoolPrefix,
+    ourSchoolIds: effectiveOurSchoolIds,
     warnings: warnings,
   );
   final staffRecords = _buildStaffRecords(
@@ -164,11 +167,19 @@ LinkedSnapshot link(
 /// the key set and the resolve calls from ever drifting: any key returned here
 /// is exactly one [link] will resolve, and vice versa. Group records carry no
 /// [PersonId] (a group is keyed by name), so groups contribute nothing.
+///
+/// [ourSchoolIds] is passed through to the student pass for the same reason
+/// [schoolPrefix] is — so the two entry points run the *identical* build. It
+/// cannot move a key on its own (ownership only picks which of one person's
+/// WISA rows supplies the class placement, #318, and every row of a person
+/// carries the same `wisaId`), but leaving it out would make "identical passes"
+/// a claim rather than a fact.
 Set<String> naturalKeysFor(
   wapi.WisaSnapshot wisaSnapshot,
   ss.SmartschoolSnapshot smartschoolSnapshot,
   az.AzureSnapshot azureSnapshot, {
   required String schoolPrefix,
+  Set<int>? ourSchoolIds,
 }) {
   // The duplicate-mail warnings are a byproduct of building; discarded here.
   final warnings = <LinkWarning>[];
@@ -177,6 +188,7 @@ Set<String> naturalKeysFor(
     smartschoolSnapshot,
     azureSnapshot,
     schoolPrefix: schoolPrefix,
+    ourSchoolIds: ourSchoolIds ?? const <int>{},
     warnings: warnings,
   );
   final staffRecords = _buildStaffRecords(
@@ -197,11 +209,17 @@ Set<String> naturalKeysFor(
 /// identity resolution to the caller. Records are returned in creation order so
 /// the output is a deterministic function of the input order (INV-20).
 /// Duplicate-mail warnings (INV-23) are appended to [warnings].
+///
+/// [ourSchoolIds] is read for one decision only (#318): when the WISA pull
+/// returns the same person from two group schools, which of those rows sits on
+/// [_Record.wisa]. It never changes which records exist or what they are keyed
+/// by — see [_prefersWisaRow].
 List<_Record> _buildStudentRecords(
   wapi.WisaSnapshot wisaSnapshot,
   ss.SmartschoolSnapshot smartschoolSnapshot,
   az.AzureSnapshot azureSnapshot, {
   required String schoolPrefix,
+  required Set<int> ourSchoolIds,
   required List<LinkWarning> warnings,
 }) {
   // Records in creation order; the output preserves this order so the result
@@ -242,18 +260,34 @@ List<_Record> _buildStudentRecords(
   }
 
   // 2. Attach WISA students by wisaId; unmatched ones become WISA-only
-  //    placeholders. INV-21: every WISA student lands in exactly one record.
+  //    placeholders. INV-21: every WISA student lands in exactly one record —
+  //    one record per **person**, not per row (#318). The two are not the same
+  //    thing: the WISA pull runs once per group school and concatenates the
+  //    results, and `WisaStudent.schoolId` is a single int, so a student
+  //    enrolled in two group schools arrives as *two rows sharing one wisaId*.
+  //    Both rows are the same person, so the second merges its school id into
+  //    the record the first made. Spawning a second record instead (what this
+  //    did before) put two records on one `LinkedAccountId` — `_naturalKey`
+  //    returns `wisa:<wisaId>` for either of them — and the action engine then
+  //    offered one card the actions of both: create the Office 365 account of
+  //    the ours-school record next to the Smartschool departure of the
+  //    sibling-school one. The placeholder branch stays for the genuinely
+  //    unmatched student, who is the first row of their own record.
   for (final student in wisaSnapshot.students) {
     final key = _norm(student.wisaId.value);
     final match = key == null ? null : byWisaId[key];
-    if (match != null && match.wisa == null) {
-      match.wisa = student;
-      match.wisaSchoolIds.add(student.schoolId);
-    } else {
+    if (match == null) {
       final placeholder = _Record(wisa: student)
         ..wisaSchoolIds.add(student.schoolId);
       records.add(placeholder);
       if (key != null) byWisaId.putIfAbsent(key, () => placeholder);
+      continue;
+    }
+    // Every school this person was found in, so `_presence` can see that one
+    // of them is ours even when another is not.
+    match.wisaSchoolIds.add(student.schoolId);
+    if (_prefersWisaRow(match.wisa, student, ourSchoolIds)) {
+      match.wisa = student;
     }
   }
 
@@ -691,7 +725,13 @@ Group _wisaToCoreGroup(wapi.WisaClassGroup g) => Group(
 /// an immutable [LinkedAccount] at the end.
 class _Record {
   ss.SmartschoolAccount? smartschool;
+
+  /// The WISA row this person's class placement is read from. A person enrolled
+  /// in two group schools has two rows (#318); the one from a school we manage
+  /// wins, see [_prefersWisaRow]. Every school they were found in is on
+  /// [wisaSchoolIds] regardless of which row this holds.
   wapi.WisaStudent? wisa;
+
   az.AzureUser? azure;
 
   /// The WISA school ids this record's student was found in — accumulated as
@@ -754,6 +794,32 @@ String? _norm(String? value) {
   if (value == null) return null;
   final trimmed = value.trim();
   return trimmed.isEmpty ? null : trimmed.toLowerCase();
+}
+
+/// Whether [candidate] should displace [held] as the WISA row a record carries
+/// on [_Record.wisa], when both rows are the *same person* read from two
+/// different group schools (#318).
+///
+/// The rows agree on identity — one `wisaId` — but not on `schoolId`, and with
+/// it not on `classGroup`/`classSubGroup`. That class is what every downstream
+/// placement is derived from (the Smartschool class to enrol into, the Office
+/// 365 class group to join), and it must come from **our** school's row, not
+/// from whichever school the concatenated pull happened to read first. So a row
+/// of a managed school displaces one of a sibling school, and nothing else
+/// displaces anything: ours-vs-ours and sibling-vs-sibling both keep the row
+/// already held, so the result stays a deterministic function of snapshot order
+/// (INV-20). With ownership unconfigured ([ourSchoolIds] empty) every school
+/// counts as ours — the same fallback [_presence] applies — so the first row
+/// stands, exactly as it did before #318.
+bool _prefersWisaRow(
+  wapi.WisaStudent? held,
+  wapi.WisaStudent candidate,
+  Set<int> ourSchoolIds,
+) {
+  if (held == null) return true;
+  if (ourSchoolIds.isEmpty) return false;
+  return ourSchoolIds.contains(candidate.schoolId) &&
+      !ourSchoolIds.contains(held.schoolId);
 }
 
 /// Classifies a student's WISA presence (#134) from the [wisaSchoolIds] its

--- a/packages/account_linker/test/link_properties_test.dart
+++ b/packages/account_linker/test/link_properties_test.dart
@@ -211,6 +211,57 @@ void main() {
     );
 
     Glados(_scenario).test(
+      'INV-24: a shared LinkedAccountId is always reported, never silent',
+      (specs) {
+        // This is the property #319 delivers, and it is deliberately *not* "ids
+        // never collide". They do: an INV-23 duplicate-mail pair keeps two
+        // records for one person, and both key on the same `accountId` — or,
+        // with no accountId, on the very mail that made them collide — so the
+        // resolver hands them one id. That is a live cause, independent of the
+        // one #318 fixed, and it is filed as #323. Asserting its absence would
+        // be asserting something false; what must hold is that no collision
+        // gets through quietly.
+        final linked = _build(specs, SeqResolver()).linked;
+
+        final claims = <String, int>{};
+        for (final a in linked.accounts) {
+          claims[a.id.value] = (claims[a.id.value] ?? 0) + 1;
+        }
+        for (final s in linked.staff) {
+          claims[s.id.value] = (claims[s.id.value] ?? 0) + 1;
+        }
+        final colliding = <String>{
+          for (final e in claims.entries)
+            if (e.value > 1) e.key,
+        };
+
+        final warnings =
+            linked.warnings.whereType<DuplicateLinkedId>().toList();
+        // Exactly one warning per colliding id: no misses, no false alarms, and
+        // one warning per *id* rather than one per extra claimant.
+        expect(warnings.map((w) => w.id.value).toSet(), colliding);
+        expect(warnings, hasLength(colliding.length));
+        for (final w in warnings) {
+          expect(w.holdings, hasLength(claims[w.id.value]),
+              reason: 'every record claiming ${w.id.value} must be listed');
+        }
+
+        // The tally counts people, so it can never exceed the distinct ids…
+        for (final counts in [linked.wisa, linked.smartschool, linked.azure]) {
+          expect(counts.total, lessThanOrEqualTo(claims.length));
+          expect(counts.total, counts.linked + counts.unlinked);
+        }
+        // …and on a collision-free scenario it is exactly the pre-#319 number,
+        // so the guard stays invisible on healthy data.
+        if (colliding.isEmpty) {
+          final wisa = linked.accounts.where((a) => a.wisa != null).length +
+              linked.staff.where((s) => s.wisa != null).length;
+          expect(linked.wisa.total, wisa);
+        }
+      },
+    );
+
+    Glados(_scenario).test(
       'INV-12: case/whitespace in mail and upn does not change linking',
       (specs) {
         final clean = _build(specs, SeqResolver()).linked;

--- a/packages/account_linker/test/link_properties_test.dart
+++ b/packages/account_linker/test/link_properties_test.dart
@@ -133,14 +133,27 @@ void main() {
     });
 
     Glados(_scenario).test(
-      'INV-21: every WISA student appears in exactly one account',
+      'INV-21: every WISA person appears in exactly one account',
       (specs) {
+        // Per **person**, not per row (#318). The shared WISA credentials pull
+        // one school at a time and concatenate, and `schoolId` is a single int,
+        // so one person enrolled in two group schools arrives as two rows
+        // sharing a `wisaId`. Read per row — as this property was until #318 —
+        // the invariant demanded a record for each of them, which is exactly
+        // the second record that collapsed onto the first's `LinkedAccountId`.
+        // What must hold is that the person links **once**, holding one of
+        // their own rows; the tag pool is small enough that these scenarios
+        // generate repeated wisaIds routinely.
         final built = _build(specs, SeqResolver());
+        final rowsOf = <String, List<wapi.WisaStudent>>{};
         for (final student in built.students) {
+          (rowsOf[student.wisaId.value] ??= <wapi.WisaStudent>[]).add(student);
+        }
+        for (final entry in rowsOf.entries) {
           final hits = built.linked.accounts
-              .where((a) => identical(a.wisa, student))
+              .where((a) => entry.value.any((row) => identical(a.wisa, row)))
               .length;
-          expect(hits, 1, reason: 'student ${student.wisaId} appeared $hits×');
+          expect(hits, 1, reason: 'person ${entry.key} appeared $hits×');
         }
       },
     );

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -1546,4 +1546,107 @@ void main() {
       expect(snapshot.accounts[1].wisaSchoolIds, {2});
     });
   });
+
+  group('INV-24 — a shared LinkedAccountId is reported, not merged (#319)', () {
+    // The collision is constructed with a [CollidingResolver]; see its doc for
+    // why it is not driven through the dual-enrolment path #318 fixed.
+    test('two records on one id raise a DuplicateLinkedId naming both', () {
+      final snapshot = link(
+        wisaSnap([wisaStudent('W1'), wisaStudent('W2')]),
+        ssSnap([ssAccount(uid: 'jane', accountId: 'W1', mail: 'jane@s.be')]),
+        azSnap(const []),
+        CollidingResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      expect(snapshot.accounts, hasLength(2),
+          reason: 'both records are kept — a silent drop is INV-23\'s sin');
+      final warning = snapshot.warnings.whereType<DuplicateLinkedId>().single;
+      expect(warning.id.value, 'p-shared');
+      expect(warning.holdings.map((h) => h.wisa), ['W1', 'W2']);
+      expect(warning.holdings.first.smartschool, 'jane');
+      expect(warning.holdings.last.smartschool, isNull);
+    });
+
+    test('the shared id is counted once, so the WISA total is not inflated',
+        () {
+      final snapshot = link(
+        wisaSnap([wisaStudent('W1'), wisaStudent('W2')]),
+        ssSnap(const []),
+        azSnap(const []),
+        CollidingResolver(),
+        schoolPrefix: _prefix,
+      );
+      // Two WISA rows, one id ⇒ one person as far as the dashboard's
+      // linked/total ratio is concerned. Counting per record read 2.
+      expect(snapshot.wisa.total, 1);
+      expect(snapshot.wisa.unlinked, 1);
+    });
+
+    test('a student and a staff member colliding are both listed', () {
+      final snapshot = link(
+        wisaSnap([wisaStudent('W1')], staff: [wisaStaff('PEE')]),
+        ssSnap(const []),
+        azSnap(const []),
+        CollidingResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      final warning = snapshot.warnings.whereType<DuplicateLinkedId>().single;
+      expect(warning.holdings, hasLength(2));
+      expect(warning.holdings.map((h) => h.wisa), ['W1', 'PEE']);
+      expect(warning.holdings.map((h) => h.role),
+          [PersonRole.student, PersonRole.teacher]);
+    });
+
+    test('an INV-23 duplicate-mail pair collides on id too, and says so (#323)',
+        () {
+      // Not constructed: the ordinary resolver produces this. INV-23 keeps both
+      // Smartschool accounts of a colliding pair as separate records, and both
+      // key on the same `accountId`, so they resolve to one id. That makes the
+      // deliberate admin+user setup a live cause of the very card #319 is
+      // about — found by the property test, filed as #323, and left unfixed
+      // here on purpose: #319 makes collisions visible, it does not decide how
+      // the linker should merge them.
+      final snapshot = link(
+        wisaSnap(const []),
+        ssSnap([
+          ssAccount(uid: 'twin-a', accountId: 'W6', mail: 'twin@s.be'),
+          ssAccount(uid: 'twin-b', accountId: 'W6', mail: 'twin@s.be'),
+        ]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+
+      expect(snapshot.accounts.map((a) => a.id.value).toSet(), hasLength(1),
+          reason: 'the two records really do share one id');
+      final warning = snapshot.warnings.whereType<DuplicateLinkedId>().single;
+      expect(warning.holdings.map((h) => h.smartschool), ['twin-a', 'twin-b']);
+      // The duplicate-mail warning is still raised alongside it — the two
+      // invariants report different things about the same pair.
+      expect(snapshot.warnings.whereType<ResolveDuplicateMail>(), hasLength(1));
+      // And one person, not two, for the dashboard.
+      expect(snapshot.smartschool.total, 1);
+    });
+
+    test('the ordinary resolver keeps every snapshot collision-free', () {
+      // The guard must stay invisible on healthy data — nothing about it may
+      // change what an ordinary pass reports.
+      final snapshot = link(
+        wisaSnap([
+          wisaStudent('W1'),
+          wisaStudent('W2')
+        ], staff: [
+          wisaStaff('PEE'),
+        ]),
+        ssSnap([ssAccount(uid: 'jane', accountId: 'W1', mail: 'jane@s.be')]),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+      );
+      expect(snapshot.warnings.whereType<DuplicateLinkedId>(), isEmpty);
+      expect(snapshot.wisa.total, 3);
+    });
+  });
 }

--- a/packages/account_linker/test/link_test.dart
+++ b/packages/account_linker/test/link_test.dart
@@ -1389,4 +1389,161 @@ void main() {
       expect(a.hasLeftGroup, isTrue);
     });
   });
+
+  group('link — a student enrolled in two WISA schools (#318)', () {
+    /// The shared WISA credentials pull one school at a time and concatenate,
+    /// and `WisaStudent.schoolId` is a single int — so a student enrolled in
+    /// two group schools arrives as **two rows sharing one `wisaId`**, in
+    /// whatever order the schools were read. [rows] is that pair (or more), in
+    /// arrival order.
+    LinkedSnapshot linkRows(
+      List<wapi.WisaStudent> rows, {
+      Set<int>? ourSchoolIds,
+      bool inSmartschool = true,
+    }) =>
+        link(
+          wisaSnap(rows,
+              schools: [wisaSchool(1), wisaSchool(2), wisaSchool(3)]),
+          ssSnap(inSmartschool
+              ? [ssAccount(uid: 'jane', accountId: 'W1', mail: 'jane@s.be')]
+              : const []),
+          azSnap(const []),
+          SeqResolver(),
+          schoolPrefix: _prefix,
+          ourSchoolIds: ourSchoolIds,
+        );
+
+    /// The connector-typed WISA row a record ended up carrying.
+    /// [LinkedAccount.wisa] is the `account_core` interface, which exposes only
+    /// the `wisaId` — and the whole question here is which *row* won, so the
+    /// test has to look at `schoolId` / `classGroup`.
+    wapi.WisaStudent? rowOf(LinkedAccount a) => a.wisa as wapi.WisaStudent?;
+
+    test('links to one record holding both school ids, and reads ours', () {
+      // The reported card: our school's row said "create the Office 365
+      // account", the sibling school's row said "unregister in Smartschool",
+      // and both records carried the same id. One person, one record.
+      final snapshot = linkRows(
+        [
+          wisaStudent('W1', schoolId: 2, classGroup: '4ECO'),
+          wisaStudent('W1', schoolId: 1, classGroup: '3BO'),
+        ],
+        ourSchoolIds: {1},
+      );
+
+      expect(snapshot.accounts, hasLength(1));
+      final a = snapshot.accounts.single;
+      expect(a.wisaSchoolIds, {1, 2});
+      expect(a.wisaPresence, WisaPresence.ours);
+      expect(a.isInOurWisa, isTrue);
+      // The half that made the card contradict itself: the departure predicate
+      // both Smartschool departure actions gate on must stay false.
+      expect(a.hasLeftOurSchool, isFalse);
+      expect(a.hasLeftGroup, isFalse);
+    });
+
+    test('never mints two records onto one LinkedAccountId', () {
+      // Both rows produce the natural key `wisa:w1`, so two records would have
+      // been handed the *same* id — which is what put two records' actions on
+      // one card. Assert the property, not just the count.
+      final snapshot = linkRows(
+        [
+          wisaStudent('W1', schoolId: 1, classGroup: '3BO'),
+          wisaStudent('W1', schoolId: 2, classGroup: '4ECO'),
+        ],
+        ourSchoolIds: {1},
+      );
+      final ids = snapshot.accounts.map((a) => a.id).toSet();
+      expect(ids, hasLength(snapshot.accounts.length));
+    });
+
+    test('the class comes from our school, whichever row was read first', () {
+      // The placement every downstream action derives — the Smartschool class
+      // to enrol into, the Office 365 class group to join — must not depend on
+      // which school the concatenated pull happened to reach first.
+      final sibfirst = linkRows(
+        [
+          wisaStudent('W1', schoolId: 2, classGroup: '4ECO'),
+          wisaStudent('W1', schoolId: 1, classGroup: '3BO'),
+        ],
+        ourSchoolIds: {1},
+      );
+      expect(rowOf(sibfirst.accounts.single)?.classGroup, '3BO');
+      expect(rowOf(sibfirst.accounts.single)?.schoolId, 1);
+
+      final oursFirst = linkRows(
+        [
+          wisaStudent('W1', schoolId: 1, classGroup: '3BO'),
+          wisaStudent('W1', schoolId: 2, classGroup: '4ECO'),
+        ],
+        ourSchoolIds: {1},
+      );
+      expect(rowOf(oursFirst.accounts.single)?.classGroup, '3BO');
+      expect(rowOf(oursFirst.accounts.single)?.schoolId, 1);
+    });
+
+    test('merges onto a WISA-only record too, with no Smartschool anchor', () {
+      // The merge target is normally the record a Smartschool account seeded;
+      // when there is none, the first row's own placeholder is the target.
+      final snapshot = linkRows(
+        [
+          wisaStudent('W1', schoolId: 2, classGroup: '4ECO'),
+          wisaStudent('W1', schoolId: 1, classGroup: '3BO'),
+        ],
+        ourSchoolIds: {1},
+        inSmartschool: false,
+      );
+      final a = snapshot.accounts.single;
+      expect(a.smartschool, isNull);
+      expect(a.wisaSchoolIds, {1, 2});
+      expect(rowOf(a)?.classGroup, '3BO');
+    });
+
+    test('two sibling schools, neither ours → one record, still groupOnly', () {
+      final snapshot = linkRows(
+        [
+          wisaStudent('W1', schoolId: 2, classGroup: '4ECO'),
+          wisaStudent('W1', schoolId: 3, classGroup: '5WE'),
+        ],
+        ourSchoolIds: {1},
+      );
+      final a = snapshot.accounts.single;
+      expect(a.wisaSchoolIds, {2, 3});
+      expect(a.wisaPresence, WisaPresence.groupOnly);
+      expect(a.hasLeftOurSchool, isTrue);
+      // Nothing is ours, so nothing displaces the first row (INV-20).
+      expect(rowOf(a)?.classGroup, '4ECO');
+    });
+
+    test('ownership unconfigured → one record, and the first row stands', () {
+      // Every school counts as ours, the same fallback `_presence` applies, so
+      // there is no "ours row" to prefer and arrival order decides.
+      final snapshot = linkRows([
+        wisaStudent('W1', schoolId: 2, classGroup: '4ECO'),
+        wisaStudent('W1', schoolId: 1, classGroup: '3BO'),
+      ]);
+      final a = snapshot.accounts.single;
+      expect(a.wisaSchoolIds, {1, 2});
+      expect(a.wisaPresence, WisaPresence.ours);
+      expect(rowOf(a)?.classGroup, '4ECO');
+    });
+
+    test('two genuinely different students still get a record each', () {
+      // The merge keys on `wisaId`; distinct people are untouched by it.
+      final snapshot = link(
+        wisaSnap(
+          [wisaStudent('W1', schoolId: 1), wisaStudent('W2', schoolId: 2)],
+          schools: [wisaSchool(1), wisaSchool(2)],
+        ),
+        ssSnap(const []),
+        azSnap(const []),
+        SeqResolver(),
+        schoolPrefix: _prefix,
+        ourSchoolIds: {1},
+      );
+      expect(snapshot.accounts, hasLength(2));
+      expect(snapshot.accounts[0].wisaSchoolIds, {1});
+      expect(snapshot.accounts[1].wisaSchoolIds, {2});
+    });
+  });
 }

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -21,10 +21,18 @@ const Address _blankAddress = Address(
 /// A WISA student carrying only the fields the linker reads (`wisaId`,
 /// `schoolId`); the rest are inert defaults. [schoolId] selects which group
 /// school the student sits in (the ours-vs-group join, #134).
-wapi.WisaStudent wisaStudent(String wisaId, {int schoolId = 1}) =>
+///
+/// [classGroup] is otherwise inert to the linker, but it is what tells two rows
+/// of the *same* person apart when they come from two group schools (#318) —
+/// the class is the payload the ours-school row has to win with.
+wapi.WisaStudent wisaStudent(
+  String wisaId, {
+  int schoolId = 1,
+  String classGroup = '',
+}) =>
     wapi.WisaStudent(
       wisaId: WisaId(wisaId),
-      classGroup: '',
+      classGroup: classGroup,
       classSubGroup: '',
       name: 'Doe',
       firstName: 'Jane',

--- a/packages/account_linker/test/support/fixtures.dart
+++ b/packages/account_linker/test/support/fixtures.dart
@@ -280,6 +280,27 @@ class SeqResolver implements PersonIdResolver {
   }
 }
 
+/// A [PersonIdResolver] that hands every natural key the **same** [id] — the
+/// simplest way to construct the INV-24 collision (#319).
+///
+/// It has to be constructed rather than provoked through the data: #318 removed
+/// the one known way two records ended up on one id (a student the aggregated
+/// WISA pull returns from two group schools now merges into a single record), so
+/// reproducing it that way is impossible, and re-breaking the merge to get it
+/// back is not what the invariant is for. INV-24 exists for the cause nobody has
+/// found yet, and a resolver is exactly the seam where any such cause would
+/// eventually express itself: `link` mints identity through this interface and
+/// nothing about the contract stops two keys from mapping to one id.
+class CollidingResolver implements PersonIdResolver {
+  CollidingResolver([this.id = 'p-shared']);
+
+  /// The id every key resolves to.
+  final String id;
+
+  @override
+  PersonId resolve(String naturalKey) => PersonId(id);
+}
+
 /// A stable, order-sensitive textual signature of a [LinkedSnapshot] for
 /// equality assertions (the type has no `==`). Captures every account's id,
 /// confidence, and which systems are present (plus their keys), the warnings,
@@ -315,12 +336,21 @@ List<String> structuralSignature(LinkedSnapshot snapshot) {
         'a:${g.azure?.id ?? '-'}',
       ].join('|');
 
+  String holding(LinkedIdHolding h) =>
+      '${h.role.name}/w:${h.wisa ?? '-'}/s:${h.smartschool ?? '-'}'
+      '/a:${h.azure ?? '-'}';
+
   String warning(LinkWarning w) => switch (w) {
         ResolveDuplicateMail(:final mail, :final accounts) =>
           'dupmail:$mail:${(accounts.map((x) => x.uid).toList()..sort()).join(',')}',
         SmartschoolNamesakeSkipped(:final wisaName, :final smartschool) =>
           'namesake:$wisaName:${smartschool.id.value}:'
               '${smartschool.official ? 'official' : 'group'}',
+        // INV-24 (#319). The holdings are already in a deterministic order
+        // (snapshot order, students before staff), so they are not re-sorted:
+        // a shift in *which* record claimed the id first is a real difference.
+        DuplicateLinkedId(:final id, :final holdings) =>
+          'dupid:${id.value}:${holdings.map(holding).join(',')}',
       };
 
   return [

--- a/packages/account_state/lib/src/apply/wisa_import_rules.dart
+++ b/packages/account_state/lib/src/apply/wisa_import_rules.dart
@@ -20,7 +20,8 @@ import 'package:wisa_api/wisa_api.dart';
 /// final importRules = WisaImportRules();
 /// final wisa = SystemState<WisaSnapshot>(
 ///   system: Origin.wisa,
-///   syncer: (_) => connector.sync(
+///   // `fullRead` is ignored: WISA is read whole on every pass (#316).
+///   syncer: (_, {bool fullRead = false}) => connector.sync(
 ///     schools: schools,
 ///     workDate: workDate,
 ///     // read live, so a later add() — and a later save — takes effect

--- a/packages/account_state/lib/src/link/linked_state.dart
+++ b/packages/account_state/lib/src/link/linked_state.dart
@@ -133,8 +133,9 @@ class LinkedState {
   ///
   /// A network-backed resolver cannot mint inside the synchronous pure `link()`,
   /// so its id map is populated up front: this computes the exact key set with
-  /// `naturalKeysFor` (over the same snapshots and `schoolPrefix` the linker
-  /// uses) and awaits `resolver.prepare(keys)` before delegating to the
+  /// `naturalKeysFor` (over the same snapshots, `schoolPrefix` and
+  /// managed-school set the linker uses) and awaits
+  /// `resolver.prepare(keys)` before delegating to the
   /// synchronous [recompute]. A plain [PersonIdResolver] (file/in-memory) is not
   /// preparable and mints lazily, so it skips the prepare step and this behaves
   /// exactly like [recompute].
@@ -154,6 +155,9 @@ class LinkedState {
         smartschool,
         azure,
         schoolPrefix: studentConfig.schoolPrefix,
+        // Same managed-school set `link()` gets below, so both entry points run
+        // the identical record-building pass (#318).
+        ourSchoolIds: ourSchoolIds,
       );
       await resolver.prepare(keys);
     }

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -530,6 +530,21 @@ Map<String, List<String>> _warningsByUid(List<core.LinkWarning> warnings) {
         // `ClassExistsAsSmartschoolGroup` candidate on its group document, and
         // the sync log names every skipped namesake (#225).
         break;
+      case core.DuplicateLinkedId():
+        // Names an *id*, not an account (#319). Deliberately not hung on a uid,
+        // for two reasons. The colliding records materialize onto the same
+        // document, so the card a per-uid string would land on is itself the
+        // symptom — the thing the operator cannot trust. And `decisions_merge`
+        // reads `MaterializedAccount.warnings` type-blind: any warning string
+        // there is taken as evidence that an accepted duplicate-*mail*
+        // collision still exists, so hanging an unrelated warning on an account
+        // would quietly keep a stale acceptance alive.
+        //
+        // It is surfaced snapshot-wide instead: the sync log names every
+        // collision and the Synchronisatie overview lists what each colliding
+        // record holds. Both are reachable with no Smartschool account at all,
+        // which a uid-keyed message would not be.
+        break;
     }
   }
   return byUid;

--- a/packages/account_state/lib/src/sync/application_state.dart
+++ b/packages/account_state/lib/src/sync/application_state.dart
@@ -38,14 +38,21 @@ class ApplicationState {
   /// [core.Origin.smartschool], or [core.Origin.azure]); the [core.Origin.all]
   /// and [core.Origin.other] wildcards are not syncable and throw
   /// [ArgumentError].
-  Future<core.Snapshot> sync(core.Origin system) {
+  ///
+  /// [fullRead] asks for a deliberate re-read rather than an incremental resume
+  /// (#316) — see [Syncer]. It is what **Controleer op drift** passes: a pass
+  /// whose whole job is to find what somebody changed behind the app's back
+  /// cannot be scoped to what the stored resume point happens to report. WISA
+  /// and Smartschool read in full every pass anyway, so it changes nothing for
+  /// them.
+  Future<core.Snapshot> sync(core.Origin system, {bool fullRead = false}) {
     switch (system) {
       case core.Origin.wisa:
-        return wisa.sync();
+        return wisa.sync(fullRead: fullRead);
       case core.Origin.smartschool:
-        return smartschool.sync();
+        return smartschool.sync(fullRead: fullRead);
       case core.Origin.azure:
-        return azure.sync();
+        return azure.sync(fullRead: fullRead);
       case core.Origin.all:
       case core.Origin.other:
         throw ArgumentError.value(
@@ -102,6 +109,14 @@ class ApplicationState {
 /// pull this syncer performed, the stored token and previous list are dropped
 /// and the pass re-reads in full — the same recovery #213 already makes when
 /// Graph refuses a token.
+///
+/// **A caller can force the same full read** by passing `fullRead: true`
+/// (#316), which is what **Controleer op drift** does. That case is narrower
+/// than a moved prefix: the snapshot in hand still describes *our* school, so
+/// only the token is dropped and `previous` goes in untouched — the pass reads
+/// Azure whole while [retainedStaffEmployeeIds] still remembers who to keep
+/// asking about (#269).
+///
 /// [expectedGroupMailNicknames] is the group half of the same idea (#280), and
 /// is read at sync time **with the prefix this pass resolved**: the addresses
 /// are `<PREFIX>-<KLAS>`, so the callback cannot be handed a frozen prefix any
@@ -118,7 +133,7 @@ Syncer<AzureSnapshot> azureSyncer(
   // value, which is the one the cold seed (if any) was pulled with: bootstrap
   // wires this from the very document it just loaded.
   var pulledWith = schoolPrefix?.call() ?? connector.credentials.schoolPrefix;
-  return (previous) {
+  return (previous, {bool fullRead = false}) {
     final prefix = schoolPrefix?.call() ?? connector.credentials.schoolPrefix;
     final moved = prefix != pulledWith;
     pulledWith = prefix;
@@ -127,7 +142,15 @@ Syncer<AzureSnapshot> azureSyncer(
     // *previous* school — so it is dropped whole rather than in pieces.
     final carried = moved ? null : previous;
     return connector.sync(
-      deltaToken: carried?.deltaToken,
+      // A [fullRead] pass drops the resume point and **only** the resume point
+      // (#316). `/users/delta` reports what changed since our token, so an edit
+      // older than it — or one an earlier walk dropped — survives every later
+      // incremental pass; the connector's `_fullRead` branch is what asks Azure
+      // what it holds right now. The snapshot itself still goes in: the ids the
+      // back-fill keeps asking about are remembered from it (#269), and a
+      // re-read that forgot them would take a departed staff member's account
+      // out of the app's view on the very pass meant to repair the view.
+      deltaToken: fullRead ? null : carried?.deltaToken,
       previous: carried,
       expectedEmployeeIds: <String>{
         ...?expectedEmployeeIds?.call(),

--- a/packages/account_state/lib/src/sync/snapshot_persistence.dart
+++ b/packages/account_state/lib/src/sync/snapshot_persistence.dart
@@ -24,8 +24,11 @@ Syncer<S> persistingSyncer<S extends core.Snapshot>({
   String? Function(S snapshot)? deltaTokenOf,
   void Function(Object error)? onError,
 }) {
-  return (previous) async {
-    final fresh = await inner(previous);
+  return (previous, {bool fullRead = false}) async {
+    // Forwarded rather than swallowed: whether the pass is a re-read is the
+    // caller's decision (#316), and this wrapper only adds persistence to
+    // whatever [inner] produces.
+    final fresh = await inner(previous, fullRead: fullRead);
     try {
       await store.save(
         system,

--- a/packages/account_state/lib/src/sync/system_state.dart
+++ b/packages/account_state/lib/src/sync/system_state.dart
@@ -9,9 +9,21 @@ import 'package:account_core/account_core.dart' as core;
 /// (PAIN-2). Syncers whose systems do a full read each time (WISA, Smartschool)
 /// simply ignore it.
 ///
+/// [fullRead] says **this pass is a deliberate re-read**: build the snapshot
+/// from what the system holds right now rather than resuming whatever
+/// incremental state [previous] carries (#316). Only the *resume point* is
+/// dropped — [previous] is still handed in, so a syncer that remembers things
+/// from the snapshot in hand (Azure's retained staff ids, #269) keeps
+/// remembering them. Syncers that read the whole system every pass ignore it,
+/// exactly as they ignore [previous]; it costs them nothing because they have no
+/// resume point to drop.
+///
 /// A syncer that throws leaves the [SystemState] untouched — the previous
 /// snapshot and `lastSync` survive a failed sync (domain-model §6.1).
-typedef Syncer<S extends core.Snapshot> = Future<S> Function(S? previous);
+typedef Syncer<S extends core.Snapshot> = Future<S> Function(
+  S? previous, {
+  bool fullRead,
+});
 
 /// Tests whether a connector is configured and reachable. Returns `true` on a
 /// successful probe. Used by [SystemState.test]; kept separate from [Syncer]
@@ -75,13 +87,18 @@ class SystemState<S extends core.Snapshot> {
   /// intact and the error propagates to the caller (domain-model §6.1).
   /// Concurrent syncs are rejected with a [StateError] rather than racing on
   /// the shared snapshot slot.
-  Future<S> sync() async {
+  ///
+  /// [fullRead] asks the syncer for a deliberate re-read instead of an
+  /// incremental resume (#316) — see [Syncer]. The snapshot in hand is handed to
+  /// the syncer either way; the flag only says whether the pass may build on the
+  /// resume point that snapshot carries.
+  Future<S> sync({bool fullRead = false}) async {
     if (_syncing) {
       throw StateError('A $system sync is already in progress');
     }
     _syncing = true;
     try {
-      final fresh = await _syncer(_snapshot);
+      final fresh = await _syncer(_snapshot, fullRead: fullRead);
       _snapshot = fresh;
       _lastSync = fresh.fetchedAt;
       return fresh;

--- a/packages/account_state/test/application_state_test.dart
+++ b/packages/account_state/test/application_state_test.dart
@@ -542,6 +542,178 @@ void main() {
     });
   });
 
+  group('azureSyncer repairs a companyName no delta can report (#315)', () {
+    // The report, at the layer that decides it. Acties offered `Office 365 ·
+    // Wijzig de school in Azure` — `companyName: SBE → SSM` — for a student
+    // whose Azure account already carried `SSM`, and the proposal survived
+    // **Controleer op drift** pass after pass, so the write was offered for a
+    // 29-account bulk apply that would have changed nothing.
+    //
+    // Adam Bidri is a transferred student: `companyName SSM`, `department 4EWb`.
+    // The correction landed in the tenant before the token this session holds
+    // was minted (or an earlier walk dropped the row), so `/users/delta` — which
+    // reports what changed *since* that token — has nothing to say about him,
+    // on this pass and on every later one. The action's own guard is right
+    // (`!_eq(_az.companyName, config.schoolPrefix)`, case-insensitive and
+    // trimmed); what was wrong was the record it judged. Only a read of what
+    // Graph holds *now* can produce a truthful one, which is what a drift pass
+    // asks for (#316).
+    late _RecordingGraphTransport transport;
+
+    /// The `employeeId in (…)` filters this pass issued, in order.
+    List<String> lookups() => transport.requests
+        .map((r) => r.url.queryParameters[r'$filter'])
+        .whereType<String>()
+        .where((f) => f.startsWith('employeeId in'))
+        .toList();
+
+    /// The school-scoped bulk reads this pass issued, in order.
+    List<String> bulkReads() => transport.requests
+        .where((r) => r.url.path.endsWith('/users'))
+        .map((r) => r.url.queryParameters[r'$filter'] ?? '')
+        .where((f) => !f.startsWith('employeeId in'))
+        .toList();
+
+    GraphResponse route(GraphRequest req) {
+      final path = req.url.path;
+      if (path.contains('groups')) return _jsonOk({'value': <Object?>[]});
+      if (path.contains('users/delta')) {
+        return _jsonOk({
+          '@odata.deltaLink':
+              'https://graph.microsoft.com/v1.0/users/delta?\$deltatoken=NEXT',
+          // Nothing changed *since the token*, which is not the same thing as
+          // nothing being wrong. This is the whole shape of the bug.
+          'value': <Object?>[],
+        });
+      }
+      final filter = req.url.queryParameters[r'$filter'] ?? '';
+      if (filter.startsWith('employeeId in')) {
+        return _jsonOk({'value': <Object?>[]});
+      }
+      // Graph as it stands right now: our prefix is already on the account, and
+      // only the department is legitimately stale (last year's class).
+      return _jsonOk({
+        'value': [
+          {
+            'id': 'az-33223',
+            'userPrincipalName': 'adam.bidri@student.school.example',
+            'employeeId': '33223',
+            'displayName': 'Bidri Adam',
+            'givenName': 'Adam',
+            'surname': 'Bidri',
+            'companyName': 'SSM',
+            'department': '4EWb',
+            'accountEnabled': true,
+          },
+        ],
+      });
+    }
+
+    /// Last night's snapshot: the school he was at *before* the transfer, and
+    /// the token whose walks all missed the correction.
+    AzureSnapshot held() => AzureSnapshot(
+          fetchedAt: DateTime.utc(2026),
+          deltaToken: 'AZ-TOKEN',
+          users: const [
+            AzureUser(
+              id: 'az-33223',
+              upn: 'adam.bidri@student.school.example',
+              employeeId: '33223',
+              displayName: 'Bidri Adam',
+              givenName: 'Adam',
+              surname: 'Bidri',
+              companyName: 'SBE',
+              department: '4EWb',
+            ),
+          ],
+          groups: const [],
+        );
+
+    SystemState<AzureSnapshot> stateFor() => SystemState<AzureSnapshot>(
+          system: core.Origin.azure,
+          initial: held(),
+          syncer: azureSyncer(
+            AzureConnector(
+              credentials: AzureCredentials(
+                clientId: 'c',
+                tenantId: 't',
+                azureDomain: 'school.example',
+                schoolPrefix: 'SSM',
+              ),
+              authProvider: const StaticAuthProvider('T'),
+              transport: transport,
+            ),
+            // WISA still places him here, so the back-fill would ask about him
+            // if the read had not turned him up (#224).
+            expectedEmployeeIds: () => const <String>['33223'],
+            schoolPrefix: () => 'SSM',
+          ),
+        );
+
+    setUp(() => transport = _RecordingGraphTransport(route));
+
+    test(
+        'a drift pass ends with the companyName Graph holds, not the stored one',
+        () async {
+      final snapshot = await stateFor().sync(fullRead: true);
+
+      // The one assertion the issue asks for: stored `SBE`, Graph `SSM`, a
+      // delta that reports nothing — and the pass still ends with `SSM`, so
+      // `ModifyAzureSchool.evaluate()` is false and no phantom PATCH is offered.
+      expect(snapshot.users.single.companyName, 'SSM');
+
+      // …and it came from asking Graph what it holds now. The stored token was
+      // never resumed from, so the empty delta above could not have supplied it.
+      expect(
+        transport.requests
+            .where((r) => r.url.path.contains('users/delta'))
+            .map((r) => r.url.queryParameters[r'$deltatoken']),
+        isNot(contains('AZ-TOKEN')),
+      );
+      expect(bulkReads(),
+          ["companyName eq 'SSM' or startswith(department,'SSM')"]);
+      // Not the `employeeId` back-fill either: the bulk read turned him up, so
+      // that leg had nothing to ask about. The repair is the re-read itself.
+      expect(lookups(), isEmpty);
+
+      // Nothing else about him moved, and the pass leaves a fresh resume point.
+      expect(
+        snapshot.users.single,
+        const AzureUser(
+          id: 'az-33223',
+          upn: 'adam.bidri@student.school.example',
+          employeeId: '33223',
+          displayName: 'Bidri Adam',
+          givenName: 'Adam',
+          surname: 'Bidri',
+          companyName: 'SSM',
+          department: '4EWb',
+        ),
+      );
+      expect(snapshot.deltaToken, 'NEXT');
+    });
+
+    test(
+        'the incremental pass, resuming the token, can only confirm the stale copy',
+        () async {
+      // The counterweight that makes the test above mean something. This is
+      // what every pass did before #316 — including the drift pass, which is
+      // why the operator could press it forever. `/users/delta` is doing its
+      // job: it reports changes since our token and there are none. The
+      // snapshot it leaves is therefore the stale one, unchanged.
+      final snapshot = await stateFor().sync();
+
+      expect(snapshot.users.single.companyName, 'SBE');
+      expect(
+        transport.requests
+            .where((r) => r.url.path.contains('users/delta'))
+            .map((r) => r.url.queryParameters[r'$deltatoken']),
+        contains('AZ-TOKEN'),
+      );
+      expect(bulkReads(), isEmpty, reason: 'no read of what Graph holds now');
+    });
+  });
+
   group('managedStudentEmployeeIds (#224)', () {
     WisaStudent student(String id, {int schoolId = 1}) => WisaStudent(
           wisaId: core.WisaId(id),

--- a/packages/account_state/test/application_state_test.dart
+++ b/packages/account_state/test/application_state_test.dart
@@ -63,7 +63,7 @@ void main() {
       ) =>
           SystemState<S>(
             system: system,
-            syncer: (_) async {
+            syncer: (_, {bool fullRead = false}) async {
               synced.add(system);
               return make();
             },
@@ -507,6 +507,38 @@ void main() {
       await state.sync();
       expect(lookups(), ["employeeId in ('42')"],
           reason: 'no second lookup: GBS staff are not SSM\'s to remember');
+    });
+
+    test('a forced re-read drops the token but keeps remembering her (#316)',
+        () async {
+      // The interaction the drift pass turns on: `fullRead` drops the *resume
+      // point* and nothing else. A re-read that dropped the snapshot too — the
+      // way a moved prefix does — would forget the very ids the back-fill has to
+      // ask about, and the account would leave the app's view on the pass meant
+      // to repair it.
+      final snapshot =
+          await stateFor(held(deltaToken: 'AZ-TOKEN')).sync(fullRead: true);
+
+      expect(
+        transport.requests.where((r) => r.url.path.contains('users/delta')).map(
+              (r) => r.url.queryParameters[r'$deltatoken'],
+            ),
+        isNot(contains('AZ-TOKEN')),
+        reason: 'the stored token is not resumed from',
+      );
+      expect(
+        transport.requests
+            .where((r) => r.url.path.endsWith('/users'))
+            .map((r) => r.url.queryParameters[r'$filter'])
+            .where((f) => !(f ?? '').startsWith('employeeId in')),
+        ["companyName eq 'GBS' or startswith(department,'GBS')"],
+        reason: 'the school-scoped bulk read ran instead',
+      );
+      expect(lookups(), ["employeeId in ('42')"],
+          reason: 'previous still went in, so #269 still remembers her');
+      expect(snapshot.users.map((u) => u.id), ['az-staff']);
+      expect(snapshot.deltaToken, 'NEXT',
+          reason: 'the re-read mints a fresh token rather than carrying one');
     });
   });
 

--- a/packages/account_state/test/linked_state_test.dart
+++ b/packages/account_state/test/linked_state_test.dart
@@ -213,7 +213,7 @@ final _staffConfig =
 SystemState<S> _sys<S extends core.Snapshot>(core.Origin o, S? initial) =>
     SystemState<S>(
       system: o,
-      syncer: (_) async => initial as S,
+      syncer: (_, {bool fullRead = false}) async => initial as S,
       initial: initial,
     );
 

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -107,6 +107,38 @@ class _SeqResolver implements core.PersonIdResolver {
       core.PersonId(_seen.putIfAbsent(naturalKey, () => 'p${_seen.length}'));
 }
 
+/// Hands every natural key one id, to construct the INV-24 collision (#319).
+class _CollidingResolver implements core.PersonIdResolver {
+  @override
+  core.PersonId resolve(String naturalKey) => const core.PersonId('p-shared');
+}
+
+/// Two unrelated students on **one** `LinkedAccountId` — the id collision
+/// INV-24 reports (#319). Constructed through the resolver rather than through
+/// the data: #318 removed the one known way a snapshot produced this.
+LinkedState _idCollisionLinked() => LinkedState.recompute(
+      wisa: wapi.WisaSnapshot(
+        fetchedAt: _d,
+        students: [
+          _wStudent(wisaId: '1', classGroup: '3C'),
+          _wStudent(wisaId: '2', classGroup: '3C'),
+        ],
+        staff: const [],
+        classGroups: const [],
+        schools: const [],
+      ),
+      smartschool: ss.SmartschoolSnapshot(
+        fetchedAt: _d,
+        groups: const [],
+        accounts: [_ssAccount()],
+        memberships: const [],
+      ),
+      azure: az.AzureSnapshot(fetchedAt: _d, users: const [], groups: const []),
+      resolver: _CollidingResolver(),
+      studentConfig: _studentConfig,
+      staffConfig: _staffConfig,
+    );
+
 /// A fully-linked student whose WISA class (3C) differs from her Smartschool
 /// membership (2B), so the dispatch yields exactly one pending action
 /// (`MoveToSmartschoolClassGroup`) — the shared fixture scenario.
@@ -297,6 +329,37 @@ void main() {
       );
       expect(account.candidates.every((c) => c.canApply), isTrue);
       expect(account.hasPending, isTrue);
+    });
+
+    group('a LinkedAccountId claimed twice (INV-24, #319)', () {
+      test('the linker reports it rather than the materializer swallowing it',
+          () {
+        final linked = _idCollisionLinked();
+        final warning =
+            linked.snapshot.warnings.whereType<core.DuplicateLinkedId>().single;
+        expect(warning.id.value, 'p-shared');
+        expect(warning.holdings.map((h) => h.wisa), ['1', '2']);
+      });
+
+      test('the collision does not become an account warning string', () {
+        // Deliberate. `decisions_merge._situationExists` reads
+        // `MaterializedAccount.warnings` type-blind: for an
+        // `acceptedDuplicate` decision, *any* warning string there is taken as
+        // proof the duplicate-mail collision still exists. Hanging an
+        // unrelated warning on an account would quietly keep a stale
+        // acceptance alive, so this one is reported snapshot-wide instead.
+        final view = materialize(_idCollisionLinked(), generation: 1);
+        expect(view.accounts.every((a) => a.warnings.isEmpty), isTrue);
+      });
+
+      test('both records still materialize, onto the one document id', () {
+        // Documents the damage the warning exists to make visible: the store
+        // keeps one document per id, so one of these two is what every other
+        // operator inherits.
+        final view = materialize(_idCollisionLinked(), generation: 1);
+        expect(view.accounts, hasLength(2));
+        expect(view.accounts.map((a) => a.id.value).toSet(), {'p-shared'});
+      });
     });
 
     test('rollup counts match the accounts beneath them', () {

--- a/packages/account_state/test/password_queue_capture_test.dart
+++ b/packages/account_state/test/password_queue_capture_test.dart
@@ -221,17 +221,17 @@ class _Harness {
       wisa: SystemState<wapi.WisaSnapshot>(
         system: core.Origin.wisa,
         initial: wisa ?? _wSnap(),
-        syncer: (_) async => wisa ?? _wSnap(),
+        syncer: (_, {bool fullRead = false}) async => wisa ?? _wSnap(),
       ),
       smartschool: SystemState<ss.SmartschoolSnapshot>(
         system: core.Origin.smartschool,
         initial: smartschool ?? _sSnap(),
-        syncer: (_) async => smartschool ?? _sSnap(),
+        syncer: (_, {bool fullRead = false}) async => smartschool ?? _sSnap(),
       ),
       azure: SystemState<az.AzureSnapshot>(
         system: core.Origin.azure,
         initial: azure ?? _aSnap(),
-        syncer: (_) async => azure ?? _aSnap(),
+        syncer: (_, {bool fullRead = false}) async => azure ?? _aSnap(),
       ),
     );
     var n = 0;

--- a/packages/account_state/test/state_applier_test.dart
+++ b/packages/account_state/test/state_applier_test.dart
@@ -313,7 +313,7 @@ class _Harness {
       initial: wisa ?? _wSnap(),
       // A re-sync re-reads the base rows filtered by the current rule set —
       // exactly what the real WISA connector does at snapshot construction.
-      syncer: (_) async {
+      syncer: (_, {bool fullRead = false}) async {
         counts[0]++;
         // Students carry no drop rule; staff are filtered by the accumulated
         // DontImportUserFromWisa rules, as the real connector does.
@@ -326,7 +326,7 @@ class _Harness {
     final ssState = SystemState<ss.SmartschoolSnapshot>(
       system: core.Origin.smartschool,
       initial: ssSnap,
-      syncer: (_) async {
+      syncer: (_, {bool fullRead = false}) async {
         counts[1]++;
         return ssSnap;
       },
@@ -334,7 +334,7 @@ class _Harness {
     final azState = SystemState<az.AzureSnapshot>(
       system: core.Origin.azure,
       initial: azSnap,
-      syncer: (_) async {
+      syncer: (_, {bool fullRead = false}) async {
         counts[2]++;
         return azSnap;
       },
@@ -1138,17 +1138,17 @@ void main() {
           wisa: SystemState<wapi.WisaSnapshot>(
             system: core.Origin.wisa,
             initial: _wSnap(),
-            syncer: (_) async => _wSnap(),
+            syncer: (_, {bool fullRead = false}) async => _wSnap(),
           ),
           smartschool: SystemState<ss.SmartschoolSnapshot>(
             system: core.Origin.smartschool,
             initial: _sSnap(),
-            syncer: (_) async => _sSnap(),
+            syncer: (_, {bool fullRead = false}) async => _sSnap(),
           ),
           azure: SystemState<az.AzureSnapshot>(
             system: core.Origin.azure,
             initial: _aSnap(users: [_azUser(id: 'az-orphan')]),
-            syncer: (_) async => _aSnap(),
+            syncer: (_, {bool fullRead = false}) async => _aSnap(),
           ),
         ),
         connectors:

--- a/packages/account_state/test/sync/snapshot_persistence_test.dart
+++ b/packages/account_state/test/sync/snapshot_persistence_test.dart
@@ -49,7 +49,8 @@ void main() {
         syncedBy: 'op@school.example',
         payloadOf: (s) => s.toJson(),
         deltaTokenOf: (s) => s.deltaToken,
-        inner: (_) async => _azSnap(deltaToken: 'TOK-9'),
+        inner: (_, {bool fullRead = false}) async =>
+            _azSnap(deltaToken: 'TOK-9'),
       );
 
       final fresh = await syncer(null);
@@ -73,7 +74,7 @@ void main() {
         syncedBy: 'op',
         payloadOf: (s) => s.toJson(),
         onError: (e) => reported = e,
-        inner: (_) async => _azSnap(),
+        inner: (_, {bool fullRead = false}) async => _azSnap(),
       );
 
       final fresh = await syncer(null);
@@ -93,7 +94,7 @@ void main() {
         store: store,
         syncedBy: 'op',
         payloadOf: (s) => s.toJson(),
-        inner: (_) async => throw Exception('network'),
+        inner: (_, {bool fullRead = false}) async => throw Exception('network'),
       );
 
       await expectLater(syncer(null), throwsException);

--- a/packages/account_state/test/system_state_test.dart
+++ b/packages/account_state/test/system_state_test.dart
@@ -24,7 +24,8 @@ void main() {
       final fetchedAt = DateTime.utc(2026, 7, 3, 9);
       final state = SystemState<_FakeSnapshot>(
         system: core.Origin.wisa,
-        syncer: (_) async => _FakeSnapshot(fetchedAt, tag: 'fresh'),
+        syncer: (_, {bool fullRead = false}) async =>
+            _FakeSnapshot(fetchedAt, tag: 'fresh'),
       );
 
       expect(state.snapshot, isNull);
@@ -42,7 +43,7 @@ void main() {
       var calls = 0;
       final state = SystemState<_FakeSnapshot>(
         system: core.Origin.azure,
-        syncer: (previous) async {
+        syncer: (previous, {bool fullRead = false}) async {
           seen = previous;
           return _FakeSnapshot(DateTime.utc(2026, 7, calls += 1));
         },
@@ -58,13 +59,38 @@ void main() {
               'second sync threads the stored snapshot back in (delta seam)');
     });
 
+    test('forwards fullRead to the syncer, defaulting to an ordinary sync',
+        () async {
+      // The seam **Controleer op drift** threads down to the Azure syncer
+      // (#316): the pass says whether it may build on the resume point the
+      // stored snapshot carries. The snapshot itself goes in either way.
+      final asked = <bool>[];
+      final seen = <String?>[];
+      final state = SystemState<_FakeSnapshot>(
+        system: core.Origin.azure,
+        initial: _FakeSnapshot(DateTime.utc(2026), tag: 'held'),
+        syncer: (previous, {bool fullRead = false}) async {
+          asked.add(fullRead);
+          seen.add(previous?.tag);
+          return _FakeSnapshot(DateTime.utc(2026, 7), tag: 'fresh');
+        },
+      );
+
+      await state.sync();
+      await state.sync(fullRead: true);
+
+      expect(asked, <bool>[false, true]);
+      expect(seen, <String?>['held', 'fresh'],
+          reason: 'a re-read still gets the snapshot in hand as `previous`');
+    });
+
     test('a failed sync leaves the previous snapshot and lastSync intact',
         () async {
       final good = DateTime.utc(2026, 7, 1);
       var shouldFail = false;
       final state = SystemState<_FakeSnapshot>(
         system: core.Origin.smartschool,
-        syncer: (_) async {
+        syncer: (_, {bool fullRead = false}) async {
           if (shouldFail) throw const _SyncFailure();
           return _FakeSnapshot(good, tag: 'good');
         },
@@ -85,7 +111,8 @@ void main() {
       final at = DateTime.utc(2025, 12, 31);
       final state = SystemState<_FakeSnapshot>(
         system: core.Origin.wisa,
-        syncer: (_) async => _FakeSnapshot(DateTime.utc(2026)),
+        syncer: (_, {bool fullRead = false}) async =>
+            _FakeSnapshot(DateTime.utc(2026)),
         initial: _FakeSnapshot(at, tag: 'cached'),
       );
       expect(state.snapshot?.tag, 'cached');
@@ -97,7 +124,7 @@ void main() {
       final gate = Completer<void>();
       final state = SystemState<_FakeSnapshot>(
         system: core.Origin.wisa,
-        syncer: (_) async {
+        syncer: (_, {bool fullRead = false}) async {
           await gate.future;
           return _FakeSnapshot(DateTime.utc(2026));
         },
@@ -116,7 +143,8 @@ void main() {
   group('SystemState.test (transient connection state)', () {
     SystemState<_FakeSnapshot> make() => SystemState<_FakeSnapshot>(
           system: core.Origin.wisa,
-          syncer: (_) async => _FakeSnapshot(DateTime.utc(2026)),
+          syncer: (_, {bool fullRead = false}) async =>
+              _FakeSnapshot(DateTime.utc(2026)),
         );
 
     test('starts unknown on a fresh state (never persisted)', () {

--- a/packages/azure_api/README.md
+++ b/packages/azure_api/README.md
@@ -20,7 +20,15 @@ The legacy connector downloads roughly **6000** tenant users to keep the
   It also primes a delta token (`$deltatoken=latest`) for next time.
 - **Incremental sync** — `/users/delta` returns only the users that changed
   since the last token; the connector upserts and removes them on top of the
-  previous snapshot.
+  previous snapshot. `UserDelta` splits the walk three ways: `changed` (upsert),
+  `removedIds` (Graph's `@removed` — the object is gone from the directory) and
+  `leftSchoolIds` (#317 — a record we already held whose row, merged whole, no
+  longer names our school). The last two are dropped from the snapshot alike,
+  but they are kept apart because they are not the same news: a left-school
+  account still exists, and the `employeeId` back-fill re-adopts it with the
+  fresh Graph record when this pass still expects it. Reporting it at all is what
+  makes it actionable — `changed` only ever upserts, so a walk that stayed silent
+  left the contradicted record in place on every later pass too.
 
 `$select` is pinned to exactly the fields the port uses: `id`,
 `userPrincipalName`, `employeeId`, `displayName`, `givenName`, `surname`,

--- a/packages/azure_api/lib/src/connector.dart
+++ b/packages/azure_api/lib/src/connector.dart
@@ -393,16 +393,36 @@ class AzureConnector {
     return '${age.inMinutes}m';
   }
 
-  /// Upserts [delta.changed] and drops [delta.removedIds] over [base], keeping
-  /// the result keyed by Azure object id.
+  /// Upserts [delta.changed] and drops both [delta.removedIds] and
+  /// [delta.leftSchoolIds] over [base], keeping the result keyed by Azure object
+  /// id.
   ///
   /// A whole-record upsert is only safe because [UserManager.delta] was handed
   /// the same [base] and has already merged each sparse Graph row onto the
   /// record it updates (#288); the entries here are complete users, not
   /// fragments.
+  ///
+  /// The two removal buckets mean different things and land in the same place
+  /// here (#317). A `@removed` id is an object that is gone from the directory;
+  /// a [UserDelta.leftSchoolIds] id is an account that still exists but whose
+  /// `companyName`/`department` no longer names our school. Either way the
+  /// record we hold is one this snapshot has no business asserting: because the
+  /// upsert set is the *only* thing that would have touched it, keeping it would
+  /// leave a row that contradicts Graph and does so permanently — every later
+  /// walk reaches the same verdict about the same row.
+  ///
+  /// Dropping is not the last word on a left-school account: [_adoptByEmployeeId]
+  /// runs after this and re-adopts any id the caller still expects (#224), with
+  /// the whole record straight off Graph. So a student WISA still places here
+  /// comes back correct rather than stale, and one WISA has let go stays gone.
+  /// The upserts run last so a walk that reported an id in both buckets — a row
+  /// that left and a later row that came back — ends up keeping the account.
   static List<AzureUser> _applyDelta(List<AzureUser> base, UserDelta delta) {
     final byId = {for (final u in base) u.id: u};
     for (final id in delta.removedIds) {
+      byId.remove(id);
+    }
+    for (final id in delta.leftSchoolIds) {
       byId.remove(id);
     }
     for (final u in delta.changed) {

--- a/packages/azure_api/lib/src/user_manager.dart
+++ b/packages/azure_api/lib/src/user_manager.dart
@@ -20,12 +20,30 @@ class UserDelta {
   /// reconciles these against the users it already knows.
   final List<String> removedIds;
 
+  /// Azure object ids of users the caller **already held** whose row, merged
+  /// whole, no longer passes the school test (#317) — a student whose
+  /// `companyName` now names a sibling school, a staff member other software
+  /// dropped from the comma-separated `department` list.
+  ///
+  /// These accounts still exist in the directory; they are simply not ours any
+  /// more, which is why they are not [removedIds]. Reporting them is what makes
+  /// the news actionable at all: [changed] is an upsert-only set, so a caller
+  /// told nothing keeps the record it had, and the snapshot goes on insisting
+  /// the account carries our prefix while Graph says otherwise — forever, since
+  /// every later walk drops the same row again.
+  ///
+  /// Only ids the caller passed in as `known` appear here. A sparse row about a
+  /// user we have never seen carries nothing to classify it by and stays
+  /// dropped, silently: there is no record to reconcile it against.
+  final List<String> leftSchoolIds;
+
   /// Token to resume the next incremental sync from.
   final String? deltaToken;
 
   const UserDelta({
     required this.changed,
     required this.removedIds,
+    required this.leftSchoolIds,
     this.deltaToken,
   });
 }
@@ -290,6 +308,11 @@ class UserManager {
   /// the row never spoke about. A sparse row about a user [known] does not hold
   /// stays unclassifiable and is dropped, exactly as before.
   ///
+  /// When the school test fails on a record [known] *does* hold, the id lands in
+  /// [UserDelta.leftSchoolIds] instead of being dropped (#317) — the account
+  /// moved out of our school, and a caller told nothing would keep upserting
+  /// nothing over a record Graph has just contradicted.
+  ///
   /// This is the one read whose caller (`AzureConnector.sync`) comes prepared
   /// for a refusal: a token Graph no longer accepts is recovered from with a
   /// full read (#213). The transport is told so, so it logs that reply as a
@@ -325,6 +348,7 @@ class UserManager {
     final result = await _graph.getDelta(url, expected: expected);
     final changed = <AzureUser>[];
     final removedIds = <String>[];
+    final leftSchoolIds = <String>[];
     for (final row in result.values) {
       if (AzureUser.isRemoved(row)) {
         final id = row['id'] as String?;
@@ -335,16 +359,27 @@ class UserManager {
       final user = previous == null
           ? AzureUser.fromGraphJson(row)
           : previous.mergeGraphJson(row);
-      if (_belongsToSchool(user, schoolPrefix)) changed.add(user);
+      if (_belongsToSchool(user, schoolPrefix)) {
+        changed.add(user);
+      } else if (previous != null) {
+        // Graph just told us this account is no longer ours. Saying nothing
+        // would leave the caller's own — now contradicted — record in place,
+        // because [UserDelta.changed] only ever upserts (#317). A row about a
+        // stranger stays dropped: there is nothing to reconcile it against.
+        leftSchoolIds.add(previous.id);
+      }
     }
     _log?.addMessage(
       core.Origin.azure,
       'Azure: delta voor "$schoolPrefix" — ${changed.length} gewijzigd, '
-      '${removedIds.length} verwijderd.',
+      '${removedIds.length} verwijderd'
+      '${leftSchoolIds.isEmpty ? '' : ', ${leftSchoolIds.length} niet langer '
+          'van onze school'}.',
     );
     return UserDelta(
       changed: changed,
       removedIds: removedIds,
+      leftSchoolIds: leftSchoolIds,
       deltaToken: result.deltaToken,
     );
   }

--- a/packages/azure_api/test/connector_test.dart
+++ b/packages/azure_api/test/connector_test.dart
@@ -384,6 +384,121 @@ void main() {
     });
   });
 
+  group('a delta row that moves a user out of our school (#317)', () {
+    /// The student as our snapshot holds her: ours, in step with WISA.
+    const stored = AzureUser(
+      id: 'az1',
+      upn: 'jane.doe@student.school.example',
+      employeeId: 'W1',
+      displayName: 'Jane Doe',
+      givenName: 'Jane',
+      surname: 'Doe',
+      companyName: 'GBS',
+      department: '3C',
+    );
+
+    AzureSnapshot previousWith(List<AzureUser> users) => AzureSnapshot(
+          fetchedAt: DateTime.utc(2026, 6, 1),
+          deltaToken: 'OLDTOKEN',
+          users: users,
+          groups: const [],
+        );
+
+    GraphResponse Function(GraphRequest) walkOf(
+      List<Map<String, dynamic>> rows, {
+      List<Map<String, dynamic>> backfill = const [],
+    }) =>
+        (req) {
+          final path = req.url.path;
+          if (path.contains('/members') || path.contains('groups')) {
+            return jsonOk({'value': const <Object>[]});
+          }
+          if (path.contains('users/delta')) {
+            return jsonOk({
+              '@odata.deltaLink':
+                  'https://graph.microsoft.com/v1.0/users/delta?\$deltatoken=T2',
+              'value': rows,
+            });
+          }
+          final filter = req.url.queryParameters[r'$filter'] ?? '';
+          if (filter.startsWith('employeeId in')) {
+            return jsonOk({'value': backfill});
+          }
+          return jsonOk({'value': const <Object>[]});
+        };
+
+    test('the account we held is dropped instead of surviving stale', () async {
+      // The report: Graph says the account moved to a sibling school and the
+      // snapshot goes on insisting it is ours. The walk dropped the row, and
+      // `_applyDelta` only ever upserts what the walk kept — so nothing touched
+      // the record, and nothing ever would: every later pass drops the same row
+      // for the same reason.
+      final connector = connectorWith(FakeGraphTransport(walkOf(
+        <Map<String, dynamic>>[
+          <String, dynamic>{'id': 'az1', 'companyName': 'OTHER'},
+        ],
+      )));
+
+      final snapshot = await connector.sync(
+        deltaToken: 'OLDTOKEN',
+        previous: previousWith(const [stored]),
+      );
+
+      expect(snapshot.users, isEmpty);
+    });
+
+    test('a student WISA still places here comes back, from Graph', () async {
+      // The #224 leg and this one have to agree rather than fight. The record
+      // leaves on the delta leg and the back-fill re-adopts it on the same pass
+      // — with the account exactly as Graph holds it, so what the snapshot ends
+      // up asserting is Graph's version and not the one we had.
+      final connector = connectorWith(FakeGraphTransport(walkOf(
+        <Map<String, dynamic>>[
+          <String, dynamic>{'id': 'az1', 'companyName': 'OTHER'},
+        ],
+        backfill: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'az1',
+            'userPrincipalName': 'jane.doe@student.school.example',
+            'employeeId': 'W1',
+            'displayName': 'Jane Doe',
+            'givenName': 'Jane',
+            'surname': 'Doe',
+            'companyName': 'OTHER',
+            'department': '3C',
+            'accountEnabled': true,
+          },
+        ],
+      )));
+
+      final snapshot = await connector.sync(
+        deltaToken: 'OLDTOKEN',
+        previous: previousWith(const [stored]),
+        expectedEmployeeIds: const ['W1'],
+      );
+
+      expect(snapshot.users.single, stored.copyWith(companyName: 'OTHER'));
+    });
+
+    test('a row about a stranger still changes nothing', () async {
+      // Unchanged behaviour, and the reason the bucket is keyed on what we
+      // already hold: a sparse row we cannot classify is not evidence that
+      // somebody left, and there is no record of ours to take away anyway.
+      final connector = connectorWith(FakeGraphTransport(walkOf(
+        <Map<String, dynamic>>[
+          <String, dynamic>{'id': 'az-unknown', 'displayName': 'Someone Else'},
+        ],
+      )));
+
+      final snapshot = await connector.sync(
+        deltaToken: 'OLDTOKEN',
+        previous: previousWith(const [stored]),
+      );
+
+      expect(snapshot.users.single, stored);
+    });
+  });
+
   group('rejected delta token (#213)', () {
     /// Routes a delta *resume* to [rejection] while the full-read path
     /// (`$deltatoken=latest` + the `$filter` bulk read) succeeds.

--- a/packages/azure_api/test/user_manager_test.dart
+++ b/packages/azure_api/test/user_manager_test.dart
@@ -288,10 +288,15 @@ void main() {
       expect(delta.changed.single.displayName, 'Jane Doe');
     });
 
-    test('a sparse row moving someone out of our school is dropped', () async {
+    test('a sparse row moving someone out of our school is reported as such',
+        () async {
       // The merge is not a way to keep everybody: judged whole, this record no
-      // longer belongs to us, so it leaves the changed set (and the connector
-      // stops carrying it).
+      // longer belongs to us, so it leaves the changed set.
+      //
+      // Leaving it at that was the bug of #317. `changed` is upsert-only, so a
+      // caller told nothing keeps the copy it has — the one that still says
+      // `GBS` — and every later walk reaches the same verdict about the same
+      // row, so the contradiction never resolves. The id gets its own bucket.
       final transport = walkOf(<Map<String, dynamic>>[
         <String, dynamic>{'id': 'az1', 'companyName': 'OTHER'},
       ]);
@@ -303,6 +308,10 @@ void main() {
       );
 
       expect(delta.changed, isEmpty);
+      expect(delta.leftSchoolIds, <String>['az1']);
+      expect(delta.removedIds, isEmpty,
+          reason: 'the account still exists — it is simply not ours, which is '
+              'not what a Graph @removed row means');
     });
 
     test('a sparse row about a user we have never seen is still dropped',
@@ -317,6 +326,41 @@ void main() {
       final delta = await UserManager(clientWith(transport)).delta('T1', 'GBS');
 
       expect(delta.changed, isEmpty);
+      expect(delta.leftSchoolIds, isEmpty,
+          reason: 'there is no record of ours to reconcile a stranger against, '
+              'so reporting a departure would invent one');
+    });
+
+    test(
+        'a staff member dropped from the department list leaves; a reorder '
+        'does not (#317)', () async {
+      // `department` is the comma-separated list of every school the teacher is
+      // active at, maintained by other software, and #279 made `belongsToSchool`
+      // read it as a list. So the two shapes that look alike on the wire mean
+      // opposite things, and only the merged record can tell them apart.
+      const staff = AzureUser(
+        id: 'az-staff',
+        upn: 'anna.smit@school.example',
+        employeeId: 'W7',
+        displayName: 'Anna Smit',
+        department: 'SSM,GBS',
+      );
+
+      final reordered = await UserManager(clientWith(walkOf(
+        <Map<String, dynamic>>[
+          <String, dynamic>{'id': 'az-staff', 'department': 'GBS,SSM'},
+        ],
+      ))).delta('T1', 'GBS', known: const {'az-staff': staff});
+      expect(reordered.leftSchoolIds, isEmpty);
+      expect(reordered.changed.single.department, 'GBS,SSM');
+
+      final departed = await UserManager(clientWith(walkOf(
+        <Map<String, dynamic>>[
+          <String, dynamic>{'id': 'az-staff', 'department': 'SSM'},
+        ],
+      ))).delta('T1', 'GBS', known: const {'az-staff': staff});
+      expect(departed.changed, isEmpty);
+      expect(departed.leftSchoolIds, <String>['az-staff']);
     });
   });
 
@@ -825,6 +869,40 @@ void main() {
         contains('Azure: delta voor "GBS" — 0 gewijzigd, 0 verwijderd.'),
       );
       expect(log.messages, isNot(contains(contains('changed, '))));
+    });
+
+    test('a pass that lost accounts to another school says so, in Dutch (#317)',
+        () async {
+      // The count the report went without: the walk found a row, acted on it,
+      // and the line still read `0 gewijzigd, 0 verwijderd` — which is how the
+      // operator was left with no way to tell an uneventful pass from one that
+      // had just handed an account over. The clause only appears when there is
+      // something to say, so an ordinary pass stays the short line above.
+      final transport = FakeGraphTransport(
+        (_) => jsonOk({
+          '@odata.deltaLink':
+              'https://graph.microsoft.com/v1.0/users/delta?\$deltatoken=T',
+          'value': <Map<String, dynamic>>[
+            <String, dynamic>{'id': 'az1', 'companyName': 'OTHER'},
+          ],
+        }),
+      );
+      final log = RecordingLog();
+
+      await UserManager(clientWith(transport), log: log).delta(
+        'OLD',
+        'GBS',
+        known: const <String, AzureUser>{
+          'az1': AzureUser(id: 'az1', upn: 'jane@x', companyName: 'GBS'),
+        },
+      );
+
+      expect(
+        log.messages,
+        contains('Azure: delta voor "GBS" — 0 gewijzigd, 0 verwijderd, '
+            '1 niet langer van onze school.'),
+      );
+      expect(log.messages, isNot(contains(contains('no longer'))));
     });
 
     test('the employeeId back-fill lookup reports in Dutch', () async {


### PR DESCRIPTION
Batch of six bug fixes in the Azure-sync / linker area, one commit per issue. Four of the six were found by chasing a single operator-visible symptom — a phantom `companyName: SBE → SSM` that survived every drift pass — down through the read path, the apply path, and the linker.

## What changed

- **#316 — `Controleer op drift` re-reads Azure in full** (`f27ff48`). The drift check ran the ordinary incremental syncer, handing the connector `previous.deltaToken`, so it could only ever surface what Graph reported *since our token* — which is precisely not "what does Azure hold right now". A `fullRead` flag on the `Syncer` typedef is threaded `checkDrift` → `ApplicationState.sync` → `SystemState.sync` → `azureSyncer`, where it nulls **only** the token while still passing `previous` (so #269's `retainedStaffEmployeeIds` survive). Logs `Azure AD volledig opnieuw gelezen — N account(s).` so the two pass types are distinguishable after the fact. The delta path stays what **Synchroniseer** uses.
- **#317 — a delta row that moves a known user out of our school is no longer dropped** (`fd75bae`). `_walkDelta` merged each sparse row onto the held record and kept it only if `belongsToSchool` passed; since `_applyDelta` upserts only `changed`, a known record that Graph said had moved away survived untouched forever, still carrying our prefix. `UserDelta` gains a third bucket, `leftSchoolIds`, keeping those removal semantics distinct from a Graph `@removed` row. A row about a user we have never seen still drops silently (correct — an unclassifiable fragment), and the `employeeId` back-fill re-adopts a still-expected id with the fresh Graph record on the same pass.
- **#315 — the phantom itself: no production defect remained** (`efd3040`). Driving the failing scenario showed #316's forced full re-read is the whole read-side root cause and #317 closed the delta walk's silent drop; reverting `fullRead ? null :` in `azureSyncer` reproduces `SBE` exactly. This commit is the regression test the issue asks for — the production `azureSyncer` over a fake Graph transport where the snapshot says `SBE`, Graph says `SSM`, and the delta resume returns no row for that user — plus its incremental counterweight. The issue's remaining two suspects were investigated and filed separately (see below).
- **#318 — a student enrolled in two WISA schools is linked once** (`5ff2990`). The WISA pull is per school and concatenated, so a dual-enrolled student arrives as two rows with one `wisaId`; `_buildStudentRecords` pass 2 attached only the first and spawned a second record for the same person, which produced the same `_naturalKey` and so the same `LinkedAccountId` — a card offering "create Office 365" and "unregister in Smartschool" at once. Pass 2 now merges the second row into the record (its school id joins `wisaSchoolIds`, so `_presence` reads `ours` and the departure actions stay silent). New `_prefersWisaRow` makes a managed school's row displace a sibling's, so class placement is *decided* rather than arrival-order. INV-21/INV-11 restated per *person* in `link.dart`, `docs/domain-model.md` and the property test; `ourSchoolIds` threaded through `naturalKeysFor` so both entry points run the identical pass.
- **#319 — a shared `LinkedAccountId` is reported, not merged away silently** (`8f06662`). Every layer below the linker is keyed by that id and each one unioned or dropped without a word. New INV-24 and a `DuplicateLinkedId` warning (the id plus a `LinkedIdHolding` per colliding record) are enforced in `LinkedSnapshot.fromRecords`, so the invariant lives with the type rather than in each consumer's assumptions. Both records are kept; `LinkCounts` now counts each id once (it was inflating the WISA total and skewing the dashboard's linked/total ratio). Surfaced snapshot-wide via a sync log line and an always-open Synchronisatie notice rather than on the account cards — the colliding records share one card, a collision with no Smartschool account has no card at all, and `decisions_merge` reads `MaterializedAccount.warnings` type-blind, so an unrelated string there would keep a stale accepted-duplicate alive. A comment now marks the lossy `pendingEntries` map literal.
- **#321 — a second Azure write in one apply pass no longer reverts the first one's splice** (`c88dc5e`). *Filed and fixed during this batch* (it was #315's suspect 2). `ReconcileController._run` walked a list of actions frozen before the first write, and each Azure modify projects `_az.copyWith(...)` off that same pre-apply record — so the second splice overwrote the first one's field, Graph held both writes and the snapshot only the last, and the relink re-raised an action for a change Azure already had. The loop now rebuilds a `family|targetId|kind` index of the relinked view after every write and re-binds each remaining decision to the action that view holds (falling back to the planned binding when the fresh view no longer raises it) — the same treatment `_chainFollowUps` already had. The contradicted record was also what `_shareApplied` published to other operators.

## Test plan

At the branch tip:

- [x] `dart format --set-exit-if-changed .` clean (319 files, 0 changed)
- [x] `flutter analyze` / `dart analyze --fatal-infos --fatal-warnings` clean across the workspace
- [x] **1465** package unit tests pass (11 skipped — the opt-in live ones); up from 1440 at the start of the batch
- [x] **576** `account_manager` widget/unit tests pass; up from 566
- [x] **124** integration tests pass on `flutter test integration_test/app_launch_test.dart -d windows`; up from 121, one new e2e per behavioural fix

Per-commit, each verified failing before its fix:

- **#316** — new `azureSyncer` unit test + new e2e both confirmed failing on the unpatched code. The e2e tests for #213/#268/#288 were rehomed onto a Synchroniseer armed by a saved *beheerde scholen* change, and #269's was adapted, since drift no longer reaches the delta walk (this is what #320 is about).
- **#317** — 6 new tests (3 walk-level, 3 connector-level) plus the new e2e, all verified failing on the unpatched code; the `_applyDelta` leg verified separately.
- **#315** — the new syncer test fails on the reverted code with exactly the reported symptom, `Expected: 'SSM' Actual: 'SBE'`.
- **#318** — 7 new linker cases, 6 of which fail unpatched; the new e2e fails pre-fix on `Expected: not contains 'UnregisterStudentFromSmartschool'`.
- **#319** — new tests at every layer (core, linker, materializer, controller, screen, e2e) each verified to fail with the guard neutered.
- **#321** — 2 of 4 new unit cases and the new e2e fail on the unpatched controller with `Expected: 'Jane Doe' Actual: ''`.

## Follow-ups filed during this batch

`#321` was filed and worked here. Three others are left open because each needs a decision rather than an implementation:

- **#320** — after #316, nothing in normal operation spends an Azure delta token, so PAIN-2's incremental pull is effectively dead code. Three named options (retire the delta path / give it a caller / make the re-read a second affordance on the drift button); a deliberate trade to revisit, not a regression.
- **#322** — `_adoptByEmployeeId` never re-reads an id it already holds, so an adopted transfer record cannot be repaired on the incremental path. Already correct on the full-read path, so it cannot survive drift; scoped by whatever is decided on #320.
- **#323** — an INV-23 duplicate-mail pair keys both records on one `LinkedAccountId`, found by #319's new property test. A live cause of the #319 collision independent of #318. Open design question: merge the co-account pair into one record, or disambiguate the natural key — the latter changes persisted ids in Cosmos. #319 deliberately only made it visible.

Closes #315
Closes #316
Closes #317
Closes #318
Closes #319
Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
