### PR TITLE
Stop offering a no-op as a resolution, and make the bulk guard real (#326–#329, #335)

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -1,5 +1,12 @@
 # Arcadia Account Manager - Project Overview
 
+> **Scope: this document describes the legacy WPF application** under
+> `legacy-wpf/`. It is the architectural reference for that code - the
+> behaviour oracle the Flutter/Dart port is measured against - and is
+> deliberately *not* a description of the port. See
+> [§2](#2-migration-status-and-where-the-port-is-documented) for where the
+> port's own model is written down.
+
 ## 1. Purpose
 
 Arcadia Account Manager is a Windows desktop application that synchronizes user
@@ -18,23 +25,35 @@ reconcile them, and lets the operator apply those actions individually or in
 bulk. It also generates and distributes passwords (PDFs) for new students,
 co-accounts and staff members.
 
-## 2. Migration status
+## 2. Migration status and where the port is documented
 
 The project is being ported from WPF / .NET Framework 4.8 to **Flutter / Dart**.
 The original C# code has been moved under `legacy-wpf/` and is preserved as
-read-only reference material. The Dart and Flutter packages that will replace
-it - `account_api/` (pure Dart) and `account_manager/` (Flutter app) - exist
-as empty placeholders today and will be filled in incrementally; see
-[docs/port-plan.md](docs/port-plan.md) and [CLAUDE.md](CLAUDE.md) for the
-porting strategy.
+read-only reference material - it is what the rest of this document describes.
+
+The port is well past its placeholder stage: most of the application's code is
+now the Dart workspace under `packages/` plus the Flutter app in
+`account_manager/` (see §3). **This document does not describe that code**, and
+nothing here should be read as a statement about how the port behaves today.
+The port's own model lives in:
+
+- [docs/domain-model.md](docs/domain-model.md) - the **spec** the port
+  implements against: entities, identifiers, numbered invariants, and the
+  `sync` / `link` / `evaluate` / `apply` operations. Where the new code diverges
+  from legacy, the rationale is recorded there.
+- [docs/port-plan.md](docs/port-plan.md) - the running port strategy.
+- the per-package `README.md` files under `packages/`. In particular
+  [packages/account_actions/README.md](packages/account_actions/README.md)
+  owns the rules that govern **what a card offers** - `canApply`,
+  `canApplyToAll`, `alternativeGroup`, `noticeFor` - which have no counterpart
+  in the legacy action model described in §6.4.
+- [CLAUDE.md](CLAUDE.md) - repository conventions and port order.
 
 ## 3. Solution Layout
 
-The repository is currently in transition. The top-level layout is:
-
 ```
 Accountmanager/
-├── legacy-wpf/         Original C# / WPF solution (reference, read-only)
+├── legacy-wpf/         Original C# / WPF solution (read-only) - what this document describes
 │   ├── AccountApi/         Class library: domain model + connectors to WISA, Smartschool, Azure
 │   ├── AccountManager/     WPF desktop application (WinExe) - the UI
 │   ├── Setup/              Visual Studio Installer project (.vdproj)
@@ -42,13 +61,26 @@ Accountmanager/
 │   ├── WisaAPIService.wsdl WSDL used to generate the WISA SOAP web reference
 │   ├── MigrationBackup/    Visual Studio upgrade artefacts
 │   └── AccountManager.sln  Visual Studio solution (two C# projects, .NET Framework 4.8)
-├── account_api/        Future pure-Dart package (domain, connectors, linker, action engine) - empty
-├── account_manager/    Future Flutter application (depends on account_api/) - empty
+├── packages/           Pure-Dart workspace packages - the port (documented in their own READMEs)
+│   ├── account_core/       Canonical domain model: entities, id types, enums, password generator, ILog
+│   ├── account_store/      File-backed PersonId resolver (stable local ids across syncs)
+│   ├── wisa_api/           WISA SOAP connector -> WisaSnapshot
+│   ├── smartschool_api/    Smartschool SOAP (V3) connector + account/group/password writes
+│   ├── azure_api/          Microsoft Graph connector + user/group writes
+│   ├── account_linker/     Pure, deterministic cross-system linker -> LinkedSnapshot
+│   ├── account_actions/    Action engine: evaluate / describeChanges / apply, with a dry-run path
+│   └── account_state/      Orchestration: sync, link, apply, materialize, settings, passwords,
+│                           Cosmos / Blob / Key Vault / SignalR
+├── account_manager/    Flutter application (depends on packages/* via path: dependencies)
 ├── docs/
+│   ├── domain-model.md The spec the port implements against
 │   └── port-plan.md    Running document describing the port strategy
+├── tool/               PowerShell helpers (opt-in live integration tests, Cosmos provisioning)
+├── pubspec.yaml        Dart workspace definition (lists the workspace members)
+├── analysis_options.yaml  Lint/analyzer config applied to every workspace member
 ├── CLAUDE.md           Guidance for Claude Code sessions in this repo
 ├── PROJECT_OVERVIEW.md This document
-└── README.md           (if present)
+└── README.md           Entry point: badges, how to run the Flutter app
 ```
 
 The legacy Visual Studio solution `legacy-wpf/AccountManager.sln` contains two
@@ -308,6 +340,12 @@ The action layer is the heart of reconciliation. Every detected divergence
 between Wisa, Smartschool, and Azure becomes a typed Action that the user can
 inspect and apply.
 
+> The port keeps the three families and most of the action names, but **not**
+> this model: it adds mutually-exclusive alternatives, informational actions
+> that are card context rather than an option, and a separate bulk sanction.
+> Read [packages/account_actions/README.md](packages/account_actions/README.md)
+> for those rules - the section below is legacy behaviour only.
+
 Three action families, each with its own abstract base class:
 
 - **Group actions** ([Action/Group/](legacy-wpf/AccountManager/Action/Group/)) -
@@ -421,6 +459,10 @@ Modal MaterialDesign dialogs used for rule editing and confirmation:
    filterable by origin and severity.
 
 ## 9. Extensibility points
+
+These describe how the **legacy** application was extended, and are kept as
+reference for reading that code. `legacy-wpf/` is read-only: new connectors,
+actions and import rules belong in the Dart packages under `packages/` (see §2).
 
 - **Adding a sync target** - implement an `AbstractState` for the new system,
   expose `Account`/`Group` types implementing `IAccount`/`IGroup`, write a

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2051,8 +2051,8 @@ void main() {
   });
 
   testWidgets(
-      'an empty class beside a sibling school\'s populated namesake stays the '
-      'read-only empty notice end-to-end (#222)', (WidgetTester tester) async {
+      'an empty class beside a sibling school\'s populated namesake keeps its '
+      'empty-class notice end-to-end (#222/#329)', (WidgetTester tester) async {
     // The real app, real fonts, real navigation. Our school 1 has an empty
     // `1A`; the sibling school 2 we do not manage has its own populated `1A`,
     // pulled by the same shared WISA credentials. Only ours is linked (#205), so
@@ -2089,45 +2089,62 @@ void main() {
         find.textContaining('Voeg deze klas toe aan Smartschool'), findsNothing,
         reason: 'nobody of ours is in 1A — creating + enrolling is not due');
 
-    // The notice leads the either/or choice of #244 — the "ignore this class"
-    // opt-out is its alternative, not a second to-do — so the collapsed row
-    // reads as a choice, and the opt-out is not on it.
-    expect(find.textContaining('(keuze)'), findsOneWidget);
-    expect(find.textContaining('(manueel)'), findsNothing);
-    expect(find.textContaining('Negeer deze klas bij het importeren uit WISA'),
-        findsNothing,
-        reason: 'blacklisting is the alternative, not a second to-do');
+    // The notice is **context**, not one of two answers (#329): there is
+    // nothing for this app to create, so the row states the instruction —
+    // marked "(manueel)" — above the single thing it can do about the class.
+    // It was the pre-selected half of a radio pair until then, which asked the
+    // operator to choose between "delete this by hand" and "never import it".
+    expect(find.textContaining('(keuze)'), findsNothing,
+        reason: 'a diagnosis and a write are not two solutions');
+    expect(find.textContaining('wacht tot ze leerlingen bevat. (manueel)'),
+        findsOneWidget);
+    expect(find.text('Negeer deze klas bij het importeren uit WISA'),
+        findsOneWidget,
+        reason: 'the lone proposal, stated plainly under the notice');
 
-    // Expanding it offers both readings as radios, the notice pre-selected —
-    // and the entry has nothing to apply until the operator picks the opt-out.
+    // Expanding it shows the same two, in the same order, and no radios.
     await tester.tap(find.byKey(const ValueKey('entry-group-1A')));
     await tester.pumpAndSettle();
-    expect(find.text('Kies één oplossing:'), findsOneWidget);
+    expect(find.text('Kies één oplossing:'), findsNothing,
+        reason: 'nothing to choose between');
+    expect(find.byIcon(Icons.radio_button_checked), findsNothing);
+    expect(find.byIcon(Icons.radio_button_unchecked), findsNothing);
+    expect(find.textContaining('wacht tot ze leerlingen bevat. (manueel)'),
+        findsOneWidget,
+        reason: 'the instruction survives the removal of the radio');
     expect(find.text('Negeer deze klas bij het importeren uit WISA'),
         findsOneWidget);
-    // The pre-selected notice writes nothing, and the detail under the radios
-    // says so in Dutch (#253) — it used to read "(manual — not applied
-    // automatically)" on an otherwise Dutch screen.
-    expect(
-      find.textContaining('(manueel — wordt niet automatisch toegepast)'),
-      findsOneWidget,
-    );
+    expect(find.text('DontImportClass: ∅ → 1A'), findsOneWidget,
+        reason: 'and the card shows exactly what pressing would write');
+
+    // The card proposes; it does not interrogate. Toepassen is live because
+    // there genuinely is a write here — what keeps it out of a *bulk* pass is
+    // `canApplyToAll`, not the polarity of a pair (#293/#326).
     expect(
       tester
           .widget<FilledButton>(find.byKey(const ValueKey('entry-apply-1A')))
           .onPressed,
-      isNull,
-      reason: 'there is nothing to write for an empty class',
+      isNotNull,
     );
+    expect(
+        harness.controller.groupPendingSituations
+            .firstWhere((c) => c.key == 'group|class-import')
+            .bulkApplyable,
+        isEmpty);
 
     // And the pass itself never constructed the create-and-enrol action for it.
-    final kinds = harness.controller.pendingEntries
-        .expand((e) => e.choices)
-        .expand((c) => c.alternatives)
-        .map((a) => a.kind)
-        .toList();
-    expect(kinds, contains('CreateInSmartschool'));
+    final decisions =
+        harness.controller.pendingEntries.expand((e) => e.choices);
+    final kinds = decisions.expand((c) => c.alternatives).map((a) => a.kind);
+    expect(kinds, contains('DoNotImportFromWisa'));
     expect(kinds, isNot(contains('AddToSmartschool')));
+    expect(kinds, isNot(contains('CreateInSmartschool')),
+        reason: 'the notice is never an alternative');
+    expect(
+      decisions.expand((c) => c.notices).map((a) => a.kind),
+      contains('CreateInSmartschool'),
+      reason: 'it is context on the decision instead',
+    );
   });
 
   testWidgets(
@@ -2177,15 +2194,18 @@ void main() {
         reason: 'the empty-class advice is wrong for a provisioned class');
 
     // The pass never constructed either create action for it, and the notice
-    // is manual — there is nothing here for the app to write.
-    final kinds = harness.controller.pendingEntries
-        .expand((e) => e.choices)
-        .expand((c) => c.alternatives)
-        .map((a) => a.kind)
-        .toList();
-    expect(kinds, contains('ClassExistsAsSmartschoolGroup'));
+    // it raised instead is context on the one decision there is (#329) — never
+    // an alternative, because the app cannot perform a hand edit in Smartschool.
+    final decisions =
+        harness.controller.pendingEntries.expand((e) => e.choices);
+    final kinds = decisions.expand((c) => c.alternatives).map((a) => a.kind);
     expect(kinds, isNot(contains('AddToSmartschool')));
     expect(kinds, isNot(contains('CreateInSmartschool')));
+    expect(kinds, isNot(contains('ClassExistsAsSmartschoolGroup')));
+    expect(
+      decisions.expand((c) => c.notices).map((a) => a.kind),
+      contains('ClassExistsAsSmartschoolGroup'),
+    );
 
     // The subgroup keeps its own, correct Smartschool-only notice: it is an
     // official class WISA has no counterpart for.
@@ -2281,7 +2301,7 @@ void main() {
 
   testWidgets(
       'a class the #225 notice says to fix by hand survives "Alles toepassen" '
-      'untouched end-to-end (#250)', (WidgetTester tester) async {
+      'untouched end-to-end (#250/#329)', (WidgetTester tester) async {
     // The real app, real fonts, real navigation, over the real Smartschool
     // write path. Four WISA classes: `1A`/`1B` are genuinely new, while `2G`
     // and `2H` already exist in Smartschool on groups that are not flagged as
@@ -2295,11 +2315,19 @@ void main() {
     // beside them had just said to align by hand: they dropped out of the next
     // WISA snapshot while the Smartschool groups stayed behind, unmanaged.
     //
-    // This is the layer that sees it. Which half of a choice is pre-selected,
-    // which bulk subset a class lands in, and what the button on that subset
-    // writes are three different halves of the screen, composed by the
-    // dispatch, the entry grouping and the drill-down — only a full run puts
-    // the notice and the button that acts on it on screen together.
+    // #250 fixed it by making the notice the pre-selected half of a pair, and
+    // #329 took that pair away again — an instruction to go and edit something
+    // in Smartschool is not a resolution an apply can run, so it is context on
+    // the card rather than one of two answers. The blacklist is therefore the
+    // selected resolution of both rows once more, which makes this run the
+    // proof that the *replacement* guard holds: `canApplyToAll == false`,
+    // refused by every bulk affordance since #326.
+    //
+    // This is the layer that sees it. What a card states, which bulk subset a
+    // class lands in, and what the button on that subset writes are three
+    // different halves of the screen, composed by the dispatch, the entry
+    // grouping and the drill-down — only a full run puts the notice and the
+    // button that acts on it on screen together.
     useTallWindow(tester);
     final harness = namesakeClassChoiceHarness();
     await tester.pumpWidget(AccountManagerApp(
@@ -2310,61 +2338,74 @@ void main() {
     await tester.pumpAndSettle();
     await syncThenOpenKlasgroepen(tester);
 
-    // Every class is on the list, and each namesake one reads as the hand-fix
-    // notice — the resolution that is pre-selected for it.
+    // Every class is on the list, and each namesake one still states the
+    // hand-fix instruction — now marked "(manueel)", above the one thing this
+    // app can actually do about the class.
     for (final id in const ['2G', '2H']) {
+      final row = find.byKey(ValueKey('entry-group-$id'));
       expect(
         find.descendant(
-          of: find.byKey(ValueKey('entry-group-$id')),
+          of: row,
           matching: find.textContaining(
               'Deze klas bestaat in Smartschool maar is geen officiële klas'),
         ),
         findsOneWidget,
       );
+      expect(
+        find.descendant(of: row, matching: find.textContaining('(manueel)')),
+        findsOneWidget,
+        reason: 'the notice reads as write-free from the inventory row',
+      );
+      expect(
+        find.descendant(
+          of: row,
+          matching: find.text('Negeer deze klas bij het importeren uit WISA'),
+        ),
+        findsOneWidget,
+        reason: 'and the single proposal is stated plainly, not as "(keuze)"',
+      );
     }
     expect(find.text('Voeg deze klas toe aan Smartschool (keuze)'),
         findsNWidgets(2),
-        reason: '1A and 1B are the ordinary new-class case');
-    expect(
-        find.text('Negeer deze klas bij het importeren uit WISA'), findsNothing,
-        reason: 'the opt-out is an alternative to pick, never a to-do that '
-            'also runs');
+        reason: '1A and 1B are the ordinary new-class case, and keep their '
+            'either/or: both halves of it write');
 
     // The namesake classes form a bulk cohort of their own. Pooling them with
     // the new classes would have filed them under a header offering to create
     // classes that already exist.
+    const String namesakeKey = 'group|class-namesake';
+    const String newKey = 'group|class-import';
     final cohorts = harness.controller.groupPendingSituations;
-    final namesakeKey = cohorts
-        .firstWhere((c) => c.label.startsWith('Deze klas bestaat in '
-            'Smartschool'))
-        .key;
-    final newKey = cohorts
-        .firstWhere((c) => c.label.startsWith('Voeg deze klas toe aan '
-            'Smartschool'))
-        .key;
-    expect(namesakeKey, isNot(newKey));
+    expect(
+      cohorts.firstWhere((c) => c.key == namesakeKey).decisions.length,
+      2,
+    );
+    expect(cohorts.firstWhere((c) => c.key == newKey).decisions.length, 2);
 
-    final namesakeHeader = find.textContaining(
-        'dan wordt ze gekoppeld. / Negeer deze klas bij het importeren uit '
-        'WISA');
+    // Exact, not a substring: the new classes' own header ends in the same
+    // words, because the blacklist is one half of *their* either/or.
+    final namesakeHeader = find.text(
+        'Negeer deze klas bij het importeren uit WISA — 2 klassen in dezelfde '
+        'situatie');
     await tester.ensureVisible(namesakeHeader);
     expect(
       namesakeHeader,
       findsOneWidget,
-      reason: 'the header names one either/or led by the hand-fix notice',
+      reason: 'the header names the one decision these two classes share',
     );
 
     // And it offers nothing to run. Since #292 the cohort is that one decision
-    // rather than the whole card, and neither of its resolutions may be written
-    // in bulk — the notice is a hand repair the app cannot perform, and the
-    // blacklist beside it is withheld by #293 — so since #326 the pair is not
-    // rendered at all. Under the old grouping the button was live, because the
-    // classes also need an Office 365 group (#228): pressing a header that said
-    // "this class is already there" wrote something else entirely.
+    // rather than the whole card, and its resolution is withheld from every
+    // bulk pass by #293 — so since #326 the pair is not rendered at all. Under
+    // the old grouping the button was live, because the classes also need an
+    // Office 365 group (#228): pressing a header that said "this class is
+    // already there" wrote something else entirely.
     final pulls = harness.wisaSyncs;
-    expect(find.byKey(ValueKey('situation-apply-$namesakeKey')), findsNothing);
-    expect(find.byKey(ValueKey('situation-dry-run-$namesakeKey')), findsNothing,
-        reason: 'nothing to write means nothing to press');
+    expect(find.byKey(const ValueKey('situation-apply-$namesakeKey')),
+        findsNothing);
+    expect(find.byKey(const ValueKey('situation-dry-run-$namesakeKey')),
+        findsNothing,
+        reason: 'nothing a bulk pass may write means nothing to press');
     expect(harness.soap.soapActions.where((a) => a.endsWith('#saveClass')),
         isEmpty,
         reason: 'Smartschool already holds 2G and 2H');
@@ -2383,7 +2424,7 @@ void main() {
 
     // And the fix did not simply silence the list: the other cohort still
     // creates the genuinely new classes, and blacklists neither.
-    final newBulk = find.byKey(ValueKey('situation-apply-$newKey'));
+    final newBulk = find.byKey(const ValueKey('situation-apply-$newKey'));
     await tester.ensureVisible(newBulk);
     await tester.tap(newBulk);
     await tester.pumpAndSettle();
@@ -2424,11 +2465,12 @@ void main() {
     //
     // End-to-end rather than on the action alone, because the line the operator
     // reads is assembled across the whole path: the group dispatch's
-    // `ChangeSet`, the collapse of the notice and its "negeer deze klas" half
-    // into one either/or, the radio that decides whose fields are on screen, and
-    // only then `fieldChangeLine`. "No cleared field anywhere on this card" is
-    // also a claim about the page as composed — this tab renders the second
-    // namesake class and the two ordinary new classes beside it.
+    // `ChangeSet`, the collapse that lifts the notice onto the "negeer deze
+    // klas" decision it is context for (#329), the block that states it above
+    // that decision, and only then `fieldChangeLine`. "No cleared field
+    // anywhere on this card" is also a claim about the page as composed — this
+    // tab renders the second namesake class and the two ordinary new classes
+    // beside it.
     useTallWindow(tester);
     final harness = namesakeClassChoiceHarness();
     await tester.pumpWidget(AccountManagerApp(
@@ -2445,7 +2487,7 @@ void main() {
     await tester.tap(entry);
     await tester.pumpAndSettle();
 
-    // The notice is the pre-selected half, and it states the code as a fact.
+    // The notice is context on the card, and it states the code as a fact.
     expect(
       find.textContaining(
           'Deze klas bestaat in Smartschool maar is geen officiële klas'),
@@ -2455,6 +2497,38 @@ void main() {
 
     // The repair it *is* asking for still reads as the transition it is.
     expect(find.text('officiële klas: nee → ja'), findsOneWidget);
+
+    // And the open card asks no question (#329): the instruction is stated,
+    // marked "(manueel)", above the single write this app has for the class.
+    final Finder card = find.byKey(const ValueKey('entry-group-2G'));
+    expect(
+        find.descendant(of: card, matching: find.text('Kies één oplossing:')),
+        findsNothing);
+    expect(
+      find.descendant(
+          of: card, matching: find.byIcon(Icons.radio_button_checked)),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+          of: card, matching: find.byIcon(Icons.radio_button_unchecked)),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: card,
+        matching: find.textContaining('dan wordt ze gekoppeld. (manueel)'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: card,
+        matching: find.text('Negeer deze klas bij het importeren uit WISA'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('DontImportClass: ∅ → 2G'), findsOneWidget);
 
     // And nothing on this page claims a field is being emptied — least of all
     // an action that cannot be applied.

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2336,30 +2336,26 @@ void main() {
         .key;
     expect(namesakeKey, isNot(newKey));
 
-    final namesakeBulk = find.byKey(ValueKey('situation-apply-$namesakeKey'));
-    await tester.ensureVisible(namesakeBulk);
+    final namesakeHeader = find.textContaining(
+        'dan wordt ze gekoppeld. / Negeer deze klas bij het importeren uit '
+        'WISA');
+    await tester.ensureVisible(namesakeHeader);
     expect(
-      find.textContaining('dan wordt ze gekoppeld. / Negeer deze klas bij '
-          'het importeren uit WISA'),
+      namesakeHeader,
       findsOneWidget,
       reason: 'the header names one either/or led by the hand-fix notice',
     );
 
-    // And it offers nothing to run, out loud. Since #292 the cohort is that one
-    // decision rather than the whole card, and that decision's pre-selected
-    // resolution is a hand repair the app cannot perform — so the button counts
-    // zero and is dead. Under the old grouping it was live, because the classes
-    // also need an Office 365 group (#228): pressing a header that said "this
-    // class is already there" wrote something else entirely.
+    // And it offers nothing to run. Since #292 the cohort is that one decision
+    // rather than the whole card, and neither of its resolutions may be written
+    // in bulk — the notice is a hand repair the app cannot perform, and the
+    // blacklist beside it is withheld by #293 — so since #326 the pair is not
+    // rendered at all. Under the old grouping the button was live, because the
+    // classes also need an Office 365 group (#228): pressing a header that said
+    // "this class is already there" wrote something else entirely.
     final pulls = harness.wisaSyncs;
-    expect(
-      find.descendant(
-          of: namesakeBulk,
-          matching: find.text('Alles toepassen '
-              '(0)')),
-      findsOneWidget,
-    );
-    expect(tester.widget<FilledButton>(namesakeBulk).onPressed, isNull,
+    expect(find.byKey(ValueKey('situation-apply-$namesakeKey')), findsNothing);
+    expect(find.byKey(ValueKey('situation-dry-run-$namesakeKey')), findsNothing,
         reason: 'nothing to write means nothing to press');
     expect(harness.soap.soapActions.where((a) => a.endsWith('#saveClass')),
         isEmpty,
@@ -3656,22 +3652,12 @@ void main() {
         findsOneWidget);
 
     // Both stale groups share one situation, so the tab collects them under a
-    // bulk header — and it counts **zero** writes, because leaving the group
-    // standing is the default of the pair. A destructive default here would
+    // bulk header — and that header offers no bulk pass at all: neither half of
+    // the pair may be written that way (#293/#326). A bulk affordance here would
     // take two mailboxes, Teams and file libraries on one click.
     expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
-    final bulkApply = find.textContaining('Alles toepassen (');
-    expect(tester.widget<Text>(bulkApply).data, 'Alles toepassen (0)');
-    expect(
-      tester
-          .widget<FilledButton>(find.ancestor(
-            of: bulkApply,
-            matching: find.byType(FilledButton),
-          ))
-          .onPressed,
-      isNull,
-      reason: 'a bulk pass over stale groups must write nothing at all',
-    );
+    expect(find.textContaining('Alles toepassen ('), findsNothing,
+        reason: 'a bulk pass over stale groups must write nothing at all');
 
     // The row itself carries the either/or, with the delete as the half the
     // operator has to reach for.
@@ -3719,6 +3705,92 @@ void main() {
   });
 
   testWidgets(
+      'flipping every stale group to its delete still arms no bulk pass, '
+      'end-to-end (#326)', (WidgetTester tester) async {
+    // The reported hole, in the real app. `GBS-9Z` and `GBS-8Y` are the Office
+    // 365 groups of two classes that stopped running, so Klasgroepen files them
+    // under one "same situation" header. That header counted
+    // `PendingDecision.canApply` — "does the selected option write anything" —
+    // and never the #293 sanction the action itself declares. So what kept a
+    // delete off the bulk path was not the sanction at all: it was the
+    // *polarity* of the pair, the notice being pre-selected. Two flipped radios
+    // and the header read "Alles toepassen (2)", one confirmation away from
+    // taking two mailboxes, two Teams and two file libraries.
+    //
+    // Only a full run can see it. The radios are rendered per row from the live
+    // dispatch; the header is a separate derivation over the whole tab, above
+    // the inventory rather than beside the rows it acts on; and the claim is
+    // about what that second surface does *after* the operator has touched the
+    // first. A widget test that renders the header in isolation is handed a
+    // cohort somebody else built, which is precisely the seam that drifted.
+    useTallWindow(tester);
+    final harness = staleClassGroupHarness();
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+    expect(harness.controller.error, isNull);
+
+    // Untouched, the tab already offers no bulk pass: both rows default to the
+    // notice, which writes nothing. Since #326 the pair is *absent* rather than
+    // dead at (0) — a disabled button invites the operator to go and make it
+    // live, which is the very move this guards against.
+    expect(find.text('Klassen in dezelfde situatie'), findsOneWidget,
+        reason: 'the cohort is still named; only the bulk pair is withdrawn');
+    expect(find.textContaining('Alles toepassen ('), findsNothing);
+    expect(find.text('Dry-run alles'), findsNothing);
+
+    // Now make the delete the selected resolution of every row in the cohort —
+    // the four taps that used to arm it.
+    for (final String id in const <String>['GBS-9Z', 'GBS-8Y']) {
+      final Finder entry = find.byKey(ValueKey('entry-group-$id'));
+      await tester.ensureVisible(entry);
+      await tester.tap(entry);
+      await tester.pumpAndSettle();
+      final Finder delete =
+          find.byKey(ValueKey('alt-$id-DeleteAzureClassGroup'));
+      await tester.ensureVisible(delete);
+      await tester.tap(delete);
+      await tester.pumpAndSettle();
+      // Collapse again so the next row's radios are reachable on the same page.
+      await tester.ensureVisible(entry);
+      await tester.tap(entry);
+      await tester.pumpAndSettle();
+    }
+
+    // Both rows are set to a delete, and the header still offers nothing: the
+    // sanction is a property of the action, not of how many rows happen to be
+    // set to it.
+    expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
+    expect(find.textContaining('Alles toepassen ('), findsNothing,
+        reason: 'a flipped radio must never arm a bulk delete');
+    expect(find.text('Dry-run alles'), findsNothing);
+    expect(harness.graph.deletedGroups, isEmpty);
+
+    // What the operator kept is the per-row path: one group at a time, from the
+    // card that shows what the write would do.
+    final Finder entry = find.byKey(const ValueKey('entry-group-GBS-9Z'));
+    await tester.ensureVisible(entry);
+    await tester.tap(entry);
+    await tester.pumpAndSettle();
+    final Finder apply = find.byKey(const ValueKey('entry-apply-GBS-9Z'));
+    await tester.ensureVisible(apply);
+    expect(tester.widget<FilledButton>(apply).onPressed, isNotNull);
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(harness.graph.deletedGroups, ['az-GBS-9Z']);
+    expect(find.byKey(const ValueKey('class-row-GBS-8Y')), findsOneWidget,
+        reason: 'the group beside it was flipped too, and still stands');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'the class groups the legacy app left behind offer their delete too, '
       'end-to-end (#312)', (WidgetTester tester) async {
     // The reported bug, in the real app. Our school runs `1A`; Office 365 still
@@ -3758,11 +3830,10 @@ void main() {
         findsOneWidget,
         reason: 'both leftovers now ask something instead of showing a ✓');
 
-    // Widened, not loosened: the notice is still the default of the pair, so a
-    // bulk pass over the whole tab writes nothing.
+    // Widened, not loosened: neither half of the pair is bulk-sanctioned, so
+    // the tab offers no bulk pass over these groups at all (#293/#326).
     expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
-    final bulkApply = find.textContaining('Alles toepassen (');
-    expect(tester.widget<Text>(bulkApply).data, 'Alles toepassen (0)');
+    expect(find.textContaining('Alles toepassen ('), findsNothing);
 
     // The renamed group is its class's group by the address it answers on
     // (#280), so its row carries the pair under the name somebody typed over
@@ -3860,11 +3931,10 @@ void main() {
     expect(find.textContaining('Verwijder ze manueel'), findsNothing,
         reason: 'the app has the API to act on this; it stops delegating');
 
-    // Widened, not loosened: the notice is still the default of the pair, so a
-    // bulk pass over the whole tab writes nothing.
+    // Widened, not loosened: neither half of the pair is bulk-sanctioned, so
+    // the tab offers no bulk pass over these classes at all (#293/#326).
     expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
-    final bulkApply = find.textContaining('Alles toepassen (');
-    expect(tester.widget<Text>(bulkApply).data, 'Alles toepassen (0)');
+    expect(find.textContaining('Alles toepassen ('), findsNothing);
 
     final entry = find.byKey(const ValueKey('entry-group-9Z'));
     await tester.ensureVisible(entry);

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -366,7 +366,15 @@ void main() {
     expect(find.text('Overzicht'), findsOneWidget);
     expect(find.byKey(const ValueKey('reconcile-category-students')),
         findsOneWidget);
-    expect(find.text('2 openstaande acties'), findsOneWidget);
+    // Scoped to her card: since #328 the fixture's two Smartschool-only classes
+    // each propose a delete, so the class-groups card carries the same count.
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('reconcile-category-students')),
+        matching: find.text('2 openstaande acties'),
+      ),
+      findsOneWidget,
+    );
     expect(find.textContaining('Pending actions'), findsNothing);
     expect(
       find.byWidgetPredicate((w) =>
@@ -1095,7 +1103,7 @@ void main() {
     // The terminal ready line is logged (newest-first in the log panel) so the
     // operator knows the pass finished, and it names the pending-action count.
     expect(
-      find.textContaining('Sync voltooid — 6 openstaande actie(s). Klaar.'),
+      find.textContaining('Sync voltooid — 4 openstaande actie(s). Klaar.'),
       findsOneWidget,
     );
     // The last-sync freshness now renders as a dedicated box headed "Last sync"
@@ -3946,8 +3954,8 @@ void main() {
   });
 
   testWidgets(
-      'a Smartschool class WISA does not have offers its delete too, '
-      'end-to-end (#313)', (WidgetTester tester) async {
+      'a Smartschool class WISA does not have proposes its delete and nothing '
+      'else, end-to-end (#313/#328)', (WidgetTester tester) async {
     // The reported bug, in the real app. Our school runs `1A`; Smartschool
     // still carries `9Z` and `8Y`, two official classes WISA has no counterpart
     // for. Each row's whole content used to be
@@ -3956,16 +3964,18 @@ void main() {
     //   manueel als ze niet meer nodig is. (manueel)
     //
     // — an instruction to go and repeat the same judgement by hand in
-    // Smartschool's own UI, with `Toepassen` dead on the row. That is the dead
-    // end #271 removed on the Office 365 side, and at a September changeover
-    // there is a screenful of it.
+    // Smartschool's own UI, with `Toepassen` dead on the row. #313 put a delete
+    // beside it, and #328 dropped the "laat deze klas staan" half: that option
+    // and "doe niets" are the same act, and the operator performs the second by
+    // not pressing Toepassen. What the half also *said* — that a lagging WISA
+    // snapshot is the common cause — survives as a line on the card.
     //
-    // Only a full run shows the fix: the inventory is composed from the
-    // *stored* documents while the either/or radios come from the live
-    // dispatch, the same-situation bulk header from a third derivation, and
-    // "the tab still writes nothing by default" is a claim about the page as
-    // composed. The write itself has to travel the real Smartschool connector
-    // — a `delClass` addressed to the class **code**, not the name on screen.
+    // Only a full run shows it: the inventory is composed from the *stored*
+    // documents while the card's controls come from the live dispatch, the
+    // same-situation bulk header from a third derivation, and "no bulk pass
+    // over a cohort of selected deletes" is a claim about the page as composed.
+    // The write itself has to travel the real Smartschool connector — a
+    // `delClass` addressed to the class **code**, not the name on screen.
     useTallWindow(tester);
     final harness = smartschoolLeftoverClassHarness();
     await tester.pumpWidget(AccountManagerApp(
@@ -3985,47 +3995,122 @@ void main() {
     expect(find.textContaining('Verwijder ze manueel'), findsNothing,
         reason: 'the app has the API to act on this; it stops delegating');
 
-    // Widened, not loosened: neither half of the pair is bulk-sanctioned, so
-    // the tab offers no bulk pass over these classes at all (#293/#326).
+    // Both rows are set to a delete out of the box (#328), and the header
+    // offers nothing: the sanction is a property of the action, not of how many
+    // rows happen to be set to it (#293/#326). A bulk affordance here would
+    // take two classes with every membership and subgroup under them.
     expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
     expect(find.textContaining('Alles toepassen ('), findsNothing);
+    expect(find.text('Dry-run alles'), findsNothing);
 
     final entry = find.byKey(const ValueKey('entry-group-9Z'));
     await tester.ensureVisible(entry);
     await tester.tap(entry);
     await tester.pumpAndSettle();
+
+    // One proposal, no radios, no no-op to read past.
     expect(
-      find.text('Laat deze klas staan — ze bestaat in Smartschool maar niet '
-          'in WISA'),
+      find.text('Verwijder de klas 9Z uit Smartschool — ze bestaat niet in '
+          'WISA'),
       findsWidgets,
     );
+    expect(find.textContaining('Laat deze klas staan'), findsNothing);
+    expect(find.byKey(const ValueKey('alt-9Z-DeleteSmartschoolClass')),
+        findsNothing,
+        reason: 'a lone action renders no radio at all');
+    expect(find.text('Kies één oplossing:'), findsNothing);
+
+    // The class's facts, the caution the dropped default used to carry, and the
+    // inventory of what goes — all on the card, before anything is pressed.
     expect(find.text('code: C9Z'), findsOneWidget);
     expect(find.text('omschrijving: Zesde jaar Z'), findsOneWidget);
-    expect(find.textContaining('→ ∅'), findsNothing,
-        reason: 'the option that writes nothing clears nothing');
-
-    final delete = find.byKey(const ValueKey('alt-9Z-DeleteSmartschoolClass'));
-    await tester.ensureVisible(delete);
-    await tester.tap(delete);
-    await tester.pumpAndSettle();
+    expect(
+      find.text('WISA: kent deze klas (nog) niet — vroeg in het schooljaar '
+          'loopt WISA achter, controleer daar of ze bestaat voor je ze '
+          'verwijdert'),
+      findsOneWidget,
+      reason: 'the card warns; it does not offer waiting as a resolution',
+    );
     expect(find.text('lidmaatschappen en subgroepen: verdwijnen mee'),
         findsOneWidget);
+    expect(find.textContaining('→ ∅'), findsNothing,
+        reason: 'the inventory of what goes is stated, never diffed');
+    expect(harness.soap.deletedClasses, isEmpty,
+        reason: 'opening a card writes nothing');
 
     final apply = find.byKey(const ValueKey('entry-apply-9Z'));
     await tester.ensureVisible(apply);
     expect(tester.widget<FilledButton>(apply).onPressed, isNotNull);
     await tester.tap(apply);
     await tester.pumpAndSettle();
+    expect(harness.soap.deletedClasses, isEmpty,
+        reason: 'the confirmation dialog is still standing');
+    expect(find.textContaining('9Z'), findsWidgets,
+        reason: 'the dialog names the class it is about to take');
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
-    // Exactly the one class the operator picked, addressed by its code, and its
-    // row goes with it.
+    // Exactly the one class the operator pressed on, addressed by its code, and
+    // its row goes with it.
     expect(harness.soap.deletedClasses, ['C9Z']);
     expect(row('9Z'), findsNothing);
     expect(row('8Y'), findsOneWidget,
-        reason: 'the class beside it was never selected');
+        reason: 'the class beside it proposes the same delete, and still '
+            'stands — one press, one class');
     expect(row('1A'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'a Smartschool leftover the delete cannot address keeps its lone '
+      '"(manueel)" notice end-to-end (#328)', (WidgetTester tester) async {
+    // The other side of #328. `9Z` is a leftover exactly as above, but
+    // Smartschool handed us no class code for it, so there is nothing to
+    // address a `delClass` to. That is the one case where "leave it standing"
+    // is not a no-op dressed as a choice but the honest whole content of the
+    // row — and it must survive as the informational, "(manueel)"-marked notice
+    // it always was, with no apply of its own.
+    //
+    // End-to-end because the claim spans three surfaces a widget test sees
+    // separately: the collapsed row line (composed from the *stored* candidate
+    // document), the expanded card (from the live dispatch), and the tab's bulk
+    // header — plus the entry-level Toepassen button, which is gated on the
+    // whole card rather than on this decision.
+    useTallWindow(tester);
+    final harness = smartschoolLeftoverClassHarness(codelessLeftover: true);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+    expect(harness.controller.error, isNull);
+
+    // The collapsed row states the situation and marks it as hand work.
+    expect(find.textContaining('Laat deze klas staan'), findsWidgets);
+    expect(find.textContaining('(manueel)'), findsWidgets);
+    expect(find.textContaining('(keuze)'), findsNothing,
+        reason: 'a lone notice is not a choice');
+
+    final Finder entry = find.byKey(const ValueKey('entry-group-9Z'));
+    await tester.ensureVisible(entry);
+    await tester.tap(entry);
+    await tester.pumpAndSettle();
+
+    // No delete on offer, and nothing on the card can write.
+    expect(find.textContaining('Verwijder de klas 9Z uit Smartschool'),
+        findsNothing);
+    expect(find.text('Kies één oplossing:'), findsNothing);
+    expect(find.textContaining('controleer daar of ze bestaat'), findsNothing,
+        reason: 'nothing is proposed here, so there is nothing to caution '
+            'against pressing');
+    expect(find.text('omschrijving: Zesde jaar Z'), findsOneWidget,
+        reason: 'the notice still states what the class is');
+    final Finder apply = find.byKey(const ValueKey('entry-apply-9Z'));
+    await tester.ensureVisible(apply);
+    expect(tester.widget<FilledButton>(apply).onPressed, isNull);
+    expect(harness.soap.deletedClasses, isEmpty);
     expect(tester.takeException(), isNull);
   });
 
@@ -5471,8 +5556,16 @@ void main() {
         find.byKey(const ValueKey('reconcile-category-staff')), findsOneWidget);
     expect(find.byKey(const ValueKey('reconcile-category-groups')),
         findsOneWidget);
-    // The one fixture student is summed from the rollup with a pending indicator.
-    expect(find.text('2 openstaande acties'), findsOneWidget);
+    // The one fixture student is summed from the rollup with a pending
+    // indicator on her own card (the class-groups card carries the same count
+    // since #328, so the finder is scoped rather than global).
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('reconcile-category-students')),
+        matching: find.text('2 openstaande acties'),
+      ),
+      findsOneWidget,
+    );
     expect(resumed.controller.linked, isNull,
         reason: 'link() is never called in a passive session');
     expect(resumed.wisaSyncs, 0);
@@ -5484,9 +5577,9 @@ void main() {
       'a passive session surfaces pending group actions on Klasgroepen '
       'with no pull and no link() (#119)', (WidgetTester tester) async {
     // Session 1 (offline harness) syncs and materializes the shared view. The
-    // fixture's two Smartschool-only classes (2B, 3C) raise the orphan-class
-    // either/or of #313 — the group-action family — whose pre-selected half is
-    // the notice that leaves the class standing.
+    // fixture's two Smartschool-only classes (2B, 3C) each raise the
+    // orphan-class delete of #313 — the group-action family — which since #328
+    // is the lone proposal on such a row.
     final snapshots = InMemorySnapshotStore();
     final linkedStore = InMemoryLinkedStore();
     await ReconcileHarness(store: snapshots, linkedStore: linkedStore)
@@ -5505,13 +5598,13 @@ void main() {
     await tester.pumpAndSettle();
 
     // The class inventory renders straight from the store — no Synchronise
-    // tapped — on its own tab, listing the orphan
-    // Smartschool classes with their notice (#227).
+    // tapped — on its own tab, listing the orphan Smartschool classes with the
+    // delete each of them proposes (#227).
     await openKlasgroepen(tester);
 
     expect(find.byType(ClassGroupsScreen), findsOneWidget);
     expect(find.byKey(const ValueKey('class-row-2B')), findsOneWidget);
-    expect(find.textContaining('ze bestaat in Smartschool maar niet in WISA'),
+    expect(find.textContaining('Verwijder de klas 2B uit Smartschool'),
         findsWidgets);
     // …all without a single connector pull or link().
     expect(resumed.wisaSyncs, 0);

--- a/account_manager/integration_test/app_launch_test.dart
+++ b/account_manager/integration_test/app_launch_test.dart
@@ -2612,14 +2612,17 @@ void main() {
     expect(find.byKey(const ValueKey('class-row-1A')), findsOneWidget);
     expect(find.text('deelgroep van 2F'), findsNWidgets(2));
 
-    // The group of a class that no longer exists reads as the either/or it
-    // became in #271 — leave it standing (the default) or delete it — so the
-    // collapsed line is marked "(keuze)" rather than "(manueel)".
+    // The group of a class that no longer exists reads as the one thing it
+    // proposes since #327 — the delete — so its collapsed line is that summary,
+    // bare: not "(keuze)", because there is nothing to choose between, and not
+    // "(manueel)", because this one is applyable.
     expect(
-      find.textContaining('Laat de Office 365-groep GBS-9Z staan'),
+      find.textContaining('Verwijder de Office 365-groep GBS-9Z'),
       findsWidgets,
     );
-    expect(find.textContaining('(keuze)'), findsWidgets);
+    expect(find.textContaining('Laat de Office 365-groep GBS-9Z staan'),
+        findsNothing);
+    expect(find.textContaining('(keuze)'), findsNothing);
 
     // Expand the class's row and apply just it.
     const entry = ValueKey('entry-group-2F ECO');
@@ -3611,13 +3614,14 @@ void main() {
     // `GBS - Leerlingenraad`, `GBS - Frans - 3D`).
     //
     // This is the layer that sees what the issue is about. The inventory is
-    // composed from the *stored* documents while the either/or radios come from
+    // composed from the *stored* documents while the card's controls come from
     // the live dispatch, the bulk headers from a third derivation, and the row
     // only disappears once the write, the relink and the store patch have all
     // landed — halves of the app that only a full run puts on screen together.
     // And the action under test is destructive: a widget test rendering the row
-    // in isolation cannot show that "Alles toepassen" over the whole tab leaves
-    // every one of these groups alone.
+    // in isolation cannot show that the whole tab still offers no bulk pass
+    // over these groups now that the delete is each row's selected resolution
+    // (#327).
     useTallWindow(tester);
     final harness = staleClassGroupHarness();
     await tester.pumpWidget(AccountManagerApp(
@@ -3652,40 +3656,46 @@ void main() {
         findsOneWidget);
 
     // Both stale groups share one situation, so the tab collects them under a
-    // bulk header — and that header offers no bulk pass at all: neither half of
-    // the pair may be written that way (#293/#326). A bulk affordance here would
-    // take two mailboxes, Teams and file libraries on one click.
+    // bulk header — and that header offers no bulk pass at all, because the
+    // delete withholds the #293 sanction and #326 taught the header to read it.
+    // A bulk affordance here would take two mailboxes, Teams and file libraries
+    // on one click, and since #327 the delete is each row's *selected*
+    // resolution rather than a radio away.
     expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
     expect(find.textContaining('Alles toepassen ('), findsNothing,
         reason: 'a bulk pass over stale groups must write nothing at all');
 
-    // The row itself carries the either/or, with the delete as the half the
-    // operator has to reach for.
+    // The row proposes exactly one thing — no radios, no "laat de groep staan"
+    // no-op to read past (#327).
     final entry = find.byKey(const ValueKey('entry-group-GBS-9Z'));
     await tester.ensureVisible(entry);
     await tester.tap(entry);
     await tester.pumpAndSettle();
     expect(
-      find.text('Laat de Office 365-groep GBS-9Z staan — klas 9Z bestaat niet '
-          'meer in WISA of Smartschool'),
+      find.text('Verwijder de Office 365-groep GBS-9Z van de verdwenen '
+          'klas 9Z'),
       findsWidgets,
     );
-    final delete =
-        find.byKey(const ValueKey('alt-GBS-9Z-DeleteAzureClassGroup'));
-    expect(delete, findsOneWidget);
-    final apply = find.byKey(const ValueKey('entry-apply-GBS-9Z'));
-    await tester.ensureVisible(apply);
-    expect(tester.widget<FilledButton>(apply).onPressed, isNull,
-        reason:
-            'nothing is applyable while the default is "leave it standing"');
+    expect(find.textContaining('Laat de Office 365-groep GBS-9Z staan'),
+        findsNothing);
+    expect(find.byKey(const ValueKey('alt-GBS-9Z-DeleteAzureClassGroup')),
+        findsNothing,
+        reason: 'a lone action renders no radio at all');
+    expect(find.text('Kies één oplossing:'), findsNothing);
+    // What the delete takes with it, on the card, before anything is pressed.
+    expect(find.text('leden: 21'), findsOneWidget);
+    expect(find.text('postvak, Teams en bestanden: verdwijnen mee'),
+        findsOneWidget);
+    expect(harness.graph.deletedGroups, isEmpty,
+        reason: 'opening a card writes nothing');
 
-    await tester.ensureVisible(delete);
-    await tester.tap(delete);
-    await tester.pumpAndSettle();
+    final apply = find.byKey(const ValueKey('entry-apply-GBS-9Z'));
     await tester.ensureVisible(apply);
     expect(tester.widget<FilledButton>(apply).onPressed, isNotNull);
     await tester.tap(apply);
     await tester.pumpAndSettle();
+    expect(harness.graph.deletedGroups, isEmpty,
+        reason: 'the confirmation dialog is still standing');
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
@@ -3705,8 +3715,59 @@ void main() {
   });
 
   testWidgets(
-      'flipping every stale group to its delete still arms no bulk pass, '
-      'end-to-end (#326)', (WidgetTester tester) async {
+      'a stale group the delete cannot address keeps its lone "(manueel)" '
+      'notice end-to-end (#327)', (WidgetTester tester) async {
+    // The other side of #327. `GBS-9Z` is stale exactly as above, but the
+    // tenant handed us no object id for it, so there is nothing to address a
+    // `DELETE /groups/` to. That is the one case where "leave it standing" is
+    // not a no-op dressed as a choice but the honest whole content of the row —
+    // and it must survive as the informational, "(manueel)"-marked notice it
+    // always was, with no apply of its own.
+    //
+    // End-to-end because the claim spans three surfaces a widget test sees
+    // separately: the collapsed row line (composed from the *stored* candidate
+    // document), the expanded card (from the live dispatch), and the tab's
+    // bulk header — plus the entry-level Toepassen button, which is gated on
+    // the whole card rather than on this decision.
+    useTallWindow(tester);
+    final harness = staleClassGroupHarness(idlessStaleGroup: true);
+    await tester.pumpWidget(AccountManagerApp(
+      session: SignInSession(_FakeBroker(silent: (_) => _token('AT'))),
+      graph: graph,
+      reconcileBootstrap: harness.bootstrap,
+    ));
+    await tester.pumpAndSettle();
+    await syncThenOpenKlasgroepen(tester);
+    expect(harness.controller.error, isNull);
+
+    // The collapsed row states the situation and marks it as hand work.
+    expect(find.textContaining('Laat de Office 365-groep GBS-9Z staan'),
+        findsWidgets);
+    expect(find.textContaining('(manueel)'), findsWidgets);
+    expect(find.textContaining('(keuze)'), findsNothing,
+        reason: 'a lone notice is not a choice');
+
+    final Finder entry = find.byKey(const ValueKey('entry-group-GBS-9Z'));
+    await tester.ensureVisible(entry);
+    await tester.tap(entry);
+    await tester.pumpAndSettle();
+
+    // No delete on offer, and nothing on the card can write.
+    expect(find.textContaining('Verwijder de Office 365-groep GBS-9Z'),
+        findsNothing);
+    expect(find.text('Kies één oplossing:'), findsNothing);
+    expect(find.text('leden: 21'), findsOneWidget,
+        reason: 'the notice still states what the group holds');
+    final Finder apply = find.byKey(const ValueKey('entry-apply-GBS-9Z'));
+    await tester.ensureVisible(apply);
+    expect(tester.widget<FilledButton>(apply).onPressed, isNull);
+    expect(harness.graph.deletedGroups, isEmpty);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'a whole cohort of stale groups set to delete still arms no bulk pass, '
+      'end-to-end (#326/#327)', (WidgetTester tester) async {
     // The reported hole, in the real app. `GBS-9Z` and `GBS-8Y` are the Office
     // 365 groups of two classes that stopped running, so Klasgroepen files them
     // under one "same situation" header. That header counted
@@ -3717,12 +3778,16 @@ void main() {
     // and the header read "Alles toepassen (2)", one confirmation away from
     // taking two mailboxes, two Teams and two file libraries.
     //
-    // Only a full run can see it. The radios are rendered per row from the live
+    // #327 then removed the pair outright, so the delete is now the selected
+    // resolution of every stale row from the moment the tab opens — the state
+    // that used to take four taps to reach is the *default*. Which makes #326's
+    // guard the only thing standing between this cohort and one press.
+    //
+    // Only a full run can see it. The cards are rendered per row from the live
     // dispatch; the header is a separate derivation over the whole tab, above
-    // the inventory rather than beside the rows it acts on; and the claim is
-    // about what that second surface does *after* the operator has touched the
-    // first. A widget test that renders the header in isolation is handed a
-    // cohort somebody else built, which is precisely the seam that drifted.
+    // the inventory rather than beside the rows it acts on. A widget test that
+    // renders the header in isolation is handed a cohort somebody else built,
+    // which is precisely the seam that drifted.
     useTallWindow(tester);
     final harness = staleClassGroupHarness();
     await tester.pumpWidget(AccountManagerApp(
@@ -3734,40 +3799,36 @@ void main() {
     await syncThenOpenKlasgroepen(tester);
     expect(harness.controller.error, isNull);
 
-    // Untouched, the tab already offers no bulk pass: both rows default to the
-    // notice, which writes nothing. Since #326 the pair is *absent* rather than
+    // Both rows are set to a delete out of the box (#327), and the header
+    // offers nothing: the sanction is a property of the action, not of how many
+    // rows happen to be set to it. Since #326 the pair is *absent* rather than
     // dead at (0) — a disabled button invites the operator to go and make it
     // live, which is the very move this guards against.
     expect(find.text('Klassen in dezelfde situatie'), findsOneWidget,
         reason: 'the cohort is still named; only the bulk pair is withdrawn');
-    expect(find.textContaining('Alles toepassen ('), findsNothing);
+    expect(find.textContaining('Alles toepassen ('), findsNothing,
+        reason: 'a cohort of selected deletes must never arm a bulk pass');
     expect(find.text('Dry-run alles'), findsNothing);
 
-    // Now make the delete the selected resolution of every row in the cohort —
-    // the four taps that used to arm it.
+    // Each row really is set to its delete — the state that used to need a
+    // flipped radio on every one of them.
     for (final String id in const <String>['GBS-9Z', 'GBS-8Y']) {
       final Finder entry = find.byKey(ValueKey('entry-group-$id'));
       await tester.ensureVisible(entry);
       await tester.tap(entry);
       await tester.pumpAndSettle();
-      final Finder delete =
-          find.byKey(ValueKey('alt-$id-DeleteAzureClassGroup'));
-      await tester.ensureVisible(delete);
-      await tester.tap(delete);
-      await tester.pumpAndSettle();
-      // Collapse again so the next row's radios are reachable on the same page.
+      final Finder rowApply = find.byKey(ValueKey('entry-apply-$id'));
+      await tester.ensureVisible(rowApply);
+      expect(tester.widget<FilledButton>(rowApply).onPressed, isNotNull);
+      expect(find.textContaining('Verwijder de Office 365-groep $id'),
+          findsWidgets);
+      // Collapse again so the next row is reachable on the same page.
       await tester.ensureVisible(entry);
       await tester.tap(entry);
       await tester.pumpAndSettle();
     }
 
-    // Both rows are set to a delete, and the header still offers nothing: the
-    // sanction is a property of the action, not of how many rows happen to be
-    // set to it.
-    expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
-    expect(find.textContaining('Alles toepassen ('), findsNothing,
-        reason: 'a flipped radio must never arm a bulk delete');
-    expect(find.text('Dry-run alles'), findsNothing);
+    expect(find.textContaining('Alles toepassen ('), findsNothing);
     expect(harness.graph.deletedGroups, isEmpty);
 
     // What the operator kept is the per-row path: one group at a time, from the
@@ -3786,7 +3847,8 @@ void main() {
 
     expect(harness.graph.deletedGroups, ['az-GBS-9Z']);
     expect(find.byKey(const ValueKey('class-row-GBS-8Y')), findsOneWidget,
-        reason: 'the group beside it was flipped too, and still stands');
+        reason: 'the group beside it proposes the same delete, and still '
+            'stands — one press, one group');
     expect(tester.takeException(), isNull);
   });
 
@@ -3830,26 +3892,23 @@ void main() {
         findsOneWidget,
         reason: 'both leftovers now ask something instead of showing a ✓');
 
-    // Widened, not loosened: neither half of the pair is bulk-sanctioned, so
-    // the tab offers no bulk pass over these groups at all (#293/#326).
+    // Widened, not loosened: the delete is not bulk-sanctioned, so the tab
+    // offers no bulk pass over these groups at all (#293/#326) even though it
+    // is now each row's selected resolution (#327).
     expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
     expect(find.textContaining('Alles toepassen ('), findsNothing);
 
     // The renamed group is its class's group by the address it answers on
-    // (#280), so its row carries the pair under the name somebody typed over
+    // (#280), so its row carries the delete under the name somebody typed over
     // it.
     final renamed = find.byKey(const ValueKey('entry-group-Klas van juf An'));
     await tester.ensureVisible(renamed);
     await tester.tap(renamed);
     await tester.pumpAndSettle();
     expect(
-      find.text('Laat de Office 365-groep Klas van juf An staan — klas 8Y '
-          'bestaat niet meer in WISA of Smartschool'),
+      find.text('Verwijder de Office 365-groep Klas van juf An van de '
+          'verdwenen klas 8Y'),
       findsWidgets,
-    );
-    expect(
-      find.byKey(const ValueKey('alt-Klas van juf An-DeleteAzureClassGroup')),
-      findsOneWidget,
     );
     await tester.tap(renamed);
     await tester.pumpAndSettle();
@@ -3861,19 +3920,14 @@ void main() {
     await tester.tap(entry);
     await tester.pumpAndSettle();
     expect(
-      find.text('Laat de Office 365-groep GBS-9Z staan — klas 9Z bestaat niet '
-          'meer in WISA of Smartschool'),
+      find.text('Verwijder de Office 365-groep GBS-9Z van de verdwenen '
+          'klas 9Z'),
       findsWidgets,
     );
     expect(find.text('leden: 21'), findsOneWidget);
     expect(find.text('mail: '), findsNothing,
         reason: 'a security group has no address, so no line states one');
 
-    final delete =
-        find.byKey(const ValueKey('alt-GBS-9Z-DeleteAzureClassGroup'));
-    await tester.ensureVisible(delete);
-    await tester.tap(delete);
-    await tester.pumpAndSettle();
     final apply = find.byKey(const ValueKey('entry-apply-GBS-9Z'));
     await tester.ensureVisible(apply);
     expect(tester.widget<FilledButton>(apply).onPressed, isNotNull);
@@ -3882,11 +3936,11 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
-    // Exactly the one group the operator picked, and its row goes with it.
+    // Exactly the one group the operator pressed on, and its row goes with it.
     expect(harness.graph.deletedGroups, ['az-GBS-9Z']);
     expect(row('GBS-9Z'), findsNothing);
     expect(row('Klas van juf An'), findsOneWidget,
-        reason: 'the group beside it was never selected');
+        reason: 'the group beside it was never applied');
     expect(row('1A'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
@@ -3976,27 +4030,28 @@ void main() {
   });
 
   testWidgets(
-      'the "laat de groep staan" notice states its facts end-to-end, it does '
-      'not diff them (#305)', (WidgetTester tester) async {
+      'a stale group\'s card states its facts end-to-end, it does not diff '
+      'them (#305/#327)', (WidgetTester tester) async {
     // The reported card, in the real app. `GBS-9Z` is the group of a class that
-    // stopped running, still holding its 21 members, and the pre-selected half
-    // of its either/or is the notice that leaves it alone. It read
+    // stopped running, still holding its 21 members. Its card read
     //
     //   Laat de Office 365-groep GBS-9Z staan — klas 9Z bestaat niet meer …
     //   mail: GBS-9Z@student.school.example → ∅
     //   leden: 21 → ∅
     //
     // — a heading promising the group stays, over two lines saying its address
-    // and its 21 members are going away. That is what the *other* radio does,
-    // and it is the reading a bulk pass would run.
+    // and its 21 members are going away. Since #327 that heading is gone with
+    // the no-op it named, and the card leads with the delete; the fields are
+    // the inventory of what goes with the group, which is a statement, not a
+    // diff against an empty half.
     //
     // End-to-end rather than on the widget alone, because the shape has to
     // survive the whole path the operator's card is built from: the group
-    // dispatch's `ChangeSet`, the alternative collapse into one choice, the
-    // radio that swaps which option's fields are on screen, and only then a
-    // line of text in the tile. And "no arrow anywhere" is a claim about the
-    // page as composed — this tab also renders a same-situation bulk header
-    // over the two stale groups, which a row-scoped widget test cannot see.
+    // dispatch's `ChangeSet`, the collapse into one decision, the choice
+    // heading, and only then a line of text in the tile. And "no arrow
+    // anywhere" is a claim about the page as composed — this tab also renders a
+    // same-situation bulk header over the two stale groups, which a row-scoped
+    // widget test cannot see.
     useTallWindow(tester);
     final harness = staleClassGroupHarness();
     await tester.pumpWidget(AccountManagerApp(
@@ -4013,33 +4068,24 @@ void main() {
     await tester.tap(entry);
     await tester.pumpAndSettle();
 
-    // The default half is the notice, and under its heading are two facts.
+    // The card's only heading is the delete's own summary, and under it the
+    // inventory of what the delete takes.
     expect(
-      find.text('Laat de Office 365-groep GBS-9Z staan — klas 9Z bestaat niet '
-          'meer in WISA of Smartschool'),
+      find.text('Verwijder de Office 365-groep GBS-9Z van de verdwenen '
+          'klas 9Z'),
       findsWidgets,
     );
-    expect(find.text('mail: GBS-9Z@student.school.example'), findsOneWidget);
-    expect(find.text('leden: 21'), findsOneWidget);
-    expect(find.textContaining('→ ∅'), findsNothing,
-        reason: 'the option that writes nothing clears nothing — and no other '
-            'card on this page diffs against an empty half either');
-
-    // Flip to the delete and the same two facts are the inventory of what goes,
-    // joined by the consequence that was never a field value at all.
-    final delete =
-        find.byKey(const ValueKey('alt-GBS-9Z-DeleteAzureClassGroup'));
-    await tester.ensureVisible(delete);
-    await tester.tap(delete);
-    await tester.pumpAndSettle();
-
+    expect(find.textContaining('Laat de Office 365-groep GBS-9Z staan'),
+        findsNothing);
     expect(find.text('mail: GBS-9Z@student.school.example'), findsOneWidget);
     expect(find.text('leden: 21'), findsOneWidget);
     expect(find.text('postvak, Teams en bestanden: verdwijnen mee'),
         findsOneWidget);
-    expect(find.textContaining('→ ∅'), findsNothing);
+    expect(find.textContaining('→ ∅'), findsNothing,
+        reason: 'the inventory of what goes is stated, never diffed — and no '
+            'other card on this page diffs against an empty half either');
     expect(harness.graph.deletedGroups, isEmpty,
-        reason: 'picking a radio writes nothing on its own');
+        reason: 'reading a card writes nothing on its own');
     expect(tester.takeException(), isNull);
   });
 

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -133,6 +133,7 @@ class PendingActionOption {
     required this.changes,
     required this.canApply,
     this.canApplyToAll = false,
+    this.noticeFor,
     this.unlockedSystems = const {},
   });
 
@@ -177,6 +178,15 @@ class PendingActionOption {
   /// mechanism — the action classes pin `canApplyToAll ⇒ canApply` — so nothing
   /// here has to re-check it.
   final bool canApplyToAll;
+
+  /// The situation this **informational** option is context for (#329) —
+  /// `StudentAction.noticeFor` et al. — or `null` when it is a decision in its
+  /// own right.
+  ///
+  /// Non-null only where [canApply] is false. It is what the collapse reads to
+  /// keep the option out of an either/or and hand it to the decision it
+  /// explains instead ([PendingChoice.notices]).
+  final String? noticeFor;
 
   /// The systems only a **chained follow-up** of this option would write to
   /// (`StudentAction.unlockedSystems` et al., #234) — never the option's own
@@ -278,17 +288,38 @@ class ApplyStep {
 /// the alternatives as one choice — rather than independent rows — is the core
 /// of #110: the operator picks one resolution and never runs both.
 class PendingChoice {
-  PendingChoice({required this.alternatives, required this.selected})
-      : assert(alternatives.isNotEmpty);
+  PendingChoice({
+    required this.alternatives,
+    required this.selected,
+    this.notices = const <PendingActionOption>[],
+  }) : assert(alternatives.isNotEmpty);
 
-  /// The mutually-exclusive options (one or more).
+  /// The mutually-exclusive options (one or more). **Every one of them writes**
+  /// (#329) — an informational action is [notices], never an alternative.
   final List<PendingActionOption> alternatives;
 
   /// The currently-chosen option (defaults to the group's default).
   final PendingActionOption selected;
 
+  /// The informational actions this decision carries as **context** (#329), in
+  /// dispatch order — read above the decision on the card, without a radio and
+  /// without an apply of their own, still marked "(manueel)".
+  ///
+  /// Two situations have one: a class Smartschool already carries under a group
+  /// the linker could not adopt ("make it official there and it will link",
+  /// #225/#250) and an empty WISA class ("delete it by hand, or wait until it
+  /// has students", #244). In both, the single thing this app can do is stop
+  /// importing the class — so the card proposes that, and states the repair the
+  /// operator makes instead. Pairing the two as radios asked them to choose
+  /// between a diagnosis and a resolution.
+  ///
+  /// Empty for nearly every decision.
+  final List<PendingActionOption> notices;
+
   /// True when this is a real choice the operator must resolve (more than one
-  /// alternative), false for a lone action.
+  /// alternative), false for a lone action. Since #329 both sides of such a
+  /// choice always write, so "Kies één oplossing:" is only ever asked about two
+  /// things that do.
   bool get isChoice => alternatives.length > 1;
 
   /// The situation this choice resolves — the alternative-group key for a real
@@ -363,10 +394,10 @@ class PendingDecision {
 
   /// Whether an apply pass would write anything for **this decision** — the
   /// selected alternative is applyable. Deliberately not
-  /// [PendingAccountEntry.canApply], which answers for the whole card: a
-  /// namesake class whose import decision is a hand-fix notice still has an
-  /// applyable Office 365 group decision beside it, and a cohort of the former
-  /// must not count itself as work.
+  /// [PendingAccountEntry.canApply], which answers for the whole card: a class
+  /// whose only informational row is a lone notice still has an applyable
+  /// Office 365 group decision beside it, and a cohort of the former must not
+  /// count itself as work.
   bool get canApply => choice.selected.canApply;
 
   /// Whether this account's stake in the decision may be written by a
@@ -417,12 +448,14 @@ class SituationCohort {
   /// "delete" armed a header that took both groups — mailboxes, Teams and files
   /// — on one press, on an action whose own class says no bulk affordance may
   /// offer it. Since #327 and #328 dropped the no-op half of that pair and of
-  /// the Smartschool-leftover one beside it, both deletes are the *selected*
-  /// resolution of every such row from the moment the tab opens, so this
-  /// narrowing is the only thing standing between either cohort and one press.
-  /// Both flags, because a cohort is a mix: the members of a
-  /// `classImportAlternative` cohort set to "create" are sanctioned, the ones
-  /// flipped to the blacklist beside it are not.
+  /// the Smartschool-leftover one beside it, and #329 turned the two remaining
+  /// notices into context rather than pre-selected halves, both deletes *and*
+  /// the class blacklist are the *selected* resolution of every such row from
+  /// the moment the tab opens — so this narrowing is the only thing standing
+  /// between those cohorts and one press. Both flags, because a cohort is a
+  /// mix: the members of a `classImportAlternative` cohort set to "create" are
+  /// sanctioned, the ones flipped to the blacklist beside it — and the empty
+  /// classes whose lone decision *is* that blacklist — are not.
   ///
   /// (`canApplyToAll ⇒ canApply` is pinned on the action classes, so the second
   /// test is redundant. It is written out anyway: a bulk write must not inherit
@@ -1078,6 +1111,9 @@ class ReconcileController extends ChangeNotifier {
       // The school-wide sanction of #293, carried here so #296's per-decision
       // "Toepassen op alle" can read it off the pending list.
       canApplyToAll: (a) => a.canApplyToAll,
+      // The #329 notice relation, read off the action for every family so no
+      // screen has to know which one happens to have notices today.
+      noticeFor: (a) => a.noticeFor,
       unlockedSystems: (a) => a.unlockedSystems,
     ));
     entries.addAll(_entriesFor(
@@ -1092,6 +1128,7 @@ class ReconcileController extends ChangeNotifier {
       // action is applyable today, but nothing here should assume it.
       canApply: (a) => a.canApply,
       canApplyToAll: (a) => a.canApplyToAll,
+      noticeFor: (a) => a.noticeFor,
       unlockedSystems: (a) => a.unlockedSystems,
     ));
     entries.addAll(_entriesFor(
@@ -1104,6 +1141,7 @@ class ReconcileController extends ChangeNotifier {
       changes: (a) => a.describeChanges(),
       canApply: (a) => a.canApply,
       canApplyToAll: (a) => a.canApplyToAll,
+      noticeFor: (a) => a.noticeFor,
       unlockedSystems: (a) => a.unlockedSystems,
     ));
     _pendingCacheKey = l;
@@ -1346,6 +1384,7 @@ class ReconcileController extends ChangeNotifier {
     required actions.ChangeSet Function(T) changes,
     required bool Function(T) canApply,
     required bool Function(T) canApplyToAll,
+    required String? Function(T) noticeFor,
     required Set<core.Origin> Function(T) unlockedSystems,
   }) {
     final order = <String>[];
@@ -1379,6 +1418,7 @@ class ReconcileController extends ChangeNotifier {
                   changes: changes(a),
                   canApply: canApply(a),
                   canApplyToAll: canApplyToAll(a),
+                  noticeFor: noticeFor(a),
                   unlockedSystems: unlockedSystems(a),
                 ),
             ],
@@ -1395,8 +1435,11 @@ class ReconcileController extends ChangeNotifier {
   /// The partition itself is `account_actions`' [actions.collapseAlternatives]
   /// (#251) — the one definition of "these actions are one either/or", shared
   /// with the materializer so the badges and this list cannot disagree about
-  /// what a decision is. Only the operator's session-local pick is layered on
-  /// here; a passive session has no picks to apply.
+  /// what a decision is. It is also where "an informational action is context,
+  /// not an alternative" is enforced (#329): an option declaring `noticeFor`
+  /// never enters an option list and is handed to the decision it names as
+  /// [PendingChoice.notices]. Only the operator's session-local pick is layered
+  /// on here; a passive session has no picks to apply.
   List<PendingChoice> _choicesFor(
     String targetId,
     List<PendingActionOption> options,
@@ -1406,10 +1449,16 @@ class ReconcileController extends ChangeNotifier {
           options,
           groupOf: (o) => o.group,
           isDefault: (o) => o.isDefault,
+          // An informational action that names a situation is context on that
+          // decision, never one of its answers (#329) — the collapse is where
+          // that rule lives, so the pending list and the materialized view
+          // cannot disagree about what a decision is.
+          noticeFor: (o) => o.noticeFor,
         ))
           PendingChoice(
             alternatives: choice.options,
             selected: _chosen(targetId, choice),
+            notices: choice.notices,
           ),
       ];
 

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -416,7 +416,10 @@ class SituationCohort {
   /// first meant that flipping two rows of a stale Office 365 class group to
   /// "delete" armed a header that took both groups — mailboxes, Teams and files
   /// — on one press, on an action whose own class says no bulk affordance may
-  /// offer it. Both flags, because a cohort is a mix: the members of a
+  /// offer it. Since #327 dropped that pair's no-op half, the delete is the
+  /// *selected* resolution of every such row from the moment the tab opens, so
+  /// this narrowing is the only thing standing between the cohort and one
+  /// press. Both flags, because a cohort is a mix: the members of a
   /// `classImportAlternative` cohort set to "create" are sanctioned, the ones
   /// flipped to the blacklist beside it are not.
   ///

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -416,10 +416,11 @@ class SituationCohort {
   /// first meant that flipping two rows of a stale Office 365 class group to
   /// "delete" armed a header that took both groups — mailboxes, Teams and files
   /// — on one press, on an action whose own class says no bulk affordance may
-  /// offer it. Since #327 dropped that pair's no-op half, the delete is the
-  /// *selected* resolution of every such row from the moment the tab opens, so
-  /// this narrowing is the only thing standing between the cohort and one
-  /// press. Both flags, because a cohort is a mix: the members of a
+  /// offer it. Since #327 and #328 dropped the no-op half of that pair and of
+  /// the Smartschool-leftover one beside it, both deletes are the *selected*
+  /// resolution of every such row from the moment the tab opens, so this
+  /// narrowing is the only thing standing between either cohort and one press.
+  /// Both flags, because a cohort is a mix: the members of a
   /// `classImportAlternative` cohort set to "create" are sanctioned, the ones
   /// flipped to the blacklist beside it are not.
   ///

--- a/account_manager/lib/src/reconcile/reconcile_controller.dart
+++ b/account_manager/lib/src/reconcile/reconcile_controller.dart
@@ -405,10 +405,34 @@ class SituationCohort {
   /// cohort answers the same question.
   String get label => decisions.first.choice.situationLabel;
 
+  /// The members a **bulk** affordance may write (#326) — the same narrowing
+  /// [ReconcileController.applyToAllCohortFor] applies, so the two bulk paths
+  /// answer one question instead of two.
+  ///
+  /// [PendingDecision.canApply] alone is not it. That asks "does the selected
+  /// option write anything", which every flipped radio makes true; the sanction
+  /// of #293 asks "may this be written to a whole cohort off one confirmation",
+  /// which the destructive and judgement-call actions refuse. Counting only the
+  /// first meant that flipping two rows of a stale Office 365 class group to
+  /// "delete" armed a header that took both groups — mailboxes, Teams and files
+  /// — on one press, on an action whose own class says no bulk affordance may
+  /// offer it. Both flags, because a cohort is a mix: the members of a
+  /// `classImportAlternative` cohort set to "create" are sanctioned, the ones
+  /// flipped to the blacklist beside it are not.
+  ///
+  /// (`canApplyToAll ⇒ canApply` is pinned on the action classes, so the second
+  /// test is redundant. It is written out anyway: a bulk write must not inherit
+  /// its whole guard from an invariant one layer away.)
+  List<PendingDecision> get bulkApplyable => <PendingDecision>[
+        for (final d in decisions)
+          if (d.canApply && d.canApplyToAll) d,
+      ];
+
   /// How many of them a bulk apply would actually write — the count the "Alles
-  /// toepassen (n)" button quotes. Zero for a cohort of informational notices,
-  /// which is what disables the button.
-  int get applyableCount => decisions.where((d) => d.canApply).length;
+  /// toepassen (n)" button quotes, and the length of [bulkApplyable]. Zero for a
+  /// cohort of informational notices *and* for one whose rows are all set to a
+  /// resolution #293 withholds, which is what drops the button.
+  int get applyableCount => bulkApplyable.length;
 }
 
 /// One colliding Smartschool account inside a [DuplicateMailWarning] (#109),
@@ -2737,14 +2761,64 @@ class ReconcileController extends ChangeNotifier {
   /// the header named one action and the pass ran whatever else was there.
   ///
   /// Each member still contributes its **own** selected alternative, exactly as
-  /// the whole-card pass does: a cohort of departed students where one is set to
-  /// unregister and one to delete applies each as chosen.
+  /// the whole-card pass does — among the resolutions #293 sanctions for a bulk
+  /// pass. A cohort of departed students where one is set to unregister and one
+  /// to delete writes neither: both resolutions are withheld, and this is the
+  /// bulk path. Their per-card **Toepassen** still applies each as chosen.
+  ///
+  /// That narrowing is [_bulkSanctioned], and it lives here rather than in the
+  /// affordances so the invariant survives a new one (#326).
   Future<void> applyDecisions(Iterable<PendingDecision> decisions) =>
-      _run(decisions, dry: false);
+      _runBulk(decisions, dry: false);
 
   /// Dry-runs [decisions] — [applyDecisions] with no writes.
   Future<void> dryRunDecisions(Iterable<PendingDecision> decisions) =>
-      _run(decisions, dry: true);
+      _runBulk(decisions, dry: true);
+
+  /// [_run] over the members of [decisions] a bulk pass may write (#326).
+  Future<void> _runBulk(
+    Iterable<PendingDecision> decisions, {
+    required bool dry,
+  }) async {
+    final sanctioned = _bulkSanctioned(decisions);
+    if (sanctioned.isEmpty) return;
+    return _run(sanctioned, dry: dry);
+  }
+
+  /// [decisions] narrowed to the ones a **bulk** pass is allowed to write
+  /// (#326): the resolution each is set to must declare
+  /// [PendingActionOption.canApplyToAll], the sanction of #293.
+  ///
+  /// The guard the situation header reads ([SituationCohort.bulkApplyable]) and
+  /// the guard the pass applies are deliberately the same rule stated twice.
+  /// Before #326 it was stated only in the header's count, and only *by
+  /// accident*: the destructive resolutions were kept off the bulk path by
+  /// their alternative group's polarity — the informational half is the default,
+  /// so nothing counted until the operator flipped a radio, and flipping two of
+  /// them armed the button. A guard that holds only while a default holds is
+  /// not a guard, and the defaults are exactly what #327–#329 take away.
+  ///
+  /// A skip here means an affordance offered something it must not have, so it
+  /// is stated in the log rather than swallowed.
+  List<PendingDecision> _bulkSanctioned(Iterable<PendingDecision> decisions) {
+    final kept = <PendingDecision>[];
+    var withheld = 0;
+    for (final d in decisions) {
+      if (d.canApply && d.canApplyToAll) {
+        kept.add(d);
+      } else if (d.canApply) {
+        withheld++;
+      }
+    }
+    if (withheld > 0) {
+      log.addMessage(
+        core.Origin.all,
+        'Overgeslagen in de groepsbewerking: $withheld actie(s) die enkel per '
+        'record toegepast mogen worden.',
+      );
+    }
+    return kept;
+  }
 
   /// Runs the selected, applyable option of every decision in [decisions]
   /// through the apply path (dry or real). Shared by the per-entry and

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -896,6 +896,18 @@ String pendingChoiceLine(PendingChoice c) {
   return c.selected.canApply ? summary : '$summary (manueel)';
 }
 
+/// The collapsed line one of a decision's [PendingChoice.notices] reads as
+/// (#329) — the instruction, marked "(manueel)" exactly as a standalone
+/// informational action is.
+///
+/// A notice is context rather than a decision, so it is *not* one of
+/// [pendingChoiceLine]'s cases: a preview lists both, the notice first and the
+/// decision it explains under it. That order is the point of showing it here at
+/// all — from an inventory row, "Negeer deze klas bij het importeren uit WISA"
+/// on its own does not say why the class is in that state.
+String pendingNoticeLine(PendingActionOption notice) =>
+    '${notice.changes.summary} (manueel)';
+
 /// The expandable card the Klasgroepen inventory builds a class with pending
 /// work on. (Acties built one too until #295 moved its decisions into a details
 /// pane of their own; the rule below is what made that move possible.)
@@ -1070,13 +1082,22 @@ List<Widget> entryDetail(
 /// the "(manueel)" marker exists to make an informational action scannable in a
 /// list of many, while inside the block [OptionDetail] already spells the same
 /// thing out in a full sentence.
+///
+/// **"Kies één oplossing:" is asked only about alternatives that both write**
+/// (#329). It follows from [PendingChoice.isChoice] rather than being re-checked
+/// here, because the collapse keeps an informational action out of the option
+/// list altogether — it becomes [PendingChoice.notices] and is stated above this
+/// heading instead. Before that, a card could ask the operator to choose between
+/// "this class already exists in Smartschool, go make it official" and "never
+/// import this class": one of those is not a solution, so the heading was
+/// putting a question to them that had one real answer.
 String choiceHeading(PendingChoice choice) =>
     choice.isChoice ? 'Kies één oplossing:' : choice.selected.changes.summary;
 
-/// One decision of a card, as a block of its own (#281): the heading that names
-/// it, then the radios (for an either/or) and the field diff of the resolution
-/// that would actually run — and, since #283, what the last pass did about
-/// *this* decision.
+/// One decision of a card, as a block of its own (#281): whatever notices are
+/// context for it (#329), the heading that names it, then the radios (for an
+/// either/or) and the field diff of the resolution that would actually run —
+/// and, since #283, what the last pass did about *this* decision.
 ///
 /// The reading this exists for: a class that is new to Smartschool **and** has
 /// no Office 365 group raises two independent decisions on one card. The body
@@ -1138,6 +1159,18 @@ class EntryChoiceBlock extends StatelessWidget {
           Divider(height: 1, color: Theme.of(context).dividerColor),
           const SizedBox(height: PlinkSpacing.s3),
         ],
+        // Context before proposal (#329). A notice states what is *already* the
+        // case — "this class exists in Smartschool but is not an official
+        // class", "this WISA class has no students yet" — and the heading under
+        // it says what this app proposes about that. Read the other way round
+        // the proposal is a non sequitur, which is exactly how the radio pair
+        // these used to be half of read.
+        for (final notice in choice.notices)
+          ChoiceNotice(
+            key: ValueKey(
+                'notice-${entry.family}-${entry.targetId}-$index-${notice.kind}'),
+            notice: notice,
+          ),
         // Led by the system it writes to, exactly as the collapsed preview is
         // (#298). Since #300 that preview gives way while the card is open, so
         // this heading is the only thing left saying where the write lands —
@@ -1446,6 +1479,69 @@ String fieldChangeLine(actions.FieldChange f) => switch (f.shape) {
       actions.FieldChangeShape.transition =>
         '${f.field}: ${f.before ?? '∅'} → ${f.after ?? '∅'}',
     };
+
+/// One informational action a decision carries as **context** (#329): the
+/// instruction, marked "(manueel)", with the facts it states about the record
+/// under it — and no radio, no apply, nothing to choose.
+///
+/// The rule it enforces: *a notice is context, not an alternative.* Two
+/// decisions used to pair one of these with the single write the app has for
+/// the situation and offer them as radios — "make this group official in
+/// Smartschool" beside "never import this class", "delete this empty WISA class
+/// by hand" beside the same. Only one of each pair is something an apply can
+/// run; the other is an instruction to go elsewhere, and an operator cannot
+/// "apply" it. So the card states it and proposes the write, rather than asking
+/// a question whose two answers are not comparable.
+///
+/// Deliberately not [OptionDetail] with the radio suppressed. That widget
+/// renders *the resolution that would run*: its lifecycle fallback says
+/// "Levenscyclusactie — geen wijzigingen per veld", and its "(manueel)"
+/// sentence appears only when an informational option has no fields at all — so
+/// a notice with fields (the namesake one names the group's code and its
+/// official flag) would have rendered as a bare field list with nothing marking
+/// it as write-free. Here the marker is on the sentence, always.
+class ChoiceNotice extends StatelessWidget {
+  const ChoiceNotice({super.key, required this.notice});
+
+  /// The informational option this states — [PendingChoice.notices]' member.
+  final PendingActionOption notice;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: PlinkSpacing.s2),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          // Led by the system the operator has to go and act in — the same tag
+          // every other line on the card carries (#298), and here it is the
+          // more useful half: the instruction is "do this over there".
+          ActionLine(
+            system: notice.changes.system,
+            line: pendingNoticeLine(notice),
+            style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+          ),
+          // How the operator finds the thing the instruction is about. Stated,
+          // never diffed — these are the notice's own `FieldChange`s and
+          // [fieldChangeLine] already keeps a statement from reading as a
+          // value being cleared (#305).
+          for (final f in notice.changes.fields)
+            Padding(
+              padding: const EdgeInsets.only(top: PlinkSpacing.s1),
+              child: Text(
+                fieldChangeLine(f),
+                style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
 
 /// The per-field diff (or a lifecycle note) for a single option — the one that
 /// stands alone, or the one selected inside a [ChoiceControl].

--- a/account_manager/lib/src/screens/action_tiles.dart
+++ b/account_manager/lib/src/screens/action_tiles.dart
@@ -795,6 +795,18 @@ class MessagePanel extends StatelessWidget {
 /// email fix one of them happens to need. That is what makes the claim on the
 /// button verifiable at all — the operator can read one action's description and
 /// know what the button does to everyone in the cohort.
+///
+/// And since #326 the pair is offered only over resolutions #293 sanctions for
+/// a bulk pass ([SituationCohort.bulkApplyable]) — never merely over the ones
+/// that write *something*. The two questions came apart the moment an operator
+/// flipped two rows of one situation to a destructive alternative: the header
+/// counted them, armed, and took both Office 365 groups off one press, on an
+/// action whose own class says no bulk affordance may offer it. When nothing in
+/// the cohort survives that narrowing the buttons are gone rather than dead,
+/// because a disabled "Alles toepassen (0)" invites the operator to go and make
+/// it enabled — which is precisely the move this guards against. The line
+/// naming the cohort stays: "2 klassen in dezelfde situatie" is worth reading
+/// even when there is nothing to press.
 class SituationHeader extends StatelessWidget {
   const SituationHeader({
     super.key,
@@ -814,7 +826,11 @@ class SituationHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final TextTheme text = Theme.of(context).textTheme;
     final String key = cohort.key;
-    final int applyable = cohort.applyableCount;
+    // The members a bulk pass may write — [PendingDecision.canApply] *and* the
+    // #293 sanction (#326). The pair below is built from this list, quotes its
+    // length, confirms its scope and hands it to the pass, so the four cannot
+    // drift apart; when it is empty there is no pair at all.
+    final List<PendingDecision> writable = cohort.bulkApplyable;
 
     return Padding(
       padding: const EdgeInsets.only(
@@ -830,37 +846,38 @@ class SituationHeader extends StatelessWidget {
               style: text.titleSmall,
             ),
           ),
-          const SizedBox(width: PlinkSpacing.s2),
-          OutlinedButton(
-            key: ValueKey('situation-dry-run-$key'),
-            onPressed: controller.busy || applyable == 0
-                ? null
-                : () => runWithProgress(
-                      context,
-                      controller: controller,
-                      dry: true,
-                      run: () => controller.dryRunDecisions(cohort.decisions),
-                    ),
-            child: const Text('Dry-run alles'),
-          ),
-          const SizedBox(width: PlinkSpacing.s2),
-          FilledButton(
-            key: ValueKey('situation-apply-$key'),
-            onPressed: controller.busy || applyable == 0
-                ? null
-                : () => confirmAndApply(
-                      context,
-                      controller: controller,
-                      title: 'Toepassen op ${cohort.length} $noun?',
-                      // The dialog is scoped to the very decisions the pass
-                      // below runs — the ones this header counted (#234/#252),
-                      // and only those (#292).
-                      scope:
-                          controller.applyScopeForDecisions(cohort.decisions),
-                      apply: () => controller.applyDecisions(cohort.decisions),
-                    ),
-            child: Text('Alles toepassen ($applyable)'),
-          ),
+          if (writable.isNotEmpty) ...<Widget>[
+            const SizedBox(width: PlinkSpacing.s2),
+            OutlinedButton(
+              key: ValueKey('situation-dry-run-$key'),
+              onPressed: controller.busy
+                  ? null
+                  : () => runWithProgress(
+                        context,
+                        controller: controller,
+                        dry: true,
+                        run: () => controller.dryRunDecisions(writable),
+                      ),
+              child: const Text('Dry-run alles'),
+            ),
+            const SizedBox(width: PlinkSpacing.s2),
+            FilledButton(
+              key: ValueKey('situation-apply-$key'),
+              onPressed: controller.busy
+                  ? null
+                  : () => confirmAndApply(
+                        context,
+                        controller: controller,
+                        title: 'Toepassen op ${writable.length} $noun?',
+                        // The dialog is scoped to the very decisions the pass
+                        // below runs — the ones this header counted
+                        // (#234/#252), and only those (#292/#326).
+                        scope: controller.applyScopeForDecisions(writable),
+                        apply: () => controller.applyDecisions(writable),
+                      ),
+              child: Text('Alles toepassen (${writable.length})'),
+            ),
+          ],
         ],
       ),
     );

--- a/account_manager/lib/src/screens/class_groups_screen.dart
+++ b/account_manager/lib/src/screens/class_groups_screen.dart
@@ -50,18 +50,26 @@ export 'action_tiles.dart' show compareClassNames;
 ///   inventory right?", which only the full list can. The name search (#262) is
 ///   what makes those few hundred rows navigable without shortening them, and it
 ///   composes with the switch rather than replacing it.
-/// - **Informational notices are not buried.** A class Smartschool already
-///   holds, or an Office 365 group left behind by a class that is gone, is real
-///   manual work with no automated write, so it contributes nothing to a pending
-///   count (#225/#250). The filter and the row **highlight** therefore key on
-///   [MaterializedGroup.needsAttention], never on the pending count — and that
-///   stays true under #298, which is not the contradiction it looks like. The
-///   reconciling principle is *colour by work that can be done on this screen*:
-///   here the manual notice is the work you do on this screen, so it lights the
-///   row; in Acties an informational candidate diagnoses work that happens
-///   somewhere else, so it colours nothing there. The system **cells** are the
-///   narrower reading — they promise a write, so they count only applyable
-///   work. See the library doc of `system_indicator.dart`.
+/// - **Informational notices are not buried.** A row whose only content is a
+///   diagnosis — a leftover class or group this app cannot address a delete to
+///   (#327/#328) — is real manual work with no automated write, so it
+///   contributes nothing to a pending count. The filter and the row
+///   **highlight** therefore key on [MaterializedGroup.needsAttention], never on
+///   the pending count — and that stays true under #298, which is not the
+///   contradiction it looks like. The reconciling principle is *colour by work
+///   that can be done on this screen*: here the manual notice is the work you do
+///   on this screen, so it lights the row; in Acties an informational candidate
+///   diagnoses work that happens somewhere else, so it colours nothing there.
+///   The system **cells** are the narrower reading — they promise a write, so
+///   they count only applyable work. See the library doc of
+///   `system_indicator.dart`.
+///
+///   A notice that sits *beside* a decision is a different thing again (#329):
+///   a class Smartschool already holds, and an empty WISA class, each carry an
+///   instruction the operator acts on elsewhere **and** the one write this app
+///   has for them ("negeer deze klas"). The row previews both, the notice first
+///   and marked "(manueel)", and it counts and colours on the write — because
+///   there is one.
 ///
 /// A class that needs work is inspected — and, where it is applyable, dry-run
 /// and applied — right here, through the same tiles Acties uses
@@ -782,19 +790,35 @@ class _ClassRow extends StatelessWidget {
   ///
   /// A preview, and only that: an open card renders the decisions themselves
   /// and these lines stand down (#300).
+  ///
+  /// A decision's notices (#329) are previewed above it, in both sessions. They
+  /// are not decisions and are counted nowhere, but the row is what an operator
+  /// scans the inventory by: "Negeer deze klas bij het importeren uit WISA" on
+  /// its own does not say that the class already exists in Smartschool under a
+  /// group nobody flagged official, which is the whole reason that is the only
+  /// thing on offer.
   List<({core.Origin system, String text})> _lines(
     PendingAccountEntry? entry,
     MaterializedGroup group,
   ) {
     if (entry != null) {
       return <({core.Origin system, String text})>[
-        for (final c in entry.choices)
+        for (final c in entry.choices) ...<({core.Origin system, String text})>[
+          for (final n in c.notices)
+            (system: n.changes.system, text: pendingNoticeLine(n)),
           (system: c.selected.changes.system, text: pendingChoiceLine(c)),
+        ],
       ];
     }
     return <({core.Origin system, String text})>[
-      for (final c in candidateChoices(group.candidates))
+      for (final c in candidateChoices(group.candidates)) ...<({
+        core.Origin system,
+        String text
+      })>[
+        for (final n in c.notices)
+          (system: n.system, text: '${n.summary} (manueel)'),
         (system: c.selected.system, text: readOnlyCandidateLine(c)),
+      ],
     ];
   }
 

--- a/account_manager/lib/src/screens/system_indicator.dart
+++ b/account_manager/lib/src/screens/system_indicator.dart
@@ -24,11 +24,18 @@
 ///
 /// The two screens look like they disagree, and they do not. Klasgroepen keys
 /// its row **highlight** on `MaterializedGroup.needsAttention`, informational
-/// notices included (#225/#250), because there the manual notice *is* the work
-/// the operator does on that screen — a class Smartschool already holds, or an
-/// Office 365 group left behind by a class that is gone, is answered right
-/// there. In Acties an informational candidate is a diagnosis of work that
-/// happens somewhere else, so it colours nothing.
+/// notices included (#327/#328), because there the manual notice *is* the work
+/// the operator does on that screen — a leftover class or group this app cannot
+/// address a delete to is answered right there. In Acties an informational
+/// candidate is a diagnosis of work that happens somewhere else, so it colours
+/// nothing.
+///
+/// A notice attached to a decision (#329) does not enter into this at all: it
+/// is context, and the decision beside it is what the cell answers for. A
+/// namesake or empty class therefore colours its **WISA** cell, because "negeer
+/// deze klas" is a live decision about the WISA side of that class — the same
+/// consequence #327/#328 had on the other two systems when their no-op halves
+/// went.
 ///
 /// Both are the same rule: **a coloured cell means work you can do here.** The
 /// next reader will otherwise see two rules and assume one is a bug.

--- a/account_manager/test/reconcile/reconcile_controller_test.dart
+++ b/account_manager/test/reconcile/reconcile_controller_test.dart
@@ -220,19 +220,19 @@ void main() {
       await h.controller.sync();
 
       // The count mirrors the relink summary's pendingActions.length (the
-      // fixture derives six pending actions across the families — its two
-      // Smartschool-only classes each carry the #313 either/or, which is two
-      // actions and one decision), and the line names the operator who ran the
-      // pass (#169).
+      // fixture derives four pending actions across the families — its two
+      // Smartschool-only classes each propose one delete since #328 dropped the
+      // no-op half of the #313 pair), and the line names the operator who ran
+      // the pass (#169).
       expect(
         h.log.entries.map((e) => e.message),
-        contains('Sync voltooid — 6 openstaande actie(s). Klaar. '
+        contains('Sync voltooid — 4 openstaande actie(s). Klaar. '
             'Operator: operator@school.example.'),
       );
       // It is the *last* line — the operator sees it closing the pass.
       expect(
           h.log.entries.last.message,
-          'Sync voltooid — 6 openstaande actie(s). Klaar. '
+          'Sync voltooid — 4 openstaande actie(s). Klaar. '
           'Operator: operator@school.example.');
     });
 
@@ -243,7 +243,7 @@ void main() {
       await h.controller.sync();
 
       expect(h.log.entries.last.message,
-          'Sync voltooid — 6 openstaande actie(s). Klaar.');
+          'Sync voltooid — 4 openstaande actie(s). Klaar.');
     });
 
     test('the "no changes needed" path also logs a ready line', () async {
@@ -281,7 +281,7 @@ void main() {
       // actually ran, because a drift check is not a sync.
       expect(
           h.log.entries.last.message,
-          'Driftcontrole voltooid — 6 openstaande actie(s). Klaar. '
+          'Driftcontrole voltooid — 4 openstaande actie(s). Klaar. '
           'Operator: operator@school.example.');
       expect(
         h.log.entries.where((e) => e.message.startsWith('Sync voltooid')),
@@ -299,7 +299,7 @@ void main() {
       await h.controller.checkDrift();
 
       expect(h.log.entries.last.message,
-          'Driftcontrole voltooid — 6 openstaande actie(s). Klaar.');
+          'Driftcontrole voltooid — 4 openstaande actie(s). Klaar.');
     });
   });
 
@@ -1377,15 +1377,18 @@ void main() {
     });
 
     test('informational group actions are listed but never applied', () async {
-      // An orphan Smartschool class (no WISA counterpart) surfaces the
-      // informational DoNotImportFromSmartschool — visible in the pending
-      // list, skipped by the apply pass (its apply() throws by contract).
+      // An orphan Smartschool class the app cannot delete — `9Z` names no class
+      // code, so there is nothing to address a `delClass` to (#328) — surfaces
+      // the informational DoNotImportFromSmartschool, visible in the pending
+      // list and skipped by the apply pass (its apply() throws by contract).
+      // Its two neighbours do name codes, so they propose the delete instead
+      // and keep the applyable count non-trivial.
       final h = ReconcileHarness(
         smartschool: ssSnap(
           groups: [
             ssGroup('2B', code: '2B_ss'),
             ssGroup('3C', code: '3C_ss'),
-            ssGroup('9Z', code: '9Z_ss'),
+            ssGroup('9Z', code: ' '),
           ],
         ),
       );
@@ -1829,9 +1832,10 @@ void main() {
       expectSummary(h.controller.studentSummary, total: 1, pending: 2);
       // No staff in the fixture ⇒ the staff bucket is absent.
       expectSummary(h.controller.staffSummary, total: 0, pending: 0);
-      // Two Smartschool-only classes (2B, 3C) are informational group notices,
-      // so they count toward the total but carry no applyable pending action.
-      expectSummary(h.controller.groupSummary, total: 2, pending: 0);
+      // Two Smartschool-only classes (2B, 3C). Each proposes one delete since
+      // #328 — where the notice used to be the pre-selected half, so the pair
+      // counted toward the total and nothing toward the pending work.
+      expectSummary(h.controller.groupSummary, total: 2, pending: 2);
     });
 
     test('departed students sum across the unassigned bucket, not staff',
@@ -1866,7 +1870,7 @@ void main() {
 
       expect(s2.controller.linked, isNull);
       expectSummary(s2.controller.studentSummary, total: 1, pending: 2);
-      expectSummary(s2.controller.groupSummary, total: 2, pending: 0);
+      expectSummary(s2.controller.groupSummary, total: 2, pending: 2);
     });
   });
 

--- a/account_manager/test/reconcile/reconcile_decision_cohort_test.dart
+++ b/account_manager/test/reconcile/reconcile_decision_cohort_test.dart
@@ -146,9 +146,11 @@ void main() {
 
     test('each member still contributes its own selected alternative',
         () async {
-      // A cohort of departed students where one is set to unregister and one to
-      // delete applies each as chosen — the #110 guarantee, unchanged by the
-      // move to per-decision passes.
+      // Two departed students, one set to unregister and one to delete, applied
+      // as cards — the #110 guarantee, unchanged by the move to per-decision
+      // passes. Read as *cards* rather than as a cohort because neither
+      // resolution is bulk-sanctioned: see the #326 test below, which is the
+      // other half of this pair.
       final h = departedHarness();
       await h.controller.sync();
       final departure =
@@ -160,17 +162,56 @@ void main() {
         group: actions.smartschoolDepartureAlternative,
         kind: 'DeleteStudentFromSmartschool',
       );
-      // Re-read after the pick, exactly as the header does: `chooseAlternative`
-      // notifies and the cohort is rebuilt from the entries on screen.
+      // Re-read after the pick, exactly as the screen does: `chooseAlternative`
+      // notifies and the entries are rebuilt.
       final chosen =
           cohort(h, 'student|${actions.smartschoolDepartureAlternative}');
 
-      await h.controller.applyDecisions(chosen.decisions);
+      await h.controller
+          .applyEntries(chosen.decisions.map((d) => d.entry).toList());
 
       expect(summariesOf(h), hasLength(2));
       expect(
           summariesOf(h), contains('Schrijf de leerling uit in Smartschool'));
       expect(summariesOf(h), contains('Verwijder dit account uit Smartschool'));
+    });
+
+    test('a bulk pass writes none of a situation #293 withholds (#326)',
+        () async {
+      // The same two departed students, through the bulk seam this time. Both
+      // resolutions of the departure either/or are withheld from a bulk pass —
+      // unregistering a student who merely fell out of a lagging WISA snapshot
+      // is as wrong as deleting them — so the pass must write neither, however
+      // the radios are set. It used to write both: the narrowing lived only in
+      // the situation header's count, which asked whether the *selected* option
+      // writes anything, and a flipped radio makes that true.
+      final h = departedHarness();
+      await h.controller.sync();
+      final departure =
+          cohort(h, 'student|${actions.smartschoolDepartureAlternative}');
+      h.controller.chooseAlternative(
+        entry: departure.decisions.last.entry,
+        group: actions.smartschoolDepartureAlternative,
+        kind: 'DeleteStudentFromSmartschool',
+      );
+      final chosen =
+          cohort(h, 'student|${actions.smartschoolDepartureAlternative}');
+      expect(chosen.decisions.every((d) => d.canApply), isTrue,
+          reason: 'both rows are set to a resolution that writes something — '
+              'the pre-#326 count would have read 2');
+      expect(chosen.applyableCount, 0,
+          reason: 'and not one of them may be written in bulk');
+      expect(chosen.bulkApplyable, isEmpty);
+
+      await h.controller.applyDecisions(chosen.decisions);
+
+      expect(h.controller.applyResults, isNull,
+          reason: 'the pass never started, so no verdict block appears');
+      expect(
+        h.soap.soapActions.where(
+            (a) => a.endsWith('#delUser') || a.endsWith('#unregisterStudent')),
+        isEmpty,
+      );
     });
 
     test('the whole-card apply still writes every decision on that card',

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -2186,9 +2186,9 @@ ReconcileHarness azureClassGroupHarness({
 ///
 /// Two of them, deliberately: one stale group is a row, **two** are a "same
 /// situation" bulk subset, which is where a destructive action would do its
-/// worst. The notice is the default of the pair, so the header's "Alles
-/// toepassen" counts zero and the delete is only ever the pick an operator made
-/// on one row.
+/// worst. Neither half of the pair is bulk-sanctioned (#293), so since #326 the
+/// header offers no bulk pass at all — whichever way the radios are set — and
+/// the delete is only ever the pick an operator made on one row.
 ///
 /// The four prefixed non-class groups are here too — they must not appear in the
 /// inventory at all, let alone in that subset.

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -2314,7 +2314,15 @@ ReconcileHarness legacyStaleClassGroupHarness() => ReconcileHarness(
 /// worst. Before #313 each row's whole content was "Verwijder ze manueel als ze
 /// niet meer nodig is" — an instruction to go elsewhere, and a screenful of them
 /// at a September changeover.
-ReconcileHarness smartschoolLeftoverClassHarness() => ReconcileHarness(
+///
+/// [codelessLeftover] strips `9Z` of its class code, which is the one leftover
+/// `DeleteSmartschoolClass` cannot act on: with nothing to address a `delClass`
+/// to, the row falls back to the lone informational `DoNotImportFromSmartschool`
+/// notice (#328).
+ReconcileHarness smartschoolLeftoverClassHarness({
+  bool codelessLeftover = false,
+}) =>
+    ReconcileHarness(
       wisa: wisaSnap(
         students: [wisaStudent(wisaId: '1', classGroup: '1A')],
         schools: [wisaSchool(1)],
@@ -2327,7 +2335,7 @@ ReconcileHarness smartschoolLeftoverClassHarness() => ReconcileHarness(
               instituteNumber: '123',
               untis: '1A'),
           ssGroup('9Z',
-              code: 'C9Z',
+              code: codelessLeftover ? ' ' : 'C9Z',
               description: 'Zesde jaar Z',
               instituteNumber: '123',
               untis: '9Z'),

--- a/account_manager/test/reconcile/reconcile_fakes.dart
+++ b/account_manager/test/reconcile/reconcile_fakes.dart
@@ -2186,17 +2186,24 @@ ReconcileHarness azureClassGroupHarness({
 ///
 /// Two of them, deliberately: one stale group is a row, **two** are a "same
 /// situation" bulk subset, which is where a destructive action would do its
-/// worst. Neither half of the pair is bulk-sanctioned (#293), so since #326 the
-/// header offers no bulk pass at all — whichever way the radios are set — and
-/// the delete is only ever the pick an operator made on one row.
+/// worst. The delete is not bulk-sanctioned (#293), so since #326 the header
+/// offers no bulk pass at all, and it is only ever the pick an operator made on
+/// one row — which since #327 is the row's single proposal rather than one
+/// radio of two.
 ///
 /// The four prefixed non-class groups are here too — they must not appear in the
 /// inventory at all, let alone in that subset.
 ///
-/// `GBS-9Z` still holds the 21 members its class left behind (#305): both halves
-/// of the either/or name that number, and a stale group with an empty roster
-/// cannot show whether the card *states* it or claims it is being cleared.
-ReconcileHarness staleClassGroupHarness() => ReconcileHarness(
+/// `GBS-9Z` still holds the 21 members its class left behind (#305): the card
+/// names that number, and a stale group with an empty roster cannot show
+/// whether it *states* it or claims it is being cleared.
+///
+/// [idlessStaleGroup] strips `GBS-9Z` of its Azure object id, which is the one
+/// stale group `DeleteAzureClassGroup` cannot act on: with no id to address a
+/// `DELETE /groups/` to, the row falls back to the lone informational
+/// `AzureClassGroupWithoutClass` notice (#327).
+ReconcileHarness staleClassGroupHarness({bool idlessStaleGroup = false}) =>
+    ReconcileHarness(
       wisa: wisaSnap(
         students: [wisaStudent(wisaId: '1', classGroup: '1A')],
         schools: [wisaSchool(1)],
@@ -2226,6 +2233,7 @@ ReconcileHarness staleClassGroupHarness() => ReconcileHarness(
         groups: [
           azClassGroup('1A', memberIds: const ['az1']),
           azClassGroup('9Z',
+              id: idlessStaleGroup ? '' : null,
               memberIds: List<String>.generate(21, (int i) => 'az-oud-$i')),
           azClassGroup('8Y'),
           azNonClassGroup('GBS - GOK'),
@@ -3140,9 +3148,10 @@ az.AzureSnapshot azSnap({
 az.AzureGroup azClassGroup(
   String className, {
   List<String> memberIds = const [],
+  String? id,
 }) =>
     az.AzureGroup(
-      id: 'az-GBS-$className',
+      id: id ?? 'az-GBS-$className',
       displayName: 'GBS-$className',
       mail: 'GBS-$className@student.school.example',
       mailNickname: 'GBS-$className',

--- a/account_manager/test/reconcile/reconcile_pending_choice_test.dart
+++ b/account_manager/test/reconcile/reconcile_pending_choice_test.dart
@@ -246,8 +246,14 @@ void main() {
       expect(cohort.decisions, hasLength(3),
           reason: 'three students share the rename');
 
+      // Run as cards rather than through the cohort seam: the rename is not
+      // bulk-sanctioned (#293), so since #326 `applyDecisions` writes none of
+      // it. What is under test here is the pinning of the derived lists across
+      // a multi-write pass, and the whole-card pass is one — each of these
+      // three cards carries the rename and nothing else.
       h.controller.addListener(record);
-      await h.controller.applyDecisions(cohort.decisions);
+      await h.controller
+          .applyEntries(cohort.decisions.map((d) => d.entry).toList());
       h.controller.removeListener(record);
 
       const reason = 'the view the pass started from, then the settled one — '

--- a/account_manager/test/reconcile/reconcile_pending_choice_test.dart
+++ b/account_manager/test/reconcile/reconcile_pending_choice_test.dart
@@ -379,11 +379,13 @@ void main() {
     });
 
     test(
-        'an empty class defaults to its notice, so a bulk apply writes '
-        'nothing for it', () async {
-      // The empty-class reading takes the create's place inside the same
-      // choice. It is informational, so the entry offers no apply at all until
-      // the operator deliberately picks "ignore this class".
+        'an empty class states its notice as context, with the blacklist as '
+        'the lone action (#329)', () async {
+      // There is nothing to create for an empty class, so the card proposes
+      // exactly one thing and says why: "delete it by hand, or wait until it
+      // has students". Until #329 that instruction was the pre-selected half of
+      // a radio pair, which asked the operator to choose between a diagnosis
+      // and the one write there is.
       final h = siblingPopulatedClassHarness();
       await h.controller.sync();
 
@@ -393,15 +395,49 @@ void main() {
         (c) => c.situationId == actions.classImportAlternative,
       );
 
-      expect(choice.selected.kind, 'CreateInSmartschool');
-      expect(choice.selected.canApply, isFalse);
-      expect(entry.canApply, isFalse,
-          reason: 'nothing to write for an empty class until the operator '
-              'picks the opt-out');
+      expect(choice.isChoice, isFalse, reason: 'no radio group');
+      expect(choice.alternatives.map((a) => a.kind),
+          <String>['DoNotImportFromWisa']);
+      expect(choice.selected.kind, 'DoNotImportFromWisa');
       expect(
-        choice.alternatives.map((a) => a.kind),
-        containsAll(<String>['CreateInSmartschool', 'DoNotImportFromWisa']),
+        choice.notices.map((a) => a.kind),
+        <String>['CreateInSmartschool'],
+        reason: 'the instruction survives as context on the decision',
       );
+      expect(choice.notices.single.canApply, isFalse);
+      expect(
+        choice.notices.single.changes.summary,
+        contains('bevat nog geen leerlingen'),
+      );
+    });
+
+    test('no bulk pass writes DontImportClass on an empty class (#250/#329)',
+        () async {
+      // What replaces the polarity that used to keep the blacklist off this
+      // path: the #293 sanction, which every bulk affordance reads since #326.
+      // The blacklist is the *selected* resolution of an empty class now, so
+      // this is the only thing standing between it and one press.
+      final h = siblingPopulatedClassHarness();
+      await h.controller.sync();
+      final pulls = h.wisaSyncs;
+
+      final cohort = h.controller.groupPendingSituations.firstWhere(
+          (c) => c.key == 'group|${actions.classImportAlternative}');
+      expect(cohort.decisions.map((d) => d.entry.targetId), contains('1A'));
+      expect(
+        cohort.bulkApplyable.map((d) => d.entry.targetId),
+        isNot(contains('1A')),
+        reason: 'the header offers this class nothing (#326)',
+      );
+
+      await h.controller.applyDecisions(cohort.decisions);
+
+      expect(
+        (h.controller.applyResults ?? const []).map((r) => r.changes.summary),
+        isNot(contains(ignore)),
+      );
+      expect(h.wisaSyncs, pulls,
+          reason: 'no import rule was added, so WISA was never re-pulled');
     });
   });
 
@@ -422,24 +458,33 @@ void main() {
           (c) => c.alternatives.any((a) => a.kind == 'DoNotImportFromWisa'),
         );
 
-    test('the notice and the blacklist collapse into one choice, notice first',
+    test('the notice is context on the blacklist, not a radio beside it (#329)',
         () async {
       final h = namesakeClassChoiceHarness();
       await h.controller.sync();
       final choice = importChoiceOf(entryFor(h, '2G'));
 
       expect(choice.situationId, actions.namesakeClassAlternative);
-      expect(choice.isChoice, isTrue,
-          reason: 'repair it by hand or stop offering it — never both, and '
-              'never a choice of one');
+      expect(choice.isChoice, isFalse,
+          reason: '"go and make it official in Smartschool" is not something '
+              'an apply can run, so it is not one of the answers');
       expect(
         choice.alternatives.map((a) => a.kind),
-        ['ClassExistsAsSmartschoolGroup', 'DoNotImportFromWisa'],
-        reason: 'the notice leads the radio pair',
+        <String>['DoNotImportFromWisa'],
       );
-      expect(choice.selected.kind, 'ClassExistsAsSmartschoolGroup');
-      expect(choice.selected.canApply, isFalse,
-          reason: 'the default writes nothing: the repair is a hand edit');
+      expect(choice.selected.kind, 'DoNotImportFromWisa');
+      expect(
+        choice.notices.map((a) => a.kind),
+        <String>['ClassExistsAsSmartschoolGroup'],
+        reason: 'the repair instruction is still on the card, as context',
+      );
+      expect(choice.notices.single.canApply, isFalse);
+      expect(choice.notices.single.changes.summary, contains(notice));
+      expect(
+        choice.notices.single.changes.fields.map((f) => f.field),
+        contains('code'),
+        reason: 'the group code is how the operator finds it in Smartschool',
+      );
     });
 
     test('a namesake class is not pooled with the new classes for bulk apply',
@@ -467,58 +512,82 @@ void main() {
       expect(
           fresh.decisions.map((d) => d.entry.targetId), <String>['1A', '1B']);
       expect(namesake.applyableCount, 0,
-          reason: 'the hand-fix notice writes nothing, so its cohort offers '
-              'nothing to apply — the Office 365 group beside it on the same '
-              'cards is a cohort of its own (#292)');
+          reason: 'the blacklist withholds the #293 sanction, so this cohort '
+              'offers nothing to apply in bulk even though it is now the '
+              'selected resolution of both its rows (#326/#329)');
+      expect(namesake.bulkApplyable, isEmpty);
     });
 
-    test('"apply to all" creates the new classes and blacklists no namesake',
-        () async {
+    test('no bulk pass blacklists a namesake class (#250/#329)', () async {
       // The report's headline: Apply to all wrote a DontImportClass rule on
       // every class the #225 notice had just told the operator to repair by
       // hand.
+      //
+      // What refused it then was the *polarity* of a radio pair — the notice
+      // was the pre-selected half, so nothing was written unless the operator
+      // flipped a radio, and flipping two of them armed the header anyway. The
+      // notice is context now, so the blacklist is what every namesake row is
+      // set to, and this pins the replacement guard directly: the #293 sanction
+      // the blacklist withholds, refused at the bulk seam itself since #326.
       final h = namesakeClassChoiceHarness();
       await h.controller.sync();
       final pulls = h.wisaSyncs;
 
-      await h.controller.applyEntries(h.controller.groupPendingEntries);
+      final cohorts = h.controller.groupPendingSituations;
+      final namesake = cohorts.firstWhere(
+        (c) => c.key == 'group|${actions.namesakeClassAlternative}',
+      );
+      final fresh = cohorts.firstWhere(
+        (c) => c.key == 'group|${actions.classImportAlternative}',
+      );
 
-      final summaries = summariesOf(h);
-      expect(summaries, isNot(contains(ignore)),
-          reason: 'the rule would drop the classes the notice says to repair');
-      expect(summaries.where((s) => s == create), hasLength(2),
-          reason: 'the genuinely new classes are still created');
+      await h.controller.applyDecisions(namesake.decisions);
+      expect(h.controller.applyResults, isNull,
+          reason: 'every member is withheld, so the pass never starts');
       expect(
         h.soap.soapActions.where((a) => a.endsWith('#saveClass')),
-        hasLength(2),
-        reason: '2G and 2H already exist downstream — never created again',
+        isEmpty,
       );
       expect(h.wisaSyncs, pulls,
           reason: 'no import rule was added, so WISA was never re-pulled');
+      expect(
+        h.log.entries.map((e) => e.message),
+        contains(contains('Overgeslagen in de groepsbewerking')),
+        reason: 'a refused bulk write is stated, not swallowed (#326)',
+      );
+
+      // And the fix did not simply silence the list: the genuinely new classes
+      // beside them are still created by their own cohort's bulk pass.
+      await h.controller.applyDecisions(fresh.decisions);
+      final summaries = summariesOf(h);
+      expect(summaries.where((s) => s == create), hasLength(2));
+      expect(summaries, isNot(contains(ignore)));
     });
 
-    test('the operator can still blacklist a namesake class deliberately',
+    test('the per-card Toepassen writes the blacklist, and only that (#329)',
         () async {
+      // The card proposes; it does not interrogate. The operator reads the
+      // notice above it — "this class already exists in Smartschool, make it
+      // official there" — and either presses Toepassen, which blacklists the
+      // class, or ignores the card, which is a complete answer. What they are
+      // no longer asked to do is record which of the two they meant.
       final h = namesakeClassChoiceHarness();
       await h.controller.sync();
       final entry = entryFor(h, '2G');
-      expect(importChoiceOf(entry).selected.canApply, isFalse,
-          reason: 'the import decision writes nothing until the operator '
-              'picks the opt-out (the class\'s Office 365 group is a '
-              'separate, orthogonal decision)');
 
-      h.controller.chooseAlternative(
-        entry: entry,
-        group: actions.namesakeClassAlternative,
-        kind: 'DoNotImportFromWisa',
-      );
-      final chosen = entryFor(h, '2G');
-      expect(chosen.canApply, isTrue);
+      expect(importChoiceOf(entry).selected.kind, 'DoNotImportFromWisa');
+      expect(entry.canApply, isTrue);
 
-      await h.controller.applyEntry(chosen);
+      await h.controller.applyEntry(entry);
 
       expect(summariesOf(h), contains(ignore));
-      expect(summariesOf(h), isNot(contains(notice)));
+      expect(summariesOf(h), isNot(contains(notice)),
+          reason: 'a notice is never dispatched — its apply throws');
+      expect(
+        h.soap.soapActions.where((a) => a.endsWith('#saveClass')),
+        isEmpty,
+        reason: '2G already exists downstream — never created',
+      );
     });
   });
 

--- a/account_manager/test/reconcile/reconcile_screen_test.dart
+++ b/account_manager/test/reconcile/reconcile_screen_test.dart
@@ -109,8 +109,16 @@ void main() {
     expect(find.byKey(const ValueKey('reconcile-category-groups')),
         findsOneWidget);
     expect(find.text('LEERLINGEN'), findsOneWidget); // PlinkBadge uppercases
-    // The one fixture student's applyable actions surface as a pending indicator.
-    expect(find.text('2 openstaande acties'), findsOneWidget);
+    // The one fixture student's applyable actions surface as a pending
+    // indicator. Scoped to her card: since #328 the two Smartschool-only
+    // classes propose a delete each, so the groups card carries the same count.
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('reconcile-category-students')),
+        matching: find.text('2 openstaande acties'),
+      ),
+      findsOneWidget,
+    );
 
     // …but the pending actions moved to the Actions tab: neither the title, an
     // apply affordance, nor any entry tile is on the Reconcile screen (#154).
@@ -517,8 +525,16 @@ void main() {
         find.byKey(const ValueKey('reconcile-category-staff')), findsOneWidget);
     expect(find.byKey(const ValueKey('reconcile-category-groups')),
         findsOneWidget);
-    // The one fixture student is summed from the rollup, with a pending indicator.
-    expect(find.text('2 openstaande acties'), findsOneWidget);
+    // The one fixture student is summed from the rollup, with a pending
+    // indicator on her own card (the groups card carries the same count since
+    // #328, so the finder is scoped rather than global).
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('reconcile-category-students')),
+        matching: find.text('2 openstaande acties'),
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets(

--- a/account_manager/test/screens/actions_screen_test.dart
+++ b/account_manager/test/screens/actions_screen_test.dart
@@ -1057,9 +1057,12 @@ void main() {
       // fakes really *settle* is one of those. (The Smartschool fake takes a
       // write without folding it back into its snapshot, so the sanctioned
       // class move of #296 leaves its accounts pending and never reaches the
-      // state this test is about.) What #299 pins here is what the screen does
-      // once a pass has written several accounts, whichever button began it;
-      // the cohort review's own path is covered in the #296 group above.
+      // state this test is about.) It is the whole-card seam for the same
+      // reason: since #326 the per-decision one refuses what #293 withholds,
+      // and each of these three cards carries the rename alone. What #299 pins
+      // here is what the screen does once a pass has written several accounts,
+      // whichever button began it; the cohort review's own path is covered in
+      // the #296 group above.
       final harness = crossClassSituationHarness();
       await open(tester, harness);
 
@@ -1073,7 +1076,8 @@ void main() {
       ]).single;
       expect(cohort.key, 'student|ModifyAzureName');
       expect(cohort.length, 3, reason: 'one decision, three accounts');
-      await harness.controller.applyDecisions(cohort.decisions);
+      await harness.controller
+          .applyEntries(cohort.decisions.map((d) => d.entry).toList());
       await tester.pumpAndSettle();
 
       expect(harness.controller.applyResults, hasLength(3));

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -207,17 +207,18 @@ void main() {
   testWidgets(
       'an informational-only class colours no cell, and still lights its row '
       '(#298)', (WidgetTester tester) async {
-    // `9Z` is an official Smartschool class WISA does not have. Its decision is
-    // an either/or whose default half is the "laat deze klas staan" notice
-    // (#313), so there is no write pending and the Smartschool cell stays green
-    // — while the row itself is highlighted, because `needsAttention` counts the
-    // notice and on this screen the notice *is* the work (#225/#250).
+    // `9Z` is an official Smartschool class WISA does not have, and here it
+    // names no class code — so there is nothing to address a `delClass` to and
+    // its lone reading is the "laat deze klas staan" notice (#328). Nothing is
+    // written, so the Smartschool cell stays green — while the row itself is
+    // highlighted, because `needsAttention` counts the notice and on this
+    // screen the notice *is* the work (#225/#250).
     //
-    // (This claim used to be made on a stale Office 365 group, whose pair had
-    // the same polarity. Since #327 that row proposes a delete outright, so it
-    // is no longer an informational-only class — see the test below.)
+    // (This claim has moved twice. It was made on a stale Office 365 group
+    // until #327 and on any Smartschool leftover until #328; both of those rows
+    // now propose a delete outright — see the two tests below.)
     _useTallWindow(tester);
-    final harness = smartschoolLeftoverClassHarness();
+    final harness = smartschoolLeftoverClassHarness(codelessLeftover: true);
     await harness.controller.sync();
     await tester
         .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
@@ -259,6 +260,27 @@ void main() {
         SystemIndicatorState.missing);
     expect(_cell(tester, 'GBS-9Z', core.Origin.smartschool),
         SystemIndicatorState.missing);
+  });
+
+  testWidgets(
+      'a Smartschool leftover colours its own cell, because the delete is work '
+      'this screen can do (#298/#328)', (WidgetTester tester) async {
+    // The twin of the test above, on the other system. `9Z` is an official
+    // Smartschool class WISA does not have, and it names a code — so the delete
+    // can fire, and since #328 it is the row's single proposal rather than one
+    // radio behind a notice that wrote nothing. The cell says so.
+    _useTallWindow(tester);
+    final harness = smartschoolLeftoverClassHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(_cell(tester, '9Z', core.Origin.smartschool),
+        SystemIndicatorState.needsWork);
+    expect(_cell(tester, '9Z', core.Origin.wisa), SystemIndicatorState.missing);
+    expect(
+        _cell(tester, '9Z', core.Origin.azure), SystemIndicatorState.missing);
   });
 
   testWidgets(
@@ -744,12 +766,14 @@ void main() {
     // The stored classes are there, with their stored candidates marked exactly
     // as Acties marks them (#255).
     expect(find.byKey(const ValueKey('class-row-2B')), findsOneWidget);
-    // A Smartschool class WISA does not have is an either/or since #313, so the
-    // stored row reads as the choice it is — on its pre-selected half, which is
-    // the notice that writes nothing.
-    expect(find.textContaining('ze bestaat in Smartschool maar niet in WISA'),
+    // A Smartschool class WISA does not have proposes one delete since #328, so
+    // the stored row reads as the lone proposal it is: no "(keuze)" marker,
+    // because there is nothing to choose between, and no "(manueel)" one,
+    // because the app can act on it.
+    expect(find.textContaining('Verwijder de klas 2B uit Smartschool'),
         findsWidgets);
-    expect(find.textContaining('(keuze)'), findsWidgets);
+    expect(find.textContaining('(keuze)'), findsNothing);
+    expect(find.textContaining('(manueel)'), findsNothing);
     // Nothing interactive: a passive session has nothing to apply.
     expect(find.byKey(const ValueKey('entry-group-2B')), findsNothing);
   });
@@ -1176,11 +1200,12 @@ void main() {
   // --- The Smartschool leftovers (#313) --------------------------------------
 
   testWidgets(
-      'a Smartschool class WISA does not have offers a delete, and leaving it '
-      'alone is the default (#313)', (WidgetTester tester) async {
+      'a Smartschool class WISA does not have proposes its delete and nothing '
+      'else (#313/#328)', (WidgetTester tester) async {
     // Until #313 this row's whole content was "Verwijder ze manueel als ze niet
     // meer nodig is" — an instruction to go and do it by hand in Smartschool,
-    // the dead end #271 removed on the Office 365 side.
+    // the dead end #271 removed on the Office 365 side. #313 put a delete
+    // beside it as a radio pair; #328 dropped the no-op half.
     _useTallWindow(tester);
     final harness = smartschoolLeftoverClassHarness();
     await harness.controller.sync();
@@ -1193,46 +1218,56 @@ void main() {
     await tester.tap(find.byKey(entry));
     await tester.pumpAndSettle();
 
-    // Two radios, one choice — never two independent to-dos.
-    final leave =
-        find.byKey(const ValueKey('alt-9Z-DoNotImportFromSmartschool'));
-    final delete = find.byKey(const ValueKey('alt-9Z-DeleteSmartschoolClass'));
-    expect(leave, findsOneWidget);
-    expect(delete, findsOneWidget);
+    // One proposal, no radio pair: "laat deze klas staan" and "doe niets" are
+    // the same act, and the operator performs the second by not pressing
+    // Toepassen (#328).
+    expect(find.byKey(const ValueKey('alt-9Z-DoNotImportFromSmartschool')),
+        findsNothing);
+    expect(find.byKey(const ValueKey('alt-9Z-DeleteSmartschoolClass')),
+        findsNothing);
+    expect(find.byIcon(Icons.radio_button_checked), findsNothing);
+    expect(find.byIcon(Icons.radio_button_unchecked), findsNothing);
+    expect(find.text('Kies één oplossing:'), findsNothing);
     expect(
-      find.text('Laat deze klas staan — ze bestaat in Smartschool maar niet '
-          'in WISA'),
-      findsWidgets,
+      find.textContaining('Laat deze klas staan'),
+      findsNothing,
+      reason: 'the no-op is not on offer any more',
     );
     expect(find.textContaining('Verwijder ze manueel'), findsNothing);
-    // The notice states the class instead of instructing; the code is how the
-    // operator finds it in Smartschool.
-    expect(find.text('code: C9Z'), findsOneWidget);
-    expect(find.textContaining('→ ∅'), findsNothing,
-        reason: 'the option that writes nothing clears nothing');
 
-    // The default is the informational half, so nothing is applyable until the
-    // operator deliberately picks the delete.
-    final apply = find.byKey(const ValueKey('entry-apply-9Z'));
-    await tester.ensureVisible(apply);
-    expect(tester.widget<FilledButton>(apply).onPressed, isNull,
-        reason: 'a delete must never be the pre-selected resolution');
-
-    await tester.ensureVisible(delete);
-    await tester.tap(delete);
-    await tester.pumpAndSettle();
+    // The card leads with the delete's own summary, states the class's facts,
+    // warns that WISA may simply be lagging, and only then inventories what
+    // goes with the class.
     expect(
       find.text('Verwijder de klas 9Z uit Smartschool — ze bestaat niet in '
           'WISA'),
       findsWidgets,
     );
+    expect(find.text('code: C9Z'), findsOneWidget);
+    expect(
+      find.text('WISA: kent deze klas (nog) niet — vroeg in het schooljaar '
+          'loopt WISA achter, controleer daar of ze bestaat voor je ze '
+          'verwijdert'),
+      findsOneWidget,
+      reason: 'the lagging-snapshot reading survives as context on the card',
+    );
     expect(find.text('lidmaatschappen en subgroepen: verdwijnen mee'),
         findsOneWidget);
+    expect(find.textContaining('→ ∅'), findsNothing,
+        reason: 'the inventory of what goes is stated, never diffed');
 
+    // Nothing was written by opening the card: the delete runs on the
+    // operator's press, behind the ordinary confirmation.
+    expect(harness.soap.deletedClasses, isEmpty);
+    final apply = find.byKey(const ValueKey('entry-apply-9Z'));
     await tester.ensureVisible(apply);
     expect(tester.widget<FilledButton>(apply).onPressed, isNotNull);
     await tester.tap(apply);
     await tester.pumpAndSettle();
+    expect(harness.soap.deletedClasses, isEmpty,
+        reason: 'the confirmation is still standing');
+    expect(find.textContaining('9Z'), findsWidgets,
+        reason: 'the dialog names the class it is about to take');
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
@@ -1241,13 +1276,47 @@ void main() {
     expect(_row('9Z'), findsNothing,
         reason: 'the relink drops the class the operator just removed');
     expect(_row('8Y'), findsOneWidget,
-        reason: 'the class beside it was never selected');
+        reason: 'the class beside it was never applied');
     expect(_row('1A'), findsOneWidget, reason: 'no other class was touched');
   });
 
   testWidgets(
-      'a flipped radio never arms the bulk header over Smartschool leftovers '
-      '(#293/#313/#326)', (WidgetTester tester) async {
+      'a leftover class with no code keeps its lone "(manueel)" notice (#328)',
+      (WidgetTester tester) async {
+    // The one leftover the delete cannot act on: there is nothing to address a
+    // `delClass` to, so the row falls back to stating the situation —
+    // informational, marked "(manueel)", with no apply of its own.
+    _useTallWindow(tester);
+    final harness = smartschoolLeftoverClassHarness(codelessLeftover: true);
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Laat deze klas staan'), findsWidgets);
+    expect(find.textContaining('(manueel)'), findsWidgets,
+        reason: 'an informational row is still marked as one');
+
+    await tester.tap(find.byKey(const ValueKey('entry-group-9Z')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('alt-9Z-DeleteSmartschoolClass')),
+        findsNothing);
+    expect(find.textContaining('Verwijder de klas 9Z uit Smartschool'),
+        findsNothing);
+    expect(find.textContaining('controleer daar of ze bestaat'), findsNothing,
+        reason: 'no delete is proposed, so there is nothing to caution about');
+    final apply = find.byKey(const ValueKey('entry-apply-9Z'));
+    await tester.ensureVisible(apply);
+    expect(tester.widget<FilledButton>(apply).onPressed, isNull,
+        reason: 'an informational row writes nothing');
+    expect(harness.soap.deletedClasses, isEmpty);
+  });
+
+  testWidgets(
+      'a cohort of selected deletes never arms the bulk header over '
+      'Smartschool leftovers (#293/#313/#326/#328)',
+      (WidgetTester tester) async {
     // `9Z` and `8Y` share the situation, so the tab collects them into one
     // header — the surface where a destructive default would do the most
     // damage, and the reason the delete withholds `canApplyToAll`.
@@ -1258,30 +1327,37 @@ void main() {
         .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
+    expect(find.text('Klassen in dezelfde situatie'), findsOneWidget,
+        reason: 'the cohort is still worth naming; only the pair is withdrawn');
+    // Since #328 the delete is the *selected* resolution of both rows, so the
+    // only thing keeping it off the bulk path is the #293 sanction #326 taught
+    // the header to read — hence no pair rather than a dead "Alles toepassen
+    // (2)" one confirmation away from two deleted classes, each taking every
+    // membership and subgroup with it.
     expect(find.textContaining('Alles toepassen ('), findsNothing,
-        reason: 'neither resolution of this situation is bulk-sanctioned');
+        reason: 'this situation is not bulk-sanctioned');
+    expect(find.text('Dry-run alles'), findsNothing);
 
-    // Flipping the rows to the delete used to *arm* the header: it counted the
-    // selected option's `canApply` and nothing else, so two flipped radios read
-    // "Alles toepassen (2)" and one press took both classes — every membership
-    // and subgroup with them — on an action whose own class says no bulk
-    // affordance may offer it (#326).
+    // Each row really is set to its delete — the state that used to need a
+    // flipped radio on every one of them.
     for (final String id in const <String>['9Z', '8Y']) {
       final entry = find.byKey(ValueKey('entry-group-$id'));
       await tester.ensureVisible(entry);
       await tester.tap(entry);
       await tester.pumpAndSettle();
-      final delete = find.byKey(ValueKey('alt-$id-DeleteSmartschoolClass'));
-      await tester.ensureVisible(delete);
-      await tester.tap(delete);
+      final rowApply = find.byKey(ValueKey('entry-apply-$id'));
+      await tester.ensureVisible(rowApply);
+      expect(tester.widget<FilledButton>(rowApply).onPressed, isNotNull);
+      expect(find.textContaining('Verwijder de klas $id uit Smartschool'),
+          findsWidgets);
+      await tester.ensureVisible(entry);
+      await tester.tap(entry);
       await tester.pumpAndSettle();
     }
 
     expect(find.textContaining('Alles toepassen ('), findsNothing,
         reason: 'the sanction is a property of the action, not of how many '
             'rows happen to be set to it');
-    expect(find.text('Dry-run alles'), findsNothing);
     expect(harness.soap.deletedClasses, isEmpty);
 
     // …and the per-row apply is untouched: one class at a time, from the card

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -211,12 +211,15 @@ void main() {
     // names no class code — so there is nothing to address a `delClass` to and
     // its lone reading is the "laat deze klas staan" notice (#328). Nothing is
     // written, so the Smartschool cell stays green — while the row itself is
-    // highlighted, because `needsAttention` counts the notice and on this
-    // screen the notice *is* the work (#225/#250).
+    // highlighted, because `needsAttention` counts the notice and on this row
+    // the notice *is* the whole of what the screen has to say.
     //
-    // (This claim has moved twice. It was made on a stale Office 365 group
-    // until #327 and on any Smartschool leftover until #328; both of those rows
-    // now propose a delete outright — see the two tests below.)
+    // (This claim has moved twice, and this is where it settles. It was made on
+    // a stale Office 365 group until #327 and on any Smartschool leftover until
+    // #328 — both of those now propose a delete outright — while the namesake
+    // and empty-class rows of #225/#244 stopped being informational-only at
+    // #329, where their notice became context beside a blacklist that writes.
+    // What is left is exactly the rows no decision can be raised on at all.)
     _useTallWindow(tester);
     final harness = smartschoolLeftoverClassHarness(codelessLeftover: true);
     await harness.controller.sync();
@@ -1382,6 +1385,162 @@ void main() {
     expect(find.textContaining('Verwijder de klas 1A uit Smartschool'),
         findsNothing,
         reason: '1A is a running class — deleting it is not on offer');
+  });
+
+  // --- A notice is context, not an alternative (#329) ------------------------
+
+  testWidgets(
+      'a namesake class states the Smartschool repair as context and proposes '
+      'the blacklist alone (#225/#250/#329)', (WidgetTester tester) async {
+    // `2G` exists in Smartschool on a group nobody flagged official, so the
+    // linker cannot adopt it and this app can do exactly one thing about the
+    // class: stop importing it. The repair — make the group official over
+    // there — is an instruction, not a resolution an apply can run, so it is
+    // stated above the proposal rather than offered as the other radio of a
+    // pair the operator was asked to resolve.
+    _useTallWindow(tester);
+    final harness = namesakeClassChoiceHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    // Collapsed, the row previews both lines: the situation, then what the app
+    // proposes about it. "(manueel)" is what makes the first scannable.
+    final row = _row('2G');
+    expect(
+      find.descendant(
+        of: row,
+        matching: find.textContaining('dan wordt ze gekoppeld. (manueel)'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: row,
+        matching: find.text('Negeer deze klas bij het importeren uit WISA'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.descendant(of: row, matching: find.textContaining('(keuze)')),
+        findsNothing);
+
+    final entry = find.byKey(const ValueKey('entry-group-2G'));
+    await tester.ensureVisible(entry);
+    await tester.tap(entry);
+    await tester.pumpAndSettle();
+
+    // Open, there is nothing to choose: no radios, no "Kies één oplossing:".
+    expect(find.byKey(const ValueKey('alt-2G-ClassExistsAsSmartschoolGroup')),
+        findsNothing);
+    expect(
+        find.byKey(const ValueKey('alt-2G-DoNotImportFromWisa')), findsNothing);
+    expect(find.byIcon(Icons.radio_button_checked), findsNothing);
+    expect(find.byIcon(Icons.radio_button_unchecked), findsNothing);
+    expect(find.text('Kies één oplossing:'), findsNothing);
+
+    // The notice keeps the facts that let the operator find the group, and the
+    // repair it asks for still reads as the transition it is.
+    expect(find.text('code: G2G'), findsOneWidget);
+    expect(find.text('officiële klas: nee → ja'), findsOneWidget);
+    // …and the proposal shows exactly what pressing would write.
+    expect(find.text('DontImportClass: ∅ → 2G'), findsOneWidget);
+    final apply = find.byKey(const ValueKey('entry-apply-2G'));
+    await tester.ensureVisible(apply);
+    expect(tester.widget<FilledButton>(apply).onPressed, isNotNull,
+        reason: 'the card proposes one write, and the operator may press it');
+  });
+
+  testWidgets(
+      'a namesake class colours its WISA cell, because the blacklist is work '
+      'this screen can do (#298/#329)', (WidgetTester tester) async {
+    // The twin of the #327/#328 consequence on the other two systems. The
+    // decision used to default to a notice that wrote nothing, so every cell
+    // read green while the card carried a blacklist one radio away. It is the
+    // card's single proposal now, and the cell says so — a decision about the
+    // WISA side of this class is pending on this very screen.
+    _useTallWindow(tester);
+    final harness = namesakeClassChoiceHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(
+        _cell(tester, '2G', core.Origin.wisa), SystemIndicatorState.needsWork);
+    expect(_cell(tester, '2G', core.Origin.smartschool),
+        SystemIndicatorState.missing,
+        reason: 'the namesake group is not the class — that is the whole '
+            'situation');
+  });
+
+  testWidgets(
+      'no bulk affordance is offered over the namesake classes (#250/#329)',
+      (WidgetTester tester) async {
+    // `2G` and `2H` share the situation, so the tab collects them into one
+    // header. The blacklist is what both rows are set to now that the notice is
+    // context, so the #293 sanction is the whole of what keeps "Alles
+    // toepassen" from writing a DontImportClass rule on two classes the app has
+    // just told the operator to repair by hand.
+    _useTallWindow(tester);
+    final harness = namesakeClassChoiceHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Negeer deze klas bij het importeren uit WISA — 2 klassen in '
+          'dezelfde situatie'),
+      findsOneWidget,
+      reason: 'the cohort is still worth naming; only the pair is withdrawn',
+    );
+    expect(
+      find.byKey(const ValueKey('situation-apply-group|class-namesake')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('situation-dry-run-group|class-namesake')),
+      findsNothing,
+    );
+    expect(
+      harness.controller.groupPendingSituations
+          .firstWhere((c) => c.key == 'group|class-namesake')
+          .bulkApplyable,
+      isEmpty,
+      reason: 'the header has nothing it may write, so it renders no pair',
+    );
+  });
+
+  testWidgets(
+      'an empty WISA class states its wait-or-delete notice as context '
+      '(#244/#329)', (WidgetTester tester) async {
+    // The other site the pair was removed from. There is nothing to create for
+    // an empty class, so the blacklist is the lone decision and "delete it by
+    // hand, or wait until it has students" is what the operator reads above it.
+    _useTallWindow(tester);
+    final harness = siblingPopulatedClassHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('wacht tot ze leerlingen bevat. (manueel)'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('(keuze)'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('entry-group-1A')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Kies één oplossing:'), findsNothing);
+    expect(find.byIcon(Icons.radio_button_checked), findsNothing);
+    expect(
+        find.byKey(const ValueKey('alt-1A-CreateInSmartschool')), findsNothing);
+    expect(find.text('Negeer deze klas bij het importeren uit WISA'),
+        findsOneWidget);
+    expect(find.text('DontImportClass: ∅ → 1A'), findsOneWidget);
   });
 
   testWidgets('classes sort by year, numerically (#227)',

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -207,11 +207,45 @@ void main() {
   testWidgets(
       'an informational-only class colours no cell, and still lights its row '
       '(#298)', (WidgetTester tester) async {
-    // `GBS-9Z` is the group of a class that stopped running. Its decision is an
-    // either/or whose default half is the "laat staan" notice (#271), so there
-    // is no write pending and the Office 365 cell stays green — while the row
-    // itself is highlighted, because `needsAttention` counts the notice and on
-    // this screen the notice *is* the work (#225/#250).
+    // `9Z` is an official Smartschool class WISA does not have. Its decision is
+    // an either/or whose default half is the "laat deze klas staan" notice
+    // (#313), so there is no write pending and the Smartschool cell stays green
+    // — while the row itself is highlighted, because `needsAttention` counts the
+    // notice and on this screen the notice *is* the work (#225/#250).
+    //
+    // (This claim used to be made on a stale Office 365 group, whose pair had
+    // the same polarity. Since #327 that row proposes a delete outright, so it
+    // is no longer an informational-only class — see the test below.)
+    _useTallWindow(tester);
+    final harness = smartschoolLeftoverClassHarness();
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(_cell(tester, '9Z', core.Origin.smartschool),
+        SystemIndicatorState.inOrder);
+    expect(_cell(tester, '9Z', core.Origin.wisa), SystemIndicatorState.missing);
+    expect(
+        _cell(tester, '9Z', core.Origin.azure), SystemIndicatorState.missing);
+
+    final ColorScheme colors = Theme.of(tester.element(_row('9Z'))).colorScheme;
+    final Container box = tester.widget<Container>(_row('9Z'));
+    expect(
+      ((box.decoration! as BoxDecoration).border! as Border).top.color,
+      colors.primary,
+      reason: 'the row still asks something of the operator',
+    );
+  });
+
+  testWidgets(
+      'a stale Office 365 group colours its own cell, because the delete is '
+      'work this screen can do (#298/#327)', (WidgetTester tester) async {
+    // `GBS-9Z` is the group of a class that stopped running. Until #327 its
+    // decision defaulted to a notice that wrote nothing, so the cell read green
+    // while the card in fact carried a delete one radio away. Now the delete is
+    // the card's single proposal, and the cell says so: there is an applyable
+    // Office 365 write pending on this very screen.
     _useTallWindow(tester);
     final harness = azureClassGroupHarness(withStaleGroup: true);
     await harness.controller.sync();
@@ -220,20 +254,11 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(_cell(tester, 'GBS-9Z', core.Origin.azure),
-        SystemIndicatorState.inOrder);
+        SystemIndicatorState.needsWork);
     expect(_cell(tester, 'GBS-9Z', core.Origin.wisa),
         SystemIndicatorState.missing);
     expect(_cell(tester, 'GBS-9Z', core.Origin.smartschool),
         SystemIndicatorState.missing);
-
-    final ColorScheme colors =
-        Theme.of(tester.element(_row('GBS-9Z'))).colorScheme;
-    final Container box = tester.widget<Container>(_row('GBS-9Z'));
-    expect(
-      ((box.decoration! as BoxDecoration).border! as Border).top.color,
-      colors.primary,
-      reason: 'the row still asks something of the operator',
-    );
   });
 
   testWidgets(
@@ -953,8 +978,8 @@ void main() {
   });
 
   testWidgets(
-      'a stale class group offers a delete, and leaving it alone is the '
-      'default (#271)', (WidgetTester tester) async {
+      'a stale class group proposes its delete and nothing else (#271/#327)',
+      (WidgetTester tester) async {
     _useTallWindow(tester);
     final harness = azureClassGroupHarness(withStaleGroup: true);
     await harness.controller.sync();
@@ -966,34 +991,48 @@ void main() {
     await tester.tap(find.byKey(entry));
     await tester.pumpAndSettle();
 
-    // Two radios, one choice — never two independent to-dos.
-    final leave =
-        find.byKey(const ValueKey('alt-GBS-9Z-AzureClassGroupWithoutClass'));
-    final delete =
-        find.byKey(const ValueKey('alt-GBS-9Z-DeleteAzureClassGroup'));
-    expect(leave, findsOneWidget);
-    expect(delete, findsOneWidget);
+    // One proposal, no radio pair: "laat de groep staan" and "doe niets" are
+    // the same act, and the operator performs the second by not pressing
+    // Toepassen (#327).
+    expect(
+      find.byKey(const ValueKey('alt-GBS-9Z-AzureClassGroupWithoutClass')),
+      findsNothing,
+    );
+    expect(find.byKey(const ValueKey('alt-GBS-9Z-DeleteAzureClassGroup')),
+        findsNothing);
+    expect(find.byIcon(Icons.radio_button_checked), findsNothing);
+    expect(find.byIcon(Icons.radio_button_unchecked), findsNothing);
+    expect(find.text('Kies één oplossing:'), findsNothing);
+    expect(
+      find.textContaining('Laat de Office 365-groep GBS-9Z staan'),
+      findsNothing,
+      reason: 'the no-op is not on offer any more',
+    );
+
+    // The card leads with the delete's own summary, and states the inventory of
+    // what goes with the group.
     expect(
       find.text('Verwijder de Office 365-groep GBS-9Z van de verdwenen '
           'klas 9Z'),
-      findsOneWidget,
+      findsWidgets,
     );
+    expect(find.text('leden: 0'), findsOneWidget);
+    expect(find.text('postvak, Teams en bestanden: verdwijnen mee'),
+        findsOneWidget);
 
-    // The default is the informational half, so nothing is applyable until the
-    // operator deliberately picks the delete.
+    // Nothing was written by opening the card: the delete runs on the
+    // operator's press, behind the ordinary confirmation.
+    expect(harness.graph.deletedGroups, isEmpty);
     final apply = find.byKey(const ValueKey('entry-apply-GBS-9Z'));
-    await tester.ensureVisible(apply);
-    expect(tester.widget<FilledButton>(apply).onPressed, isNull,
-        reason: 'a delete must never be the pre-selected resolution');
-
-    await tester.ensureVisible(delete);
-    await tester.tap(delete);
-    await tester.pumpAndSettle();
     await tester.ensureVisible(apply);
     expect(tester.widget<FilledButton>(apply).onPressed, isNotNull);
 
     await tester.tap(apply);
     await tester.pumpAndSettle();
+    expect(harness.graph.deletedGroups, isEmpty,
+        reason: 'the confirmation is still standing');
+    expect(find.textContaining('GBS-9Z'), findsWidgets,
+        reason: 'the dialog names the group it is about to take');
     await tester.tap(find.byKey(const ValueKey('actions-apply-confirm')));
     await tester.pumpAndSettle();
 
@@ -1001,6 +1040,39 @@ void main() {
     expect(_row('GBS-9Z'), findsNothing,
         reason: 'the relink drops the group the operator just removed');
     expect(_row('1A'), findsOneWidget, reason: 'no other class was touched');
+  });
+
+  testWidgets(
+      'a stale group with no object id keeps its lone "(manueel)" notice '
+      '(#327)', (WidgetTester tester) async {
+    // The one stale group the delete cannot act on: there is no id to address a
+    // DELETE to, so the row falls back to stating the situation — informational,
+    // marked "(manueel)", with no apply of its own.
+    _useTallWindow(tester);
+    final harness = staleClassGroupHarness(idlessStaleGroup: true);
+    await harness.controller.sync();
+    await tester
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Laat de Office 365-groep GBS-9Z staan'),
+      findsWidgets,
+    );
+    expect(find.textContaining('(manueel)'), findsWidgets,
+        reason: 'an informational row is still marked as one');
+
+    await tester.tap(find.byKey(const ValueKey('entry-group-GBS-9Z')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('alt-GBS-9Z-DeleteAzureClassGroup')),
+        findsNothing);
+    expect(find.textContaining('Verwijder de Office 365-groep GBS-9Z'),
+        findsNothing);
+    final apply = find.byKey(const ValueKey('entry-apply-GBS-9Z'));
+    await tester.ensureVisible(apply);
+    expect(tester.widget<FilledButton>(apply).onPressed, isNull,
+        reason: 'an informational row writes nothing');
   });
 
   testWidgets('a class that still exists is offered no delete (#271)',
@@ -1019,7 +1091,8 @@ void main() {
       find.byKey(const ValueKey('alt-2F ECO-DeleteAzureClassGroup')),
       findsNothing,
     );
-    expect(find.textContaining('Verwijder de Office 365-groep'), findsNothing,
+    expect(find.textContaining('Verwijder de Office 365-groep GBS-2F'),
+        findsNothing,
         reason: '2F is a running class — deleting its group is not on offer');
   });
 
@@ -1038,10 +1111,10 @@ void main() {
 
     expect(find.text('Klassen in dezelfde situatie'), findsOneWidget,
         reason: 'the cohort is still worth naming; only the pair is withdrawn');
-    // Neither half of this either/or may be written in bulk — the notice
-    // because it writes nothing, the delete because #293 withholds it — so the
-    // header carries no pair rather than a dead "Alles toepassen (0)" the
-    // operator can go and make live (#326).
+    // Since #327 the delete is the *selected* resolution of both rows, so the
+    // only thing keeping it off the bulk path is the #293 sanction #326 taught
+    // the header to read — hence no pair rather than a dead "Alles toepassen
+    // (2)" one confirmation away from two deleted groups.
     expect(find.textContaining('Alles toepassen ('), findsNothing);
     expect(find.text('Dry-run alles'), findsNothing);
 
@@ -1058,14 +1131,15 @@ void main() {
       'the stale-group card states the group\'s facts instead of diffing them '
       '(#305)', (WidgetTester tester) async {
     // `GBS-9Z` is the group of a class that stopped running, still holding its
-    // 21 members. Under the heading "Laat de Office 365-groep GBS-9Z staan"
-    // its two fields read
+    // 21 members. Under the heading "Verwijder de Office 365-groep GBS-9Z" its
+    // three fields once read
     //
     //   mail: GBS-9Z@student.school.example → ∅
     //   leden: 21 → ∅
+    //   postvak, Teams en bestanden: verdwijnen mee → ∅
     //
-    // — the address and the members going away, which is precisely what the
-    // *other* radio does and what this one promises not to.
+    // — three fields each being emptied, when they are the inventory of what
+    // goes with the group, and "verdwijnen mee" was never a value at all.
     _useTallWindow(tester);
     final harness = staleClassGroupHarness();
     await harness.controller.sync();
@@ -1078,20 +1152,25 @@ void main() {
 
     expect(find.text('mail: GBS-9Z@student.school.example'), findsOneWidget);
     expect(find.text('leden: 21'), findsOneWidget);
-    expect(find.textContaining('→ ∅'), findsNothing,
-        reason: 'the option that writes nothing clears nothing');
+    expect(find.text('postvak, Teams en bestanden: verdwijnen mee'),
+        findsOneWidget);
+    expect(find.textContaining('→ ∅'), findsNothing);
 
-    // The delete beside it names the same facts — the inventory of what goes,
-    // not three fields each being emptied. "verdwijnen mee" was never a value.
+    // The notice the delete cannot be offered for states the same two facts the
+    // same way (#327): it is the other reading of one group, not a diff.
+    final idless = staleClassGroupHarness(idlessStaleGroup: true);
+    await idless.controller.sync();
     await tester
-        .tap(find.byKey(const ValueKey('alt-GBS-9Z-DeleteAzureClassGroup')));
+        .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: idless.bootstrap)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('entry-group-GBS-9Z')));
     await tester.pumpAndSettle();
 
     expect(find.text('mail: GBS-9Z@student.school.example'), findsOneWidget);
     expect(find.text('leden: 21'), findsOneWidget);
-    expect(find.text('postvak, Teams en bestanden: verdwijnen mee'),
-        findsOneWidget);
-    expect(find.textContaining('→ ∅'), findsNothing);
+    expect(find.textContaining('→ ∅'), findsNothing,
+        reason: 'the option that writes nothing clears nothing');
   });
 
   // --- The Smartschool leftovers (#313) --------------------------------------

--- a/account_manager/test/screens/class_groups_screen_test.dart
+++ b/account_manager/test/screens/class_groups_screen_test.dart
@@ -1024,8 +1024,8 @@ void main() {
   });
 
   testWidgets(
-      'a bulk header over stale groups writes nothing by default, and is '
-      'narrowed by the search (#262/#271)', (WidgetTester tester) async {
+      'a bulk header over stale groups offers no bulk pass at all, and is '
+      'narrowed by the search (#262/#271/#326)', (WidgetTester tester) async {
     // `GBS-9Z` and `GBS-8Y` share the stale-group situation, so the tab collects
     // them into one header — the surface where a destructive default would do
     // the most damage.
@@ -1036,19 +1036,14 @@ void main() {
         .pumpWidget(_wrap(ClassGroupsScreen(bootstrap: harness.bootstrap)));
     await tester.pumpAndSettle();
 
-    expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
-    final bulk = find.textContaining('Alles toepassen (');
-    expect(tester.widget<Text>(bulk).data, 'Alles toepassen (0)',
-        reason: 'the default resolution of both rows writes nothing');
-    expect(
-      tester
-          .widget<FilledButton>(find.ancestor(
-            of: bulk,
-            matching: find.byType(FilledButton),
-          ))
-          .onPressed,
-      isNull,
-    );
+    expect(find.text('Klassen in dezelfde situatie'), findsOneWidget,
+        reason: 'the cohort is still worth naming; only the pair is withdrawn');
+    // Neither half of this either/or may be written in bulk — the notice
+    // because it writes nothing, the delete because #293 withholds it — so the
+    // header carries no pair rather than a dead "Alles toepassen (0)" the
+    // operator can go and make live (#326).
+    expect(find.textContaining('Alles toepassen ('), findsNothing);
+    expect(find.text('Dry-run alles'), findsNothing);
 
     // Narrowed to one class, the bulk affordance is gone altogether — a delete
     // must not be able to reach a class the operator filtered off the screen.
@@ -1172,8 +1167,8 @@ void main() {
   });
 
   testWidgets(
-      'a bulk header over Smartschool leftovers writes nothing by default '
-      '(#293/#313)', (WidgetTester tester) async {
+      'a flipped radio never arms the bulk header over Smartschool leftovers '
+      '(#293/#313/#326)', (WidgetTester tester) async {
     // `9Z` and `8Y` share the situation, so the tab collects them into one
     // header — the surface where a destructive default would do the most
     // damage, and the reason the delete withholds `canApplyToAll`.
@@ -1185,39 +1180,36 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Klassen in dezelfde situatie'), findsOneWidget);
-    final bulk = find.textContaining('Alles toepassen (');
-    expect(tester.widget<Text>(bulk).data, 'Alles toepassen (0)',
-        reason: 'the default resolution of both rows writes nothing');
-    expect(
-      tester
-          .widget<FilledButton>(find.ancestor(
-            of: bulk,
-            matching: find.byType(FilledButton),
-          ))
-          .onPressed,
-      isNull,
-    );
+    expect(find.textContaining('Alles toepassen ('), findsNothing,
+        reason: 'neither resolution of this situation is bulk-sanctioned');
 
-    // Flipping one row to the delete moves the header by exactly one: the
-    // classes beside it keep the notice they defaulted to, so a leftover is
-    // never swept into a delete somebody else's row asked for. That is what
-    // makes the label honest — "alles" is only ever the picks on screen.
-    const entry = ValueKey('entry-group-9Z');
-    await tester.ensureVisible(find.byKey(entry));
-    await tester.tap(find.byKey(entry));
-    await tester.pumpAndSettle();
-    final delete = find.byKey(const ValueKey('alt-9Z-DeleteSmartschoolClass'));
-    await tester.ensureVisible(delete);
-    await tester.tap(delete);
-    await tester.pumpAndSettle();
+    // Flipping the rows to the delete used to *arm* the header: it counted the
+    // selected option's `canApply` and nothing else, so two flipped radios read
+    // "Alles toepassen (2)" and one press took both classes — every membership
+    // and subgroup with them — on an action whose own class says no bulk
+    // affordance may offer it (#326).
+    for (final String id in const <String>['9Z', '8Y']) {
+      final entry = find.byKey(ValueKey('entry-group-$id'));
+      await tester.ensureVisible(entry);
+      await tester.tap(entry);
+      await tester.pumpAndSettle();
+      final delete = find.byKey(ValueKey('alt-$id-DeleteSmartschoolClass'));
+      await tester.ensureVisible(delete);
+      await tester.tap(delete);
+      await tester.pumpAndSettle();
+    }
 
-    expect(tester.widget<Text>(find.textContaining('Alles toepassen (')).data,
-        'Alles toepassen (1)');
-    expect(find.byKey(const ValueKey('alt-8Y-DeleteSmartschoolClass')),
-        findsNothing,
-        reason: 'the row beside it was never opened, let alone flipped');
-    expect(harness.soap.deletedClasses, isEmpty,
-        reason: 'nothing is written until the operator confirms');
+    expect(find.textContaining('Alles toepassen ('), findsNothing,
+        reason: 'the sanction is a property of the action, not of how many '
+            'rows happen to be set to it');
+    expect(find.text('Dry-run alles'), findsNothing);
+    expect(harness.soap.deletedClasses, isEmpty);
+
+    // …and the per-row apply is untouched: one class at a time, from the card
+    // that shows what the write would do.
+    final apply = find.byKey(const ValueKey('entry-apply-9Z'));
+    await tester.ensureVisible(apply);
+    expect(tester.widget<FilledButton>(apply).onPressed, isNotNull);
   });
 
   testWidgets('a class WISA still has is offered no Smartschool delete (#313)',

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -170,8 +170,20 @@ class names carry no spaces, so the name is used verbatim as the `mailNickname`
 — a name that would not survive as one yields no proposal rather than a mangled
 slug. Because `LinkedGroup` is keyed on the `fullName`, the bare name is carried
 alongside it as `LinkedGroup.className`, which is also what the Azure side of
-the group link matches on after stripping the prefix. Groups are never deleted
-automatically; a class that vanished leaves an informational notice.
+the group link matches on after stripping the prefix.
+
+**A class that stopped running is deleted where the app can act on it**
+(#271/#313). `DeleteAzureClassGroup` removes the Office 365 group of a class
+WISA no longer runs; `DeleteSmartschoolClass` removes an `official` Smartschool
+class WISA does not have. Since #327/#328 each delete is the **whole** of what
+such a row proposes — there is no "leave it standing" no-op paired against it,
+because a no-op is not an answer the app can write. An informational notice
+survives only where the delete cannot fire at all: the record names no Azure
+object id, or the Smartschool leftover is not an official class naming a class
+code. Such a notice stands alone, marked "(manueel)"; it is never one half of
+an either/or (#329). What keeps a delete out of a bulk pass
+is `canApplyToAll` (#293/#326), not the polarity of a pair; see
+[packages/account_actions/README.md](../packages/account_actions/README.md).
 
 ### 3.8 `Snapshot`
 

--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -182,13 +182,17 @@ class's Smartschool state and ride alongside **both** branches:
   Smartschool leftovers, where the notice is the default so a bulk pass writes
   nothing and the delete is a per-row pick a bulk affordance may never reach
   (#293).
-- **Azure-only, class-shaped** (a group whose class stopped running) → the
-  `staleClassGroupAlternative` pair of #271: the informational
-  `AzureClassGroupWithoutClass` (leave it standing) and the applyable
-  `DeleteAzureClassGroup`. The notice is the default, so a bulk apply over stale
-  groups writes nothing and a delete — which takes the group's mailbox, Team and
-  files with it — is only ever the pick an operator made on that one row. A
-  prefixed group whose remainder is *not* class-shaped (`SSM - GOK`,
+- **Azure-only, class-shaped** (a group whose class stopped running) →
+  `DeleteAzureClassGroup` (#271), and since #327 that is the **whole** of what
+  the row proposes. It used to be one radio of a pair whose default half was an
+  informational "laat de groep staan"; that half was a no-op — the operator
+  performs it by not pressing **Toepassen** — so the card asked them to record a
+  non-decision. The delete takes the group's mailbox, Team and files with it, and
+  what keeps it out of every bulk pass is `canApplyToAll == false` (#293), read
+  by both bulk paths since #326, rather than the polarity of a pair.
+  `AzureClassGroupWithoutClass` survives as the lone `(manueel)` notice for the
+  one stale group the delete cannot address — a record naming no Azure object
+  id. A prefixed group whose remainder is *not* class-shaped (`SSM - GOK`,
   `SSM-OKAN`) is not orphaned by the linker at all and so raises nothing.
 - **Present in both** → only `ModifySmartschoolData` (sync institute number,
   Untis code, and description).
@@ -281,8 +285,8 @@ account row diagnoses and names the class, and the class row applies. Both are
 derived from the same `AzureClassGroupResolver` indexes in `account_state`, so
 they cannot disagree — and a class whose group does not exist yet, or a group
 whose class has vanished, is deliberately silent per student: neither has a
-per-student remedy (`CreateAzureClassGroup` and the
-`AzureClassGroupWithoutClass` / `DeleteAzureClassGroup` pair own those).
+per-student remedy (`CreateAzureClassGroup` and `DeleteAzureClassGroup` own
+those).
 
 ## Deferred (documented divergences)
 

--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -163,10 +163,9 @@ class's Smartschool state and ride alongside **both** branches:
   parser order: `DoNotImportFromWisa` (WISA-only class; adds a `DontImportClass`
   rule), `AddToSmartschool` (WISA-only class **with students**; creates the
   official class in Smartschool), `CreateInSmartschool` (WISA-only class with
-  **no** students; informational), and the `staleSmartschoolClassAlternative`
-  pair of #313 for an orphan Smartschool class — the informational
-  `DoNotImportFromSmartschool` (leave it standing) and the applyable
-  `DeleteSmartschoolClass` (`delClass` on the class code). A WISA-only class
+  **no** students; informational), and — for an orphan Smartschool class —
+  `DeleteSmartschoolClass` (#313; `delClass` on the class code), which since
+  #328 is the **whole** of what that row proposes. A WISA-only class
   therefore raises `DoNotImportFromWisa` plus exactly one of `AddToSmartschool` /
   `CreateInSmartschool` — or, when Smartschool already carries the name on a
   group the linker could not adopt (#225), the informational
@@ -178,10 +177,20 @@ class's Smartschool state and ride alongside **both** branches:
   `classImportAlternative` for a genuinely new class (#244) and
   `namesakeClassAlternative` for one Smartschool already has (#250), which keeps
   the two situations in separate bulk-apply subsets. The default is always the
-  provisioning/diagnosis half, never the blacklist — and the same holds for the
-  Smartschool leftovers, where the notice is the default so a bulk pass writes
-  nothing and the delete is a per-row pick a bulk affordance may never reach
-  (#293).
+  provisioning/diagnosis half, never the blacklist.
+
+  The **Smartschool leftovers** had a third such key until #328. It went for the
+  reason the Office 365 one did (see below): its default half was an
+  informational "laat deze klas staan", and the operator performs that by not
+  pressing **Toepassen**. What keeps `delClass` — which takes the class, every
+  membership and every subgroup with it — out of a bulk pass is
+  `canApplyToAll == false` (#293), read by both bulk paths since #326.
+  `DoNotImportFromSmartschool` survives as the lone `(manueel)` notice for a
+  leftover the delete cannot address (a non-official group, or one naming no
+  class code). The reading the default *also* carried — that early in a school
+  year the WISA snapshot lags, so a live class can read as a leftover — is a
+  fact about the situation rather than a resolution, and is stated on the
+  delete's own card (`WISA: kent deze klas (nog) niet — …`).
 - **Azure-only, class-shaped** (a group whose class stopped running) →
   `DeleteAzureClassGroup` (#271), and since #327 that is the **whole** of what
   the row proposes. It used to be one radio of a pair whose default half was an

--- a/packages/account_actions/README.md
+++ b/packages/account_actions/README.md
@@ -64,6 +64,43 @@ Two independent flags, on all three families:
 presupposes the mechanism — `canApplyToAll` is never `true` where `canApply` is
 `false`.
 
+### A notice is context, not an alternative (#329)
+
+The rule the whole alternative mechanism rests on, and the third flag on all
+three families:
+
+| Flag | Question | Default |
+|---|---|---|
+| `alternativeGroup` | Which either/or is this action one **answer** to? | `null` |
+| `noticeFor` | Which decision is this informational action **context** for? | `null` |
+
+**Every member of an `alternativeGroup` writes.** An action whose `canApply` is
+`false` may never join one: "here is what is wrong, go fix it by hand over
+there" and "here is the one thing this app can do about it" are not comparable
+answers to a single question, so offering them as radios asks the operator to
+choose between a diagnosis and a resolution — and makes every such card
+ambiguous about whether a decision is owed at all. Such an action declares
+`noticeFor` instead; `collapseAlternatives` lifts it out of the option list and
+hands it to the decision it names, which the UI states above its own proposal,
+marked `(manueel)`, with no radio and no apply of its own.
+
+`noticeFor` is therefore non-null only where `canApply` is `false`, and never
+together with a non-null `alternativeGroup`. `test/group_dispatch_test.dart`
+asserts both over the student, staff and group dispatches.
+
+Two group actions carry one: `ClassExistsAsSmartschoolGroup` (#225/#250) and
+`CreateInSmartschool` (#244). Both were the pre-selected half of a pair with
+`DoNotImportFromWisa` until #329. Being the default did a second job — it kept
+the blacklist out of a bulk pass — and that job belongs to `canApplyToAll`,
+withheld since #293 and honoured by every bulk affordance since #326. A guard
+that holds only while a default holds is not a guard.
+
+The three informational actions that carry **no** `noticeFor`
+(`AzureClassGroupMembership`, `DoNotImportFromSmartschool`,
+`AzureClassGroupWithoutClass`) each fire exactly where no decision can be
+raised, so the row *is* the notice and there is nothing for it to be context
+for.
+
 `canApplyToAll` ports legacy's `AccountAction.canBeAppliedToAll`, which the two
 account families carried and granted deliberately, action by action. The line it
 draws: **mechanical corrections and provisioning** may go in bulk;
@@ -171,13 +208,17 @@ class's Smartschool state and ride alongside **both** branches:
   group the linker could not adopt (#225), the informational
   `ClassExistsAsSmartschoolGroup` in place of both creates.
 
-  These are never independent to-dos: `DoNotImportFromWisa` shares an
-  `alternativeGroup` key with the reading it contradicts, so the pending list
-  renders one either/or and an apply runs only the picked half. The key is
-  `classImportAlternative` for a genuinely new class (#244) and
-  `namesakeClassAlternative` for one Smartschool already has (#250), which keeps
-  the two situations in separate bulk-apply subsets. The default is always the
-  provisioning/diagnosis half, never the blacklist.
+  These are never independent to-dos, but they are not all the same relation
+  either. A **populated** new class is a genuine either/or: `AddToSmartschool`
+  and `DoNotImportFromWisa` share the `classImportAlternative` key, both write,
+  and an apply runs only the picked half (#244). An **empty** class and a
+  **namesake** class have nothing for this app to create, so
+  `DoNotImportFromWisa` is the lone decision under its key — `classImportAlternative`
+  and `namesakeClassAlternative` respectively, still distinct so the two
+  situations keep separate bulk-apply subsets (#250) — and the informational
+  action beside it declares `noticeFor` on that same key and rides along as
+  card context (#329). The default of a real either/or is always the
+  provisioning half, never the blacklist.
 
   The **Smartschool leftovers** had a third such key until #328. It went for the
   reason the Office 365 one did (see below): its default half was an
@@ -214,7 +255,9 @@ for the two creation actions, an injected `GroupPlacement` (see below).
 returns a `WisaImportRule` via `ActionResult.wisaRule`. `DoNotImportFromSmartschool`
 and `CreateInSmartschool` are **informational** (`canApply == false`, legacy
 `CanBeApplied == false`): they surface a diagnosis and their `apply` throws
-`UnsupportedError`. The two deletes — `DeleteAzureClassGroup` and
+`UnsupportedError`. `CreateInSmartschool` and `ClassExistsAsSmartschoolGroup`
+are the two that declare `noticeFor` (see above), so they are read as context on
+the blacklist beside them rather than offered as answers. The two deletes — `DeleteAzureClassGroup` and
 `DeleteSmartschoolClass` — carry no record back at all: they set
 `ActionResult.removed`, and the State layer drops the record from the owning
 snapshot rather than patching it.

--- a/packages/account_actions/lib/src/alternatives.dart
+++ b/packages/account_actions/lib/src/alternatives.dart
@@ -13,28 +13,52 @@
 library;
 
 /// One decision point: a set of mutually-exclusive [options] of which exactly
-/// one — [selected] — is the resolution that will actually run.
+/// one — [selected] — is the resolution that will actually run, plus whatever
+/// [notices] are context for it.
 ///
 /// A departed student's "unregister *vs* delete" pair is one [Alternatives] with
 /// two options; an ordinary modify action is one with a single option. The
 /// distinction is [isChoice].
 class Alternatives<T> {
-  Alternatives({required this.options, required this.selected})
-      : assert(options.isNotEmpty);
+  Alternatives({
+    required this.options,
+    required this.selected,
+    this.notices = const [],
+  }) : assert(options.isNotEmpty);
 
   /// The mutually-exclusive options (at least one), in first-seen order.
+  ///
+  /// **Every one of them writes** (#329). An informational item — one with no
+  /// automated write — is never an option here: it is context on the decision,
+  /// which is what [notices] holds.
   final List<T> options;
 
   /// The pre-selected option — the declared default of the group, or the lone
   /// option. Callers that let an operator pick may substitute their own choice.
   final T selected;
 
+  /// The informational items this decision carries as **context** (#329), in
+  /// dispatch order — what a card states above the decision rather than offering
+  /// as one of its answers.
+  ///
+  /// The rule they exist for: *a notice is context, not an alternative.* An
+  /// action with no automated write and a real write are not comparable answers
+  /// to one question, so pairing them as radios asked the operator to choose
+  /// between "here is what is wrong" and "here is the one thing the app can do".
+  /// The notice still has to be read — "go make this group official in
+  /// Smartschool" is genuine instruction — so it stays on the decision it
+  /// belongs to, marked as informational, without a radio of its own.
+  ///
+  /// Empty for every decision that carries no such notice, which is nearly all
+  /// of them.
+  final List<T> notices;
+
   /// True when this is a real either/or the operator resolves, false for a lone
-  /// action.
+  /// action. Since #329 both sides of such a choice always write.
   bool get isChoice => options.length > 1;
 }
 
-/// Collapses [items] into the decision points they represent (#110/#251).
+/// Collapses [items] into the decision points they represent (#110/#251/#329).
 ///
 /// Items whose [groupOf] key is the same non-null string are alternatives of one
 /// choice, ordered by where the group was first seen; every item with a `null`
@@ -45,15 +69,38 @@ class Alternatives<T> {
 ///
 /// Counting the result — rather than the raw items — is what makes one either/or
 /// one pending decision instead of two.
+///
+/// [noticeFor], when supplied, reads the situation an **informational** item is
+/// context for (#329). Such an item is not a decision and never an option: it is
+/// lifted out and attached to the choice keyed by the string it names, as
+/// [Alternatives.notices]. That is what makes "an informational action never
+/// stands in an either/or" a property of this one collapse rather than of every
+/// caller that renders one. A notice naming a situation this list does not
+/// contain becomes a lone choice of its own, at the end — it is still something
+/// the operator has to read, and dropping a row silently is the one outcome that
+/// would not be honest.
 List<Alternatives<T>> collapseAlternatives<T>(
   Iterable<T> items, {
   required String? Function(T) groupOf,
   required bool Function(T) isDefault,
+  String? Function(T)? noticeFor,
 }) {
+  final noticesByKey = <String, List<T>>{};
+  final noticeKeyOrder = <String>[];
+  if (noticeFor != null) {
+    for (final item in items) {
+      final key = noticeFor(item);
+      if (key == null) continue;
+      if (!noticesByKey.containsKey(key)) noticeKeyOrder.add(key);
+      (noticesByKey[key] ??= <T>[]).add(item);
+    }
+  }
+
   final choices = <Alternatives<T>>[];
   final order = <String>[];
   final byGroup = <String, List<T>>{};
   for (final item in items) {
+    if (noticeFor != null && noticeFor(item) != null) continue;
     final group = groupOf(item);
     if (group == null) {
       choices.add(Alternatives<T>(options: <T>[item], selected: item));
@@ -68,7 +115,13 @@ List<Alternatives<T>> collapseAlternatives<T>(
       options: alternatives,
       selected:
           alternatives.firstWhere(isDefault, orElse: () => alternatives.first),
+      notices: noticesByKey.remove(group) ?? const [],
     ));
+  }
+  for (final key in noticeKeyOrder) {
+    for (final orphan in noticesByKey[key] ?? <T>[]) {
+      choices.add(Alternatives<T>(options: <T>[orphan], selected: orphan));
+    }
   }
   return choices;
 }

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -88,12 +88,17 @@ sealed class GroupAction {
 
   /// The key shared by mutually-exclusive alternatives resolving the same
   /// situation (#110). `null` (the default) means the action stands on its own.
-  /// The group family has four: [classImportAlternative] for a class
+  /// The group family has three: [classImportAlternative] for a class
   /// Smartschool does not have (#244), [namesakeClassAlternative] for one it
-  /// already carries under a group the linker could not adopt (#250),
-  /// [staleClassGroupAlternative] for an Office 365 group whose class is gone
-  /// (#271), and [staleSmartschoolClassAlternative] for a Smartschool class
-  /// WISA does not have (#313). See [StudentAction.alternativeGroup].
+  /// already carries under a group the linker could not adopt (#250), and
+  /// [staleSmartschoolClassAlternative] for a Smartschool class WISA does not
+  /// have (#313). See [StudentAction.alternativeGroup].
+  ///
+  /// An Office 365 group whose class is gone had a fourth until #327. It lost
+  /// it because its conservative half was a no-op: "laat de groep staan" and
+  /// "doe niets" are the same act, and the operator performs the second one by
+  /// not pressing **Toepassen**. [DeleteAzureClassGroup] now stands alone where
+  /// it can fire and [AzureClassGroupWithoutClass] alone where it cannot.
   String? get alternativeGroup => null;
 
   /// Whether this action is the default alternative within its
@@ -584,13 +589,17 @@ class ClassExistsAsSmartschoolGroup extends GroupAction {
 /// official Smartschool class WISA does not have (#313): leave it standing
 /// ([DoNotImportFromSmartschool]) *or* delete it ([DeleteSmartschoolClass]).
 ///
-/// The Smartschool twin of [staleClassGroupAlternative], and deliberately the
-/// same shape — one predicate, one facts helper, the notice as the default and
-/// the delete as the non-default that no bulk pass may reach. Until #313 the
-/// notice was the *only* reading, and its whole content was an instruction to
-/// go and do it by hand in Smartschool: the dead end #271 removed on the Office
-/// 365 side, still standing here, and a screenful of it at a September
-/// changeover.
+/// The Smartschool twin of the Office 365 stale-group decision, and
+/// deliberately the same shape — one predicate, one facts helper, the notice as
+/// the default and the delete as the non-default that no bulk pass may reach.
+/// Until #313 the notice was the *only* reading, and its whole content was an
+/// instruction to go and do it by hand in Smartschool: the dead end #271
+/// removed on the Office 365 side, still standing here, and a screenful of it
+/// at a September changeover.
+///
+/// The Azure pair has since lost its radios altogether (#327), and #328 is
+/// where this one is weighed against the same argument — the polarity here
+/// carries a job the Azure one's never did, spelled out below.
 ///
 /// **The default is the notice**, and here the polarity carries an extra job
 /// the Azure pair does not have. Early in a school year the WISA snapshot lags
@@ -1193,65 +1202,54 @@ class SyncAzureClassGroupMembers extends GroupAction {
   }
 }
 
-/// The [GroupAction.alternativeGroup] key shared by the two readings of an
-/// Office 365 class group whose class is gone (#271): leave it standing
-/// ([AzureClassGroupWithoutClass]) *or* delete it
-/// ([DeleteAzureClassGroup]).
-///
-/// **The default is the notice**, the same polarity [CreateInSmartschool] has
-/// inside [classImportAlternative] and [ClassExistsAsSmartschoolGroup] inside
-/// [namesakeClassAlternative] — and here it matters more than in either. The
-/// notice is informational, so the selected option of a bulk pass writes
-/// **nothing**: "Alles toepassen" over a year's worth of stale groups leaves
-/// every one of them alone, and deleting one is a radio the operator flips on
-/// that one row. Deleting an Office 365 group takes its mailbox, its Team and
-/// its files with it, so the polarity is not a preference — it is the guard.
-///
-/// A key of its own rather than a third member of an existing one, for the
-/// reason [namesakeClassAlternative] is separate from [classImportAlternative]:
-/// the pending list keys its "same situation" bulk subsets on this very string
-/// (`PendingChoice.situationId`), so pooling stale groups with new classes
-/// would file both under one header offering one **Apply to all**.
-const String staleClassGroupAlternative = 'class-group-stale';
-
 /// An Office 365 class group whose class no longer exists in WISA or
-/// Smartschool (#228) — **leave it standing**, the conservative half of the
-/// [staleClassGroupAlternative] pair and its default (#271).
+/// Smartschool (#228) **and that this app cannot delete for you** — the lone
+/// informational row such a group is left with (#327).
 ///
 /// Informational (`canApply == false`), so it is the reading under which
 /// nothing is written: it is the Azure analogue of the Smartschool orphan notice
 /// [DoNotImportFromSmartschool]. Until #271 it was the *only* reading — it told
 /// the operator to delete the group by hand — which left the class inventory
-/// carrying rows whose whole content was an instruction to go elsewhere.
-/// [DeleteAzureClassGroup] now sits beside it as the non-default alternative.
+/// carrying rows whose whole content was an instruction to go elsewhere. From
+/// #271 to #327 it was the pre-selected half of a radio pair whose other half
+/// was [DeleteAzureClassGroup].
+///
+/// **It is neither any more.** "Laat de Office 365-groep staan" and "doe niets"
+/// are the same act, and the operator performs the second one by not pressing
+/// **Toepassen**; offering it as a radio asked them to record a non-decision,
+/// and made a card proposing exactly one thing read as a question with two
+/// answers — two sentences to read per stale group to discover that one of them
+/// means "nothing happens". Being the pair's default did carry a second job,
+/// keeping the delete out of a bulk pass, but that job belongs to
+/// [GroupAction.canApplyToAll]: [DeleteAzureClassGroup] withholds the sanction
+/// (#293) and since #326 every bulk affordance honours it, so the polarity
+/// trick is redundant and the guard is stated where it is enforced.
+///
+/// So this now fires **exactly where the delete cannot** — see
+/// [_deletableStaleClassGroup] — which in practice means a linked record naming
+/// no Azure object id to address a `DELETE /groups/` to. There is then
+/// genuinely nothing to offer, and saying so *is* the whole content of the row,
+/// marked "(manueel)" like every other informational action.
 ///
 /// It is narrow, but no narrower than the linker's own orphan rule: an
 /// unmatched Azure group is reported when the name it answers on inside the
 /// school's `<PREFIX>-` namespace is *shaped like a class* — the one signal
 /// #228 made available and the only one [_staleClassGroup] reads (#312).
 /// Anything outside the namespace, and anything prefixed that is not
-/// class-shaped (`SSM-GOK`, `SSM-Personeel`), is left unmentioned rather than
-/// filling the Klasgroepen list with rows nobody will act on (the clutter
-/// #209/#225/#271 fixed).
+/// class-shaped (`SSM-GOK`, `SSM-Personeel`), is left unmentioned by *both*
+/// readings rather than filling the Klasgroepen list with rows nobody will act
+/// on (the clutter #209/#225/#271 fixed).
 class AzureClassGroupWithoutClass extends GroupAction {
   const AzureClassGroupWithoutClass(super.group);
 
   az.AzureGroup? get _azure => group.azure as az.AzureGroup?;
 
   @override
-  bool evaluate() => _staleClassGroup(group);
+  bool evaluate() =>
+      _staleClassGroup(group) && !_deletableStaleClassGroup(group);
 
   @override
   bool get canApply => false;
-
-  /// The notice leads — and is the default of — the pair (#271), so a bulk
-  /// apply over stale groups writes nothing and the delete stays a deliberate,
-  /// per-row pick.
-  @override
-  String? get alternativeGroup => staleClassGroupAlternative;
-
-  @override
-  bool get isDefaultAlternative => true;
 
   @override
   ChangeSet describeChanges() => ChangeSet(
@@ -1274,25 +1272,31 @@ class AzureClassGroupWithoutClass extends GroupAction {
       );
 }
 
-/// Delete the Office 365 group of a class that no longer runs (#271) — the
-/// applyable half of the [staleClassGroupAlternative] pair, and never its
-/// default.
+/// Delete the Office 365 group of a class that no longer runs (#271) — since
+/// #327 the **only** thing a stale class group proposes, not one radio of two.
 ///
 /// Genuinely destructive, and the only group action that is: Graph deletes the
 /// group together with its mailbox and history, its Team, and its SharePoint
 /// files. Three things therefore hold it in place, and each of them is tested:
 ///
-/// - **It proposes on exactly the record the notice does**, via the one
-///   [_staleClassGroup] predicate — Azure-only, and carrying a class name the
-///   linker recovered from inside the school's `<PREFIX>-` namespace — plus a
-///   restatement of that predicate's own shape guard ([looksLikeClassName]).
-///   The restatement is belt-and-braces and deliberately redundant: a delete
-///   must not inherit its whole scope from a predicate it does not spell out.
-/// - **It is never the selected option of a bulk pass**, because the notice
-///   beside it is the default of their shared alternative group. The operator
-///   flips this radio on one row, and only that row is written.
+/// - **It proposes on exactly the record [_deletableStaleClassGroup]
+///   describes** — Azure-only, carrying a class name the linker recovered from
+///   inside the school's `<PREFIX>-` namespace, plus a restatement of that
+///   predicate's own shape guard ([looksLikeClassName]). The restatement is
+///   belt-and-braces and deliberately redundant: a delete must not inherit its
+///   whole scope from a predicate it does not spell out.
+/// - **No bulk affordance may offer it**, because [canApplyToAll] is false and,
+///   since #326, both bulk paths read it. This is now the *whole* of that
+///   guard: until #327 it leaned on the polarity of a radio pair, which meant
+///   two flipped radios could arm a header the flag had already refused.
 /// - **The linked record must actually name a group to delete** — a blank Azure
-///   object id yields no proposal rather than a `DELETE /groups/`.
+///   object id yields no proposal rather than a `DELETE /groups/`, and
+///   [AzureClassGroupWithoutClass] states the situation instead.
+///
+/// Nothing is written until the operator presses **Dry-run** or **Toepassen**
+/// on this card, behind the ordinary confirmation — which is why
+/// [describeChanges] carries the inventory of what goes with the group rather
+/// than the summary alone.
 ///
 /// Deliberately no `unlocks`: nothing follows a delete.
 class DeleteAzureClassGroup extends GroupAction {
@@ -1301,24 +1305,13 @@ class DeleteAzureClassGroup extends GroupAction {
   az.AzureGroup? get _azure => group.azure as az.AzureGroup?;
 
   @override
-  bool evaluate() =>
-      _staleClassGroup(group) &&
-      looksLikeClassName(group.className) &&
-      (_azure?.id.trim().isNotEmpty ?? false);
-
-  /// The destructive half, so never the default (#271). See
-  /// [staleClassGroupAlternative].
-  @override
-  String? get alternativeGroup => staleClassGroupAlternative;
-
-  @override
-  bool get isDefaultAlternative => false;
+  bool evaluate() => _deletableStaleClassGroup(group);
 
   /// **Never in bulk** (#293), and the clearest case in the whole port: Graph
   /// takes the group's mailbox, its Team and its SharePoint files with it, and
-  /// none of that comes back. A fourth guard beside the three above — the
-  /// operator flips this radio on one row, and even then no bulk affordance may
-  /// offer it.
+  /// none of that comes back. Since #327 removed the pair this used to sit in,
+  /// this flag is the only thing keeping the delete off every bulk path — and
+  /// #326 is what makes every one of them ask.
   @override
   bool get canApplyToAll => false;
 
@@ -1375,10 +1368,10 @@ class DeleteAzureClassGroup extends GroupAction {
 /// longer exists anywhere (#228/#271) — the one condition
 /// [AzureClassGroupWithoutClass] and [DeleteAzureClassGroup] share.
 ///
-/// One definition rather than two copies, because the pair are alternatives:
-/// they must fire together or a stale group is left with a lone applyable
-/// delete as its only reading, which is precisely the "no safe default" state
-/// [staleClassGroupAlternative] exists to prevent.
+/// One definition rather than two copies, because the two readings partition
+/// it: [_deletableStaleClassGroup] is the half the delete proposes on and the
+/// notice is exactly the remainder, so a stale group raises one row and never
+/// none or two.
 ///
 /// **It reads the linker's own orphan rule, not a second, stricter one**
 /// (#312). [LinkedGroup.className] on an Azure-only record is exactly the bare
@@ -1409,8 +1402,28 @@ bool _staleClassGroup(LinkedGroup group) {
       looksLikeClassName(group.className);
 }
 
-/// The facts both halves of [staleClassGroupAlternative] state about the group
-/// they are describing (#305) — stated, never diffed.
+/// Whether [group] is a stale class group this app can actually **delete**
+/// (#327) — [_staleClassGroup] plus the two things a `DELETE /groups/{id}`
+/// needs: a class-shaped name, and an object id to address the request to.
+///
+/// Written out as a predicate of its own rather than folded into
+/// [DeleteAzureClassGroup.evaluate], because it is the line the two readings of
+/// a stale group are drawn on: the delete proposes exactly where this holds,
+/// and [AzureClassGroupWithoutClass] states its "(manueel)" notice exactly
+/// where it does not. Expressed once, "the notice fires when the delete cannot"
+/// cannot drift into a second, differently-worded copy of this guard.
+///
+/// The name-shape test is a restatement of one [_staleClassGroup] already
+/// makes, deliberately: a delete must not inherit its whole scope from a
+/// predicate it does not spell out. So the case this genuinely separates off is
+/// the blank object id.
+bool _deletableStaleClassGroup(LinkedGroup group) =>
+    _staleClassGroup(group) &&
+    looksLikeClassName(group.className) &&
+    ((group.azure as az.AzureGroup?)?.id.trim().isNotEmpty ?? false);
+
+/// The facts both readings of a stale Office 365 class group state about the
+/// group they are describing (#305) — stated, never diffed.
 ///
 /// The address is stated only when there is one: a legacy class group is a
 /// security group carrying no `mail` (#312), and an empty statement renders as

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -93,20 +93,54 @@ sealed class GroupAction {
   /// carries under a group the linker could not adopt (#250). See
   /// [StudentAction.alternativeGroup].
   ///
-  /// The two **leftovers** — an Office 365 group whose class is gone, and a
-  /// Smartschool class WISA does not have — each had a key of their own until
-  /// #327 and #328. Both lost it for the same reason: their conservative half
-  /// was a no-op. "Laat de groep staan" / "laat deze klas staan" and "doe
-  /// niets" are the same act, and the operator performs the second one by not
-  /// pressing **Toepassen**, so the pair asked them to record a non-decision.
-  /// [DeleteAzureClassGroup] and [DeleteSmartschoolClass] now stand alone where
-  /// they can fire, and [AzureClassGroupWithoutClass] /
-  /// [DoNotImportFromSmartschool] alone where they cannot.
+  /// **Every member of a group writes** (#329). The rule the whole mechanism
+  /// rests on: an informational action is *context*, not an alternative. It
+  /// declares [noticeFor] and rides along beside the decision it explains,
+  /// instead of standing in it as an answer that resolves nothing.
+  ///
+  /// This family is where the rule was learned, at four sites in a row:
+  /// - the two **leftovers** — an Office 365 group whose class is gone, and a
+  ///   Smartschool class WISA does not have — each had a key of their own until
+  ///   #327 and #328. Both lost it because their conservative half was a no-op:
+  ///   "laat de groep staan" / "laat deze klas staan" and "doe niets" are the
+  ///   same act, which the operator performs by not pressing **Toepassen**.
+  ///   [DeleteAzureClassGroup] and [DeleteSmartschoolClass] now stand alone
+  ///   where they can fire, and [AzureClassGroupWithoutClass] /
+  ///   [DoNotImportFromSmartschool] alone where they cannot;
+  /// - the two **notices** — [ClassExistsAsSmartschoolGroup] and
+  ///   [CreateInSmartschool] — were paired with [DoNotImportFromWisa] until
+  ///   #329. Their content is not a no-op but genuine instruction ("go make
+  ///   this group official", "delete this empty WISA class by hand"), so they
+  ///   survive as [noticeFor] context on the very decision they used to be one
+  ///   radio of.
+  ///
+  /// What kept the blacklist and the two deletes off a bulk pass was, until
+  /// then, the *polarity* of those pairs — the informational half is the
+  /// pre-selected default, so nothing counted. A guard that holds only while a
+  /// default holds is not a guard; it is [canApplyToAll], honoured by every bulk
+  /// path since #326.
   String? get alternativeGroup => null;
 
   /// Whether this action is the default alternative within its
   /// [alternativeGroup]. Ignored when [alternativeGroup] is `null`.
   bool get isDefaultAlternative => false;
+
+  /// The situation this **informational** action is context for (#329) — the
+  /// [alternativeGroup] key of the decision it belongs beside, or `null` (the
+  /// default) when this action is not a notice. See [StudentAction.noticeFor]
+  /// for the mechanism.
+  ///
+  /// Two members carry one, and they are the reason it exists:
+  /// [ClassExistsAsSmartschoolGroup] on [namesakeClassAlternative] and
+  /// [CreateInSmartschool] on [classImportAlternative]. In both the app can do
+  /// exactly one thing — stop importing the class — and the notice says what
+  /// the operator should do *instead*, by hand, in the other system.
+  ///
+  /// The family's other two informational members
+  /// ([DoNotImportFromSmartschool] and [AzureClassGroupWithoutClass]) declare
+  /// nothing here: each fires exactly where its delete cannot, so there is no
+  /// decision beside it to be context for and the row *is* the notice.
+  String? get noticeFor => null;
 
   /// The action types this one **unlocks** on the same target (#245) — the
   /// group family's half of the chaining [StudentAction.unlocks] introduced for
@@ -168,10 +202,8 @@ sealed class GroupAction {
 // Actions for when the group is missing from one system (§6.3).
 // ---------------------------------------------------------------------------
 
-/// The [GroupAction.alternativeGroup] key shared by the mutually exclusive
-/// readings of a WISA class Smartschool does not have (#244): import the class
-/// ([AddToSmartschool] when it holds students, [CreateInSmartschool]'s
-/// wait-or-delete notice when it does not) *or* stop offering it
+/// The situation key for a WISA class Smartschool does not have (#244): import
+/// the class ([AddToSmartschool]) *or* stop offering it
 /// ([DoNotImportFromWisa]).
 ///
 /// They are opposite decisions, so they are one choice and never two to-dos.
@@ -181,21 +213,22 @@ sealed class GroupAction {
 /// while the group survived downstream, unmanaged. "Apply to all" did that to
 /// every new class of the year at once.
 ///
-/// The two create actions never fire together (the [GroupPlacement] membership
-/// signal picks exactly one), so all three can share the single key and exactly
-/// one default is ever offered — except when Smartschool already carries the
-/// name, where both creates step aside and the pair moves to
-/// [namesakeClassAlternative] instead (#250). This key therefore always has a
-/// create in it, and the blacklist is never left alone in it.
-///
 /// **The default is the create action, deliberately the opposite polarity from
 /// [smartschoolDepartureAlternative]**, where the conservative "keep the
 /// account" option leads. Adding new classes is the normal start-of-year bulk
 /// operation; a mis-defaulted bulk apply that silently blacklists a year's
-/// worth of classes is far worse than one that creates them. For an empty class
-/// the default is the informational [CreateInSmartschool], so the bulk apply
-/// writes nothing at all and the operator has to pick "ignore this class"
-/// deliberately.
+/// worth of classes is far worse than one that creates them.
+///
+/// **An empty class has no create to weigh the blacklist against** — there is
+/// nothing to create yet — so the decision there is a lone
+/// [DoNotImportFromWisa], with [CreateInSmartschool]'s wait-or-delete notice
+/// beside it as [GroupAction.noticeFor] context (#329). It stood *in* this
+/// group as its pre-selected default until then, which made a bulk apply write
+/// nothing for an empty class by polarity alone. That job is
+/// [GroupAction.canApplyToAll]'s — the blacklist withholds it (#293) and every
+/// bulk path has honoured it since #326 — while the notice's actual content
+/// ("delete the WISA class by hand, or wait until it has students") is
+/// instruction the operator still has to read, and reads on the card.
 ///
 /// The mechanism itself is family-agnostic: the pending-list grouping reads
 /// [alternativeGroup] / [isDefaultAlternative] off whatever action it is given,
@@ -207,11 +240,11 @@ sealed class GroupAction {
 /// default is ever forgotten.
 const String classImportAlternative = 'class-import';
 
-/// The [GroupAction.alternativeGroup] key shared by the mutually exclusive
-/// readings of a WISA class Smartschool **already carries**, on a group the
-/// linker could not adopt (#225): repair it in Smartschool by hand
-/// ([ClassExistsAsSmartschoolGroup]) *or* stop offering the class altogether
-/// ([DoNotImportFromWisa]).
+/// The situation key for a WISA class Smartschool **already carries**, on a
+/// group the linker could not adopt (#225/#250): the app can do exactly one
+/// thing about it — stop offering the class ([DoNotImportFromWisa]) — while
+/// [ClassExistsAsSmartschoolGroup] states the repair the operator makes by hand
+/// instead, as [GroupAction.noticeFor] context on that decision.
 ///
 /// **Why a second key and not a third member of [classImportAlternative].** The
 /// pending list keys a "same situation" bulk-apply subset on this very string
@@ -221,17 +254,25 @@ const String classImportAlternative = 'class-import';
 /// "this class is already there, go fix its flag" — so they get different keys
 /// and each keeps its own bulk pass.
 ///
-/// **The default is the notice**, the same polarity [CreateInSmartschool] has
-/// inside [classImportAlternative]: it is informational, so a bulk apply writes
-/// **nothing** for a namesake class and blacklisting one stays a deliberate
-/// pick. That is the whole of #250. Before it, the create actions refused a
-/// namesake class (they would ask Smartschool for a duplicate name) while
-/// [DoNotImportFromWisa] still declared [classImportAlternative], so the choice
-/// collapsed to a single member — and a lone option is always the selected one.
-/// "Apply to all" therefore wrote a [wapi.DontImportClass] rule on the very
-/// class the notice beside it had just told the operator to align by hand: the
-/// class dropped out of the next WISA snapshot while the Smartschool group
-/// stayed, which is exactly the failure mode #244 fixed for the create case.
+/// **The notice was the pre-selected half of a radio pair here from #250 to
+/// #329.** That was never a resolution: an operator cannot "apply" *go and make
+/// the group official in Smartschool*, so the pair asked them to choose between
+/// a diagnosis and the one write the app has. What being the default did do was
+/// keep the blacklist off a bulk pass — and that is [GroupAction.canApplyToAll],
+/// which [DoNotImportFromWisa] withholds (#293) and which every bulk path reads
+/// since #326.
+///
+/// The original bug is worth keeping in view, because this key is what fixed it
+/// and the polarity was only ever half the fix: before #250 the create actions
+/// refused a namesake class (they would ask Smartschool for a duplicate name)
+/// while [DoNotImportFromWisa] still declared [classImportAlternative], so the
+/// choice collapsed to a single member — and a lone option is always the
+/// selected one. "Apply to all" therefore wrote a [wapi.DontImportClass] rule on
+/// the very class the notice beside it had just told the operator to align by
+/// hand: the class dropped out of the next WISA snapshot while the Smartschool
+/// group stayed, which is exactly the failure mode #244 fixed for the create
+/// case. The blacklist is a lone decision again today, deliberately — and it is
+/// the sanction, not the polarity, that keeps a bulk pass off it.
 const String namesakeClassAlternative = 'class-namesake';
 
 /// Stop importing a class from WISA. Ported from `Action\Group\DoNotImportFromWisa`:
@@ -255,20 +296,25 @@ class DoNotImportFromWisa extends GroupAction {
   @override
   bool evaluate() => group.wisa != null && group.smartschool == null;
 
-  /// Blacklisting the class is never a to-do beside the reading it contradicts
-  /// — it is one half of a choice. *Which* choice depends on what Smartschool
-  /// already holds:
+  /// Blacklisting the class is never a to-do beside the reading it contradicts.
+  /// *Which* situation it resolves depends on what Smartschool already holds:
   /// - **no namesake** (#244): the class is genuinely absent downstream, so the
-  ///   either/or is [classImportAlternative] — create it ([AddToSmartschool] /
-  ///   [CreateInSmartschool]'s wait-or-delete notice) or stop offering it;
+  ///   situation is [classImportAlternative]. On a class **with students** that
+  ///   is a real either/or — create it ([AddToSmartschool]) or stop offering it
+  ///   — and it keeps its radios. On an **empty** class there is nothing to
+  ///   create, so this is the lone decision and [CreateInSmartschool]'s
+  ///   wait-or-delete instruction rides beside it as context (#329);
   /// - **a namesake** ([LinkedGroup.smartschoolNamesake], #250): the class is
-  ///   already there under a group the linker could not adopt, so the either/or
-  ///   is [namesakeClassAlternative] — repair it by hand
-  ///   ([ClassExistsAsSmartschoolGroup]) or stop offering it.
+  ///   already there under a group the linker could not adopt, so the situation
+  ///   is [namesakeClassAlternative]. The repair is a hand edit in Smartschool,
+  ///   which no API call here can make, so this is again the lone decision with
+  ///   [ClassExistsAsSmartschoolGroup] as its context.
   ///
   /// The two keys are deliberately distinct: they are different situations, and
-  /// the pending list bulk-applies per situation key. Either way this half is
-  /// never the default — an operator has to pick it.
+  /// the pending list bulk-applies per situation key. A key held by this action
+  /// alone is not the #250 bug returning — that was a *bulk* pass writing the
+  /// rule off a lone-and-therefore-selected option, and what refuses it now is
+  /// [canApplyToAll], read by every bulk path since #326.
   @override
   String? get alternativeGroup => group.smartschoolNamesake != null
       ? namesakeClassAlternative
@@ -278,10 +324,17 @@ class DoNotImportFromWisa extends GroupAction {
   /// class, and the failure it causes is silent and hard to undo: the class
   /// drops out of the next WISA snapshot while whatever exists downstream
   /// survives, unmanaged. That is precisely what #244 and #250 were filed for
-  /// after "Alles toepassen" did it to a year's worth of classes at once. The
-  /// polarity of its alternative group already keeps it off the selected path;
-  /// withholding the flag means it cannot be bulk-applied even when an operator
-  /// deliberately switches to it.
+  /// after "Alles toepassen" did it to a year's worth of classes at once.
+  ///
+  /// Since #329 this flag is the **whole** of that guard. It used to have the
+  /// polarity of an alternative group in front of it — an informational default
+  /// meant nothing counted until an operator flipped a radio — and a guard that
+  /// holds only while a default holds is not a guard: flipping two of them armed
+  /// the header. Both notices are context now rather than pre-selected halves,
+  /// so this blacklist is the selected resolution of every namesake and every
+  /// empty class from the moment the tab opens, and the sanction is what stands
+  /// between them and one press. Per-card **Toepassen** still writes it, on the
+  /// card that shows exactly what the rule would do.
   @override
   bool get canApplyToAll => false;
 
@@ -477,16 +530,25 @@ class CreateInSmartschool extends GroupAction {
       group.smartschoolNamesake == null &&
       !placement.containsStudents;
 
-  /// The empty-class reading stands in for [AddToSmartschool] inside the
-  /// [classImportAlternative] choice (#244), and is the default in its place —
-  /// the two never fire together, so exactly one default is ever offered. Being
-  /// informational, that default makes a bulk apply write **nothing** for an
-  /// empty class: blacklisting it stays a deliberate pick.
+  /// **Context on the import decision, not one of its answers** (#329). It
+  /// stood *inside* [classImportAlternative] as its pre-selected default from
+  /// #244 until then, standing in for [AddToSmartschool] on a class with no
+  /// students — so the card offered "wait, or delete the WISA class by hand"
+  /// beside "never import this class" and asked the operator to pick one. Only
+  /// the second is something this app can do; the first is an instruction to go
+  /// elsewhere, and an instruction is not a resolution.
+  ///
+  /// It is instruction worth keeping, though — which is why this is a
+  /// [noticeFor] rather than the outright removal #327/#328 gave the two no-op
+  /// halves. "Delete it by hand if it is not needed, or wait until it holds
+  /// students" is what the operator does about an empty class in nearly every
+  /// case, and they read it above the one write the card proposes.
+  ///
+  /// The job being the default *also* did — making a bulk apply write nothing
+  /// for an empty class — is [DoNotImportFromWisa.canApplyToAll]'s, withheld
+  /// since #293 and honoured by every bulk path since #326.
   @override
-  String? get alternativeGroup => classImportAlternative;
-
-  @override
-  bool get isDefaultAlternative => true;
+  String? get noticeFor => classImportAlternative;
 
   @override
   bool get canApply => false;
@@ -534,16 +596,24 @@ class ClassExistsAsSmartschoolGroup extends GroupAction {
       group.smartschool == null &&
       group.smartschoolNamesake != null;
 
-  /// The notice leads — and is the default of — the [namesakeClassAlternative]
-  /// choice (#250). [DoNotImportFromWisa] is its other half: the two are
-  /// opposite readings of one class, so they are one either/or and never two
-  /// to-dos. Being informational, the default makes a bulk apply write nothing
-  /// for a class the app has just told the operator to repair in Smartschool.
+  /// **Context on the namesake decision, not one of its answers** (#329). It
+  /// was the pre-selected half of a radio pair with [DoNotImportFromWisa] from
+  /// #250 until then — but "go and make this group official in Smartschool" is
+  /// not something an apply can run, so the card asked the operator to choose
+  /// between a diagnosis and the single write the app has for the situation.
+  ///
+  /// The instruction is the whole value of this action and survives intact: it
+  /// is stated above [DoNotImportFromWisa]'s own proposal on the card, marked
+  /// "(manueel)", with the namesake group's code and official flag beside it so
+  /// the operator can go and find it. What it no longer does is claim to be a
+  /// resolution.
+  ///
+  /// Keeping the blacklist out of a bulk pass was the pair's other job, and it
+  /// belongs to [DoNotImportFromWisa.canApplyToAll] — withheld since #293,
+  /// honoured by every bulk path since #326. That is what holds #250 fixed now
+  /// that the polarity is gone.
   @override
-  String? get alternativeGroup => namesakeClassAlternative;
-
-  @override
-  bool get isDefaultAlternative => true;
+  String? get noticeFor => namesakeClassAlternative;
 
   @override
   bool get canApply => false;

--- a/packages/account_actions/lib/src/group_action.dart
+++ b/packages/account_actions/lib/src/group_action.dart
@@ -88,17 +88,20 @@ sealed class GroupAction {
 
   /// The key shared by mutually-exclusive alternatives resolving the same
   /// situation (#110). `null` (the default) means the action stands on its own.
-  /// The group family has three: [classImportAlternative] for a class
-  /// Smartschool does not have (#244), [namesakeClassAlternative] for one it
-  /// already carries under a group the linker could not adopt (#250), and
-  /// [staleSmartschoolClassAlternative] for a Smartschool class WISA does not
-  /// have (#313). See [StudentAction.alternativeGroup].
+  /// The group family has two: [classImportAlternative] for a class Smartschool
+  /// does not have (#244) and [namesakeClassAlternative] for one it already
+  /// carries under a group the linker could not adopt (#250). See
+  /// [StudentAction.alternativeGroup].
   ///
-  /// An Office 365 group whose class is gone had a fourth until #327. It lost
-  /// it because its conservative half was a no-op: "laat de groep staan" and
-  /// "doe niets" are the same act, and the operator performs the second one by
-  /// not pressing **Toepassen**. [DeleteAzureClassGroup] now stands alone where
-  /// it can fire and [AzureClassGroupWithoutClass] alone where it cannot.
+  /// The two **leftovers** — an Office 365 group whose class is gone, and a
+  /// Smartschool class WISA does not have — each had a key of their own until
+  /// #327 and #328. Both lost it for the same reason: their conservative half
+  /// was a no-op. "Laat de groep staan" / "laat deze klas staan" and "doe
+  /// niets" are the same act, and the operator performs the second one by not
+  /// pressing **Toepassen**, so the pair asked them to record a non-decision.
+  /// [DeleteAzureClassGroup] and [DeleteSmartschoolClass] now stand alone where
+  /// they can fire, and [AzureClassGroupWithoutClass] /
+  /// [DoNotImportFromSmartschool] alone where they cannot.
   String? get alternativeGroup => null;
 
   /// Whether this action is the default alternative within its
@@ -585,67 +588,51 @@ class ClassExistsAsSmartschoolGroup extends GroupAction {
       );
 }
 
-/// The [GroupAction.alternativeGroup] key shared by the two readings of an
-/// official Smartschool class WISA does not have (#313): leave it standing
-/// ([DoNotImportFromSmartschool]) *or* delete it ([DeleteSmartschoolClass]).
-///
-/// The Smartschool twin of the Office 365 stale-group decision, and
-/// deliberately the same shape — one predicate, one facts helper, the notice as
-/// the default and the delete as the non-default that no bulk pass may reach.
-/// Until #313 the notice was the *only* reading, and its whole content was an
-/// instruction to go and do it by hand in Smartschool: the dead end #271
-/// removed on the Office 365 side, still standing here, and a screenful of it
-/// at a September changeover.
-///
-/// The Azure pair has since lost its radios altogether (#327), and #328 is
-/// where this one is weighed against the same argument — the polarity here
-/// carries a job the Azure one's never did, spelled out below.
-///
-/// **The default is the notice**, and here the polarity carries an extra job
-/// the Azure pair does not have. Early in a school year the WISA snapshot lags
-/// the real world, so a legitimately new class reads as Smartschool-only until
-/// it lands — and a class the school deliberately maintains only in Smartschool
-/// reads that way forever. Leaving it alone is therefore the right answer far
-/// more often than deleting it, which is why "Alles toepassen" over these rows
-/// writes nothing at all and the delete is a radio the operator flips on one
-/// row.
-///
-/// A key of its own rather than a third member of [classImportAlternative], for
-/// the reason [namesakeClassAlternative] is separate from it: the pending list
-/// keys its "same situation" bulk subsets on this very string
-/// (`PendingChoice.situationId`), so pooling the Smartschool leftovers with the
-/// genuinely new WISA classes would file both under one header offering one
-/// **Apply to all**.
-const String staleSmartschoolClassAlternative = 'class-smartschool-stale';
-
-/// An orphan Smartschool class with no matching WISA class — **leave it
-/// standing**, the conservative half of the [staleSmartschoolClassAlternative]
-/// pair and its default (#313).
+/// An orphan Smartschool class with no matching WISA class **that this app
+/// cannot delete for you** — the lone informational row such a class is left
+/// with (#328).
 ///
 /// Ported from `Action\Group\DoNotImportFromSmartschool`, whose legacy `Apply`
 /// throws `NotImplementedException` — it is **informational only** (legacy
-/// `CanBeApplied == false`), so [canApply] is `false` and [apply] throws. It is
-/// the Smartschool analogue of [AzureClassGroupWithoutClass], down to the
-/// wording: it states what the class is, and it no longer tells the operator to
-/// go and delete it by hand, because [DeleteSmartschoolClass] now sits beside it
-/// as the non-default alternative.
+/// `CanBeApplied == false`), so [canApply] is `false` and [apply] throws. Until
+/// #313 it was the *only* reading, and its whole content was an instruction to
+/// go and delete the class by hand in Smartschool: the dead end #271 removed on
+/// the Office 365 side, and a screenful of it at a September changeover. From
+/// #313 to #328 it was the pre-selected half of a radio pair whose other half
+/// was [DeleteSmartschoolClass].
+///
+/// **It is neither any more**, exactly as [AzureClassGroupWithoutClass] stopped
+/// being either at #327. "Laat deze klas staan" and "doe niets" are the same
+/// act, and the operator performs the second one by not pressing **Toepassen**;
+/// offering it as a radio asked them to record a non-decision, and made a card
+/// proposing exactly one thing read as a question with two answers.
+///
+/// **The job the polarity did carry is not lost.** Being the default is what
+/// kept the delete out of a bulk pass, and that job belongs to
+/// [GroupAction.canApplyToAll], which [DeleteSmartschoolClass] withholds (#293)
+/// and every bulk affordance honours since #326. The *other* thing the default
+/// said — that leaving the class alone is usually right, because early in a
+/// school year the WISA snapshot lags the real world and a class the school
+/// maintains only in Smartschool reads as a leftover forever — is a fact about
+/// the situation, not a resolution to choose. It survives as the line
+/// [_wisaMayBeLagging] states on the delete's own card, where the operator
+/// reads it before pressing rather than after picking.
+///
+/// So this now fires **exactly where the delete cannot** — see
+/// [_deletableSmartschoolClass] — which in practice means a record naming no
+/// class code to address a `delClass` to, or a group that is not an official
+/// class. There is then genuinely nothing to offer, and saying so *is* the
+/// whole content of the row, marked "(manueel)" like every other informational
+/// action.
 class DoNotImportFromSmartschool extends GroupAction {
   const DoNotImportFromSmartschool(super.group);
 
   @override
-  bool evaluate() => _smartschoolOnlyClass(group);
+  bool evaluate() =>
+      _smartschoolOnlyClass(group) && !_deletableSmartschoolClass(group);
 
   @override
   bool get canApply => false;
-
-  /// The notice leads — and is the default of — the pair (#313), so a bulk
-  /// apply over Smartschool leftovers writes nothing and the delete stays a
-  /// deliberate, per-row pick.
-  @override
-  String? get alternativeGroup => staleSmartschoolClassAlternative;
-
-  @override
-  bool get isDefaultAlternative => true;
 
   @override
   ChangeSet describeChanges() => ChangeSet(
@@ -666,56 +653,58 @@ class DoNotImportFromSmartschool extends GroupAction {
       );
 }
 
-/// Delete a Smartschool class WISA no longer has (#313) — the applyable half of
-/// the [staleSmartschoolClassAlternative] pair, and never its default.
+/// Delete a Smartschool class WISA no longer has (#313) — since #328 the
+/// **only** thing such a leftover proposes, not one radio of two.
 ///
 /// Genuinely destructive: `delClass` takes the class, the membership of every
 /// student in it, and whatever hangs under it. The same three things hold it in
 /// place that hold [DeleteAzureClassGroup] in place, and each of them is
 /// tested:
 ///
-/// - **It proposes on exactly the record the notice does**, via the one
-///   [_smartschoolOnlyClass] predicate — no WISA class, a Smartschool one —
-///   plus a restatement of the linker's own orphan rule: only an **official**
-///   Smartschool class ever seeds an orphan record, so an organisational group
-///   is already out of scope and must stay out. The restatement is
-///   belt-and-braces and deliberately redundant: a delete must not inherit its
-///   whole scope from a filter one layer away.
-/// - **It is never the selected option of a bulk pass**, because the notice
-///   beside it is the default of their shared alternative group. The operator
-///   flips this radio on one row, and only that row is written.
+/// - **It proposes on exactly the record [_deletableSmartschoolClass]
+///   describes** — no WISA class, a Smartschool one — plus a restatement of the
+///   linker's own orphan rule: only an **official** Smartschool class ever
+///   seeds an orphan record, so an organisational group is already out of scope
+///   and must stay out. The restatement is belt-and-braces and deliberately
+///   redundant: a delete must not inherit its whole scope from a filter one
+///   layer away.
+/// - **No bulk affordance may offer it**, because [canApplyToAll] is false and,
+///   since #326, both bulk paths read it. This is now the *whole* of that
+///   guard: until #328 it leaned on the polarity of a radio pair, which meant
+///   two flipped radios could arm a header the flag had already refused.
 /// - **The linked record must actually name a class to delete** — a blank
 ///   Smartschool class code yields no proposal rather than a `delClass` with an
-///   empty `code`.
+///   empty `code`, and [DoNotImportFromSmartschool] states the situation
+///   instead.
+///
+/// **The card proposes; it does not interrogate.** Losing the pair must not
+/// lose the reading the pair's default carried — that a WISA snapshot lagging
+/// early in a school year, or a class the school deliberately keeps only in
+/// Smartschool, is the *common* cause of a row landing here. That is context on
+/// the situation rather than a resolution to pick, so [describeChanges] states
+/// it ([_wisaMayBeLagging]) beside the class's own facts. Nothing is written
+/// until the operator presses **Dry-run** or **Toepassen** behind the ordinary
+/// confirmation, and ignoring the card is a complete answer.
 ///
 /// Deliberately no `unlocks`: nothing follows a delete.
 ///
 /// **What this is not.** Legacy's neighbour here was `Klas Negeren` — a
-/// persistent "do not import this class" decision. That is a third option, not
-/// a replacement for either half: if such a blacklist ever comes back it
-/// belongs in this same alternative group, beside the notice and the delete.
+/// persistent "do not import this class" decision. That is a genuine second
+/// resolution rather than the no-op #328 removed: if such a blacklist ever
+/// comes back it belongs beside this delete under an alternative key of their
+/// own, and it would be the first thing this row ever had to choose *between*.
 class DeleteSmartschoolClass extends GroupAction {
   const DeleteSmartschoolClass(super.group);
 
   @override
-  bool evaluate() =>
-      _smartschoolOnlyClass(group) &&
-      _ss.official &&
-      _ss.id.value.trim().isNotEmpty;
-
-  /// The destructive half, so never the default (#313). See
-  /// [staleSmartschoolClassAlternative].
-  @override
-  String? get alternativeGroup => staleSmartschoolClassAlternative;
-
-  @override
-  bool get isDefaultAlternative => false;
+  bool evaluate() => _deletableSmartschoolClass(group);
 
   /// **Never in bulk** (#293), for the reason [DeleteAzureClassGroup] is not:
   /// `delClass` takes the class and everything in it, and a WISA snapshot that
-  /// merely lags makes a perfectly live class look like a leftover. The
-  /// operator flips this radio on one row, and even then no bulk affordance may
-  /// offer it.
+  /// merely lags makes a perfectly live class look like a leftover. Since #328
+  /// removed the pair this used to sit in, this flag is the only thing keeping
+  /// the delete off every bulk path — and #326 is what makes every one of them
+  /// ask.
   @override
   bool get canApplyToAll => false;
 
@@ -727,8 +716,11 @@ class DeleteSmartschoolClass extends GroupAction {
         // What the delete takes with it, stated (#305). The summary already
         // says the class goes; these lines are the inventory of it, and an
         // arrow on each would claim three separate fields were being cleared.
+        // The caution sits with the class's own facts rather than with that
+        // inventory: it is why the operator might not press at all (#328).
         fields: [
           ..._smartschoolClassFacts(group.smartschool),
+          _wisaMayBeLagging,
           const FieldChange.statement(
             'lidmaatschappen en subgroepen',
             'verdwijnen mee',
@@ -780,10 +772,10 @@ class DeleteSmartschoolClass extends GroupAction {
 /// one condition [DoNotImportFromSmartschool] and [DeleteSmartschoolClass]
 /// share.
 ///
-/// One definition rather than two copies, because the pair are alternatives:
-/// they must fire together or a leftover class is left with a lone applyable
-/// delete as its only reading, which is precisely the "no safe default" state
-/// [staleSmartschoolClassAlternative] exists to prevent.
+/// One definition rather than two copies, because the two readings partition
+/// it: [_deletableSmartschoolClass] is the half the delete proposes on and the
+/// notice is exactly the remainder, so a leftover class raises one row and
+/// never none or two.
 ///
 /// It asks the linker's own question and no stricter one, exactly as
 /// [_staleClassGroup] does on the Azure side: the record is on screen because
@@ -792,7 +784,47 @@ class DeleteSmartschoolClass extends GroupAction {
 bool _smartschoolOnlyClass(LinkedGroup group) =>
     group.wisa == null && group.smartschool != null;
 
-/// The facts both halves of [staleSmartschoolClassAlternative] state about the
+/// Whether [group] is a Smartschool leftover this app can actually **delete**
+/// (#328) — [_smartschoolOnlyClass] plus the two things a `delClass` needs: an
+/// official class rather than an organisational group, and a code to address
+/// the call to.
+///
+/// Written out as a predicate of its own rather than folded into
+/// [DeleteSmartschoolClass.evaluate], for the reason [_deletableStaleClassGroup]
+/// is: it is the line the two readings of a leftover class are drawn on. The
+/// delete proposes exactly where this holds, and [DoNotImportFromSmartschool]
+/// states its "(manueel)" notice exactly where it does not. Expressed once,
+/// "the notice fires when the delete cannot" cannot drift into a second,
+/// differently-worded copy of this guard.
+///
+/// The official-class test restates the linker's own orphan rule deliberately:
+/// a delete must not inherit its whole scope from a filter one layer away.
+bool _deletableSmartschoolClass(LinkedGroup group) {
+  final smartschool = group.smartschool;
+  return _smartschoolOnlyClass(group) &&
+      smartschool!.official &&
+      smartschool.id.value.trim().isNotEmpty;
+}
+
+/// Why a class can sit in Smartschool with no WISA counterpart and still be
+/// perfectly live (#328) — stated on [DeleteSmartschoolClass]'s card, never
+/// offered as a resolution.
+///
+/// This is the reading the pre-selected "laat deze klas staan" used to carry,
+/// and the whole reason the Smartschool leftovers were weighed separately from
+/// the Office 365 ones: early in a school year the WISA snapshot lags the real
+/// world, so a legitimately new class reads as Smartschool-only until WISA
+/// catches up, and a class the school deliberately maintains only in
+/// Smartschool reads that way forever. The operator needs it *before* pressing,
+/// which is a sentence on the card — not a radio recording that they chose not
+/// to act.
+const FieldChange _wisaMayBeLagging = FieldChange.statement(
+  'WISA',
+  'kent deze klas (nog) niet — vroeg in het schooljaar loopt WISA achter, '
+      'controleer daar of ze bestaat voor je ze verwijdert',
+);
+
+/// The facts both readings of a Smartschool leftover class state about the
 /// class they are describing (#305) — stated, never diffed.
 ///
 /// Each is stated only when the class carries it: an empty statement renders as
@@ -801,8 +833,8 @@ List<FieldChange> _smartschoolClassFacts(Group? smartschool) {
   final code = smartschool?.id.value.trim() ?? '';
   final description = smartschool?.description.trim() ?? '';
   return <FieldChange>[
-    // How the operator finds the class in Smartschool, and what the delete
-    // beside this is addressed to.
+    // How the operator finds the class in Smartschool, and what a `delClass`
+    // is addressed to.
     if (code.isNotEmpty) FieldChange.statement('code', code),
     if (description.isNotEmpty)
       FieldChange.statement('omschrijving', description),

--- a/packages/account_actions/lib/src/group_dispatch.dart
+++ b/packages/account_actions/lib/src/group_dispatch.dart
@@ -20,9 +20,10 @@ import 'group_placement.dart';
 ///   them as one either/or choice and an apply runs only the picked one (#244).
 ///   Legacy ordered [DoNotImportFromWisa] first; it now trails the create it is
 ///   an alternative to, so the create leads the radio pair. A **Smartschool-only**
-///   class is the mirror image: it raises the [staleSmartschoolClassAlternative]
-///   pair of #313 — the informational [DoNotImportFromSmartschool] (leave it
-///   standing, the default) and the applyable [DeleteSmartschoolClass].
+///   class is the mirror image: it yields [DeleteSmartschoolClass] (#313) —
+///   **one action, no radio pair** since #328 — where the class is official and
+///   names a code, and the informational [DoNotImportFromSmartschool] as a lone
+///   "(manueel)" row where it is not.
 /// - If it is present in both, only [ModifySmartschoolData] is considered.
 ///
 /// [ClassExistsAsSmartschoolGroup] (#225) sits where the two create actions
@@ -102,12 +103,14 @@ List<GroupAction> groupActionsFor(
       if (placement != null) AddToSmartschool(group, placement),
       if (placement != null) CreateInSmartschool(group, placement),
       DoNotImportFromWisa(group),
-      // The Smartschool-leftover either/or (#313), notice first for the same
-      // reason the create leads the blacklist above: the order is the order the
-      // operator reads the radios in, and the fallback the grouping uses if a
-      // default is ever forgotten — so the delete is never first.
-      DoNotImportFromSmartschool(group),
+      // The Smartschool-leftover readings (#313/#328). Not an either/or: their
+      // predicates partition the leftovers, so at most one of the two ever
+      // survives `evaluate` for a given record — the delete where it can act,
+      // the "(manueel)" notice where it cannot. The delete leads because it is
+      // the ordinary case; the order carries no other meaning here, since these
+      // two never appear on one card together.
       DeleteSmartschoolClass(group),
+      DoNotImportFromSmartschool(group),
     ],
     // The Office 365 group of a class is orthogonal to its Smartschool state,
     // so these ride alongside both branches (#228).

--- a/packages/account_actions/lib/src/group_dispatch.dart
+++ b/packages/account_actions/lib/src/group_dispatch.dart
@@ -15,15 +15,26 @@ import 'group_placement.dart';
 ///   [CreateInSmartschool], [DoNotImportFromWisa],
 ///   [DoNotImportFromSmartschool], [DeleteSmartschoolClass]) are considered, so
 ///   a WISA-only class raises [DoNotImportFromWisa] *and* exactly one of
-///   [AddToSmartschool] / [CreateInSmartschool]. Those two are not two to-dos:
-///   they share the [classImportAlternative] key, so the pending list renders
-///   them as one either/or choice and an apply runs only the picked one (#244).
-///   Legacy ordered [DoNotImportFromWisa] first; it now trails the create it is
-///   an alternative to, so the create leads the radio pair. A **Smartschool-only**
-///   class is the mirror image: it yields [DeleteSmartschoolClass] (#313) —
-///   **one action, no radio pair** since #328 — where the class is official and
-///   names a code, and the informational [DoNotImportFromSmartschool] as a lone
-///   "(manueel)" row where it is not.
+///   [AddToSmartschool] / [CreateInSmartschool] / [ClassExistsAsSmartschoolGroup].
+///   Those are never two to-dos, but they are not all the same relationship
+///   either (#329):
+///   - a class **with students** and no namesake gets a genuine either/or —
+///     [AddToSmartschool] and [DoNotImportFromWisa] share the
+///     [classImportAlternative] key, both write, and an apply runs only the
+///     picked one (#244);
+///   - an **empty** class and a **namesake** class get one decision and a
+///     notice: there is nothing for this app to create, so
+///     [DoNotImportFromWisa] stands alone under its key and the informational
+///     action declares [GroupAction.noticeFor] on that same key, riding along
+///     as context rather than as an answer.
+///
+///   Legacy ordered [DoNotImportFromWisa] first; it now trails the reading it
+///   is weighed against, so a create leads the radio pair and a notice is read
+///   before the proposal it explains. A **Smartschool-only** class is the mirror
+///   image: it yields [DeleteSmartschoolClass] (#313) — **one action, no radio
+///   pair** since #328 — where the class is official and names a code, and the
+///   informational [DoNotImportFromSmartschool] as a lone "(manueel)" row where
+///   it is not.
 /// - If it is present in both, only [ModifySmartschoolData] is considered.
 ///
 /// [ClassExistsAsSmartschoolGroup] (#225) sits where the two create actions
@@ -34,13 +45,16 @@ import 'group_placement.dart';
 /// raised whether or not [placementFor] is wired, and a WISA-only class is
 /// never left with a create proposal as its only reading.
 ///
-/// Taking the create's place means taking its side of the either/or too (#250):
-/// the notice and [DoNotImportFromWisa] share [namesakeClassAlternative], a key
-/// of their own so the namesake classes are not bulk-applied together with the
-/// genuinely new ones. Without it the blacklist was the *lone* member of
-/// [classImportAlternative] on such a class, hence always selected, and "Apply
-/// to all" wrote a `DontImportClass` rule on the class the notice beside it had
-/// just said to fix by hand.
+/// It keeps a key of its own, [namesakeClassAlternative], so the namesake
+/// classes are not bulk-applied together with the genuinely new ones (#250) —
+/// "create this class" and "this class is already there, go fix its flag" are
+/// different situations and get different headers. What has changed since #250
+/// is only *how* the notice occupies that key: it was the pre-selected half of
+/// a radio pair until #329 and is the decision's [GroupAction.noticeFor] context
+/// now. The bug the pair was built for — "Apply to all" writing a
+/// `DontImportClass` rule on the class the notice had just said to fix by hand —
+/// is held by [GroupAction.canApplyToAll], which the blacklist withholds (#293)
+/// and both bulk paths honour (#326).
 ///
 /// [placementFor] wires the membership-dependent creation actions (#65). When
 /// supplied it is called for each WISA-only class (`wisa != null &&
@@ -94,11 +108,13 @@ List<GroupAction> groupActionsFor(
     if (both)
       ModifySmartschoolData(group)
     else ...[
-      // Whichever reading of the class fires — the namesake notice (#250) or a
-      // create (#244) — it leads the [DoNotImportFromWisa] it is mutually
-      // exclusive with: the order is the order the operator reads the radio
-      // pair in, and the fallback the grouping uses if a default is ever
-      // forgotten, so the blacklist is never first.
+      // Whichever reading of the class fires — the namesake notice (#250), the
+      // empty-class notice, or a create (#244) — it leads the
+      // [DoNotImportFromWisa] it is weighed against. For a create that is the
+      // order the operator reads the radio pair in, and the fallback the
+      // grouping uses if a default is ever forgotten, so the blacklist is never
+      // first. For a notice it is the order the card states things in: the
+      // situation, then what the app proposes about it (#329).
       ClassExistsAsSmartschoolGroup(group),
       if (placement != null) AddToSmartschool(group, placement),
       if (placement != null) CreateInSmartschool(group, placement),

--- a/packages/account_actions/lib/src/group_dispatch.dart
+++ b/packages/account_actions/lib/src/group_dispatch.dart
@@ -64,13 +64,15 @@ import 'group_placement.dart';
 /// dispatch is exactly as it shipped before #228.
 ///
 /// An Azure-only orphan group (`wisa == null && smartschool == null`, #52)
-/// yields the [staleClassGroupAlternative] pair — the informational
-/// [AzureClassGroupWithoutClass] and the applyable [DeleteAzureClassGroup]
-/// (#271) — and only when it is shaped like a group this app created; anything
-/// else still yields nothing. The notice leads and is the default, so a bulk
-/// apply over stale groups writes nothing at all and a delete (which takes the
-/// group's mailbox, Team and files with it) is only ever the pick the operator
-/// made on that one row.
+/// yields [DeleteAzureClassGroup] (#271) — **one action, no radio pair** since
+/// #327 — and only when it is shaped like a group this app created; anything
+/// else still yields nothing. Where the delete cannot fire because the record
+/// names no Azure object id, the informational
+/// [AzureClassGroupWithoutClass] states that instead, as a lone "(manueel)"
+/// row. The two are mutually exclusive rather than alternatives: what keeps a
+/// delete (which takes the group's mailbox, Team and files with it) out of
+/// every bulk pass is [GroupAction.canApplyToAll] (#293/#326), not the polarity
+/// of a pair.
 ///
 /// Each candidate is constructed bound to [group] and kept only when its pure
 /// [GroupAction.evaluate] returns true. Pure and deterministic (INV-40): same
@@ -113,13 +115,14 @@ List<GroupAction> groupActionsFor(
       CreateAzureClassGroup(group, azurePlan),
       SyncAzureClassGroupMembers(group, azurePlan),
     ],
-    // The stale-group either/or (#271). The notice leads because it is the
-    // default of the pair, exactly as the create leads the blacklist above: the
-    // order is the order the operator reads the radios in, and the fallback the
-    // grouping uses if a default is ever forgotten — so the delete is never
-    // first.
-    AzureClassGroupWithoutClass(group),
+    // The stale-group readings (#271/#327). Not an either/or: their predicates
+    // partition the stale groups, so at most one of the two ever survives
+    // `evaluate` for a given record — the delete where it can act, the
+    // "(manueel)" notice where it cannot. The delete leads because it is the
+    // ordinary case; the order carries no other meaning here, since these two
+    // never appear on one card together.
     DeleteAzureClassGroup(group),
+    AzureClassGroupWithoutClass(group),
   ];
 
   return [

--- a/packages/account_actions/lib/src/staff_action.dart
+++ b/packages/account_actions/lib/src/staff_action.dart
@@ -54,11 +54,21 @@ sealed class StaffAction {
   /// situation (#110). `null` (the default) means the action stands on its own.
   /// The staff family's one key is [staffImportAlternative] (#248). See
   /// [StudentAction.alternativeGroup].
+  ///
+  /// **Every member of a group writes** (#329): an informational action states
+  /// [noticeFor] instead and is context on a decision rather than one of its
+  /// answers. [staffImportAlternative] is a genuine either/or — three real
+  /// writes — and keeps its radios.
   String? get alternativeGroup => null;
 
   /// Whether this action is the default alternative within its
   /// [alternativeGroup]. Ignored when [alternativeGroup] is `null`.
   bool get isDefaultAlternative => false;
+
+  /// The situation this **informational** action is context for (#329) — see
+  /// [StudentAction.noticeFor]. No staff action carries one: every member of the
+  /// family is applyable today.
+  String? get noticeFor => null;
 
   /// Whether [apply] can perform a change. `false` for an informational action
   /// (the legacy `CanBeApplied == false` case): it surfaces a diagnosis but has

--- a/packages/account_actions/lib/src/student_action.dart
+++ b/packages/account_actions/lib/src/student_action.dart
@@ -56,12 +56,39 @@ sealed class StudentAction {
   /// must never run both (e.g. unregister *vs* delete a departed student). A
   /// `null` key (the default) means the action stands on its own. Pure; lets the
   /// UI group alternatives without pattern-matching on concrete action types.
+  ///
+  /// **Every member of a group writes** (#329). An informational action — one
+  /// whose [canApply] is `false` — may never join one: "here is what is wrong,
+  /// go fix it by hand" and "here is the one thing the app can do about it" are
+  /// not comparable answers to a single question, and offering them as radios
+  /// asked the operator to choose between a diagnosis and a resolution. Such an
+  /// action declares [noticeFor] instead and rides along as context. A dispatch
+  /// test pins the rule over all three families.
   String? get alternativeGroup => null;
 
   /// Within an [alternativeGroup], whether this action is the sensible default
   /// pre-selection. Exactly one alternative in a group should return `true`;
   /// ignored when [alternativeGroup] is `null`.
   bool get isDefaultAlternative => false;
+
+  /// The situation this **informational** action is context for (#329) — the
+  /// [alternativeGroup] key of the decision it belongs beside, or `null` (the
+  /// default) when this action is not a notice.
+  ///
+  /// A notice is not a decision and never an option: the collapse
+  /// ([collapseAlternatives]) lifts it out of the option list and hands it to
+  /// the decision it names, which renders it as context above its own action —
+  /// no radio, no apply button, still marked "(manueel)" so it stays scannable.
+  ///
+  /// Only ever non-null where [canApply] is `false`, and never together with a
+  /// non-null [alternativeGroup]: a notice writes nothing, so it cannot be one
+  /// of the things a decision picks between.
+  ///
+  /// No student action carries one today — the family's one informational
+  /// member, [AzureClassGroupMembership], stands on its own rather than beside a
+  /// decision — but the member lives here so the rule is stated once for all
+  /// three families instead of in the family that happened to need it first.
+  String? get noticeFor => null;
 
   /// Whether [apply] can perform a change. `false` for an informational action
   /// (the legacy `CanBeApplied == false` case): it surfaces a diagnosis on the

--- a/packages/account_actions/test/alternatives_test.dart
+++ b/packages/account_actions/test/alternatives_test.dart
@@ -6,10 +6,16 @@ import 'package:test/test.dart';
 /// so the reconcile controller's live options and the materialized view's
 /// persisted candidates get the same partition (#251).
 class _Option {
-  const _Option(this.kind, {this.group, this.isDefault = false});
+  const _Option(
+    this.kind, {
+    this.group,
+    this.isDefault = false,
+    this.noticeFor,
+  });
   final String kind;
   final String? group;
   final bool isDefault;
+  final String? noticeFor;
 }
 
 List<Alternatives<_Option>> _collapse(List<_Option> options) =>
@@ -17,6 +23,7 @@ List<Alternatives<_Option>> _collapse(List<_Option> options) =>
       options,
       groupOf: (o) => o.group,
       isDefault: (o) => o.isDefault,
+      noticeFor: (o) => o.noticeFor,
     );
 
 void main() {
@@ -78,6 +85,98 @@ void main() {
 
     test('no items at all is no decisions', () {
       expect(_collapse(const []), isEmpty);
+    });
+  });
+
+  group('a notice is context, not an alternative (#329)', () {
+    test('it is lifted onto the decision it names, never into its options', () {
+      final choices = _collapse(const [
+        _Option('ClassExistsAsSmartschoolGroup', noticeFor: 'class-namesake'),
+        _Option('DoNotImportFromWisa', group: 'class-namesake'),
+      ]);
+
+      expect(choices, hasLength(1),
+          reason: 'the notice is not a decision of its own');
+      final choice = choices.single;
+      expect(choice.isChoice, isFalse,
+          reason: 'one option, so no "Kies één oplossing:"');
+      expect(
+          choice.options.map((o) => o.kind), <String>['DoNotImportFromWisa']);
+      expect(choice.selected.kind, 'DoNotImportFromWisa');
+      expect(
+        choice.notices.map((o) => o.kind),
+        <String>['ClassExistsAsSmartschoolGroup'],
+      );
+    });
+
+    test('a genuine either/or can carry one too, and keeps both options', () {
+      final choices = _collapse(const [
+        _Option('Context', noticeFor: 'class-import'),
+        _Option('AddToSmartschool', group: 'class-import', isDefault: true),
+        _Option('DoNotImportFromWisa', group: 'class-import'),
+      ]);
+
+      final choice = choices.single;
+      expect(choice.isChoice, isTrue);
+      expect(choice.selected.kind, 'AddToSmartschool');
+      expect(choice.notices.map((o) => o.kind), <String>['Context']);
+    });
+
+    test('several notices on one decision keep their dispatch order', () {
+      final choices = _collapse(const [
+        _Option('First', noticeFor: 'k'),
+        _Option('Second', noticeFor: 'k'),
+        _Option('Decision', group: 'k'),
+      ]);
+
+      expect(
+        choices.single.notices.map((o) => o.kind),
+        <String>['First', 'Second'],
+      );
+    });
+
+    test('a notice whose decision is absent is shown, not dropped', () {
+      // Defensive: the dispatches pair every notice with the decision it names,
+      // but a stored document could be partial — and a row that silently
+      // vanishes is the one outcome that would not be honest.
+      final choices = _collapse(const [
+        _Option('ModifySmartschoolData'),
+        _Option('Orphan', noticeFor: 'nobody'),
+      ]);
+
+      expect(
+        choices.map((c) => c.selected.kind),
+        <String>['ModifySmartschoolData', 'Orphan'],
+      );
+      expect(choices.last.notices, isEmpty);
+    });
+
+    test('decisions keep their order when a notice sits between them', () {
+      final choices = _collapse(const [
+        _Option('Lone'),
+        _Option('Note', noticeFor: 'b'),
+        _Option('B', group: 'b'),
+        _Option('A', group: 'a'),
+      ]);
+
+      expect(choices.map((c) => c.selected.kind), <String>['Lone', 'B', 'A']);
+      expect(choices[1].notices.map((o) => o.kind), <String>['Note']);
+    });
+
+    test('no noticeFor accessor leaves the old partition untouched', () {
+      // Every caller that has no notion of notices — and every stored document
+      // written before #329 — collapses exactly as it always did.
+      final choices = collapseAlternatives<_Option>(
+        const [
+          _Option('A', group: 'g', isDefault: true),
+          _Option('B', group: 'g'),
+        ],
+        groupOf: (o) => o.group,
+        isDefault: (o) => o.isDefault,
+      );
+
+      expect(choices.single.options, hasLength(2));
+      expect(choices.single.notices, isEmpty);
     });
   });
 }

--- a/packages/account_actions/test/azure_class_group_test.dart
+++ b/packages/account_actions/test/azure_class_group_test.dart
@@ -415,36 +415,42 @@ void main() {
     });
   });
 
-  group('a vanished class: leave it standing, or delete it (#228/#271)', () {
+  group('a vanished class: delete its group (#228/#271/#327)', () {
     LinkedGroup orphan(az.AzureGroup group, {String? className = '9Z'}) =>
         linkedGroup(azure: group, className: className);
 
-    test('an app-shaped class group with no class raises the either/or', () {
+    test('an app-shaped class group with no class raises the delete alone', () {
       final actions = groupActionsFor(orphan(azureClassGroup('9Z')));
       expect(
         actions.map((a) => a.runtimeType),
-        [AzureClassGroupWithoutClass, DeleteAzureClassGroup],
-        reason: 'the notice leads because it is the default of the pair',
+        [DeleteAzureClassGroup],
+        reason: 'the no-op "leave it standing" is not an option (#327) — the '
+            'operator performs it by not pressing Toepassen',
       );
       expect(
-        actions.map((a) => a.alternativeGroup),
-        everyElement(staleClassGroupAlternative),
-        reason: 'one choice, two radios — never two independent to-dos',
+        actions.single.alternativeGroup,
+        isNull,
+        reason: 'one action, so no alternative group and no radio pair',
       );
+      expect(actions.single.isDefaultAlternative, isFalse);
     });
 
-    test('the notice is the informational default, and never writes', () {
-      final notice = groupActionsFor(orphan(azureClassGroup('9Z')))
-          .whereType<AzureClassGroupWithoutClass>()
-          .single;
+    test('the notice fires only where the delete cannot (#327)', () {
+      // A record naming no Azure object id: there is nothing to address a
+      // DELETE to, so the row falls back to stating the situation — the one
+      // case that is still genuinely informational.
+      final actions = groupActionsFor(orphan(azureClassGroup('9Z', id: ' ')));
+      final notice = actions.whereType<AzureClassGroupWithoutClass>().single;
 
+      expect(actions.map((a) => a.runtimeType), [AzureClassGroupWithoutClass]);
       expect(notice.canApply, isFalse);
-      expect(notice.isDefaultAlternative, isTrue,
-          reason: 'a bulk apply over stale groups must write nothing at all');
+      expect(notice.alternativeGroup, isNull,
+          reason: 'a lone "(manueel)" row, not half of a choice');
       expect(
         notice.describeChanges().summary,
         'Laat de Office 365-groep SSM-9Z staan — klas 9Z bestaat niet meer '
         'in WISA of Smartschool',
+        reason: 'the informational row itself is unchanged by #327',
       );
       expect(
         () => notice.apply(const Connectors(), const ApplyOptions()),
@@ -452,14 +458,26 @@ void main() {
       );
     });
 
-    test('the delete is applyable but never the default (#271)', () {
+    test('a deletable stale group raises no notice beside its delete (#327)',
+        () {
+      expect(
+        groupActionsFor(orphan(azureClassGroup('9Z')))
+            .whereType<AzureClassGroupWithoutClass>(),
+        isEmpty,
+        reason: 'the two readings partition the stale groups — never both',
+      );
+    });
+
+    test('the delete is applyable, and withheld from every bulk pass (#271)',
+        () {
       final delete = groupActionsFor(orphan(azureClassGroup('9Z')))
           .whereType<DeleteAzureClassGroup>()
           .single;
 
       expect(delete.canApply, isTrue);
-      expect(delete.isDefaultAlternative, isFalse,
-          reason: 'deleting takes the mailbox, the Team and the files with it');
+      expect(delete.canApplyToAll, isFalse,
+          reason: 'deleting takes the mailbox, the Team and the files with it, '
+              'and since #327 this flag is the whole guard');
       expect(
         delete.describeChanges().summary,
         'Verwijder de Office 365-groep SSM-9Z van de verdwenen klas 9Z',
@@ -471,22 +489,20 @@ void main() {
       expect(delete.unlocks, isEmpty, reason: 'nothing follows a delete');
     });
 
-    test('both halves state the group\'s facts, they do not diff them (#305)',
+    test('both readings state the group\'s facts, they do not diff them (#305)',
         () {
       // The notice's whole content is "this group stays", and under that
       // heading its two fields read "mail: SSM-9Z@… → ∅" and "leden: 21 → ∅" —
-      // the address and the 21 members being cleared, which is what the *other*
-      // radio does. Neither field is a value moving anywhere, so neither may be
+      // the address and the 21 members being cleared, which is what a *delete*
+      // does. Neither field is a value moving anywhere, so neither may be
       // described as one.
-      final actions = groupActionsFor(
-        orphan(azureClassGroup('9Z',
-            memberIds: List<String>.generate(21, (int i) => 'az-$i'))),
-      );
+      final members = List<String>.generate(21, (int i) => 'az-$i');
+      final actions =
+          groupActionsFor(orphan(azureClassGroup('9Z', memberIds: members)));
 
-      final notice = actions
-          .whereType<AzureClassGroupWithoutClass>()
-          .single
-          .describeChanges();
+      final notice = groupActionsFor(
+        orphan(azureClassGroup('9Z', id: ' ', memberIds: members)),
+      ).whereType<AzureClassGroupWithoutClass>().single.describeChanges();
       expect(notice.fields.map((f) => f.field), ['mail', 'leden']);
       expect(
         notice.fields.every((f) => f.shape == FieldChangeShape.statement),
@@ -557,24 +573,25 @@ void main() {
           orphan(azureClassGroup(name), className: name),
         );
         expect(actions, isEmpty,
-            reason: '$name is not a class — and both halves move together');
+            reason: '$name is not a class — and neither reading fires');
       }
     });
 
     test('a record naming no Azure object id raises no delete (#271)', () {
       final actions = groupActionsFor(orphan(azureClassGroup('9Z', id: ' ')));
-      expect(actions.whereType<AzureClassGroupWithoutClass>(), hasLength(1));
+      expect(actions.whereType<AzureClassGroupWithoutClass>(), hasLength(1),
+          reason: 'the notice takes over exactly where the delete drops out');
       expect(actions.whereType<DeleteAzureClassGroup>(), isEmpty,
           reason: 'there is nothing to address the DELETE to');
     });
 
     test(
-        'a class group the legacy app created raises the pair too — it is no '
+        'a class group the legacy app created raises its delete too — it is no '
         'less stale for being a security group (#312)', () {
       // The reported bug. The `SSM-3ECO`-shaped groups in the live tenant are
       // plain security groups carrying no address at all, made by the WPF app
       // long before this port existed. `isUnified` is false for every one of
-      // them, so the whole either/or went silent and each row was inventory
+      // them, so the whole reading went silent and each row was inventory
       // with an instruction to go elsewhere — the state #271 set out to remove.
       final actions = groupActionsFor(orphan(az.AzureGroup(
         id: 'g-legacy',
@@ -585,27 +602,22 @@ void main() {
 
       expect(
         actions.map((a) => a.runtimeType),
-        [AzureClassGroupWithoutClass, DeleteAzureClassGroup],
+        [DeleteAzureClassGroup],
         reason: 'the delete may not be limited to groups this port created',
-      );
-      expect(
-        actions.map((a) => a.alternativeGroup),
-        everyElement(staleClassGroupAlternative),
-        reason: 'widened together, so the delete is never a lone reading',
       );
     });
 
     test('a group with no address states only the facts it has (#312)', () {
-      final actions = groupActionsFor(orphan(az.AzureGroup(
-        id: 'g-legacy',
-        displayName: 'SSM-9Z',
-        securityEnabled: true,
-        mailNickname: 'SSM-9Z',
-        memberIds: const ['az-1', 'az-2'],
-      )));
+      az.AzureGroup legacy({String id = 'g-legacy'}) => az.AzureGroup(
+            id: id,
+            displayName: 'SSM-9Z',
+            securityEnabled: true,
+            mailNickname: 'SSM-9Z',
+            memberIds: const ['az-1', 'az-2'],
+          );
 
       expect(
-        actions
+        groupActionsFor(orphan(legacy(id: ' ')))
             .whereType<AzureClassGroupWithoutClass>()
             .single
             .describeChanges()
@@ -615,7 +627,7 @@ void main() {
         reason: 'a security group has no mail, and `mail: ` states nothing',
       );
       expect(
-        actions
+        groupActionsFor(orphan(legacy()))
             .whereType<DeleteAzureClassGroup>()
             .single
             .describeChanges()
@@ -637,10 +649,7 @@ void main() {
         mailNickname: 'SSM-9Z',
       )));
 
-      expect(
-        actions.map((a) => a.runtimeType),
-        [AzureClassGroupWithoutClass, DeleteAzureClassGroup],
-      );
+      expect(actions.map((a) => a.runtimeType), [DeleteAzureClassGroup]);
     });
 
     test('a group the linker recovered no class name for is left unmentioned',

--- a/packages/account_actions/test/group_apply_test.dart
+++ b/packages/account_actions/test/group_apply_test.dart
@@ -113,10 +113,13 @@ void main() {
   });
 
   group('DoNotImportFromSmartschool is informational', () {
+    /// The one leftover the delete cannot address: no code for a `delClass`.
+    /// Since #328 that is the only shape the notice fires on at all.
+    LinkedGroup undeletable({String description = 'Klas 3A'}) =>
+        linkedGroup(smartschool: ssGroup(code: ' ', description: description));
+
     test('canApply is false and apply throws UnsupportedError', () {
-      final action = DoNotImportFromSmartschool(
-        linkedGroup(smartschool: ssGroup()),
-      );
+      final action = DoNotImportFromSmartschool(undeletable());
       expect(action.canApply, isFalse);
       expect(
         () => action.apply(const Connectors(), const ApplyOptions()),
@@ -126,19 +129,20 @@ void main() {
 
     test('it no longer sends the operator into Smartschool by hand (#313)', () {
       // The dead end #271 removed on the Office 365 side: a row whose whole
-      // content was "go and do this somewhere else". The applyable delete now
-      // sits beside it, so the notice states the class instead of instructing.
+      // content was "go and do this somewhere else". The notice states the
+      // class instead of instructing — unchanged by #328, which only narrowed
+      // where it fires.
       final change =
-          DoNotImportFromSmartschool(linkedGroup(smartschool: ssGroup()))
-              .describeChanges();
+          DoNotImportFromSmartschool(undeletable()).describeChanges();
 
       expect(change.summary,
           'Laat deze klas staan — ze bestaat in Smartschool maar niet in WISA');
       expect(change.summary, isNot(contains('Verwijder ze manueel')));
       expect(change.system, Origin.smartschool);
-      // Stated, never diffed: this half writes nothing, so nothing moves.
+      // Stated, never diffed: this reading writes nothing, so nothing moves.
+      // No code here, because a class naming one is deleted rather than noticed.
       expect(change.fields.map((f) => '${f.field}:${f.before}'),
-          ['code:3A', 'omschrijving:Klas 3A']);
+          ['omschrijving:Klas 3A']);
       expect(
         change.fields.every((f) => f.shape == FieldChangeShape.statement),
         isTrue,
@@ -147,33 +151,40 @@ void main() {
     });
 
     test('a class with no description states only the facts it has (#313)', () {
-      final change = DoNotImportFromSmartschool(
-        linkedGroup(smartschool: ssGroup(description: '')),
-      ).describeChanges();
-      expect(change.fields.map((f) => f.field), ['code'],
+      final change = DoNotImportFromSmartschool(undeletable(description: ''))
+          .describeChanges();
+      expect(change.fields, isEmpty,
           reason: 'an empty statement renders as a bare `omschrijving: `');
+    });
+
+    test('it never stands beside the delete (#328)', () {
+      // The two readings partition the leftovers: "laat deze klas staan" and
+      // "doe niets" are the same act, so a class the app can delete proposes
+      // the delete and nothing else.
+      expect(
+        groupActionsFor(linkedGroup(smartschool: ssGroup()))
+            .whereType<DoNotImportFromSmartschool>(),
+        isEmpty,
+      );
+      expect(
+        groupActionsFor(undeletable()).map((a) => a.runtimeType),
+        [DoNotImportFromSmartschool],
+      );
     });
   });
 
-  group('a Smartschool class WISA does not have is one choice (#313)', () {
-    test('the notice and the delete are raised as one either/or', () {
+  group('a Smartschool class WISA does not have proposes a delete (#313)', () {
+    test('the delete is the whole row, with no radio pair (#328)', () {
       final actions = groupActionsFor(linkedGroup(smartschool: ssGroup()));
 
       expect(
         actions.map((a) => a.runtimeType),
-        [DoNotImportFromSmartschool, DeleteSmartschoolClass],
-        reason: 'the notice leads, so the delete is never the fallback pick',
+        [DeleteSmartschoolClass],
+        reason: 'the no-op "laat deze klas staan" is not an option (#328) — '
+            'the operator performs it by not pressing Toepassen',
       );
-      expect(
-        actions.map((a) => a.alternativeGroup),
-        everyElement(staleSmartschoolClassAlternative),
-        reason: 'both halves fire on the one predicate, or the delete is a '
-            'lone reading with no safe default beside it',
-      );
-      expect(
-        actions.where((a) => a.isDefaultAlternative).single,
-        isA<DoNotImportFromSmartschool>(),
-      );
+      expect(actions.single.alternativeGroup, isNull);
+      expect(actions.single.isDefaultAlternative, isFalse);
     });
 
     test('the delete describes what goes with the class', () {
@@ -185,12 +196,41 @@ void main() {
           'Verwijder de klas 3A uit Smartschool — ze bestaat niet in WISA');
       expect(
         change.fields.map((f) => f.field),
-        ['code', 'omschrijving', 'lidmaatschappen en subgroepen'],
+        ['code', 'omschrijving', 'WISA', 'lidmaatschappen en subgroepen'],
       );
       expect(
         change.fields.every((f) => f.shape == FieldChangeShape.statement),
         isTrue,
-        reason: 'an inventory of what goes, not three fields being cleared',
+        reason: 'an inventory of what goes, not four fields being cleared',
+      );
+    });
+
+    test('the card warns that WISA may simply be lagging (#328)', () {
+      // The reading the pre-selected notice used to carry. It is context on the
+      // situation, not a resolution: the card proposes a delete the operator
+      // may ignore, and this is what tells them when to.
+      final change = DeleteSmartschoolClass(linkedGroup(smartschool: ssGroup()))
+          .describeChanges();
+      final warning =
+          change.fields.singleWhere((f) => f.field == 'WISA').before!;
+
+      expect(warning, contains('(nog) niet'));
+      expect(warning, contains('loopt WISA achter'));
+      expect(warning, contains('controleer'));
+      expect(
+        change.fields.indexWhere((f) => f.field == 'WISA'),
+        lessThan(
+          change.fields
+              .indexWhere((f) => f.field == 'lidmaatschappen en subgroepen'),
+        ),
+        reason: 'it sits with the class facts, before the inventory of what '
+            'the delete takes',
+      );
+      expect(
+        groupActionsFor(linkedGroup(smartschool: ssGroup()))
+            .map((a) => a.describeChanges().summary),
+        isNot(contains(contains('Laat deze klas staan'))),
+        reason: 'stated as context, never offered as a second option',
       );
     });
 

--- a/packages/account_actions/test/group_dispatch_test.dart
+++ b/packages/account_actions/test/group_dispatch_test.dart
@@ -227,7 +227,7 @@ void main() {
       expect(notice.alternativeGroup, staleSmartschoolClassAlternative);
       expect(delete.alternativeGroup, staleSmartschoolClassAlternative);
       expect(notice.alternativeGroup, isNot(classImportAlternative));
-      expect(notice.alternativeGroup, isNot(staleClassGroupAlternative));
+      expect(notice.alternativeGroup, isNot(namesakeClassAlternative));
 
       // Polarity: the informational notice leads and is the default, so a bulk
       // apply writes *nothing* for a Smartschool leftover and the delete stays

--- a/packages/account_actions/test/group_dispatch_test.dart
+++ b/packages/account_actions/test/group_dispatch_test.dart
@@ -128,15 +128,21 @@ void main() {
       expect(actions, isEmpty);
     });
 
-    test('Smartschool only → the leave-it/delete-it pair (#313)', () {
+    test('Smartschool only → the delete, alone (#313/#328)', () {
       // The notice used to stand alone and tell the operator to go and delete
       // the class by hand in Smartschool — a row whose whole content was an
-      // instruction to go elsewhere.
+      // instruction to go elsewhere. #313 put the delete beside it as a radio
+      // pair; #328 dropped the no-op half, so the delete is the whole row.
       final actions = groupActionsFor(linkedGroup(smartschool: ssGroup()));
-      expect(
-        actions.map((a) => a.runtimeType),
-        [DoNotImportFromSmartschool, DeleteSmartschoolClass],
-      );
+      expect(actions.map((a) => a.runtimeType), [DeleteSmartschoolClass]);
+    });
+
+    test('Smartschool only, but undeletable → the lone notice (#328)', () {
+      // The remainder the delete cannot act on: no code to address `delClass`
+      // to. Exactly one of the two readings ever fires.
+      final actions =
+          groupActionsFor(linkedGroup(smartschool: ssGroup(code: ' ')));
+      expect(actions.map((a) => a.runtimeType), [DoNotImportFromSmartschool]);
     });
 
     test('orphan group with neither WISA nor Smartschool → no action', () {
@@ -215,28 +221,36 @@ void main() {
       expect(actions.single.alternativeGroup, isNull);
     });
 
-    test('the Smartschool-only orphan notice leads a choice of its own (#313)',
-        () {
-      // A key of its own, for the reason the namesake pair has one: the pending
-      // list bulk-applies per situation key, and "this Smartschool class is not
-      // in WISA" is not the situation "this WISA class is not in Smartschool".
+    test('a Smartschool leftover carries no alternative key at all (#328)', () {
+      // It had one of its own until #328 — the pending list bulk-applies per
+      // situation key, so the leftovers were kept out of the new-class subset.
+      // The pair it keyed is gone: "laat deze klas staan" and "doe niets" are
+      // the same act, and the operator performs the second by not pressing
+      // Toepassen. What keeps `delClass` off every bulk path is the #293
+      // sanction the delete withholds, read by both bulk paths since #326.
       final actions = groupActionsFor(linkedGroup(smartschool: ssGroup()));
-      final notice = actions.whereType<DoNotImportFromSmartschool>().single;
       final delete = actions.whereType<DeleteSmartschoolClass>().single;
 
-      expect(notice.alternativeGroup, staleSmartschoolClassAlternative);
-      expect(delete.alternativeGroup, staleSmartschoolClassAlternative);
-      expect(notice.alternativeGroup, isNot(classImportAlternative));
-      expect(notice.alternativeGroup, isNot(namesakeClassAlternative));
-
-      // Polarity: the informational notice leads and is the default, so a bulk
-      // apply writes *nothing* for a Smartschool leftover and the delete stays
-      // a deliberate, per-row pick.
-      expect(notice.isDefaultAlternative, isTrue);
-      expect(notice.canApply, isFalse);
+      expect(actions.map((a) => a.runtimeType), [DeleteSmartschoolClass]);
+      expect(delete.alternativeGroup, isNull,
+          reason: 'one action, so no alternative group and no radio pair');
+      expect(delete.alternativeGroup, isNot(classImportAlternative));
+      expect(delete.alternativeGroup, isNot(namesakeClassAlternative));
       expect(delete.isDefaultAlternative, isFalse);
       expect(delete.canApplyToAll, isFalse);
-      expect(actions.indexOf(notice), lessThan(actions.indexOf(delete)));
+    });
+
+    test('the leftover notice is a lone "(manueel)" row, never a half (#328)',
+        () {
+      final actions =
+          groupActionsFor(linkedGroup(smartschool: ssGroup(code: ' ')));
+      final notice = actions.whereType<DoNotImportFromSmartschool>().single;
+
+      expect(notice.canApply, isFalse);
+      expect(notice.alternativeGroup, isNull);
+      expect(notice.isDefaultAlternative, isFalse);
+      expect(actions.whereType<DeleteSmartschoolClass>(), isEmpty,
+          reason: 'the two readings partition the leftovers — never both');
     });
 
     test('the namesake notice (#225) leads a choice of its own (#250)', () {

--- a/packages/account_actions/test/group_dispatch_test.dart
+++ b/packages/account_actions/test/group_dispatch_test.dart
@@ -174,7 +174,7 @@ void main() {
       expect(actions.indexOf(create), lessThan(actions.indexOf(ignore)));
     });
 
-    test('an empty class defaults to the informational wait-or-delete notice',
+    test('an empty class states the wait-or-delete notice as context (#329)',
         () {
       final actions = groupActionsFor(
         linkedGroup(wisa: wisaGroup()),
@@ -183,32 +183,39 @@ void main() {
       final empty = actions.whereType<CreateInSmartschool>().single;
       final ignore = actions.whereType<DoNotImportFromWisa>().single;
 
-      expect(empty.alternativeGroup, classImportAlternative);
-      expect(ignore.alternativeGroup, classImportAlternative);
-      // It stands in for the create, so it takes the default with it — and it
-      // cannot be applied, so a bulk apply writes nothing for an empty class.
-      expect(empty.isDefaultAlternative, isTrue);
+      // There is nothing to create for an empty class, so the blacklist is the
+      // lone decision and the notice rides beside it as context — never as the
+      // other half of a radio pair, which is what it was until #329.
       expect(empty.canApply, isFalse);
+      expect(empty.noticeFor, classImportAlternative);
+      expect(empty.alternativeGroup, isNull);
+      expect(empty.isDefaultAlternative, isFalse);
+
+      expect(ignore.alternativeGroup, classImportAlternative);
       expect(ignore.isDefaultAlternative, isFalse);
+      // The polarity is gone, so this flag is the whole of what keeps a bulk
+      // pass off an empty class (#293/#326).
+      expect(ignore.canApplyToAll, isFalse);
     });
 
-    test('exactly one default is ever offered — the creates never co-occur',
+    test('a populated class keeps its two-writes either/or, and one default',
         () {
-      for (final hasStudents in const [true, false]) {
-        final actions = groupActionsFor(
-          linkedGroup(wisa: wisaGroup()),
-          placementFor: (_) => groupPlacement(containsStudents: hasStudents),
-        );
-        final alternatives = actions
-            .where((a) => a.alternativeGroup == classImportAlternative)
-            .toList();
-        expect(alternatives, hasLength(2));
-        expect(
-          alternatives.where((a) => a.isDefaultAlternative),
-          hasLength(1),
-          reason: 'containsStudents picks exactly one of the two creates',
-        );
-      }
+      // The genuine choice: both halves write, so the radios stay and exactly
+      // one of them is pre-selected.
+      final actions = groupActionsFor(
+        linkedGroup(wisa: wisaGroup()),
+        placementFor: (_) => groupPlacement(containsStudents: true),
+      );
+      final alternatives = actions
+          .where((a) => a.alternativeGroup == classImportAlternative)
+          .toList();
+
+      expect(
+        alternatives.map((a) => a.runtimeType),
+        [AddToSmartschool, DoNotImportFromWisa],
+      );
+      expect(alternatives.every((a) => a.canApply), isTrue);
+      expect(alternatives.where((a) => a.isDefaultAlternative), hasLength(1));
     });
 
     test('a class present in both systems carries no alternatives', () {
@@ -253,12 +260,14 @@ void main() {
           reason: 'the two readings partition the leftovers — never both');
     });
 
-    test('the namesake notice (#225) leads a choice of its own (#250)', () {
+    test('the namesake notice (#225) is context on a choice of its own (#329)',
+        () {
       // The notice takes the create's place for a class Smartschool already
-      // carries, so it takes the create's side of the either/or too — under its
-      // own key, because "this class is already there, go fix its flag" is a
-      // different situation from "create this class" and must not share a bulk
-      // apply with it.
+      // carries — but not the create's *side*: "go and make that group
+      // official" is not something an apply can run. The blacklist is the lone
+      // decision, under its own key, because "this class is already there, go
+      // fix its flag" is a different situation from "create this class" and
+      // must not share a bulk apply with it.
       final actions = groupActionsFor(
         linkedGroup(
           wisa: wisaGroup(name: '2G'),
@@ -269,27 +278,32 @@ void main() {
       final notice = actions.whereType<ClassExistsAsSmartschoolGroup>().single;
       final ignore = actions.whereType<DoNotImportFromWisa>().single;
 
-      expect(notice.alternativeGroup, namesakeClassAlternative);
+      expect(notice.canApply, isFalse);
+      expect(notice.noticeFor, namesakeClassAlternative);
+      expect(notice.alternativeGroup, isNull);
+      expect(notice.isDefaultAlternative, isFalse);
+
       expect(ignore.alternativeGroup, namesakeClassAlternative);
       expect(
-        notice.alternativeGroup,
+        ignore.alternativeGroup,
         isNot(classImportAlternative),
         reason: 'a namesake class is not bulk-applied with the new classes',
       );
-
-      // Polarity: the informational notice leads and is the default, so a bulk
-      // apply writes *nothing* for a class the operator was told to repair by
-      // hand — blacklisting it stays a deliberate pick (#250).
-      expect(notice.isDefaultAlternative, isTrue);
-      expect(notice.canApply, isFalse);
       expect(ignore.isDefaultAlternative, isFalse);
+      // What holds #250 now that the polarity is gone.
+      expect(ignore.canApplyToAll, isFalse);
+      // Dispatch order still puts the situation before the proposal: it is the
+      // order the card states them in.
       expect(actions.indexOf(notice), lessThan(actions.indexOf(ignore)));
     });
 
-    test('the blacklist is never the lone member of a choice (#250)', () {
-      // The bug: the creates refuse a namesake class, so `class-import` was
-      // left holding only `DoNotImportFromWisa` — and a lone option is always
-      // the selected one, which made "Apply to all" blacklist the class.
+    test('the blacklist stands alone with its notice beside it (#250/#329)',
+        () {
+      // #250's shape: the creates refuse a namesake class, so `class-import`
+      // was left holding only `DoNotImportFromWisa` — and a lone option is
+      // always the selected one, which made "Apply to all" blacklist the class.
+      // The lone-ness is back on purpose; the sanction is what refuses the bulk
+      // pass now, and the reading the operator needs is still on the card.
       for (final hasStudents in const [true, false]) {
         final actions = groupActionsFor(
           linkedGroup(
@@ -302,17 +316,162 @@ void main() {
         final siblings = actions
             .where((a) => a.alternativeGroup == ignore.alternativeGroup)
             .toList();
+        final notices = actions
+            .where((a) => a.noticeFor == ignore.alternativeGroup)
+            .toList();
 
-        expect(siblings, hasLength(2),
-            reason: 'the blacklist always has the reading it contradicts '
-                'beside it');
-        expect(siblings.where((a) => a.isDefaultAlternative), hasLength(1));
+        expect(siblings, hasLength(1),
+            reason: 'nothing this app can do competes with the blacklist here');
+        expect(ignore.canApplyToAll, isFalse,
+            reason: 'no bulk pass may write it — the whole of #250 now');
         expect(
-          siblings.singleWhere((a) => a.isDefaultAlternative).canApply,
-          isFalse,
-          reason: 'nothing is written for a namesake class by default',
+          notices.map((a) => a.runtimeType),
+          [ClassExistsAsSmartschoolGroup],
+          reason: 'the reading it contradicts is still on the card, as context',
         );
       }
+    });
+  });
+
+  group('a notice is context, never an alternative (#329)', () {
+    // The rule the whole alternative-group mechanism rests on, asserted over
+    // the dispatch itself rather than over the widget that renders it: an
+    // action with no automated write may not stand in an either/or, because
+    // "here is what is wrong" and "here is the one thing the app can do" are
+    // not comparable answers to one question. Such an action declares
+    // `noticeFor` and rides along as context instead.
+    //
+    // Every fixture below is one that raises an informational action, so the
+    // assertion has something to bite on in all three families.
+
+    void expectNoNoOpAlternatives(Iterable<Object> actions) {
+      for (final a in actions) {
+        final (String? group, String? notice, bool canApply, bool isDefault) =
+            switch (a) {
+          GroupAction() => (
+              a.alternativeGroup,
+              a.noticeFor,
+              a.canApply,
+              a.isDefaultAlternative
+            ),
+          StudentAction() => (
+              a.alternativeGroup,
+              a.noticeFor,
+              a.canApply,
+              a.isDefaultAlternative
+            ),
+          StaffAction() => (
+              a.alternativeGroup,
+              a.noticeFor,
+              a.canApply,
+              a.isDefaultAlternative
+            ),
+          _ => throw StateError('unclassified action ${a.runtimeType}'),
+        };
+        final String what = a.runtimeType.toString();
+
+        if (group != null) {
+          expect(canApply, isTrue,
+              reason: '$what stands in the "$group" either/or, so it must '
+                  'write something');
+        }
+        if (notice != null) {
+          expect(canApply, isFalse,
+              reason: '$what is context, so it must have no automated write');
+          expect(group, isNull,
+              reason: '$what is context, so it is not one of the answers');
+          expect(isDefault, isFalse,
+              reason: '$what is not an option and cannot be the default one');
+        }
+      }
+    }
+
+    test('the group family', () {
+      final populations = <List<GroupAction>>[
+        // A namesake class, with and without students (#225/#250).
+        for (final hasStudents in const [true, false])
+          groupActionsFor(
+            linkedGroup(
+              wisa: wisaGroup(name: '2G'),
+              smartschoolNamesake: ssGroupNode(code: 'G2G', name: '2G'),
+            ),
+            placementFor: (_) => groupPlacement(containsStudents: hasStudents),
+          ),
+        // A new class, empty and populated (#244).
+        for (final hasStudents in const [true, false])
+          groupActionsFor(
+            linkedGroup(wisa: wisaGroup()),
+            placementFor: (_) => groupPlacement(containsStudents: hasStudents),
+          ),
+        // The two leftovers, deletable and not (#327/#328).
+        groupActionsFor(linkedGroup(smartschool: ssGroup())),
+        groupActionsFor(linkedGroup(smartschool: ssGroup(code: ' '))),
+      ];
+
+      for (final actions in populations) {
+        expectNoNoOpAlternatives(actions);
+      }
+      expect(
+        populations.expand((a) => a).where((a) => !a.canApply),
+        isNotEmpty,
+        reason: 'the fixtures must actually raise informational actions',
+      );
+    });
+
+    test('the student family', () {
+      final populations = <List<StudentAction>>[
+        // The family's informational member (#245): a student missing from
+        // their own Office 365 class group.
+        studentActionsFor(
+          fullySynced(),
+          config(),
+          placementFor: (_) => classPlacement(),
+          azurePlacementFor: (_) => const AzureClassPlacement(
+            className: '3A',
+            groupName: 'SSM-3A',
+            groupExists: true,
+          ),
+        ),
+        // The family's one either/or (#110): a departed student, unregister or
+        // delete — two real writes.
+        studentActionsFor(
+          linked(smartschool: ssAccount(), azure: azureUser()),
+          config(),
+          placementFor: (_) => classPlacement(),
+        ),
+      ];
+
+      for (final actions in populations) {
+        expectNoNoOpAlternatives(actions);
+      }
+      expect(
+        populations.expand((a) => a).where((a) => !a.canApply),
+        isNotEmpty,
+        reason: 'the fixtures must actually raise an informational action',
+      );
+      expect(
+        populations.expand((a) => a).where(
+            (a) => a.alternativeGroup == smartschoolDepartureAlternative),
+        isNotEmpty,
+        reason: 'and an either/or, so both halves of the rule are exercised',
+      );
+    });
+
+    test('the staff family', () {
+      // Every staff action is applyable today, so this asserts the other half
+      // of the rule: an either/or made only of writes is exactly what the staff
+      // import decision is, and it keeps its radios.
+      final actions = staffActionsFor(
+        linkedStaff(wisa: wisaStaff()),
+        staffConfig(),
+      );
+
+      expectNoNoOpAlternatives(actions);
+      expect(
+        actions.where((a) => a.alternativeGroup == staffImportAlternative),
+        isNotEmpty,
+        reason: 'the fixture must actually raise an either/or',
+      );
     });
   });
 

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -495,8 +495,9 @@ List<_StaffRecord> _buildStaffRecords(
 /// virtual school — now becomes a Smartschool orphan record (#52) rather than
 /// linking to a class we have no business managing. The action engine then
 /// treats it as the orphan it is instead of silently considering it in sync;
-/// the orphan action is the informational `DoNotImportFromSmartschool`, which
-/// cannot be applied, so nothing is ever deleted automatically.
+/// the orphan action is `DeleteSmartschoolClass` (or, where that cannot fire,
+/// the informational `DoNotImportFromSmartschool`), and it is a proposal on one
+/// row behind a confirmation — never a bulk pass and never automatic.
 ///
 /// Only `official` Smartschool groups are considered (legacy
 /// `AddSmartschoolChildGroups` walked the "Leerlingen" subtree and linked only

--- a/packages/account_linker/lib/src/link.dart
+++ b/packages/account_linker/lib/src/link.dart
@@ -729,7 +729,9 @@ List<LinkedGroup> _linkGroups(
 /// unprefixed `5A` somebody created without the school's prefix: the exact-name
 /// match above adopts it when a class owns it, and this keeps it as an orphan
 /// when none does. It carries no recoverable class name, so it raises no
-/// stale-group action either way — see `AzureClassGroupWithoutClass`.
+/// stale-group action either way — neither `DeleteAzureClassGroup` nor the
+/// `AzureClassGroupWithoutClass` notice that stands in where the delete cannot
+/// act.
 bool _looksLikeClassGroup(String? displayName, String? bare) =>
     looksLikeClassName(bare ?? displayName);
 

--- a/packages/account_state/lib/src/materialize/linked_state_materializer.dart
+++ b/packages/account_state/lib/src/materialize/linked_state_materializer.dart
@@ -47,6 +47,7 @@ MaterializedView materialize(
       canApply: a.canApply,
       alternativeGroup: a.alternativeGroup,
       isDefaultAlternative: a.isDefaultAlternative,
+      noticeFor: a.noticeFor,
     ));
   }
   final byStaff = <String, List<CandidateAction>>{};
@@ -60,6 +61,7 @@ MaterializedView materialize(
       canApply: a.canApply,
       alternativeGroup: a.alternativeGroup,
       isDefaultAlternative: a.isDefaultAlternative,
+      noticeFor: a.noticeFor,
     ));
   }
 
@@ -171,6 +173,10 @@ List<MaterializedGroup> _materializeGroups(
       canApply: a.canApply,
       alternativeGroup: a.alternativeGroup,
       isDefaultAlternative: a.isDefaultAlternative,
+      // The group family is the only one with notices today (#329) — the
+      // namesake and empty-class instructions, which are context on the
+      // blacklist beside them rather than decisions of their own.
+      noticeFor: a.noticeFor,
     ));
     targets.putIfAbsent(key, () => a.target);
   }
@@ -570,6 +576,7 @@ CandidateAction _candidate(
   required bool canApply,
   required String? alternativeGroup,
   required bool isDefaultAlternative,
+  String? noticeFor,
 }) =>
     CandidateAction(
       family: family,
@@ -580,6 +587,7 @@ CandidateAction _candidate(
       canApply: canApply,
       alternativeGroup: alternativeGroup,
       isDefaultAlternative: isDefaultAlternative,
+      noticeFor: noticeFor,
     );
 
 // The core linked records carry only linking keys; human names live on the

--- a/packages/account_state/lib/src/materialize/materialized_state.dart
+++ b/packages/account_state/lib/src/materialize/materialized_state.dart
@@ -35,6 +35,7 @@ class CandidateAction {
     this.canApply = true,
     this.alternativeGroup,
     this.isDefaultAlternative = false,
+    this.noticeFor,
   });
 
   /// `student`, `staff`, or `group` — the dispatcher family.
@@ -74,6 +75,19 @@ class CandidateAction {
   /// switches. Ignored when [alternativeGroup] is `null`.
   final bool isDefaultAlternative;
 
+  /// The situation this **informational** candidate is context for (#329),
+  /// copied off the live action's `noticeFor`; `null` for every candidate that
+  /// is a decision in its own right.
+  ///
+  /// Persisted for the reason [alternativeGroup] is (#251): a passive session
+  /// has nothing else to tell a notice from a to-do, and without it the stored
+  /// view would render the namesake and empty-class instructions as decisions
+  /// the operator has to resolve — and count them in the badge — while a live
+  /// session states them as context beside the one write there is. Absent in
+  /// documents written before #329, which read back as `null` and behave exactly
+  /// as they did.
+  final String? noticeFor;
+
   Map<String, dynamic> toJson() => {
         'family': family,
         'kind': kind,
@@ -98,6 +112,7 @@ class CandidateAction {
         'canApply': canApply,
         if (alternativeGroup != null) 'alternativeGroup': alternativeGroup,
         if (isDefaultAlternative) 'isDefaultAlternative': true,
+        if (noticeFor != null) 'noticeFor': noticeFor,
       };
 
   factory CandidateAction.fromJson(Map<String, dynamic> json) =>
@@ -118,6 +133,7 @@ class CandidateAction {
         canApply: json['canApply'] as bool? ?? true,
         alternativeGroup: json['alternativeGroup'] as String?,
         isDefaultAlternative: json['isDefaultAlternative'] as bool? ?? false,
+        noticeFor: json['noticeFor'] as String?,
       );
 }
 
@@ -140,6 +156,12 @@ FieldChangeShape _fieldShape(String? name) =>
 /// into a single choice pre-selected on its declared default; every other
 /// candidate is a choice of one. Exposed so the read-only tiles can render an
 /// either/or as the one line it is instead of two independent bullets.
+///
+/// A candidate carrying [CandidateAction.noticeFor] is not a decision at all
+/// (#329): it is lifted onto the choice it names as [Alternatives.notices], so
+/// the stored view states the namesake and empty-class instructions as context
+/// exactly where a live session does — and, just as importantly, does not count
+/// them as work in [pendingDecisionCount].
 List<Alternatives<CandidateAction>> candidateChoices(
   Iterable<CandidateAction> candidates,
 ) =>
@@ -147,6 +169,7 @@ List<Alternatives<CandidateAction>> candidateChoices(
       candidates,
       groupOf: (c) => c.alternativeGroup,
       isDefault: (c) => c.isDefaultAlternative,
+      noticeFor: (c) => c.noticeFor,
     );
 
 /// How many pending **decisions** [candidates] leave for the operator — the
@@ -156,9 +179,17 @@ List<Alternatives<CandidateAction>> candidateChoices(
 /// which is exactly what an apply pass would write (the controller's
 /// `applyableCount` resolves the same way over the live actions). So a departed
 /// student's unregister/delete pair counts **once**, a new class's
-/// create/opt-out pair counts once, an empty class — whose default half is the
-/// informational notice — counts zero, and the informational actions of #245
-/// never count at all.
+/// create/opt-out pair counts once, an informational action that stands alone
+/// (the #245 one, and the leftover notices of #327/#328) counts zero, and a
+/// notice attached to a decision (#329) is not a choice here at all — the
+/// decision it is context for is counted, on its own merits.
+///
+/// That last one is a deliberate change of reading. An empty or namesake class
+/// counted **zero** while the notice was its pre-selected half; it counts one
+/// now, because the blacklist beside it genuinely is a write this app can make
+/// and the operator can press. The same shift #327/#328 made for the two
+/// leftovers, for the same reason: the badge says what there is to do here, and
+/// there is something.
 int pendingDecisionCount(Iterable<CandidateAction> candidates) {
   var pending = 0;
   for (final choice in candidateChoices(candidates)) {

--- a/packages/account_state/test/azure_class_groups_test.dart
+++ b/packages/account_state/test/azure_class_groups_test.dart
@@ -368,7 +368,12 @@ void main() {
   });
 
   group('a vanished class (#228)', () {
-    test('its group is reported for manual cleanup, never deleted', () {
+    test('its group is offered for deletion, and nothing is deleted for you',
+        () {
+      // Since #327 the row proposes exactly one thing — the delete — instead of
+      // pairing it with a "laat de groep staan" radio that wrote nothing. What
+      // keeps it from running on its own is `canApplyToAll` plus the operator's
+      // own press, not the polarity of a pair.
       final linked = _recompute(
         classGroups: [_wClass('2A')],
         students: [_student(wisaId: 'w1', classGroup: '2A')],
@@ -379,11 +384,16 @@ void main() {
         ],
       );
 
-      final notices =
-          _actionsOfType<actions.AzureClassGroupWithoutClass>(linked);
-      expect(notices, hasLength(1));
-      expect(notices.single.canApply, isFalse);
-      expect(notices.single.target.className, '9Z');
+      final deletes = _actionsOfType<actions.DeleteAzureClassGroup>(linked);
+      expect(deletes, hasLength(1));
+      expect(deletes.single.target.className, '9Z');
+      expect(deletes.single.canApplyToAll, isFalse,
+          reason: 'no bulk affordance may offer it (#293/#326)');
+      expect(
+        _actionsOfType<actions.AzureClassGroupWithoutClass>(linked),
+        isEmpty,
+        reason: 'the notice is only for a group the delete cannot address',
+      );
     });
   });
 
@@ -536,8 +546,8 @@ void main() {
     });
 
     test('the group of a vanished class is never reported as a stray', () {
-      // Nothing removes a member from it — AzureClassGroupWithoutClass is a
-      // manual-cleanup notice — so naming it per student would be work nobody
+      // Nothing removes a member from it — the whole group either goes or stays
+      // (DeleteAzureClassGroup) — so naming it per student would be work nobody
       // can do.
       final linked = _recompute(
         classGroups: [_wClass('2A')],
@@ -550,8 +560,8 @@ void main() {
         ],
       );
 
-      expect(_actionsOfType<actions.AzureClassGroupWithoutClass>(linked),
-          hasLength(1));
+      expect(
+          _actionsOfType<actions.DeleteAzureClassGroup>(linked), hasLength(1));
       expect(memberships(linked), isEmpty);
     });
 

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -805,6 +805,7 @@ void main() {
       String? group,
       bool isDefault = false,
       bool canApply = true,
+      String? noticeFor,
     }) =>
         CandidateAction(
           family: 'group',
@@ -814,6 +815,7 @@ void main() {
           canApply: canApply,
           alternativeGroup: group,
           isDefaultAlternative: isDefault,
+          noticeFor: noticeFor,
         );
 
     test('two alternatives of one choice count once', () {
@@ -830,15 +832,43 @@ void main() {
       expect(pendingDecisionCount(candidates), 1);
     });
 
-    test('a choice whose default is informational counts nothing', () {
-      // The empty-class reading of #244: the pre-selected half has no write, so
-      // a bulk apply writes nothing here — blacklisting stays a deliberate pick.
+    test('a choice whose selected half is informational counts nothing', () {
+      // The generic property, and the only shape that still produces it since
+      // #329: a lone informational candidate. (An either/or can no longer be in
+      // this state — every alternative writes — and the empty-class reading of
+      // #244 that used to be the example is the test below.)
+      expect(
+        pendingDecisionCount(
+            [candidate('DoNotImportFromSmartschool', canApply: false)]),
+        0,
+      );
+    });
+
+    test('a notice is not a decision, and the write beside it is (#329)', () {
+      // The empty-class reading of #244, as it stands now. The notice used to
+      // be the pre-selected half of this pair, so the badge read zero: nothing
+      // would be written unless the operator flipped a radio. It is context on
+      // the blacklist now, so the badge counts the blacklist — which genuinely
+      // is a write the operator can press. Keeping it off a *bulk* pass is
+      // `canApplyToAll`'s job (#293/#326), not the badge's.
       final candidates = [
         candidate('CreateInSmartschool',
-            group: 'class-import', isDefault: true, canApply: false),
+            canApply: false, noticeFor: 'class-import'),
         candidate('DoNotImportFromWisa', group: 'class-import'),
       ];
-      expect(pendingDecisionCount(candidates), 0);
+
+      final choices = candidateChoices(candidates);
+      expect(choices, hasLength(1));
+      expect(choices.single.isChoice, isFalse,
+          reason:
+              'a diagnosis and a write are not two answers to one question');
+      expect(choices.single.selected.kind, 'DoNotImportFromWisa');
+      expect(
+        choices.single.notices.map((c) => c.kind),
+        <String>['CreateInSmartschool'],
+        reason: 'the instruction is still on the card, as context',
+      );
+      expect(pendingDecisionCount(candidates), 1);
     });
 
     test('independent actions still count one each, informational ones zero',
@@ -873,6 +903,38 @@ void main() {
           group: 'smartschool-departure', isDefault: true);
       final restored = CandidateAction.fromJson(original.toJson());
       expect(restored.alternativeGroup, 'smartschool-departure');
+      expect(restored.isDefaultAlternative, isTrue);
+      expect(restored.noticeFor, isNull);
+    });
+
+    test('the notice key survives a candidate JSON round-trip (#329)', () {
+      // Dropped on the way through Cosmos, the namesake instruction reads back
+      // as a decision of its own in a passive session — a second bullet the
+      // operator is asked to resolve and a badge counting work nobody can do,
+      // which is the very #251 split this key exists to close.
+      final original = candidate('ClassExistsAsSmartschoolGroup',
+          canApply: false, noticeFor: 'class-namesake');
+      final restored = CandidateAction.fromJson(original.toJson());
+
+      expect(restored.noticeFor, 'class-namesake');
+      expect(restored.alternativeGroup, isNull);
+      expect(restored.canApply, isFalse);
+    });
+
+    test('a candidate written before #329 carries no notice key', () {
+      final restored = CandidateAction.fromJson(<String, dynamic>{
+        'family': 'group',
+        'kind': 'ClassExistsAsSmartschoolGroup',
+        'system': core.Origin.smartschool.toJson(),
+        'summary': 'Deze klas bestaat in Smartschool',
+        'canApply': false,
+        'alternativeGroup': 'class-namesake',
+        'isDefaultAlternative': true,
+      });
+      // It reads back exactly as it was written — the pre-#329 pair, which the
+      // next sync replaces wholesale.
+      expect(restored.noticeFor, isNull);
+      expect(restored.alternativeGroup, 'class-namesake');
       expect(restored.isDefaultAlternative, isTrue);
     });
 

--- a/packages/account_state/test/materialize/materialize_test.dart
+++ b/packages/account_state/test/materialize/materialize_test.dart
@@ -197,6 +197,34 @@ LinkedState _modifyPendingLinked() => LinkedState.recompute(
       staffConfig: _staffConfig,
     );
 
+/// A Smartschool-only class the app **cannot** delete: the group carries no
+/// class code, so there is nothing to address a `delClass` to and the dispatch
+/// falls back to the lone informational `DoNotImportFromSmartschool` (#328).
+///
+/// The one shape a class group still has manual-only work in, which is what the
+/// "attention, not pending" claim of #225/#250 is about. It used to be every
+/// Smartschool leftover, back when the notice was the pre-selected half of a
+/// radio pair.
+LinkedState _leftoverNoticeLinked() => LinkedState.recompute(
+      wisa: wapi.WisaSnapshot(
+        fetchedAt: _d,
+        students: const [],
+        staff: const [],
+        classGroups: const [],
+        schools: const [],
+      ),
+      smartschool: ss.SmartschoolSnapshot(
+        fetchedAt: _d,
+        groups: [_ssGroup('2B', code: ' ')],
+        accounts: const [],
+        memberships: const [],
+      ),
+      azure: az.AzureSnapshot(fetchedAt: _d, users: const [], groups: const []),
+      resolver: _SeqResolver(),
+      studentConfig: _studentConfig,
+      staffConfig: _staffConfig,
+    );
+
 /// A class that is **entirely in order**: present in WISA, in Smartschool with
 /// matching institute number / untis / description, and in Office 365 as
 /// `GBS-3C` with its one student already in it. So the group dispatch raises
@@ -470,7 +498,10 @@ void main() {
 
   group('materialize groups (#119)', () {
     test('a group action → a group doc in the groups partition + rollup', () {
-      // The Smartschool-only 2B class raises the informational orphan notice.
+      // The Smartschool-only 2B class names a code, so since #328 its one
+      // reading is the applyable `DeleteSmartschoolClass` — the informational
+      // notice it used to be pre-selected beside is gone. See
+      // `_leftoverNoticeLinked` for the leftover that still has no write.
       final view = materialize(_movePendingLinked(), generation: 2);
 
       expect(view.groups, hasLength(1));
@@ -483,8 +514,7 @@ void main() {
       expect(group.inWisa, isFalse);
       expect(group.candidates, isNotEmpty);
       expect(group.candidates.every((c) => c.family == 'group'), isTrue);
-      // The orphan notice is informational — nothing to apply.
-      expect(group.hasPending, isFalse);
+      expect(group.hasPending, isTrue);
 
       final rollup =
           view.rollups.firstWhere((r) => r.level == RollupLevel.groups);
@@ -492,8 +522,8 @@ void main() {
       expect(rollup.school, groupsPartition);
       expect(rollup.label, 'Klasgroepen');
       expect(rollup.accountCount, 1);
-      expect(rollup.pendingCount, 0,
-          reason: 'the orphan notice is informational');
+      expect(rollup.pendingCount, 1,
+          reason: 'the leftover proposes a delete the operator may apply');
     });
 
     test('an applyable group action counts toward the group rollup pending',
@@ -573,10 +603,16 @@ void main() {
     });
 
     test('an informational-only notice is attention, not pending work', () {
-      // #225/#250: a class Smartschool already holds carries manual work with no
-      // automated write, so it must not be filtered away with the pending count.
+      // #225/#250: a class carrying manual work with no automated write must
+      // not be filtered away with the pending count. Since #328 the shape that
+      // still does is the Smartschool leftover naming no class code — the one
+      // the delete cannot address.
       final group =
-          materialize(_movePendingLinked(), generation: 1).groups.single;
+          materialize(_leftoverNoticeLinked(), generation: 1).groups.single;
+      expect(
+        group.candidates.map((c) => c.kind),
+        ['DoNotImportFromSmartschool'],
+      );
       expect(group.hasPending, isFalse);
       expect(group.needsAttention, isTrue);
     });

--- a/packages/account_state/test/state_applier_test.dart
+++ b/packages/account_state/test/state_applier_test.dart
@@ -1022,10 +1022,12 @@ void main() {
 
       test('an informational group action is never chained', () async {
         // The orphan notice throws on apply; the walk must skip it whatever a
-        // future `unlocks` declaration says.
+        // future `unlocks` declaration says. Since #327 that notice is raised
+        // only where the delete beside it cannot fire — here, a stale group the
+        // tenant gave no object id to address a DELETE to.
         final harness = classHarness(groups: [
           az.AzureGroup(
-            id: 'az-9Z',
+            id: '',
             displayName: 'SSM-9Z',
             mail: 'SSM-9Z@student.school.example',
             mailNickname: 'SSM-9Z',

--- a/packages/account_state/test/state_applier_test.dart
+++ b/packages/account_state/test/state_applier_test.dart
@@ -1102,7 +1102,8 @@ void main() {
       expect(
         applied.linked!.groupActions.whereType<DoNotImportFromSmartschool>(),
         isEmpty,
-        reason: 'and so is the notice that was its alternative',
+        reason: 'and the relink raises no notice in its place — the record is '
+            'gone, not merely undeletable (#328)',
       );
       expect(harness.counts, [0, 0, 0], reason: 'nothing was re-pulled');
     });


### PR DESCRIPTION
## Summary

Five commits, one per issue, in dependency order.

- **#326 — the bulk guard was incidental, not real.** `SituationCohort.applyableCount` counted only `PendingDecision.canApply`, so what kept destructive resolutions off the bulk path was the *polarity of their alternative group*, not the `canApplyToAll` sanction: flipping the radio on two rows armed an "Alles toepassen (2)" that deleted both. Adds `SituationCohort.bulkApplyable` (`canApply && canApplyToAll`, matching `applyToAllCohortFor`); `SituationHeader` builds count, confirmation scope and pass from that one list and renders no bulk pair at all when it is empty, and `applyDecisions`/`dryRunDecisions` refuse withheld decisions behind the widget. This is what the three following commits are allowed to rely on.
- **#327 — the stale Office 365 group decision drops its no-op half.** "Laat de Office 365-groep staan" wrote nothing, so it was never a resolution. `staleClassGroupAlternative` is gone; a `_deletableStaleClassGroup` predicate partitions the population so the delete is the card's whole proposal where it can fire, and the "(manueel)" notice stands alone where it cannot (blank Azure object id).
- **#328 — the same for the Smartschool leftover class**, mirrored deliberately. The "WISA may simply be lagging" reading survives as a statement line on the delete's card, never as a radio option.
- **#329 — generalises the rule: a notice is context, not an alternative.** Adds `noticeFor` across the three action families, so an informational action is lifted out of an either/or and attached to the decision it explains (`ChoiceNotice`, marked "(manueel)", no radio, no apply). `ClassExistsAsSmartschoolGroup` and `CreateInSmartschool` become card context, leaving `DoNotImportFromWisa` the lone decision under `class-namesake` / `class-import`. #250's regression is now held by `canApplyToAll == false` plus #326's guard, pinned directly at unit and e2e level.
- **#335 — docs catch up** (follow-up filed by the #329 worker during this batch). `docs/domain-model.md` §3.7 said "groups are never deleted automatically", false since #271/#313 and doubly so now; `PROJECT_OVERVIEW.md` still described the Dart side as an empty `account_api/`. §3.7 restated, and PROJECT_OVERVIEW scoped explicitly to the legacy WPF app per `CLAUDE.md`, pointing at `docs/domain-model.md` and `packages/account_actions/README.md` for the port's model.

Knock-on the reviewer should expect: a stale group's Office 365 cell now reads *needsWork* (a real applyable write is pending), so the #298 "an informational-only action colours no cell" claim moved twice and now lives on the codeless leftover — the one shape it still fits.

## Test plan

- [x] `dart format --set-exit-if-changed` clean (319 files); `flutter analyze` / `dart analyze --fatal-infos --fatal-warnings` clean across the workspace
- [x] Pure-Dart packages green at each commit — final state: account_core 106, wisa_api 131, smartschool_api 150, azure_api 158, account_linker 96, account_actions 251, account_state 590
- [x] `flutter test` in `account_manager` — 591 unit/widget tests pass
- [x] `flutter test integration_test/app_launch_test.dart -d windows` — 130 pass
- [x] Fail-without-fix proven per issue by stashing only the lib files: #326's three new tests, #327's widget + reworked #271 e2e, #328's new e2e ("3 'Laat deze klas staan' widgets found") plus 7 unit tests, #329's #250 pins
- [x] #335 is docs-only; verified by grep that no test asserts on either document's contents

Closes #326
Closes #327
Closes #328
Closes #329
Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)